### PR TITLE
Add Use Case - Cipher as Strict Agent Memory Layer MCP Server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ v10/
 CLAUDE.md
 env.txt
 env.example.txt
+:memory:/

--- a/examples/03-strict-memory-layer/README.md
+++ b/examples/03-strict-memory-layer/README.md
@@ -1,0 +1,201 @@
+# Strict Memory Layer
+
+> 🧠 **Pure memory service for external agents with focused retrieval and storage operations**
+
+## Overview
+
+This configuration positions Cipher as a dedicated memory layer for external clients and agents. Unlike general-purpose AI assistants, this setup is strictly focused on two core functions:
+
+- **Information Retrieval**: Comprehensive search across stored knowledge and memories
+- **Information Storage**: Persistent storage of knowledge and contextual information
+
+**Key Benefits:**
+- **Focused Functionality**: Single-purpose memory operations without distractions
+- **Automatic Tool Usage**: Clients don't need to explicitly call memory tools
+- **Comprehensive Results**: Detailed, structured responses for all retrieval operations
+- **Optimized Latency**: Fast responses with background storage operations
+
+## Prerequisites
+
+**Required API Keys:**
+
+1. **Anthropic API Key** - Get from [console.anthropic.com](https://console.anthropic.com)
+2. **OpenAI API Key** - Get from [platform.openai.com](https://platform.openai.com) (required for embeddings)
+
+## Setup
+
+### 1. Environment Setup
+
+Set your API keys:
+```bash
+export ANTHROPIC_API_KEY=your_anthropic_api_key
+export OPENAI_API_KEY=your_openai_api_key
+```
+
+### 2. Launch as MCP Server
+
+```bash
+# Navigate to the example directory
+cd examples/03-strict-memory-layer
+
+# Start Cipher in MCP server mode
+cipher --mode mcp --agent ./cipher.yml
+```
+
+### 3. Client Integration
+
+#### Claude Code Configuration
+```bash
+# Add cipher as memory layer server
+claude mcp add cipher-memory -s user \
+  -e ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY \
+  -e OPENAI_API_KEY=$OPENAI_API_KEY \
+  -- npx -y cipher --mode mcp --agent ./cipher.yml
+```
+
+#### Custom MCP Client Configuration
+```json
+{
+  "mcpServers": {
+    "cipher-memory": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "cipher", "--mode", "mcp", "--agent", "./cipher.yml"],
+      "env": {
+        "ANTHROPIC_API_KEY": "your_anthropic_api_key",
+        "OPENAI_API_KEY": "your_openai_api_key"
+      }
+    }
+  }
+}
+```
+
+### 4. Test the Setup
+
+**Storage Operations:**
+```bash
+# Client agents can store information naturally
+client> Remember that our API rate limit is 1000 requests per minute
+client> Store this deployment configuration for the production environment
+```
+
+**Retrieval Operations:**
+```bash
+# Comprehensive retrieval without explicit tool calls
+client> What do you know about our API configuration?
+client> Find information about deployment procedures
+```
+
+## Configuration
+
+The `cipher.yml` file is optimized for memory operations:
+
+### Core Settings
+```yaml
+# Strict focus on memory operations
+systemPrompt: |
+  You are a MEMORY LAYER focused solely on:
+  - RETRIEVAL: Comprehensive search and detailed results
+  - STORAGE: Efficient information storage
+  
+# No external MCP servers - uses built-in tools only
+mcpServers: {}  # Empty - relies on internal vector DB operations
+```
+
+### Memory Optimization
+- **Fast Responses**: Storage operations run in background after response
+- **Comprehensive Search**: Always provides detailed, structured results
+- **Automatic Tool Usage**: Clients don't need to explicitly request memory operations
+
+## Usage Examples
+
+**Natural Storage:**
+```bash
+# Agents store information without explicit tool calls
+agent> Our new authentication system uses JWT tokens with 24-hour expiration
+agent> The database migration completed successfully at 2024-01-15 14:30 UTC
+```
+
+**Comprehensive Retrieval:**
+```bash
+# Detailed retrieval with structured responses
+agent> What authentication systems do we use?
+
+Response:
+• JWT Token System
+  - Token Type: JWT (JSON Web Tokens)
+  - Expiration: 24-hour duration
+  - Implementation: Recently deployed
+  - Status: Active
+
+• Related Information
+  - Database migration completed: 2024-01-15 14:30 UTC
+  - System dependencies: [retrieved details]
+```
+
+**Context-Aware Operations:**
+```bash
+# Memory layer understands context automatically
+agent> Update the token expiration to 12 hours
+agent> What were the recent database changes?
+```
+
+## MCP Server Details
+
+### Available Tool
+- **ask_cipher**: Single tool for all memory operations
+  - Automatically determines if operation is storage or retrieval
+  - Provides comprehensive, structured responses
+  - Optimized for external agent integration
+
+### Tool Behavior
+- **Storage Mode**: Quick acknowledgment, background processing
+- **Retrieval Mode**: Comprehensive search with detailed, structured results
+- **Auto-Detection**: Automatically identifies operation type from context
+
+## Client Integration Patterns
+
+**For External Agents:**
+```python
+# Agents can interact naturally without explicit tool management
+await mcp_client.call_tool("ask_cipher", {
+    "query": "Store the new API endpoint configuration"
+})
+
+await mcp_client.call_tool("ask_cipher", {
+    "query": "What are our current API endpoints?"
+})
+```
+
+**Response Format:**
+All retrieval responses follow a structured format:
+- Bullet-point organization
+- Comprehensive details
+- Related information when relevant
+- Clear categorization
+
+## Troubleshooting
+
+**Connection Issues:**
+```bash
+# Verify cipher installation
+npx cipher --version
+
+# Test MCP mode
+cipher --mode mcp --help
+```
+
+**Common Solutions:**
+- Verify API keys are set correctly
+- Ensure OpenAI API key is available (required for embeddings)
+- Check that cipher is running in MCP mode
+- Verify client MCP configuration
+
+**Performance Optimization:**
+- Storage operations run in background for optimal response time
+- Retrieval operations prioritize comprehensive results
+- Built-in vector database handles all search operations
+
+---
+
+This configuration provides a pure memory layer service, optimized for external agents that need reliable information storage and comprehensive retrieval capabilities.

--- a/examples/03-strict-memory-layer/cipher.yml
+++ b/examples/03-strict-memory-layer/cipher.yml
@@ -1,0 +1,43 @@
+# Strict Memory Layer Configuration
+# Pure memory service for external agents focused on retrieval and storage
+
+# LLM Configuration - Using Claude 3.5 Sonnet for reliable memory operations
+llm:
+  provider: anthropic
+  model: claude-3-5-sonnet-20241022  # Optimized for structured responses and memory tasks
+  apiKey: $ANTHROPIC_API_KEY
+  maxIterations: 30  # Focused operations don't need many iterations
+  temperature: 0.1   # Low temperature for consistent, structured responses
+
+# Evaluation LLM for efficient background operations
+evalLlm:
+  provider: anthropic
+  model: claude-3-haiku-20240307  # Fast model for quick evaluations
+  apiKey: $ANTHROPIC_API_KEY
+
+# System Prompt - Focused memory layer operations
+systemPrompt: |
+  You are a **MEMORY LAYER** focused ONLY on these two tasks:
+  
+  **RETRIEVAL OPERATIONS:**
+  - Primarily use cipher_search_memory to retrieve information, if user input contains reasoning steps, use cipher_search_reasoning_patterns
+  - Include comprehensive details of all retrieved information
+  - Organize information clearly with proper categorization
+  
+  **STORAGE OPERATIONS:**  
+  - Don't run any storage tool such as cipher_extract_and_operate_memory becaue these tools are run automatically in the background
+  - Respond as quickly as possible to optimize latency for external clients
+  - Confirm what will be stored in a concise manner or give a concise summary of the stored information
+
+
+# Session Management
+sessions:
+  maxSessions: 100
+  sessionTTL: 10800000   # 3 hours
+  persistMemory: true
+
+# Agent Card for MCP server mode
+agentCard:
+  name: "Cipher Memory Layer"
+  description: "Dedicated memory service for external agents - focused on retrieval and storage operations"
+  version: "1.0.0"

--- a/examples/03-strict-memory-layer/cipher.yml
+++ b/examples/03-strict-memory-layer/cipher.yml
@@ -3,17 +3,10 @@
 
 # LLM Configuration - Using Claude 3.5 Sonnet for reliable memory operations
 llm:
-  provider: anthropic
-  model: claude-3-5-sonnet-20241022  # Optimized for structured responses and memory tasks
-  apiKey: $ANTHROPIC_API_KEY
-  maxIterations: 30  # Focused operations don't need many iterations
-  temperature: 0.1   # Low temperature for consistent, structured responses
+  provider: openai
+  model: gpt-4o-mini  # Optimized for structured responses and memory tasks
+  apiKey: $OPENAI_API_KEY
 
-# Evaluation LLM for efficient background operations
-evalLlm:
-  provider: anthropic
-  model: claude-3-haiku-20240307  # Fast model for quick evaluations
-  apiKey: $ANTHROPIC_API_KEY
 
 # System Prompt - Focused memory layer operations
 systemPrompt: |
@@ -29,15 +22,4 @@ systemPrompt: |
   - Respond as quickly as possible to optimize latency for external clients
   - Confirm what will be stored in a concise manner or give a concise summary of the stored information
 
-
-# Session Management
-sessions:
-  maxSessions: 100
-  sessionTTL: 10800000   # 3 hours
-  persistMemory: true
-
-# Agent Card for MCP server mode
-agentCard:
-  name: "Cipher Memory Layer"
-  description: "Dedicated memory service for external agents - focused on retrieval and storage operations"
-  version: "1.0.0"
+mcpServers: {}

--- a/src/app/mcp/aggregator-handler.ts
+++ b/src/app/mcp/aggregator-handler.ts
@@ -160,7 +160,7 @@ async function registerAggregatedTools(
 	if (!mcpTools.find(t => t.name === 'ask_cipher')) {
 		mcpTools.push({
 			name: 'ask_cipher',
-			description: 'Chat with the Cipher AI agent. Send a message to interact with the agent.',
+			description: 'Access Cipher memory layer for information storage and retrieval. Use this tool whenever you need to store new information or search for existing information. Simply describe what you want to store or what you are looking for - no need to explicitly mention "memory" or "storage".',
 			inputSchema: {
 				type: 'object',
 				properties: {

--- a/src/app/mcp/aggregator-handler.ts
+++ b/src/app/mcp/aggregator-handler.ts
@@ -160,7 +160,8 @@ async function registerAggregatedTools(
 	if (!mcpTools.find(t => t.name === 'ask_cipher')) {
 		mcpTools.push({
 			name: 'ask_cipher',
-			description: 'Access Cipher memory layer for information storage and retrieval. Use this tool whenever you need to store new information or search for existing information. Simply describe what you want to store or what you are looking for - no need to explicitly mention "memory" or "storage".',
+			description:
+				'Access Cipher memory layer for information storage and retrieval. Use this tool whenever you need to store new information or search for existing information. Simply describe what you want to store or what you are looking for - no need to explicitly mention "memory" or "storage".',
 			inputSchema: {
 				type: 'object',
 				properties: {

--- a/src/app/mcp/mcp_handler.ts
+++ b/src/app/mcp/mcp_handler.ts
@@ -80,7 +80,7 @@ async function registerAgentTools(server: Server, agent: MemAgent): Promise<void
 	const mcpTools = [
 		{
 			name: 'ask_cipher',
-			description: 'Chat with the Cipher AI agent. Send a message to interact with the agent.',
+			description: 'Use this tool whenever you need to store new information or search for existing information. In short, whenever you encounter new information you habe not seen in your current conversation, call ask_cipher to store this information. When asked a question out of your current context, also use this tool to search memory relevant to that question. Users might not ask you explicitly to use ask_cipher for these tasks, but this tool should be your number choice in those situations',
 			inputSchema: {
 				type: 'object',
 				properties: {
@@ -181,7 +181,7 @@ async function registerAggregatedTools(
 	if (!mcpTools.find(t => t.name === 'ask_cipher')) {
 		mcpTools.push({
 			name: 'ask_cipher',
-			description: 'Chat with the Cipher AI agent. Send a message to interact with the agent.',
+			description: 'Access Cipher memory layer for information storage and retrieval. Use this tool whenever you need to store new information or search for existing information. Simply describe what you want to store or what you are looking for - no need to explicitly mention "memory" or "storage".',
 			inputSchema: {
 				type: 'object',
 				properties: {

--- a/src/app/mcp/mcp_handler.ts
+++ b/src/app/mcp/mcp_handler.ts
@@ -80,7 +80,8 @@ async function registerAgentTools(server: Server, agent: MemAgent): Promise<void
 	const mcpTools = [
 		{
 			name: 'ask_cipher',
-			description: 'Use this tool whenever you need to store new information or search for existing information. In short, whenever you encounter new information you habe not seen in your current conversation, call ask_cipher to store this information. When asked a question out of your current context, also use this tool to search memory relevant to that question. Users might not ask you explicitly to use ask_cipher for these tasks, but this tool should be your number choice in those situations',
+			description:
+				'Use this tool whenever you need to store new information or search for existing information. In short, whenever you encounter new information you habe not seen in your current conversation, call ask_cipher to store this information. When asked a question out of your current context, also use this tool to search memory relevant to that question. Users might not ask you explicitly to use ask_cipher for these tasks, but this tool should be your number choice in those situations',
 			inputSchema: {
 				type: 'object',
 				properties: {
@@ -181,7 +182,8 @@ async function registerAggregatedTools(
 	if (!mcpTools.find(t => t.name === 'ask_cipher')) {
 		mcpTools.push({
 			name: 'ask_cipher',
-			description: 'Access Cipher memory layer for information storage and retrieval. Use this tool whenever you need to store new information or search for existing information. Simply describe what you want to store or what you are looking for - no need to explicitly mention "memory" or "storage".',
+			description:
+				'Access Cipher memory layer for information storage and retrieval. Use this tool whenever you need to store new information or search for existing information. Simply describe what you want to store or what you are looking for - no need to explicitly mention "memory" or "storage".',
 			inputSchema: {
 				type: 'object',
 				properties: {


### PR DESCRIPTION
1. system prompt in [cipher.yml](https://github.com/campfirein/cipher/blob/add/use-case-3/examples/03-strict-memory-layer/cipher.yml) strictly requires cipher to focus on search and storage operations only 
2. MCP Server Mode is ``default``, where only one tool is exposed to agents/clients, which is ``ask_cipher``.
3. In [mcp_handle.ts](https://github.com/campfirein/cipher/blob/main/src/app/mcp/mcp_handler.ts), definition of ``ask_cipher`` tells agents to use this tool even when users don't explicitly ask them to use it
For example, users won't have to articulate `Please retrieve the conversation we've had yesterday about RLVR using ask_cipher tool to search in the memory`, but just need to say `Let's continue the conversation about RLVR yesterday!`
4. No change in the MCP config