### PR TITLE
Filter Retrieved Results from Extraction

### DIFF
--- a/src/core/brain/llm/messages/manager.ts
+++ b/src/core/brain/llm/messages/manager.ts
@@ -19,7 +19,7 @@ export class ContextManager {
 	async getSystemPrompt(): Promise<string> {
 		// Use the complete system prompt that includes both user instruction and built-in tool instructions
 		const prompt = await this.promptManager.getCompleteSystemPrompt();
-		logger.debug(`[SystemPrompt] Built complete system prompt:\n${prompt}`);
+		logger.debug(`[SystemPrompt] Built complete system prompt (${prompt.length} chars)`);
 		return prompt;
 	}
 


### PR DESCRIPTION
**How to test it** 
- Now cipher's tool -  **cipher_extract_and_operate_memory**, which runs after the AI Response has been displayed will skip retrieval results (from ALL search tools) from the Context Manager.
- You can observe that on debug mode, retrieved results are skipped after the AI response is displayed.
- On debug log level, these prompts are omitted to make the UI cleaner.