### PR TITLE
fix: clean up build config

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,6 @@
     "allowImportingTsExtensions": false,
     "noEmit": false
   },
-  "include": ["src/**/*", "scripts/**/*", "**/*.test.ts", "**/*.spec.ts", "vitest.config.ts"],
+  "include": ["src/**/*", "**/*.test.ts", "**/*.spec.ts", "vitest.config.ts"],
   "exclude": ["node_modules"]
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,6 +1,5 @@
 import { defineConfig } from 'tsup';
 export default defineConfig([
-  // Core entry: bundle CJS, external ESM
   {
     entry: ['src/core/index.ts'],
     format: ['cjs', 'esm'],
@@ -8,8 +7,9 @@ export default defineConfig([
     dts: true,
     shims: true,
     bundle: true,
+    noExternal: ['chalk', 'boxen'],
+    external: ['better-sqlite3', 'pg', 'redis'],
   },
-  // App entry: only ESM, bundle all dependencies except commander
   {
     entry: ['src/app/index.ts'],
     format: ['esm'],


### PR DESCRIPTION
  tsconfig.json

  - Removed "scripts/**/*" from the include array, so TypeScript will no longer
   compile files in the scripts directory

  tsup.config.ts

  - Removed code comments explaining the build configurations
  - Added noExternal: ['chalk', 'boxen'] to bundle chalk and boxen dependencies
  - Added external: ['better-sqlite3', 'pg', 'redis'] to exclude database
  dependencies from bundling
  - Removed the comment about "App entry: only ESM, bundle all dependencies
  except commander"