### PR TITLE
Fix/fix tool schema

### DIFF
--- a/src/core/brain/tools/def_reflective_memory_tools.ts
+++ b/src/core/brain/tools/def_reflective_memory_tools.ts
@@ -605,7 +605,20 @@ export const evaluateReasoning: InternalTool = {
 				description: 'The reasoning trace to evaluate (from extract_reasoning_steps)',
 				properties: {
 					id: { type: 'string' },
-					steps: { type: 'array' },
+					steps: { 
+						type: 'array',
+						items: {
+							type: 'object',
+							properties: {
+								type: { 
+									type: 'string',
+									enum: ['thought', 'action', 'observation', 'decision', 'conclusion', 'reflection']
+								},
+								content: { type: 'string' }
+							},
+							required: ['type', 'content']
+						}
+					},
 					metadata: { type: 'object' },
 				},
 				required: ['id', 'steps'],

--- a/src/core/brain/tools/def_reflective_memory_tools.ts
+++ b/src/core/brain/tools/def_reflective_memory_tools.ts
@@ -605,19 +605,26 @@ export const evaluateReasoning: InternalTool = {
 				description: 'The reasoning trace to evaluate (from extract_reasoning_steps)',
 				properties: {
 					id: { type: 'string' },
-					steps: { 
+					steps: {
 						type: 'array',
 						items: {
 							type: 'object',
 							properties: {
-								type: { 
+								type: {
 									type: 'string',
-									enum: ['thought', 'action', 'observation', 'decision', 'conclusion', 'reflection']
+									enum: [
+										'thought',
+										'action',
+										'observation',
+										'decision',
+										'conclusion',
+										'reflection',
+									],
 								},
-								content: { type: 'string' }
+								content: { type: 'string' },
 							},
-							required: ['type', 'content']
-						}
+							required: ['type', 'content'],
+						},
 					},
 					metadata: { type: 'object' },
 				},


### PR DESCRIPTION
# Issue Resolution Summary

## Problem
The error was caused by a malformed JSON Schema in the `cipher_evaluate_reasoning` tool definition. The `steps` parameter was defined as `{ type: 'array' }` without the required `items` property, violating JSON Schema specifications and causing MCP client validation to fail.

## Solution
I fixed the schema by adding the proper `items` definition that specifies the structure of reasoning step objects (with `type` and `content` properties). After checking all other cipher tools, this was the only malformed array schema in the codebase.

## Impact
The fix should resolve the MCP connection error and allow Cipher to work properly in VS Code.

## Technical Details
The corrected schema now properly defines the `steps` array with:
- **Type**: `array`
- **Items**: Object with required `type` and `content` properties
- **Type Enum**: `['thought', 'action', 'observation', 'decision', 'conclusion', 'reflection']`
- **Content**: String containing the reasoning step content

This ensures MCP clients can properly validate the tool parameters and establish successful connections.