### PR TITLE
Fixed Claude Desktop integration Error

### DIFF
--- a/memAgent/cipher.yml
+++ b/memAgent/cipher.yml
@@ -136,8 +136,8 @@ llm:
 #   maxRetries: 3
 
 # Disable embeddings entirely:
-embedding:
-  disabled: true
+# embedding:
+#   disabled: true
 
 
 

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -219,7 +219,10 @@ program
 			if (agent.services && agent.services.embeddingManager) {
 				agent.services.embeddingManager.getEmbedder('default');
 			} else {
-				console.log('No embeddingManager found in agent.services');
+				// Only log this in non-MCP modes to avoid stdout contamination
+				if (opts.mode !== 'mcp') {
+					console.log('No embeddingManager found in agent.services');
+				}
 			}
 		} catch (err) {
 			const errorMessage = err instanceof Error ? err.message : String(err);

--- a/src/core/logger/logger.ts
+++ b/src/core/logger/logger.ts
@@ -316,10 +316,6 @@ export class Logger {
 
 			// Update state
 			this.isSilent = true;
-
-			if (!this.isSilent) {
-				console.log(`Logger redirected to file: ${filePath}`);
-			}
 		} catch (error) {
 			this.error(`Failed to redirect logger to file: ${error}`);
 		}

--- a/src/core/storage/manager.ts
+++ b/src/core/storage/manager.ts
@@ -272,7 +272,6 @@ export class StorageManager {
 				});
 			} catch (err) {
 				this.logger.error('Failed to connect to SQLite database', err);
-				console.error('Failed to connect to SQLite database (raw error):', err);
 				// If the configured backend fails, try fallback to in-memory
 				this.logger.warn(`${LOG_PREFIXES.DATABASE} Connection failed, attempting fallback`, {
 					error: err instanceof Error ? err.message : String(err),

--- a/src/core/utils/service-initializer.ts
+++ b/src/core/utils/service-initializer.ts
@@ -662,10 +662,12 @@ export async function createAgentServices(
 		...advancedProviders.filter(p => !staticProvider || p.name !== staticProvider.name),
 	];
 
-	// DEBUG: Print merged provider list
-	console.log('Merged system prompt providers:');
-	for (const p of mergedProviders) {
-		console.log(`  - ${p.name} (${p.type}) enabled: ${p.enabled}`);
+	// DEBUG: Print merged provider list (skip in MCP mode to avoid stdout contamination)
+	if (appMode !== 'mcp') {
+		console.log('Merged system prompt providers:');
+		for (const p of mergedProviders) {
+			console.log(`  - ${p.name} (${p.type}) enabled: ${p.enabled}`);
+		}
 	}
 
 	// Merge settings: advancedSettings takes precedence, fallback to default


### PR DESCRIPTION
# Fix MCP stdout Contamination Breaking Claude Desktop Integration

## Summary

Fixes #163 - Debug logs were contaminating stdout in MCP mode, causing JSON parsing errors in Claude Desktop.

## Problem

Debug logs were contaminating stdout in MCP mode, causing JSON parsing errors in Claude Desktop.

## Changes Made

### Fixed:
- Removed redundant `console.log` in logger redirection
- Added MCP mode checks for debug output in service initializer
- Removed duplicate `console.error` in storage manager
- Added MCP mode check for embedding debug message

## Result

- Stdout now clean for JSON-RPC communication
- Debug logs properly redirected to log file
- Claude Desktop integration restored

**Fixes #163**