### PR TITLE
fix: update CLI bin path to match CommonJS build output

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,5 @@
+[byterover-mcp]
+
+# important 
+always use byterover-retrive-knowledge tool to get the related context before any tasks 
+always use byterover-store-knowledge to store all the critical informations after sucessful tasks

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 	"module": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"bin": {
-		"cipher": "./dist/src/app/index.js"
+		"cipher": "./dist/src/app/index.cjs"
 	},
 	"exports": {
 		".": {
@@ -36,6 +36,7 @@
 		"dev": "tsc --watch",
 		"typecheck": "tsc --project tsconfig.typecheck.json",
 		"prepare": "husky",
+		"precommit": "npm run lint && npm run typecheck && npm run format:check && npm run test:ci && npm run build",
 		"test": "vitest run",
 		"test:unit": "vitest run --exclude '**/integration/**' --exclude '**/*.integration.test.ts'",
 		"test:integration": "vitest run --include '**/integration/**' --include '**/*.integration.test.ts'",


### PR DESCRIPTION
The CLI binary entry was pointing to index.js but the build process generates index.cjs files. This fixes the "command not found: cipher" error.
