### PR TITLE
fix the typo of name of the project

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature Request or Enhancement
-about: Suggest an idea for an OpenHands feature or enhancement
+about: Suggest an idea for an Cipher feature or enhancement
 title: '[FEATURE] '
 labels: 'enhancement'
 assignees: ''


### PR DESCRIPTION
fix the typo in the name of the project