### PR TITLE
Input refinement for Search Tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -123,6 +123,7 @@ DISABLE_REFLECTION_MEMORY=true
 # NEO4J LOCAL CONFIGURATION (for local development)
 # Local Neo4j configuration
 
+
 # KNOWLEDGE_GRAPH_HOST=localhost
 # KNOWLEDGE_GRAPH_PORT=7687
 # KNOWLEDGE_GRAPH_URI=bolt://localhost:7687
@@ -152,3 +153,6 @@ DISABLE_REFLECTION_MEMORY=true
 
 # # Path to store event log files (if using file storage)
 # EVENT_PERSISTENCE_PATH=./data/events
+
+# Enable or disable input refinement for better retrieval
+ENABLE_QUERY_REFINEMENT=true 

--- a/src/core/brain/tools/__test__/phase3-service-integration.test.ts
+++ b/src/core/brain/tools/__test__/phase3-service-integration.test.ts
@@ -71,6 +71,11 @@ describe('Phase 3: Service Integration Tests', () => {
 							.fill(0)
 							.map(() => Math.random())
 					),
+					embedBatch: vi.fn().mockImplementation((queries: string[]) => {
+						// Return embeddings for each query
+						return Promise.resolve(queries.map(() => Array(128).fill(0).map(() => Math.random())));
+					}),
+					getConfig: vi.fn().mockReturnValue({ type: 'openai' }),
 				}),
 			},
 			llmService: {

--- a/src/core/brain/tools/__test__/phase3-service-integration.test.ts
+++ b/src/core/brain/tools/__test__/phase3-service-integration.test.ts
@@ -73,7 +73,13 @@ describe('Phase 3: Service Integration Tests', () => {
 					),
 					embedBatch: vi.fn().mockImplementation((queries: string[]) => {
 						// Return embeddings for each query
-						return Promise.resolve(queries.map(() => Array(128).fill(0).map(() => Math.random())));
+						return Promise.resolve(
+							queries.map(() =>
+								Array(128)
+									.fill(0)
+									.map(() => Math.random())
+							)
+						);
 					}),
 					getConfig: vi.fn().mockReturnValue({ type: 'openai' }),
 				}),

--- a/src/core/brain/tools/def_reflective_memory_tools.ts
+++ b/src/core/brain/tools/def_reflective_memory_tools.ts
@@ -749,7 +749,8 @@ export const searchReasoningPatterns: InternalTool = {
 					},
 					enable_query_refinement: {
 						type: 'boolean',
-						description: 'Whether to apply query refinement for better search results (default: false)',
+						description:
+							'Whether to apply query refinement for better search results (default: false)',
 						default: false,
 					},
 				},
@@ -819,11 +820,15 @@ export const searchReasoningPatterns: InternalTool = {
 
 			// Apply input refinement if enabled
 			let finalQueries: string[] = [input.query];
-			const enableQueryRefinement = (input.options?.enable_query_refinement === true) || (env.ENABLE_QUERY_REFINEMENT === true);
-			
+			const enableQueryRefinement =
+				input.options?.enable_query_refinement === true || env.ENABLE_QUERY_REFINEMENT === true;
+
 			if (enableQueryRefinement && _context?.services?.llmService) {
 				try {
-					const rewrittenQueries = await rewriteUserQuery(input.query, _context.services.llmService);
+					const rewrittenQueries = await rewriteUserQuery(
+						input.query,
+						_context.services.llmService
+					);
 					finalQueries = rewrittenQueries.queries;
 					logger.debug('ReasoningPatternSearch: Applied query refinement', {
 						originalQuery: input.query,
@@ -832,7 +837,8 @@ export const searchReasoningPatterns: InternalTool = {
 					});
 				} catch (refinementError) {
 					logger.warn('ReasoningPatternSearch: Query refinement failed, using original query', {
-						error: refinementError instanceof Error ? refinementError.message : String(refinementError),
+						error:
+							refinementError instanceof Error ? refinementError.message : String(refinementError),
 					});
 					// Keep original query if refinement fails
 					finalQueries = [input.query];

--- a/src/core/brain/tools/definitions/memory/__test__/search_memory.test.ts
+++ b/src/core/brain/tools/definitions/memory/__test__/search_memory.test.ts
@@ -517,6 +517,10 @@ Query 5: authentication security practices error handling
 			it('should use original query when refinement is disabled', async () => {
 				const originalQuery = 'What is TypeScript?';
 				
+				// Mock environment variable as false for this test
+				const { env } = await import('../../../../../env.js');
+				vi.mocked(env).ENABLE_QUERY_REFINEMENT = false;
+				
 				const args = {
 					query: originalQuery,
 					enable_query_refinement: false,
@@ -815,6 +819,10 @@ Query 3: Java JavaScript differences
 
 			it('should compare refined vs unrefined search performance', async () => {
 				const originalQuery = 'How to implement authentication?';
+				
+				// Mock environment variable as false for the disabled test
+				const { env } = await import('../../../../../env.js');
+				vi.mocked(env).ENABLE_QUERY_REFINEMENT = false;
 				
 				// Test with refinement disabled
 				mockLLMService.directGenerate.mockClear();

--- a/src/core/brain/tools/definitions/memory/__test__/search_memory.test.ts
+++ b/src/core/brain/tools/definitions/memory/__test__/search_memory.test.ts
@@ -3,19 +3,19 @@ import { searchMemoryTool } from '../search_memory.js';
 
 // Mock the logger
 vi.mock('../../../../../logger/index.js', () => ({
-    logger: {
-        info: vi.fn(),
-        warn: vi.fn(),
-        error: vi.fn(),
-        debug: vi.fn(),
-    },
+	logger: {
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		debug: vi.fn(),
+	},
 }));
 
 // Mock the env module
 vi.mock('../../../../../env.js', () => ({
-    env: {
-        ENABLE_QUERY_REFINEMENT: true,
-    },
+	env: {
+		ENABLE_QUERY_REFINEMENT: true,
+	},
 }));
 
 describe('Search Memory Tool', () => {
@@ -393,7 +393,7 @@ describe('Search Memory Tool', () => {
 		describe('Query Rewriting Scenarios', () => {
 			it('should rewrite simple queries into multiple search queries', async () => {
 				const originalQuery = 'What is computer language and how does it work?';
-				
+
 				mockLLMService.directGenerate.mockResolvedValue(`
 				Query 1: React framework overview
 				Query 2: React how it works
@@ -406,7 +406,7 @@ describe('Search Memory Tool', () => {
 				};
 
 				const result = await searchMemoryTool.handler(args, mockContext);
-								expect(mockLLMService.directGenerate).toHaveBeenCalledWith(
+				expect(mockLLMService.directGenerate).toHaveBeenCalledWith(
 					expect.stringContaining('QUESTION: "What is computer language and how does it work?"')
 				);
 				console.log('Result:', result);
@@ -414,13 +414,13 @@ describe('Search Memory Tool', () => {
 				expect(mockEmbedder.embedBatch).toHaveBeenCalledWith([
 					'React framework overview',
 					'React how it works',
-					'React basics concepts'
+					'React basics concepts',
 				]);
 			});
 
 			it('should handle ambiguous terms with disambiguation', async () => {
 				const originalQuery = 'What is the difference between Java and JavaScript?';
-				
+
 				mockLLMService.directGenerate.mockResolvedValue(`
 Query 1: Java programming language features
 Query 2: JavaScript programming language features
@@ -435,21 +435,21 @@ Query 4: Java JavaScript comparison
 
 				const result = await searchMemoryTool.handler(args, mockContext);
 
-							expect(mockLLMService.directGenerate).toHaveBeenCalledWith(
-				expect.stringContaining('QUESTION: "What is the difference between Java and JavaScript?"')
-			);
+				expect(mockLLMService.directGenerate).toHaveBeenCalledWith(
+					expect.stringContaining('QUESTION: "What is the difference between Java and JavaScript?"')
+				);
 				expect(result.success).toBe(true);
 				expect(mockEmbedder.embedBatch).toHaveBeenCalledWith([
 					'Java programming language features',
 					'JavaScript programming language features',
 					'Java vs JavaScript differences',
-					'Java JavaScript comparison'
+					'Java JavaScript comparison',
 				]);
 			});
 
 			it('should handle technical queries with specific terms', async () => {
 				const originalQuery = 'How to implement authentication with JWT tokens?';
-				
+
 				mockLLMService.directGenerate.mockResolvedValue(`
 Query 1: JWT authentication implementation
 Query 2: JWT tokens authentication
@@ -463,15 +463,15 @@ Query 3: implement JWT authentication
 
 				const result = await searchMemoryTool.handler(args, mockContext);
 
-							expect(mockLLMService.directGenerate).toHaveBeenCalledWith(
-				expect.stringContaining('QUESTION: "How to implement authentication with JWT tokens?"')
-			);
+				expect(mockLLMService.directGenerate).toHaveBeenCalledWith(
+					expect.stringContaining('QUESTION: "How to implement authentication with JWT tokens?"')
+				);
 				expect(result.success).toBe(true);
 			});
 
 			it('should handle very short queries', async () => {
 				const originalQuery = 'React';
-				
+
 				mockLLMService.directGenerate.mockResolvedValue(`
 Query 1: React framework
 Query 2: React library
@@ -485,15 +485,13 @@ Query 2: React library
 				const result = await searchMemoryTool.handler(args, mockContext);
 
 				expect(result.success).toBe(true);
-				expect(mockEmbedder.embedBatch).toHaveBeenCalledWith([
-					'React framework',
-					'React library'
-				]);
+				expect(mockEmbedder.embedBatch).toHaveBeenCalledWith(['React framework', 'React library']);
 			});
 
 			it('should handle very long queries', async () => {
-				const originalQuery = 'How do I implement a complete authentication system with user registration, login, password reset, email verification, and social media login using React, Node.js, and MongoDB with proper security practices and error handling?';
-				
+				const originalQuery =
+					'How do I implement a complete authentication system with user registration, login, password reset, email verification, and social media login using React, Node.js, and MongoDB with proper security practices and error handling?';
+
 				mockLLMService.directGenerate.mockResolvedValue(`
 Query 1: React authentication system implementation
 Query 2: Node.js MongoDB authentication
@@ -516,11 +514,11 @@ Query 5: authentication security practices error handling
 		describe('Query Refinement Disabled', () => {
 			it('should use original query when refinement is disabled', async () => {
 				const originalQuery = 'What is TypeScript?';
-				
+
 				// Mock environment variable as false for this test
 				const { env } = await import('../../../../../env.js');
 				vi.mocked(env).ENABLE_QUERY_REFINEMENT = false;
-				
+
 				const args = {
 					query: originalQuery,
 					enable_query_refinement: false,
@@ -536,7 +534,7 @@ Query 5: authentication security practices error handling
 
 			it('should use original query when refinement parameter is not provided', async () => {
 				const originalQuery = 'What is TypeScript?';
-				
+
 				const args = {
 					query: originalQuery,
 				};
@@ -549,27 +547,27 @@ Query 5: authentication security practices error handling
 		});
 
 		describe('Query Refinement Error Handling', () => {
-					it('should handle LLM service errors gracefully', async () => {
-			const originalQuery = 'What is React?';
-			
-			mockLLMService.directGenerate.mockRejectedValue(new Error('LLM service unavailable'));
+			it('should handle LLM service errors gracefully', async () => {
+				const originalQuery = 'What is React?';
 
-			const args = {
-				query: originalQuery,
-				enable_query_refinement: true,
-			};
+				mockLLMService.directGenerate.mockRejectedValue(new Error('LLM service unavailable'));
 
-			const result = await searchMemoryTool.handler(args, mockContext);
-			
-			// When LLM service fails, it should fallback to original query and still succeed
-			expect(result.success).toBe(true);
-			expect(result.results).toHaveLength(2); // Should still get results from original query
-			expect(mockEmbedder.embedBatch).toHaveBeenCalledWith([originalQuery]); // Should use original query
-		});
+				const args = {
+					query: originalQuery,
+					enable_query_refinement: true,
+				};
+
+				const result = await searchMemoryTool.handler(args, mockContext);
+
+				// When LLM service fails, it should fallback to original query and still succeed
+				expect(result.success).toBe(true);
+				expect(result.results).toHaveLength(2); // Should still get results from original query
+				expect(mockEmbedder.embedBatch).toHaveBeenCalledWith([originalQuery]); // Should use original query
+			});
 
 			it('should handle malformed LLM responses', async () => {
 				const originalQuery = 'What is React?';
-				
+
 				// Mock malformed response
 				mockLLMService.directGenerate.mockResolvedValue('Invalid response format');
 
@@ -585,7 +583,7 @@ Query 5: authentication security practices error handling
 
 			it('should handle empty LLM responses', async () => {
 				const originalQuery = 'What is React?';
-				
+
 				mockLLMService.directGenerate.mockResolvedValue('');
 
 				const args = {
@@ -600,7 +598,7 @@ Query 5: authentication security practices error handling
 
 			it('should handle responses with no valid queries', async () => {
 				const originalQuery = 'What is React?';
-				
+
 				mockLLMService.directGenerate.mockResolvedValue(`
 This is not a valid query format
 No Query 1: here
@@ -621,7 +619,7 @@ Just some random text
 		describe('Query Parsing Edge Cases', () => {
 			it('should handle queries with special characters', async () => {
 				const originalQuery = 'How to use @decorators in TypeScript?';
-				
+
 				mockLLMService.directGenerate.mockResolvedValue(`
 Query 1: TypeScript decorators usage
 Query 2: @decorators TypeScript
@@ -639,7 +637,7 @@ Query 2: @decorators TypeScript
 
 			it('should handle queries with numbers and symbols', async () => {
 				const originalQuery = 'What is the difference between React 16 and React 18?';
-				
+
 				mockLLMService.directGenerate.mockResolvedValue(`
 Query 1: React 16 vs React 18 differences
 Query 2: React version 16 features
@@ -659,7 +657,7 @@ Query 3: React version 18 features
 			it('should handle queries with line breaks', async () => {
 				const originalQuery = `What is the best way to
 				implement authentication in a React app?`;
-				
+
 				mockLLMService.directGenerate.mockResolvedValue(`
 Query 1: React authentication implementation
 Query 2: best authentication React app
@@ -679,7 +677,7 @@ Query 2: best authentication React app
 		describe('Query Refinement Effectiveness', () => {
 			it('should improve search results with refined queries', async () => {
 				const originalQuery = 'How to build a web app with modern tools?';
-				
+
 				// Mock refined queries that are more specific
 				mockLLMService.directGenerate.mockResolvedValue(`
 Query 1: web app development modern tools
@@ -694,45 +692,45 @@ Query 4: webpack vite build tools
 						{
 							id: 'web_dev_1',
 							score: 0.95,
-							payload: { 
+							payload: {
 								text: 'Modern web development uses React, Vue, or Angular for frontend',
 								tags: ['web-development', 'frontend'],
-								confidence: 0.9
-							}
-						}
+								confidence: 0.9,
+							},
+						},
 					])
 					.mockResolvedValueOnce([
 						{
 							id: 'react_info',
 							score: 0.88,
-							payload: { 
+							payload: {
 								text: 'React is a popular JavaScript library for building user interfaces',
 								tags: ['react', 'frontend'],
-								confidence: 0.85
-							}
-						}
+								confidence: 0.85,
+							},
+						},
 					])
 					.mockResolvedValueOnce([
 						{
 							id: 'node_backend',
 							score: 0.92,
-							payload: { 
+							payload: {
 								text: 'Node.js with Express is commonly used for backend development',
 								tags: ['nodejs', 'backend'],
-								confidence: 0.88
-							}
-						}
+								confidence: 0.88,
+							},
+						},
 					])
 					.mockResolvedValueOnce([
 						{
 							id: 'build_tools',
 							score: 0.87,
-							payload: { 
+							payload: {
 								text: 'Webpack and Vite are modern build tools for web applications',
 								tags: ['build-tools', 'webpack'],
-								confidence: 0.82
-							}
-						}
+								confidence: 0.82,
+							},
+						},
 					]);
 
 				const args = {
@@ -745,18 +743,26 @@ Query 4: webpack vite build tools
 				expect(result.success).toBe(true);
 				expect(result.results).toHaveLength(4); // Should get results from all 4 refined queries
 				expect(result.metadata.totalResults).toBe(4);
-				
+
 				// Verify that we got diverse results from different aspects of the query
 				const resultTexts = result.results.map(r => r.text);
-				expect(resultTexts).toContain('Modern web development uses React, Vue, or Angular for frontend');
-				expect(resultTexts).toContain('React is a popular JavaScript library for building user interfaces');
-				expect(resultTexts).toContain('Node.js with Express is commonly used for backend development');
-				expect(resultTexts).toContain('Webpack and Vite are modern build tools for web applications');
+				expect(resultTexts).toContain(
+					'Modern web development uses React, Vue, or Angular for frontend'
+				);
+				expect(resultTexts).toContain(
+					'React is a popular JavaScript library for building user interfaces'
+				);
+				expect(resultTexts).toContain(
+					'Node.js with Express is commonly used for backend development'
+				);
+				expect(resultTexts).toContain(
+					'Webpack and Vite are modern build tools for web applications'
+				);
 			});
 
 			it('should handle ambiguous queries with disambiguation', async () => {
 				const originalQuery = 'What is Java?';
-				
+
 				// Mock disambiguation queries
 				mockLLMService.directGenerate.mockResolvedValue(`
 Query 1: Java programming language features
@@ -770,34 +776,34 @@ Query 3: Java JavaScript differences
 						{
 							id: 'java_lang',
 							score: 0.94,
-							payload: { 
+							payload: {
 								text: 'Java is an object-oriented programming language developed by Sun Microsystems',
 								tags: ['java', 'programming'],
-								confidence: 0.9
-							}
-						}
+								confidence: 0.9,
+							},
+						},
 					])
 					.mockResolvedValueOnce([
 						{
 							id: 'java_coffee',
 							score: 0.89,
-							payload: { 
+							payload: {
 								text: 'Java coffee refers to coffee produced on the island of Java, Indonesia',
 								tags: ['coffee', 'indonesia'],
-								confidence: 0.85
-							}
-						}
+								confidence: 0.85,
+							},
+						},
 					])
 					.mockResolvedValueOnce([
 						{
 							id: 'java_js_diff',
 							score: 0.91,
-							payload: { 
+							payload: {
 								text: 'Java and JavaScript are different languages despite similar names',
 								tags: ['java', 'javascript', 'comparison'],
-								confidence: 0.88
-							}
-						}
+								confidence: 0.88,
+							},
+						},
 					]);
 
 				const args = {
@@ -809,35 +815,41 @@ Query 3: Java JavaScript differences
 
 				expect(result.success).toBe(true);
 				expect(result.results).toHaveLength(3);
-				
+
 				// Verify disambiguation worked - should get results for different meanings
 				const resultTexts = result.results.map(r => r.text);
-				expect(resultTexts).toContain('Java is an object-oriented programming language developed by Sun Microsystems');
-				expect(resultTexts).toContain('Java coffee refers to coffee produced on the island of Java, Indonesia');
-				expect(resultTexts).toContain('Java and JavaScript are different languages despite similar names');
+				expect(resultTexts).toContain(
+					'Java is an object-oriented programming language developed by Sun Microsystems'
+				);
+				expect(resultTexts).toContain(
+					'Java coffee refers to coffee produced on the island of Java, Indonesia'
+				);
+				expect(resultTexts).toContain(
+					'Java and JavaScript are different languages despite similar names'
+				);
 			});
 
 			it('should compare refined vs unrefined search performance', async () => {
 				const originalQuery = 'How to implement authentication?';
-				
+
 				// Mock environment variable as false for the disabled test
 				const { env } = await import('../../../../../env.js');
 				vi.mocked(env).ENABLE_QUERY_REFINEMENT = false;
-				
+
 				// Test with refinement disabled
 				mockLLMService.directGenerate.mockClear();
 				mockKnowledgeStore.search.mockClear();
-				
+
 				const argsWithoutRefinement = {
 					query: originalQuery,
 					enable_query_refinement: false,
 				};
 
-				const resultWithoutRefinement = await searchMemoryTool.handler(argsWithoutRefinement, mockContext);
+				await searchMemoryTool.handler(argsWithoutRefinement, mockContext);
 
 				// Verify no LLM call was made
 				expect(mockLLMService.directGenerate).not.toHaveBeenCalled();
-				
+
 				// Test with refinement enabled
 				mockLLMService.directGenerate.mockResolvedValue(`
 Query 1: authentication implementation
@@ -850,22 +862,25 @@ Query 3: OAuth authentication flow
 						{
 							id: 'auth_impl',
 							score: 0.93,
-							payload: { text: 'Authentication implementation guide', tags: ['auth'] }
-						}
+							payload: { text: 'Authentication implementation guide', tags: ['auth'] },
+						},
 					])
 					.mockResolvedValueOnce([
 						{
 							id: 'jwt_auth',
 							score: 0.96,
-							payload: { text: 'JWT token authentication best practices', tags: ['jwt', 'auth'] }
-						}
+							payload: { text: 'JWT token authentication best practices', tags: ['jwt', 'auth'] },
+						},
 					])
 					.mockResolvedValueOnce([
 						{
 							id: 'oauth_flow',
 							score: 0.89,
-							payload: { text: 'OAuth authentication flow implementation', tags: ['oauth', 'auth'] }
-						}
+							payload: {
+								text: 'OAuth authentication flow implementation',
+								tags: ['oauth', 'auth'],
+							},
+						},
 					]);
 
 				const argsWithRefinement = {
@@ -873,13 +888,16 @@ Query 3: OAuth authentication flow
 					enable_query_refinement: true,
 				};
 
-				const resultWithRefinement = await searchMemoryTool.handler(argsWithRefinement, mockContext);
+				const resultWithRefinement = await searchMemoryTool.handler(
+					argsWithRefinement,
+					mockContext
+				);
 
 				// Verify refinement was used
 				expect(mockLLMService.directGenerate).toHaveBeenCalledWith(
 					expect.stringContaining('QUESTION: "How to implement authentication?"')
 				);
-				
+
 				// Verify more comprehensive results with refinement
 				expect(resultWithRefinement.results.length).toBeGreaterThanOrEqual(3);
 				expect(resultWithRefinement.metadata.totalResults).toBeGreaterThanOrEqual(3);
@@ -889,7 +907,7 @@ Query 3: OAuth authentication flow
 		describe('Prompt Engineering', () => {
 			it('should include the original query in the prompt', async () => {
 				const originalQuery = 'What is TypeScript?';
-				
+
 				mockLLMService.directGenerate.mockResolvedValue(`
 Query 1: TypeScript programming language
 				`);
@@ -908,7 +926,7 @@ Query 1: TypeScript programming language
 
 			it('should include proper formatting instructions', async () => {
 				const originalQuery = 'What is TypeScript?';
-				
+
 				mockLLMService.directGenerate.mockResolvedValue(`
 Query 1: TypeScript programming language
 				`);
@@ -930,7 +948,7 @@ Query 1: TypeScript programming language
 
 			it('should include disambiguation guidelines', async () => {
 				const originalQuery = 'What is TypeScript?';
-				
+
 				mockLLMService.directGenerate.mockResolvedValue(`
 Query 1: TypeScript programming language
 				`);

--- a/src/core/brain/tools/definitions/memory/__test__/search_memory.test.ts
+++ b/src/core/brain/tools/definitions/memory/__test__/search_memory.test.ts
@@ -1,6 +1,23 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { searchMemoryTool } from '../search_memory.js';
 
+// Mock the logger
+vi.mock('../../../../../logger/index.js', () => ({
+    logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+    },
+}));
+
+// Mock the env module
+vi.mock('../../../../../env.js', () => ({
+    env: {
+        ENABLE_QUERY_REFINEMENT: true,
+    },
+}));
+
 describe('Search Memory Tool', () => {
 	let mockContext: any;
 	let mockEmbeddingManager: any;
@@ -9,11 +26,22 @@ describe('Search Memory Tool', () => {
 	let mockEmbedder: any;
 	let mockKnowledgeStore: any;
 	let mockReflectionStore: any;
+	let mockLLMService: any;
 
 	beforeEach(() => {
 		// Mock embedder
 		mockEmbedder = {
 			embed: vi.fn().mockResolvedValue([0.1, 0.2, 0.3, 0.4, 0.5]),
+			embedBatch: vi.fn().mockImplementation((queries: string[]) => {
+				// Return embeddings for each query
+				return Promise.resolve(queries.map(() => [0.1, 0.2, 0.3, 0.4, 0.5]));
+			}),
+			getConfig: vi.fn().mockReturnValue({ type: 'openai' }),
+		};
+
+		// Mock LLM service for query refinement
+		mockLLMService = {
+			directGenerate: vi.fn(),
 		};
 
 		// Mock knowledge store
@@ -72,6 +100,12 @@ describe('Search Memory Tool', () => {
 		// Mock embedding manager
 		mockEmbeddingManager = {
 			getEmbedder: vi.fn().mockReturnValue(mockEmbedder),
+			getSessionState: vi.fn().mockReturnValue({
+				isDisabled: vi.fn().mockReturnValue(false),
+				getDisabledReason: vi.fn().mockReturnValue(''),
+			}),
+			hasAvailableEmbeddings: vi.fn().mockReturnValue(true),
+			handleRuntimeFailure: vi.fn(),
 		};
 
 		// Mock single collection vector store manager
@@ -95,6 +129,7 @@ describe('Search Memory Tool', () => {
 			services: {
 				embeddingManager: mockEmbeddingManager,
 				vectorStoreManager: mockVectorStoreManager,
+				llmService: mockLLMService,
 			},
 			toolName: 'memory_search',
 			startTime: Date.now(),
@@ -153,7 +188,7 @@ describe('Search Memory Tool', () => {
 				expect(result.metadata.searchMode).toBe('knowledge');
 				expect(result.metadata.knowledgeResults).toBe(2);
 				expect(result.metadata.reflectionResults).toBe(0);
-				expect(mockEmbedder.embed).toHaveBeenCalledWith('programming preferences');
+				expect(mockEmbedder.embedBatch).toHaveBeenCalledWith(['programming preferences']);
 			}
 
 			// Embedding unavailable
@@ -268,13 +303,15 @@ describe('Search Memory Tool', () => {
 
 	describe('Error Handling', () => {
 		it('should handle embedding failure', async () => {
-			mockEmbedder.embed = vi.fn().mockRejectedValue(new Error('Embedding failed'));
+			mockEmbedder.embedBatch = vi.fn().mockRejectedValue(new Error('Embedding failed'));
 
 			const args = { query: 'test query' };
 			const result = await searchMemoryTool.handler(args, mockContext);
 
-			expect(result.success).toBe(false);
+			// When embedding fails, it should return empty results but still succeed
+			expect(result.success).toBe(true);
 			expect(result.results).toEqual([]);
+			expect(result.metadata.usedFallback).toBe(true);
 		});
 
 		it('should handle vector store search failure', async () => {
@@ -344,6 +381,563 @@ describe('Search Memory Tool', () => {
 				expect(result.metadata).toHaveProperty('searchTime');
 				expect(result.metadata).toHaveProperty('embeddingTime');
 			}
+		});
+	});
+
+	describe('Query Refinement Feature', () => {
+		beforeEach(() => {
+			// Reset LLM service mock
+			vi.clearAllMocks();
+		});
+
+		describe('Query Rewriting Scenarios', () => {
+			it('should rewrite simple queries into multiple search queries', async () => {
+				const originalQuery = 'What is computer language and how does it work?';
+				
+				mockLLMService.directGenerate.mockResolvedValue(`
+				Query 1: React framework overview
+				Query 2: React how it works
+				Query 3: React basics concepts
+				`);
+
+				const args = {
+					query: originalQuery,
+					enable_query_refinement: true,
+				};
+
+				const result = await searchMemoryTool.handler(args, mockContext);
+								expect(mockLLMService.directGenerate).toHaveBeenCalledWith(
+					expect.stringContaining('QUESTION: "What is computer language and how does it work?"')
+				);
+				console.log('Result:', result);
+				expect(result.success).toBe(true);
+				expect(mockEmbedder.embedBatch).toHaveBeenCalledWith([
+					'React framework overview',
+					'React how it works',
+					'React basics concepts'
+				]);
+			});
+
+			it('should handle ambiguous terms with disambiguation', async () => {
+				const originalQuery = 'What is the difference between Java and JavaScript?';
+				
+				mockLLMService.directGenerate.mockResolvedValue(`
+Query 1: Java programming language features
+Query 2: JavaScript programming language features
+Query 3: Java vs JavaScript differences
+Query 4: Java JavaScript comparison
+				`);
+
+				const args = {
+					query: originalQuery,
+					enable_query_refinement: true,
+				};
+
+				const result = await searchMemoryTool.handler(args, mockContext);
+
+							expect(mockLLMService.directGenerate).toHaveBeenCalledWith(
+				expect.stringContaining('QUESTION: "What is the difference between Java and JavaScript?"')
+			);
+				expect(result.success).toBe(true);
+				expect(mockEmbedder.embedBatch).toHaveBeenCalledWith([
+					'Java programming language features',
+					'JavaScript programming language features',
+					'Java vs JavaScript differences',
+					'Java JavaScript comparison'
+				]);
+			});
+
+			it('should handle technical queries with specific terms', async () => {
+				const originalQuery = 'How to implement authentication with JWT tokens?';
+				
+				mockLLMService.directGenerate.mockResolvedValue(`
+Query 1: JWT authentication implementation
+Query 2: JWT tokens authentication
+Query 3: implement JWT authentication
+				`);
+
+				const args = {
+					query: originalQuery,
+					enable_query_refinement: true,
+				};
+
+				const result = await searchMemoryTool.handler(args, mockContext);
+
+							expect(mockLLMService.directGenerate).toHaveBeenCalledWith(
+				expect.stringContaining('QUESTION: "How to implement authentication with JWT tokens?"')
+			);
+				expect(result.success).toBe(true);
+			});
+
+			it('should handle very short queries', async () => {
+				const originalQuery = 'React';
+				
+				mockLLMService.directGenerate.mockResolvedValue(`
+Query 1: React framework
+Query 2: React library
+				`);
+
+				const args = {
+					query: originalQuery,
+					enable_query_refinement: true,
+				};
+
+				const result = await searchMemoryTool.handler(args, mockContext);
+
+				expect(result.success).toBe(true);
+				expect(mockEmbedder.embedBatch).toHaveBeenCalledWith([
+					'React framework',
+					'React library'
+				]);
+			});
+
+			it('should handle very long queries', async () => {
+				const originalQuery = 'How do I implement a complete authentication system with user registration, login, password reset, email verification, and social media login using React, Node.js, and MongoDB with proper security practices and error handling?';
+				
+				mockLLMService.directGenerate.mockResolvedValue(`
+Query 1: React authentication system implementation
+Query 2: Node.js MongoDB authentication
+Query 3: user registration login password reset
+Query 4: email verification social media login
+Query 5: authentication security practices error handling
+				`);
+
+				const args = {
+					query: originalQuery,
+					enable_query_refinement: true,
+				};
+
+				const result = await searchMemoryTool.handler(args, mockContext);
+
+				expect(result.success).toBe(true);
+			});
+		});
+
+		describe('Query Refinement Disabled', () => {
+			it('should use original query when refinement is disabled', async () => {
+				const originalQuery = 'What is TypeScript?';
+				
+				const args = {
+					query: originalQuery,
+					enable_query_refinement: false,
+				};
+
+				const result = await searchMemoryTool.handler(args, mockContext);
+
+				// Should not call LLM service for rewriting
+				expect(mockLLMService.directGenerate).not.toHaveBeenCalled();
+				expect(result.success).toBe(true);
+				expect(mockEmbedder.embedBatch).toHaveBeenCalledWith([originalQuery]);
+			});
+
+			it('should use original query when refinement parameter is not provided', async () => {
+				const originalQuery = 'What is TypeScript?';
+				
+				const args = {
+					query: originalQuery,
+				};
+
+				const result = await searchMemoryTool.handler(args, mockContext);
+
+				// Should use original query (refinement is enabled by default but may not be called due to env)
+				expect(result.success).toBe(true);
+			});
+		});
+
+		describe('Query Refinement Error Handling', () => {
+					it('should handle LLM service errors gracefully', async () => {
+			const originalQuery = 'What is React?';
+			
+			mockLLMService.directGenerate.mockRejectedValue(new Error('LLM service unavailable'));
+
+			const args = {
+				query: originalQuery,
+				enable_query_refinement: true,
+			};
+
+			const result = await searchMemoryTool.handler(args, mockContext);
+			
+			// When LLM service fails, it should fallback to original query and still succeed
+			expect(result.success).toBe(true);
+			expect(result.results).toHaveLength(2); // Should still get results from original query
+			expect(mockEmbedder.embedBatch).toHaveBeenCalledWith([originalQuery]); // Should use original query
+		});
+
+			it('should handle malformed LLM responses', async () => {
+				const originalQuery = 'What is React?';
+				
+				// Mock malformed response
+				mockLLMService.directGenerate.mockResolvedValue('Invalid response format');
+
+				const args = {
+					query: originalQuery,
+					enable_query_refinement: true,
+				};
+
+				const result = await searchMemoryTool.handler(args, mockContext);
+
+				expect(result.success).toBe(true);
+			});
+
+			it('should handle empty LLM responses', async () => {
+				const originalQuery = 'What is React?';
+				
+				mockLLMService.directGenerate.mockResolvedValue('');
+
+				const args = {
+					query: originalQuery,
+					enable_query_refinement: true,
+				};
+
+				const result = await searchMemoryTool.handler(args, mockContext);
+
+				expect(result.success).toBe(true);
+			});
+
+			it('should handle responses with no valid queries', async () => {
+				const originalQuery = 'What is React?';
+				
+				mockLLMService.directGenerate.mockResolvedValue(`
+This is not a valid query format
+No Query 1: here
+Just some random text
+				`);
+
+				const args = {
+					query: originalQuery,
+					enable_query_refinement: true,
+				};
+
+				const result = await searchMemoryTool.handler(args, mockContext);
+
+				expect(result.success).toBe(true);
+			});
+		});
+
+		describe('Query Parsing Edge Cases', () => {
+			it('should handle queries with special characters', async () => {
+				const originalQuery = 'How to use @decorators in TypeScript?';
+				
+				mockLLMService.directGenerate.mockResolvedValue(`
+Query 1: TypeScript decorators usage
+Query 2: @decorators TypeScript
+				`);
+
+				const args = {
+					query: originalQuery,
+					enable_query_refinement: true,
+				};
+
+				const result = await searchMemoryTool.handler(args, mockContext);
+
+				expect(result.success).toBe(true);
+			});
+
+			it('should handle queries with numbers and symbols', async () => {
+				const originalQuery = 'What is the difference between React 16 and React 18?';
+				
+				mockLLMService.directGenerate.mockResolvedValue(`
+Query 1: React 16 vs React 18 differences
+Query 2: React version 16 features
+Query 3: React version 18 features
+				`);
+
+				const args = {
+					query: originalQuery,
+					enable_query_refinement: true,
+				};
+
+				const result = await searchMemoryTool.handler(args, mockContext);
+
+				expect(result.success).toBe(true);
+			});
+
+			it('should handle queries with line breaks', async () => {
+				const originalQuery = `What is the best way to
+				implement authentication in a React app?`;
+				
+				mockLLMService.directGenerate.mockResolvedValue(`
+Query 1: React authentication implementation
+Query 2: best authentication React app
+				`);
+
+				const args = {
+					query: originalQuery,
+					enable_query_refinement: true,
+				};
+
+				const result = await searchMemoryTool.handler(args, mockContext);
+
+				expect(result.success).toBe(true);
+			});
+		});
+
+		describe('Query Refinement Effectiveness', () => {
+			it('should improve search results with refined queries', async () => {
+				const originalQuery = 'How to build a web app with modern tools?';
+				
+				// Mock refined queries that are more specific
+				mockLLMService.directGenerate.mockResolvedValue(`
+Query 1: web app development modern tools
+Query 2: React Vue Angular frontend framework
+Query 3: Node.js Express backend development
+Query 4: webpack vite build tools
+				`);
+
+				// Mock different search results for each refined query
+				mockKnowledgeStore.search
+					.mockResolvedValueOnce([
+						{
+							id: 'web_dev_1',
+							score: 0.95,
+							payload: { 
+								text: 'Modern web development uses React, Vue, or Angular for frontend',
+								tags: ['web-development', 'frontend'],
+								confidence: 0.9
+							}
+						}
+					])
+					.mockResolvedValueOnce([
+						{
+							id: 'react_info',
+							score: 0.88,
+							payload: { 
+								text: 'React is a popular JavaScript library for building user interfaces',
+								tags: ['react', 'frontend'],
+								confidence: 0.85
+							}
+						}
+					])
+					.mockResolvedValueOnce([
+						{
+							id: 'node_backend',
+							score: 0.92,
+							payload: { 
+								text: 'Node.js with Express is commonly used for backend development',
+								tags: ['nodejs', 'backend'],
+								confidence: 0.88
+							}
+						}
+					])
+					.mockResolvedValueOnce([
+						{
+							id: 'build_tools',
+							score: 0.87,
+							payload: { 
+								text: 'Webpack and Vite are modern build tools for web applications',
+								tags: ['build-tools', 'webpack'],
+								confidence: 0.82
+							}
+						}
+					]);
+
+				const args = {
+					query: originalQuery,
+					enable_query_refinement: true,
+				};
+
+				const result = await searchMemoryTool.handler(args, mockContext);
+
+				expect(result.success).toBe(true);
+				expect(result.results).toHaveLength(4); // Should get results from all 4 refined queries
+				expect(result.metadata.totalResults).toBe(4);
+				
+				// Verify that we got diverse results from different aspects of the query
+				const resultTexts = result.results.map(r => r.text);
+				expect(resultTexts).toContain('Modern web development uses React, Vue, or Angular for frontend');
+				expect(resultTexts).toContain('React is a popular JavaScript library for building user interfaces');
+				expect(resultTexts).toContain('Node.js with Express is commonly used for backend development');
+				expect(resultTexts).toContain('Webpack and Vite are modern build tools for web applications');
+			});
+
+			it('should handle ambiguous queries with disambiguation', async () => {
+				const originalQuery = 'What is Java?';
+				
+				// Mock disambiguation queries
+				mockLLMService.directGenerate.mockResolvedValue(`
+Query 1: Java programming language features
+Query 2: Java coffee island Indonesia
+Query 3: Java JavaScript differences
+				`);
+
+				// Mock different results for each disambiguated query
+				mockKnowledgeStore.search
+					.mockResolvedValueOnce([
+						{
+							id: 'java_lang',
+							score: 0.94,
+							payload: { 
+								text: 'Java is an object-oriented programming language developed by Sun Microsystems',
+								tags: ['java', 'programming'],
+								confidence: 0.9
+							}
+						}
+					])
+					.mockResolvedValueOnce([
+						{
+							id: 'java_coffee',
+							score: 0.89,
+							payload: { 
+								text: 'Java coffee refers to coffee produced on the island of Java, Indonesia',
+								tags: ['coffee', 'indonesia'],
+								confidence: 0.85
+							}
+						}
+					])
+					.mockResolvedValueOnce([
+						{
+							id: 'java_js_diff',
+							score: 0.91,
+							payload: { 
+								text: 'Java and JavaScript are different languages despite similar names',
+								tags: ['java', 'javascript', 'comparison'],
+								confidence: 0.88
+							}
+						}
+					]);
+
+				const args = {
+					query: originalQuery,
+					enable_query_refinement: true,
+				};
+
+				const result = await searchMemoryTool.handler(args, mockContext);
+
+				expect(result.success).toBe(true);
+				expect(result.results).toHaveLength(3);
+				
+				// Verify disambiguation worked - should get results for different meanings
+				const resultTexts = result.results.map(r => r.text);
+				expect(resultTexts).toContain('Java is an object-oriented programming language developed by Sun Microsystems');
+				expect(resultTexts).toContain('Java coffee refers to coffee produced on the island of Java, Indonesia');
+				expect(resultTexts).toContain('Java and JavaScript are different languages despite similar names');
+			});
+
+			it('should compare refined vs unrefined search performance', async () => {
+				const originalQuery = 'How to implement authentication?';
+				
+				// Test with refinement disabled
+				mockLLMService.directGenerate.mockClear();
+				mockKnowledgeStore.search.mockClear();
+				
+				const argsWithoutRefinement = {
+					query: originalQuery,
+					enable_query_refinement: false,
+				};
+
+				const resultWithoutRefinement = await searchMemoryTool.handler(argsWithoutRefinement, mockContext);
+
+				// Verify no LLM call was made
+				expect(mockLLMService.directGenerate).not.toHaveBeenCalled();
+				
+				// Test with refinement enabled
+				mockLLMService.directGenerate.mockResolvedValue(`
+Query 1: authentication implementation
+Query 2: JWT token authentication
+Query 3: OAuth authentication flow
+				`);
+
+				mockKnowledgeStore.search
+					.mockResolvedValueOnce([
+						{
+							id: 'auth_impl',
+							score: 0.93,
+							payload: { text: 'Authentication implementation guide', tags: ['auth'] }
+						}
+					])
+					.mockResolvedValueOnce([
+						{
+							id: 'jwt_auth',
+							score: 0.96,
+							payload: { text: 'JWT token authentication best practices', tags: ['jwt', 'auth'] }
+						}
+					])
+					.mockResolvedValueOnce([
+						{
+							id: 'oauth_flow',
+							score: 0.89,
+							payload: { text: 'OAuth authentication flow implementation', tags: ['oauth', 'auth'] }
+						}
+					]);
+
+				const argsWithRefinement = {
+					query: originalQuery,
+					enable_query_refinement: true,
+				};
+
+				const resultWithRefinement = await searchMemoryTool.handler(argsWithRefinement, mockContext);
+
+				// Verify refinement was used
+				expect(mockLLMService.directGenerate).toHaveBeenCalledWith(
+					expect.stringContaining('QUESTION: "How to implement authentication?"')
+				);
+				
+				// Verify more comprehensive results with refinement
+				expect(resultWithRefinement.results.length).toBeGreaterThanOrEqual(3);
+				expect(resultWithRefinement.metadata.totalResults).toBeGreaterThanOrEqual(3);
+			});
+		});
+
+		describe('Prompt Engineering', () => {
+			it('should include the original query in the prompt', async () => {
+				const originalQuery = 'What is TypeScript?';
+				
+				mockLLMService.directGenerate.mockResolvedValue(`
+Query 1: TypeScript programming language
+				`);
+
+				const args = {
+					query: originalQuery,
+					enable_query_refinement: true,
+				};
+
+				await searchMemoryTool.handler(args, mockContext);
+
+				expect(mockLLMService.directGenerate).toHaveBeenCalledWith(
+					expect.stringContaining('QUESTION: "What is TypeScript?"')
+				);
+			});
+
+			it('should include proper formatting instructions', async () => {
+				const originalQuery = 'What is TypeScript?';
+				
+				mockLLMService.directGenerate.mockResolvedValue(`
+Query 1: TypeScript programming language
+				`);
+
+				const args = {
+					query: originalQuery,
+					enable_query_refinement: true,
+				};
+
+				await searchMemoryTool.handler(args, mockContext);
+
+				expect(mockLLMService.directGenerate).toHaveBeenCalledWith(
+					expect.stringContaining('Query 1: [first query]')
+				);
+				expect(mockLLMService.directGenerate).toHaveBeenCalledWith(
+					expect.stringContaining('Query 2: [second query]')
+				);
+			});
+
+			it('should include disambiguation guidelines', async () => {
+				const originalQuery = 'What is TypeScript?';
+				
+				mockLLMService.directGenerate.mockResolvedValue(`
+Query 1: TypeScript programming language
+				`);
+
+				const args = {
+					query: originalQuery,
+					enable_query_refinement: true,
+				};
+
+				await searchMemoryTool.handler(args, mockContext);
+
+				expect(mockLLMService.directGenerate).toHaveBeenCalledWith(
+					expect.stringContaining('DISAMBIGUATION (Only if needed)')
+				);
+			});
 		});
 	});
 });

--- a/src/core/brain/tools/definitions/memory/__test__/workspace-memory-integration.test.ts
+++ b/src/core/brain/tools/definitions/memory/__test__/workspace-memory-integration.test.ts
@@ -39,6 +39,10 @@ describe('Workspace Memory Integration Tests', () => {
 		// Mock embedder with configuration
 		mockEmbedder = {
 			embed: vi.fn().mockResolvedValue([0.1, 0.2, 0.3, 0.4, 0.5]),
+			embedBatch: vi.fn().mockImplementation((queries: string[]) => {
+				// Return embeddings for each query
+				return Promise.resolve(queries.map(() => [0.1, 0.2, 0.3, 0.4, 0.5]));
+			}),
 			getConfig: vi.fn().mockReturnValue({ type: 'openai' }),
 		};
 
@@ -160,7 +164,7 @@ describe('Workspace Memory Integration Tests', () => {
 
 			expect(result.success).toBe(true);
 			expect(mockEmbeddingManager.getEmbedder).toHaveBeenCalledWith('default');
-			expect(mockEmbedder.embed).toHaveBeenCalledWith('What is John working on?');
+			expect(mockEmbedder.embedBatch).toHaveBeenCalledWith(['What is John working on?']);
 			expect(result.results).toHaveLength(1);
 			expect(result.results[0].teamMember).toBe('John');
 		});
@@ -169,7 +173,7 @@ describe('Workspace Memory Integration Tests', () => {
 			process.env.USE_WORKSPACE_MEMORY = 'true';
 
 			// Mock embedding failure
-			mockEmbedder.embed.mockRejectedValueOnce(new Error('OpenAI API error'));
+			mockEmbedder.embedBatch.mockRejectedValueOnce(new Error('OpenAI API error'));
 
 			const args = { query: 'test query' };
 			const result = await workspaceSearchTool.handler(args, mockContext);

--- a/src/core/brain/tools/definitions/memory/search_memory.ts
+++ b/src/core/brain/tools/definitions/memory/search_memory.ts
@@ -1,3 +1,5 @@
+
+
 import { InternalTool, InternalToolContext } from '../../types.js';
 import { logger } from '../../../../logger/index.js';
 // Import payload migration utilities
@@ -8,40 +10,41 @@ import { KnowledgePayload } from './payloads.js';
  * Memory Search Tool Result Interface
  */
 interface MemorySearchResult {
-	success: boolean;
-	query: string;
-	results: Array<{
-		id: string;
-		text: string;
-		tags: string[];
-		timestamp: string;
-		similarity: number;
-		source: 'knowledge';
-		memoryType: 'knowledge';
-		version?: number;
-		// Knowledge memory fields
-		confidence?: number;
-		reasoning?: string;
-		event?: string;
-		domain?: string;
-		qualitySource?: string;
-		code_pattern?: string;
-		old_memory?: string;
-		sourceSessionId?: string;
-	}>;
-	metadata: {
-		totalResults: number;
-		searchTime: number;
-		embeddingTime: number;
-		maxSimilarity: number;
-		minSimilarity: number;
-		averageSimilarity: number;
-		knowledgeResults: number;
-		reflectionResults: number; // Always 0 for knowledge-only search
-		searchMode: 'knowledge';
-		usedFallback?: boolean;
-	};
-	timestamp: string;
+    success: boolean;
+    query: string;
+    results: Array<{
+        id: string;
+        text: string;
+        tags: string[];
+        timestamp: string;
+        similarity: number;
+        source: 'knowledge';
+        memoryType: 'knowledge';
+        version?: number;
+        // Knowledge memory fields
+        confidence?: number;
+        reasoning?: string;
+        event?: string;
+        domain?: string;
+        qualitySource?: string;
+        code_pattern?: string;
+        old_memory?: string;
+        sourceSessionId?: string;
+    }>;
+    metadata: {
+        totalResults: number;
+        searchTime: number;
+        embeddingTime: number;
+        maxSimilarity: number;
+        minSimilarity: number;
+        averageSimilarity: number;
+        knowledgeResults: number;
+        reflectionResults: number; // Always 0 for knowledge-only search
+        searchMode: 'knowledge';
+        usedFallback?: boolean;
+        queryRefinementApplied?: boolean;
+    };
+    timestamp: string;
 }
 
 /**
@@ -54,381 +57,509 @@ interface MemorySearchResult {
  * NOTE: This tool ONLY searches knowledge memory. For reflection memory, use cipher_search_reasoning_patterns.
  */
 export const searchMemoryTool: InternalTool = {
-	name: 'memory_search',
-	category: 'memory',
-	internal: true,
-	agentAccessible: true, // Agent-accessible: searches knowledge memory only
-	description:
-		'Perform semantic search over stored knowledge memory entries to retrieve relevant knowledge that can inform current decision-making.',
-	version: '1.0.0',
-	parameters: {
-		type: 'object',
-		properties: {
-			query: {
-				type: 'string',
-				description:
-					'The search query to find relevant knowledge memories. Use natural language to describe what you are looking for.',
-				minLength: 1,
-				maxLength: 1000,
-			},
-			top_k: {
-				type: 'number',
-				description: 'Maximum number of results to return (default: 5)',
-				minimum: 1,
-				maximum: 50,
-				default: 5,
-			},
-			similarity_threshold: {
-				type: 'number',
-				description: 'Minimum similarity score for results (0.0 to 1.0, default: 0.3)',
-				minimum: 0.0,
-				maximum: 1.0,
-				default: 0.3,
-			},
-			include_metadata: {
-				type: 'boolean',
-				description: 'Whether to include detailed metadata in results (default: true)',
-				default: true,
-			},
-		},
-		required: ['query'],
-	},
-	handler: async (args: any, context?: InternalToolContext): Promise<MemorySearchResult> => {
-		const startTime = Date.now();
+    name: 'memory_search',
+    category: 'memory',
+    internal: true,
+    agentAccessible: true, // Agent-accessible: searches knowledge memory only
+    description:
+        'Perform semantic search over stored knowledge memory entries to retrieve relevant knowledge that can inform current decision-making.',
+    version: '1.0.0',
+    parameters: {
+        type: 'object',
+        properties: {
+            query: {
+                type: 'string',
+                description:
+                    'The search query to find relevant knowledge memories. Use natural language to describe what you are looking for.',
+                minLength: 1,
+                maxLength: 1000,
+            },
+            top_k: {
+                type: 'number',
+                description: 'Maximum number of results to return (default: 5)',
+                minimum: 1,
+                maximum: 50,
+                default: 5,
+            },
+            similarity_threshold: {
+                type: 'number',
+                description: 'Minimum similarity score for results (0.0 to 1.0, default: 0.3)',
+                minimum: 0.0,
+                maximum: 1.0,
+                default: 0.3,
+            },
+            include_metadata: {
+                type: 'boolean',
+                description: 'Whether to include detailed metadata in results (default: true)',
+                default: true,
+            },
+            enable_query_refinement: {
+                type: 'boolean',
+                description: 'Whether to apply query refinement for better search results (default: true)',
+                default: true,
+            },
+        },
+        required: ['query'],
+    },
+    handler: async (args: any, context?: InternalToolContext): Promise<MemorySearchResult> => {
+        const startTime = Date.now();
+        const callId = Math.random().toString(36).substring(7);
 
-		try {
-			logger.debug('MemorySearch: Processing knowledge memory search request', {
-				query: args.query?.substring(0, 100) || 'undefined',
-				top_k: args.top_k || 5,
-				similarity_threshold: args.similarity_threshold || 0.3,
-			});
+        console.log(`🔍 [${callId}] search_memory tool called with:`, {
+            query: args.query?.substring(0, 100),
+            top_k: args.top_k,
+            similarity_threshold: args.similarity_threshold,
+            sessionId: context?.sessionId,
+            toolName: context?.toolName,
+        });
 
-			// Check if embeddings are disabled for this session
-			if (context?.services?.embeddingManager?.getSessionState()?.isDisabled()) {
-				const reason = context.services.embeddingManager.getSessionState().getDisabledReason();
-				logger.debug(
-					'MemorySearch: Embeddings disabled for this session, returning empty results',
-					{
-						reason,
-					}
-				);
-				return {
-					success: true,
-					query: args.query || '',
-					results: [],
-					metadata: {
-						totalResults: 0,
-						searchTime: Date.now() - startTime,
-						embeddingTime: 0,
-						maxSimilarity: 0,
-						minSimilarity: 0,
-						averageSimilarity: 0,
-						knowledgeResults: 0,
-						reflectionResults: 0,
-						searchMode: 'knowledge',
-						usedFallback: true,
-					},
-					timestamp: new Date().toISOString(),
-				};
-			}
+        try {
+            logger.debug('MemorySearch: Processing knowledge memory search request', {
+                query: args.query?.substring(0, 100) || 'undefined',
+                top_k: args.top_k || 5,
+                similarity_threshold: args.similarity_threshold || 0.3,
+                enable_query_refinement: args.enable_query_refinement !== false,
+            });
 
-			// Check if embedding manager indicates no available embeddings
-			if (
-				context?.services?.embeddingManager &&
-				!context.services.embeddingManager.hasAvailableEmbeddings()
-			) {
-				logger.debug('MemorySearch: No available embeddings, returning empty results');
-				return {
-					success: true,
-					query: args.query || '',
-					results: [],
-					metadata: {
-						totalResults: 0,
-						searchTime: Date.now() - startTime,
-						embeddingTime: 0,
-						maxSimilarity: 0,
-						minSimilarity: 0,
-						averageSimilarity: 0,
-						knowledgeResults: 0,
-						reflectionResults: 0,
-						searchMode: 'knowledge',
-						usedFallback: true,
-					},
-					timestamp: new Date().toISOString(),
-				};
-			}
+            // Check if embeddings are disabled for this session
+            if (context?.services?.embeddingManager?.getSessionState()?.isDisabled()) {
+                const reason = context.services.embeddingManager.getSessionState().getDisabledReason();
+                logger.debug(
+                    'MemorySearch: Embeddings disabled for this session, returning empty results',
+                    {
+                        reason,
+                    }
+                );
+                return {
+                    success: true,
+                    query: args.query || '',
+                    results: [],
+                    metadata: {
+                        totalResults: 0,
+                        searchTime: Date.now() - startTime,
+                        embeddingTime: 0,
+                        maxSimilarity: 0,
+                        minSimilarity: 0,
+                        averageSimilarity: 0,
+                        knowledgeResults: 0,
+                        reflectionResults: 0,
+                        searchMode: 'knowledge',
+                        usedFallback: true,
+                        queryRefinementApplied: false,
+                    },
+                    timestamp: new Date().toISOString(),
+                };
+            }
 
-			// Validate required parameters
-			if (!args.query || typeof args.query !== 'string' || args.query.trim().length === 0) {
-				throw new Error('Query is required and must be a non-empty string');
-			}
+            // Check if embedding manager indicates no available embeddings
+            if (
+                context?.services?.embeddingManager &&
+                !context.services.embeddingManager.hasAvailableEmbeddings()
+            ) {
+                logger.debug('MemorySearch: No available embeddings, returning empty results');
+                return {
+                    success: true,
+                    query: args.query || '',
+                    results: [],
+                    metadata: {
+                        totalResults: 0,
+                        searchTime: Date.now() - startTime,
+                        embeddingTime: 0,
+                        maxSimilarity: 0,
+                        minSimilarity: 0,
+                        averageSimilarity: 0,
+                        knowledgeResults: 0,
+                        reflectionResults: 0,
+                        searchMode: 'knowledge',
+                        usedFallback: true,
+                        queryRefinementApplied: false,
+                    },
+                    timestamp: new Date().toISOString(),
+                };
+            }
 
-			// Set defaults
-			const query = args.query.trim();
-			const topK = Math.max(1, Math.min(50, args.top_k || 5));
-			const similarityThreshold = Math.max(0.0, Math.min(1.0, args.similarity_threshold || 0.3));
-			// const includeMetadata = args.include_metadata !== false;
+            // Validate required parameters
+            if (!args.query || typeof args.query !== 'string' || args.query.trim().length === 0) {
+                throw new Error('Query is required and must be a non-empty string');
+            }
 
-			// Get required services from context
-			if (!context?.services) {
-				throw new Error('InternalToolContext.services is required for memory search');
-			}
+            // Set defaults
+            const originalQuery = args.query.trim();
+            const topK = Math.max(1, Math.min(50, args.top_k || 5));
+            const similarityThreshold = Math.max(0.0, Math.min(1.0, args.similarity_threshold || 0.3));
+            // const enableQueryRefinement = args.enable_query_refinement !== false; // Default to true
+            const enableQueryRefinement = true; // Default to true
 
-			const embeddingManager = context.services.embeddingManager;
-			const vectorStoreManager = context.services.vectorStoreManager;
+            // Get required services from context
+            if (!context?.services) {
+                throw new Error('InternalToolContext.services is required for memory search');
+            }
 
-			if (!embeddingManager || !vectorStoreManager) {
-				throw new Error('EmbeddingManager and VectorStoreManager are required in context.services');
-			}
+            const embeddingManager = context.services.embeddingManager;
+            const vectorStoreManager = context.services.vectorStoreManager;
 
-			const embedder = embeddingManager.getEmbedder('default');
+            if (!embeddingManager || !vectorStoreManager) {
+                throw new Error('EmbeddingManager and VectorStoreManager are required in context.services');
+            }
 
-			if (!embedder?.embed || typeof embedder.embed !== 'function') {
-				throw new Error('Embedder is not properly initialized or missing embed() method');
-			}
+            const embedder = embeddingManager.getEmbedder('default');
 
-			// Generate embedding for the search query
-			const embeddingStartTime = Date.now();
-			logger.debug('MemorySearch: Generating embedding for query', {
-				queryLength: query.length,
-				queryPreview: query.substring(0, 50),
-			});
+            if (!embedder?.embed || typeof embedder.embed !== 'function' || !embedder.embedBatch || typeof embedder.embedBatch !== 'function') {
+                throw new Error('Embedder is not properly initialized or missing embed() or embedBatch() method');
+            }
 
-			let queryEmbedding;
+            // Generate embedding for the search query
+            const embeddingStartTime = Date.now();
+            logger.debug('MemorySearch: Generating embedding for query', {
+                originalQueryLength: originalQuery.length,
+                originalQueryPreview: originalQuery.substring(0, 50),
+            });
+
+			let finalQuery: string[] = [originalQuery];
+            let queryEmbeddings: number[][];
+
 			try {
-				queryEmbedding = await embedder?.embed(query);
-			} catch (embedError) {
-				logger.error('MemorySearch: Failed to generate embedding, disabling embeddings globally', {
-					error: embedError instanceof Error ? embedError.message : String(embedError),
-					provider: embedder.getConfig().type,
-				});
-
-				// Immediately disable embeddings globally on first failure
-				if (context?.services?.embeddingManager && embedError instanceof Error) {
-					context.services.embeddingManager.handleRuntimeFailure(
-						embedError,
-						embedder.getConfig().type
-					);
+				if (enableQueryRefinement) {
+					const rewrittenQueries = await rewriteUserQuery(originalQuery, context.services.llmService);
+					finalQuery = rewrittenQueries.queries;
 				}
+			logger.info('Embedding final query:', finalQuery);
+			queryEmbeddings = await embedder.embedBatch(finalQuery);
+            } catch (embedError) {
+                logger.error('MemorySearch: Failed to generate embedding, disabling embeddings globally', {
+                    error: embedError instanceof Error ? embedError.message : String(embedError),
+                    provider: embedder.getConfig().type,
+                });
 
-				// Return empty results since embeddings are now disabled
-				return {
-					success: true,
-					query: args.query || '',
-					results: [],
-					metadata: {
-						totalResults: 0,
-						searchTime: Date.now() - startTime,
-						embeddingTime: 0,
-						maxSimilarity: 0,
-						minSimilarity: 0,
-						averageSimilarity: 0,
-						knowledgeResults: 0,
-						reflectionResults: 0,
-						searchMode: 'knowledge',
-						usedFallback: true,
+                // Immediately disable embeddings globally on first failure
+                if (context?.services?.embeddingManager && embedError instanceof Error) {
+                    context.services.embeddingManager.handleRuntimeFailure(
+                        embedError,
+                        embedder.getConfig().type
+                    );
+                }
+
+                // Return empty results since embeddings are now disabled
+                return {
+                    success: true,
+                    query: args.query || '',
+                    results: [],
+                    metadata: {
+                        totalResults: 0,
+                        searchTime: Date.now() - startTime,
+                        embeddingTime: 0,
+                        maxSimilarity: 0,
+                        minSimilarity: 0,
+                        averageSimilarity: 0,
+                        knowledgeResults: 0,
+                        reflectionResults: 0,
+                        searchMode: 'knowledge',
+                        usedFallback: true,
+                    },
+                    timestamp: new Date().toISOString(),
+                };
+            }
+
+            const embeddingTime = Date.now() - embeddingStartTime;
+
+            logger.debug('MemorySearch: Embedding generated successfully', {
+                embeddingTime: `${embeddingTime}ms`,
+                embeddingDimensions: Array.isArray(queryEmbeddings[0]) ? queryEmbeddings[0].length : 'unknown',
+            });
+            // Search knowledge memory only
+            const searchStartTime = Date.now();
+            let allResults: any[] = [];
+            let knowledgeResultCount = 0;
+            // let reflectionResultCount = 0; // Always 0 for knowledge-only search
+            let usedFallback = false;
+
+            // Check if we have a DualCollectionVectorManager
+            const isDualManager =
+                vectorStoreManager.constructor.name === 'DualCollectionVectorManager' ||
+                (typeof vectorStoreManager.getStore === 'function' &&
+                    vectorStoreManager.getStore.length === 1); // getStore(type) signature
+
+            let knowledgeStore = null;
+            if (isDualManager) {
+                logger.debug('MemorySearch: Using DualCollectionVectorManager for knowledge search', {
+                    isDualManager: true,
+                });
+
+                try {
+                    // Try dual manager API first for knowledge collection
+                    knowledgeStore = (vectorStoreManager as any).getStore('knowledge');
+                } catch {
+                    // Fallback to default store
+                    try {
+                        knowledgeStore = vectorStoreManager.getStore();
+                        usedFallback = true;
+                    } catch (fallbackError) {
+                        throw new Error(
+                            `Knowledge collection failed and fallback to default store also failed: ${fallbackError instanceof Error ? fallbackError.message : String(fallbackError)}`
+                        );
+                    }
+                }
+            } else {
+                // Single collection manager - get default store
+                logger.debug('MemorySearch: Using single collection manager for knowledge search', {
+                    isDualManager: false,
+                });
+
+                knowledgeStore = vectorStoreManager.getStore();
+            }
+
+            if (!knowledgeStore) {
+                throw new Error('Knowledge vector store not available');
+            }
+
+			for (const queryEmbedding of queryEmbeddings) {
+				// Search knowledge collection
+				const knowledgeResults = await knowledgeStore.search(queryEmbedding, topK * 2);
+				
+				// Mark results with source and add to allResults
+				const markedResults = knowledgeResults.map((result: any) => ({
+					...result,
+					payload: {
+						...result.payload,
+						source: 'knowledge',
+						memoryType: 'knowledge',
 					},
-					timestamp: new Date().toISOString(),
-				};
-			}
+				}));
 
-			const embeddingTime = Date.now() - embeddingStartTime;
+				// Accumulate results instead of overwriting
+				allResults.push(...markedResults);
 
-			logger.debug('MemorySearch: Embedding generated successfully', {
-				embeddingTime: `${embeddingTime}ms`,
-				embeddingDimensions: Array.isArray(queryEmbedding) ? queryEmbedding.length : 'unknown',
-			});
-			// Search knowledge memory only
-			const searchStartTime = Date.now();
-			let allResults: any[] = [];
-			let knowledgeResultCount = 0;
-			// let reflectionResultCount = 0; // Always 0 for knowledge-only search
-			let usedFallback = false;
-
-			// Check if we have a DualCollectionVectorManager
-			const isDualManager =
-				vectorStoreManager.constructor.name === 'DualCollectionVectorManager' ||
-				(typeof vectorStoreManager.getStore === 'function' &&
-					vectorStoreManager.getStore.length === 1); // getStore(type) signature
-
-			let knowledgeStore = null;
-			if (isDualManager) {
-				logger.debug('MemorySearch: Using DualCollectionVectorManager for knowledge search', {
-					isDualManager: true,
+				logger.debug('MemorySearch: Knowledge collection search completed for query embedding', {
+					resultsFound: knowledgeResults.length,
+					totalAccumulatedResults: allResults.length,
 				});
-
-				try {
-					// Try dual manager API first for knowledge collection
-					knowledgeStore = (vectorStoreManager as any).getStore('knowledge');
-				} catch {
-					// Fallback to default store
-					try {
-						knowledgeStore = vectorStoreManager.getStore();
-						usedFallback = true;
-					} catch (fallbackError) {
-						throw new Error(
-							`Knowledge collection failed and fallback to default store also failed: ${fallbackError instanceof Error ? fallbackError.message : String(fallbackError)}`
-						);
-					}
-				}
-			} else {
-				// Single collection manager - get default store
-				logger.debug('MemorySearch: Using single collection manager for knowledge search', {
-					isDualManager: false,
-				});
-
-				knowledgeStore = vectorStoreManager.getStore();
 			}
-
-			if (!knowledgeStore) {
-				throw new Error('Knowledge vector store not available');
-			}
-
-			// Search knowledge collection
-			const knowledgeResults = await knowledgeStore.search(queryEmbedding, topK * 2);
-			knowledgeResultCount = knowledgeResults.length;
-
-			// Mark results with source
-			allResults = knowledgeResults.map((result: any) => ({
-				...result,
-				payload: {
-					...result.payload,
-					source: 'knowledge',
-					memoryType: 'knowledge',
-				},
-			}));
-
-			logger.debug('MemorySearch: Knowledge collection search completed', {
-				resultsFound: knowledgeResultCount,
-			});
 
 			const searchTime = Date.now() - searchStartTime;
-
-			logger.debug('MemorySearch: Knowledge search completed', {
+			knowledgeResultCount = allResults.length;
+			logger.info('Knowledge results:', allResults);
+			logger.debug('MemorySearch: Knowledge search completed for all query embeddings', {
 				searchTime: `${searchTime}ms`,
 				totalResults: allResults.length,
 				knowledgeResults: knowledgeResultCount,
 			});
 
-			// Filter, rank, and format knowledge memory results
-			const filteredResults = allResults
-				.filter(result => (result.score || 0) >= similarityThreshold)
-				.sort((a, b) => (b.score || 0) - (a.score || 0)) // Sort by similarity score descending
-				.slice(0, topK) // Take top K results overall
-				.map(result => {
-					const rawPayload = result.payload || {};
+            // Filter, rank, and format knowledge memory results
+            const filteredResults = allResults
+                .filter(result => (result.score || 0) >= similarityThreshold)
+                .sort((a, b) => (b.score || 0) - (a.score || 0)) // Sort by similarity score descending
+                .slice(0, topK) // Take top K results overall
+                .map(result => {
+                    const rawPayload = result.payload || {};
 
-					// All data is V2 format after collection cleanup - no migration needed
-					const payload = rawPayload as KnowledgePayload;
+                    // All data is V2 format after collection cleanup - no migration needed
+                    const payload = rawPayload as KnowledgePayload;
 
-					// Return unified result format with V2 payload data
-					const baseResult = {
-						id: result.id || payload.id || 'unknown',
-						text: payload.text || 'No content available',
-						tags: payload.tags || [],
-						timestamp: payload.timestamp || new Date().toISOString(),
-						similarity: result.score || 0,
-						version: payload.version || 2, // All data is V2 after cleanup
-						source: 'knowledge' as const,
-						memoryType: 'knowledge' as const,
-					};
+                    // Return unified result format with V2 payload data
+                    const baseResult = {
+                        id: result.id || payload.id || 'unknown',
+                        text: payload.text || 'No content available',
+                        tags: payload.tags || [],
+                        timestamp: payload.timestamp || new Date().toISOString(),
+                        similarity: result.score || 0,
+                        version: payload.version || 2, // All data is V2 after cleanup
+                        source: 'knowledge' as const,
+                        memoryType: 'knowledge' as const,
+                    };
 
-					// Add knowledge-specific fields
-					const knowledgePayload = payload as KnowledgePayload;
-					return {
-						...baseResult,
-						confidence: knowledgePayload.confidence || 0,
-						reasoning: knowledgePayload.reasoning || 'No reasoning available',
-						event: knowledgePayload.event,
-						...(knowledgePayload.domain && { domain: knowledgePayload.domain }),
-						qualitySource: knowledgePayload.qualitySource,
-						...(knowledgePayload.sourceSessionId && {
-							sourceSessionId: knowledgePayload.sourceSessionId,
-						}),
-						...(knowledgePayload.code_pattern && { code_pattern: knowledgePayload.code_pattern }),
-						...(knowledgePayload.old_memory && { old_memory: knowledgePayload.old_memory }),
-					};
-				});
+                    // Add knowledge-specific fields
+                    const knowledgePayload = payload as KnowledgePayload;
+                    return {
+                        ...baseResult,
+                        confidence: knowledgePayload.confidence || 0,
+                        reasoning: knowledgePayload.reasoning || 'No reasoning available',
+                        event: knowledgePayload.event,
+                        ...(knowledgePayload.domain && { domain: knowledgePayload.domain }),
+                        qualitySource: knowledgePayload.qualitySource,
+                        ...(knowledgePayload.sourceSessionId && {
+                            sourceSessionId: knowledgePayload.sourceSessionId,
+                        }),
+                        ...(knowledgePayload.code_pattern && { code_pattern: knowledgePayload.code_pattern }),
+                        ...(knowledgePayload.old_memory && { old_memory: knowledgePayload.old_memory }),
+                    };
+                });
 
-			// Calculate statistics for knowledge search results
-			const totalResults = filteredResults.length;
-			const similarities = filteredResults.map(r => r.similarity);
-			const maxSimilarity = similarities.length > 0 ? Math.max(...similarities) : 0;
-			const minSimilarity = similarities.length > 0 ? Math.min(...similarities) : 0;
-			const averageSimilarity =
-				similarities.length > 0 ? similarities.reduce((a, b) => a + b, 0) / similarities.length : 0;
+            // Calculate statistics for knowledge search results
+            const totalResults = filteredResults.length;
+            const similarities = filteredResults.map(r => r.similarity);
+            const maxSimilarity = similarities.length > 0 ? Math.max(...similarities) : 0;
+            const minSimilarity = similarities.length > 0 ? Math.min(...similarities) : 0;
+            const averageSimilarity =
+                similarities.length > 0 ? similarities.reduce((a, b) => a + b, 0) / similarities.length : 0;
 
-			const totalTime = Date.now() - startTime;
+            const totalTime = Date.now() - startTime;
 
-			// Prepare result
-			const result: MemorySearchResult = {
-				success: true,
-				query: query,
-				results: filteredResults,
-				metadata: {
-					totalResults,
-					searchTime: totalTime,
-					embeddingTime,
-					maxSimilarity,
-					minSimilarity,
-					averageSimilarity,
-					knowledgeResults: totalResults, // All results are knowledge results
-					reflectionResults: 0, // No reflection results in knowledge-only search
-					searchMode: 'knowledge',
-					usedFallback,
-				},
-				timestamp: new Date().toISOString(),
-			};
+            // Prepare result
+            const result: MemorySearchResult = {
+                success: true,
+                query: originalQuery,
+                results: filteredResults,
+                metadata: {
+                    totalResults,
+                    searchTime: totalTime,
+                    embeddingTime,
+                    maxSimilarity,
+                    minSimilarity,
+                    averageSimilarity,
+                    knowledgeResults: totalResults, // All results are knowledge results
+                    reflectionResults: 0, // No reflection results in knowledge-only search
+                    searchMode: 'knowledge',
+                    usedFallback,
+                },
+                timestamp: new Date().toISOString(),
+            };
 
-			logger.debug('MemorySearch: Knowledge search completed successfully', {
-				query: query.substring(0, 50),
-				resultsFound: totalResults,
-				knowledgeResults: totalResults,
-				maxSimilarity: maxSimilarity.toFixed(3),
-				averageSimilarity: averageSimilarity.toFixed(3),
-				totalTime: `${totalTime}ms`,
-				usedFallback,
-			});
+            logger.debug('MemorySearch: Knowledge search completed successfully', {
+                query: originalQuery.substring(0, 50),
+                resultsFound: totalResults,
+                knowledgeResults: totalResults,
+                maxSimilarity: maxSimilarity.toFixed(3),
+                averageSimilarity: averageSimilarity.toFixed(3),
+                totalTime: `${totalTime}ms`,
+                usedFallback,
+            });
 
-			return result;
-		} catch (error) {
-			const errorMessage = error instanceof Error ? error.message : String(error);
-			const totalTime = Date.now() - startTime;
+            return result;
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            const totalTime = Date.now() - startTime;
 
-			logger.error('MemorySearch: Search failed', {
-				error: errorMessage,
-				query: args.query?.substring(0, 50) || 'undefined',
-				processingTime: `${totalTime}ms`,
-			});
+            logger.error('MemorySearch: Search failed', {
+                error: errorMessage,
+                query: args.query?.substring(0, 50) || 'undefined',
+                processingTime: `${totalTime}ms`,
+            });
 
-			// Check if this is a runtime failure that should disable embeddings globally
-			if (context?.services?.embeddingManager && error instanceof Error) {
-				const embeddingManager = context.services.embeddingManager;
-				if (embeddingManager && typeof embeddingManager.handleRuntimeFailure === 'function') {
-					const embedder = embeddingManager.getEmbedder('default');
-					const providerType = embedder?.getConfig()?.type || 'unknown';
-					embeddingManager.handleRuntimeFailure(error, providerType);
-				}
-			}
+            // Check if this is a runtime failure that should disable embeddings globally
+            if (context?.services?.embeddingManager && error instanceof Error) {
+                const embeddingManager = context.services.embeddingManager;
+                if (embeddingManager && typeof embeddingManager.handleRuntimeFailure === 'function') {
+                    const embedder = embeddingManager.getEmbedder('default');
+                    const providerType = embedder?.getConfig()?.type || 'unknown';
+                    embeddingManager.handleRuntimeFailure(error, providerType);
+                }
+            }
 
-			return {
-				success: false,
-				query: args.query || 'undefined',
-				results: [],
-				metadata: {
-					totalResults: 0,
-					searchTime: totalTime,
-					embeddingTime: 0,
-					maxSimilarity: 0,
-					minSimilarity: 0,
-					averageSimilarity: 0,
-					knowledgeResults: 0,
-					reflectionResults: 0,
-					searchMode: 'knowledge',
-					usedFallback: true,
-				},
-				timestamp: new Date().toISOString(),
-			};
-		}
-	},
+            return {
+                success: false,
+                query: args.query || 'undefined',
+                results: [],
+                metadata: {
+                    totalResults: 0,
+                    searchTime: totalTime,
+                    embeddingTime: 0,
+                    maxSimilarity: 0,
+                    minSimilarity: 0,
+                    averageSimilarity: 0,
+                    knowledgeResults: 0,
+                    reflectionResults: 0,
+                    searchMode: 'knowledge',
+                    usedFallback: true,
+                },
+                timestamp: new Date().toISOString(),
+            };
+        }
+    },
 };
+
+/**
+ * Step 1: Rewrite user query into sub-queries and disambiguate ambiguous terms
+ * Uses LLM to generate more targeted queries for better retrieval
+ * 
+ * @param originalInput - The original user query to rewrite
+ * @param llmService - The LLM service to use for rewriting
+ * @returns An object containing the rewritten queries
+*/
+async function rewriteUserQuery(
+    originalInput: string,
+    llmService: any,
+): Promise<{queries: string[]}> {
+    // Add debugging to track function calls
+    const callId = Math.random().toString(36).substring(7);
+    // console.log(`🔄 [${callId}] rewriteUserQuery called with: "${originalInput}"`);
+    
+    try {
+        const rewritePrompt = `
+        You are a query decomposition and disambiguation expert. Break down this question into search queries for a knowledge base while handling ambiguous terms.
+
+        QUESTION: "${originalInput}"
+
+		TASK: Create 2-4 concise search queries that capture the core information needs of the question. Only include disambiguation if absolutely necessary.
+
+		GUIDELINES:
+		- Focus on the main intent of the question.
+		- Use natural, searchable language (4-15 words per query).
+		- Only create disambiguation queries for clearly ambiguous terms.
+		- Avoid over-decomposing the question into too many subqueries.
+		- Prefer fewer, more precise queries over exhaustive coverage.
+		- Each query should stand alone and be understandable without additional context.
+
+		DISAMBIGUATION (Only if needed):
+		- For truly ambiguous terms (homonyms, abbreviations, etc.), include 1-2 alternate queries with different meanings.
+		- Do not force disambiguation where the meaning is already clear from context.
+
+        OUTPUT FORMAT:
+        Respond with ONLY the queries, one per line, using this exact format:
+        Query 1: [first query]
+        Query 2: [second query]
+        [continue as needed...]
+
+        Do not include any explanations, introductions, or other text. Only the queries.
+
+        EXAMPLES:
+        Question: "What profession does Nicholas Ray and Elia Kazan have in common?"
+        Query 1: Nicholas Ray profession career
+        Query 2: Elia Kazan profession career
+
+        Question: "Most total goals in a premier league season?"
+        Query 1: Most total goals in a premier league season by a team
+        Query 2: Most total goals in a premier league season by a player
+
+        Now decompose and disambiguate: "${originalInput}"
+        `;
+        const rewriteResponse = await llmService.directGenerate(rewritePrompt);
+        
+        // Parse the response to extract individual queries
+        const queries = rewriteResponse
+            .split('\n')
+            .map(line => line.trim())
+            .filter(line => line.length > 0)
+            .map(line => {
+                // Extract query content after "Query X:" prefix
+                const match = line.match(/^Query\s*\d+:\s*(.+)$/i);
+                return match ? match[1].trim() : null;
+            })
+            .filter(query => query !== null && query.length >= 3)
+            .filter((query, index, array) => array.indexOf(query) === index); // Remove duplicates
+        
+		logger.info(`Parsed queries:`,{ 
+								queries: queries,
+								queryCount: queries.length,
+							});
+        // Ensure we have at least one query (fallback to original)
+        if (queries.length === 0) {
+            return {
+                queries: [originalInput]
+            };
+        }
+
+        return {
+            queries: queries
+        };
+
+    } catch (error) {
+        logger.warn('MemorySearch: Query rewriting failed', {
+            originalInput: originalInput.substring(0, 100),
+            error: error instanceof Error ? error.message : String(error)
+        });
+        return {
+            queries: [originalInput]
+        };
+    }
+}
+

--- a/src/core/brain/tools/definitions/memory/search_memory.ts
+++ b/src/core/brain/tools/definitions/memory/search_memory.ts
@@ -474,7 +474,7 @@ export const searchMemoryTool: InternalTool = {
  * @param llmService - The LLM service to use for rewriting
  * @returns An object containing the rewritten queries
 */
-async function rewriteUserQuery(
+export async function rewriteUserQuery(
     originalInput: string,
     llmService: any,
 ): Promise<{queries: string[]}> {

--- a/src/core/brain/tools/definitions/memory/search_memory.ts
+++ b/src/core/brain/tools/definitions/memory/search_memory.ts
@@ -1,5 +1,3 @@
-
-
 import { InternalTool, InternalToolContext } from '../../types.js';
 import { logger } from '../../../../logger/index.js';
 // Import payload migration utilities
@@ -10,41 +8,41 @@ import { env } from '../../../../env.js';
  * Memory Search Tool Result Interface
  */
 interface MemorySearchResult {
-    success: boolean;
-    query: string;
-    results: Array<{
-        id: string;
-        text: string;
-        tags: string[];
-        timestamp: string;
-        similarity: number;
-        source: 'knowledge';
-        memoryType: 'knowledge';
-        version?: number;
-        // Knowledge memory fields
-        confidence?: number;
-        reasoning?: string;
-        event?: string;
-        domain?: string;
-        qualitySource?: string;
-        code_pattern?: string;
-        old_memory?: string;
-        sourceSessionId?: string;
-    }>;
-    metadata: {
-        totalResults: number;
-        searchTime: number;
-        embeddingTime: number;
-        maxSimilarity: number;
-        minSimilarity: number;
-        averageSimilarity: number;
-        knowledgeResults: number;
-        reflectionResults: number; // Always 0 for knowledge-only search
-        searchMode: 'knowledge';
-        usedFallback?: boolean;
-        queryRefinementApplied?: boolean;
-    };
-    timestamp: string;
+	success: boolean;
+	query: string;
+	results: Array<{
+		id: string;
+		text: string;
+		tags: string[];
+		timestamp: string;
+		similarity: number;
+		source: 'knowledge';
+		memoryType: 'knowledge';
+		version?: number;
+		// Knowledge memory fields
+		confidence?: number;
+		reasoning?: string;
+		event?: string;
+		domain?: string;
+		qualitySource?: string;
+		code_pattern?: string;
+		old_memory?: string;
+		sourceSessionId?: string;
+	}>;
+	metadata: {
+		totalResults: number;
+		searchTime: number;
+		embeddingTime: number;
+		maxSimilarity: number;
+		minSimilarity: number;
+		averageSimilarity: number;
+		knowledgeResults: number;
+		reflectionResults: number; // Always 0 for knowledge-only search
+		searchMode: 'knowledge';
+		usedFallback?: boolean;
+		queryRefinementApplied?: boolean;
+	};
+	timestamp: string;
 }
 
 /**
@@ -57,264 +55,277 @@ interface MemorySearchResult {
  * NOTE: This tool ONLY searches knowledge memory. For reflection memory, use cipher_search_reasoning_patterns.
  */
 export const searchMemoryTool: InternalTool = {
-    name: 'memory_search',
-    category: 'memory',
-    internal: true,
-    agentAccessible: true, // Agent-accessible: searches knowledge memory only
-    description:
-        'Perform semantic search over stored knowledge memory entries to retrieve relevant knowledge that can inform current decision-making.',
-    version: '1.0.0',
-    parameters: {
-        type: 'object',
-        properties: {
-            query: {
-                type: 'string',
-                description:
-                    'The search query to find relevant knowledge memories. Use natural language to describe what you are looking for.',
-                minLength: 1,
-                maxLength: 1000,
-            },
-            top_k: {
-                type: 'number',
-                description: 'Maximum number of results to return (default: 5)',
-                minimum: 1,
-                maximum: 50,
-                default: 5,
-            },
-            similarity_threshold: {
-                type: 'number',
-                description: 'Minimum similarity score for results (0.0 to 1.0, default: 0.3)',
-                minimum: 0.0,
-                maximum: 1.0,
-                default: 0.3,
-            },
-            include_metadata: {
-                type: 'boolean',
-                description: 'Whether to include detailed metadata in results (default: true)',
-                default: true,
-            },
-            enable_query_refinement: {
-                type: 'boolean',
-                description: 'Whether to apply query refinement for better search results (default: false)',
-                default: false,
-            },
-        },
-        required: ['query'],
-    },
-    handler: async (args: any, context?: InternalToolContext): Promise<MemorySearchResult> => {
-        const startTime = Date.now();
-        const callId = Math.random().toString(36).substring(7);
+	name: 'memory_search',
+	category: 'memory',
+	internal: true,
+	agentAccessible: true, // Agent-accessible: searches knowledge memory only
+	description:
+		'Perform semantic search over stored knowledge memory entries to retrieve relevant knowledge that can inform current decision-making.',
+	version: '1.0.0',
+	parameters: {
+		type: 'object',
+		properties: {
+			query: {
+				type: 'string',
+				description:
+					'The search query to find relevant knowledge memories. Use natural language to describe what you are looking for.',
+				minLength: 1,
+				maxLength: 1000,
+			},
+			top_k: {
+				type: 'number',
+				description: 'Maximum number of results to return (default: 5)',
+				minimum: 1,
+				maximum: 50,
+				default: 5,
+			},
+			similarity_threshold: {
+				type: 'number',
+				description: 'Minimum similarity score for results (0.0 to 1.0, default: 0.3)',
+				minimum: 0.0,
+				maximum: 1.0,
+				default: 0.3,
+			},
+			include_metadata: {
+				type: 'boolean',
+				description: 'Whether to include detailed metadata in results (default: true)',
+				default: true,
+			},
+			enable_query_refinement: {
+				type: 'boolean',
+				description: 'Whether to apply query refinement for better search results (default: false)',
+				default: false,
+			},
+		},
+		required: ['query'],
+	},
+	handler: async (args: any, context?: InternalToolContext): Promise<MemorySearchResult> => {
+		const startTime = Date.now();
+		const callId = Math.random().toString(36).substring(7);
 
-        console.log(`🔍 [${callId}] search_memory tool called with:`, {
-            query: args.query?.substring(0, 100),
-            top_k: args.top_k,
-            similarity_threshold: args.similarity_threshold,
-            sessionId: context?.sessionId,
-            toolName: context?.toolName,
-        });
+		console.log(`🔍 [${callId}] search_memory tool called with:`, {
+			query: args.query?.substring(0, 100),
+			top_k: args.top_k,
+			similarity_threshold: args.similarity_threshold,
+			sessionId: context?.sessionId,
+			toolName: context?.toolName,
+		});
 
-        try {
-            logger.debug('MemorySearch: Processing knowledge memory search request', {
-                query: args.query?.substring(0, 100) || 'undefined',
-                top_k: args.top_k || 5,
-                similarity_threshold: args.similarity_threshold || 0.3,
-                enable_query_refinement: args.enable_query_refinement !== false,
-            });
+		try {
+			logger.debug('MemorySearch: Processing knowledge memory search request', {
+				query: args.query?.substring(0, 100) || 'undefined',
+				top_k: args.top_k || 5,
+				similarity_threshold: args.similarity_threshold || 0.3,
+				enable_query_refinement: args.enable_query_refinement !== false,
+			});
 
-            // Check if embeddings are disabled for this session
-            if (context?.services?.embeddingManager?.getSessionState()?.isDisabled()) {
-                const reason = context.services.embeddingManager.getSessionState().getDisabledReason();
-                logger.debug(
-                    'MemorySearch: Embeddings disabled for this session, returning empty results',
-                    {
-                        reason,
-                    }
-                );
-                return {
-                    success: true,
-                    query: args.query || '',
-                    results: [],
-                    metadata: {
-                        totalResults: 0,
-                        searchTime: Date.now() - startTime,
-                        embeddingTime: 0,
-                        maxSimilarity: 0,
-                        minSimilarity: 0,
-                        averageSimilarity: 0,
-                        knowledgeResults: 0,
-                        reflectionResults: 0,
-                        searchMode: 'knowledge',
-                        usedFallback: true,
-                        queryRefinementApplied: false,
-                    },
-                    timestamp: new Date().toISOString(),
-                };
-            }
+			// Check if embeddings are disabled for this session
+			if (context?.services?.embeddingManager?.getSessionState()?.isDisabled()) {
+				const reason = context.services.embeddingManager.getSessionState().getDisabledReason();
+				logger.debug(
+					'MemorySearch: Embeddings disabled for this session, returning empty results',
+					{
+						reason,
+					}
+				);
+				return {
+					success: true,
+					query: args.query || '',
+					results: [],
+					metadata: {
+						totalResults: 0,
+						searchTime: Date.now() - startTime,
+						embeddingTime: 0,
+						maxSimilarity: 0,
+						minSimilarity: 0,
+						averageSimilarity: 0,
+						knowledgeResults: 0,
+						reflectionResults: 0,
+						searchMode: 'knowledge',
+						usedFallback: true,
+						queryRefinementApplied: false,
+					},
+					timestamp: new Date().toISOString(),
+				};
+			}
 
-            // Check if embedding manager indicates no available embeddings
-            if (
-                context?.services?.embeddingManager &&
-                !context.services.embeddingManager.hasAvailableEmbeddings()
-            ) {
-                logger.debug('MemorySearch: No available embeddings, returning empty results');
-                return {
-                    success: true,
-                    query: args.query || '',
-                    results: [],
-                    metadata: {
-                        totalResults: 0,
-                        searchTime: Date.now() - startTime,
-                        embeddingTime: 0,
-                        maxSimilarity: 0,
-                        minSimilarity: 0,
-                        averageSimilarity: 0,
-                        knowledgeResults: 0,
-                        reflectionResults: 0,
-                        searchMode: 'knowledge',
-                        usedFallback: true,
-                        queryRefinementApplied: false,
-                    },
-                    timestamp: new Date().toISOString(),
-                };
-            }
+			// Check if embedding manager indicates no available embeddings
+			if (
+				context?.services?.embeddingManager &&
+				!context.services.embeddingManager.hasAvailableEmbeddings()
+			) {
+				logger.debug('MemorySearch: No available embeddings, returning empty results');
+				return {
+					success: true,
+					query: args.query || '',
+					results: [],
+					metadata: {
+						totalResults: 0,
+						searchTime: Date.now() - startTime,
+						embeddingTime: 0,
+						maxSimilarity: 0,
+						minSimilarity: 0,
+						averageSimilarity: 0,
+						knowledgeResults: 0,
+						reflectionResults: 0,
+						searchMode: 'knowledge',
+						usedFallback: true,
+						queryRefinementApplied: false,
+					},
+					timestamp: new Date().toISOString(),
+				};
+			}
 
-            // Validate required parameters
-            if (!args.query || typeof args.query !== 'string' || args.query.trim().length === 0) {
-                throw new Error('Query is required and must be a non-empty string');
-            }
+			// Validate required parameters
+			if (!args.query || typeof args.query !== 'string' || args.query.trim().length === 0) {
+				throw new Error('Query is required and must be a non-empty string');
+			}
 
-            // Set defaults
-            const originalQuery = args.query.trim();
-            const topK = Math.max(1, Math.min(50, args.top_k || 5));
-            const similarityThreshold = Math.max(0.0, Math.min(1.0, args.similarity_threshold || 0.3));
-            const enableQueryRefinement = (args.enable_query_refinement === true) || (env.ENABLE_QUERY_REFINEMENT === true);
+			// Set defaults
+			const originalQuery = args.query.trim();
+			const topK = Math.max(1, Math.min(50, args.top_k || 5));
+			const similarityThreshold = Math.max(0.0, Math.min(1.0, args.similarity_threshold || 0.3));
+			const enableQueryRefinement =
+				args.enable_query_refinement === true || env.ENABLE_QUERY_REFINEMENT === true;
 
-            // Get required services from context
-            if (!context?.services) {
-                throw new Error('InternalToolContext.services is required for memory search');
-            }
+			// Get required services from context
+			if (!context?.services) {
+				throw new Error('InternalToolContext.services is required for memory search');
+			}
 
-            const embeddingManager = context.services.embeddingManager;
-            const vectorStoreManager = context.services.vectorStoreManager;
+			const embeddingManager = context.services.embeddingManager;
+			const vectorStoreManager = context.services.vectorStoreManager;
 
-            if (!embeddingManager || !vectorStoreManager) {
-                throw new Error('EmbeddingManager and VectorStoreManager are required in context.services');
-            }
+			if (!embeddingManager || !vectorStoreManager) {
+				throw new Error('EmbeddingManager and VectorStoreManager are required in context.services');
+			}
 
-            const embedder = embeddingManager.getEmbedder('default');
+			const embedder = embeddingManager.getEmbedder('default');
 
-            if (!embedder?.embed || typeof embedder.embed !== 'function' || !embedder.embedBatch || typeof embedder.embedBatch !== 'function') {
-                throw new Error('Embedder is not properly initialized or missing embed() or embedBatch() method');
-            }
+			if (
+				!embedder?.embed ||
+				typeof embedder.embed !== 'function' ||
+				!embedder.embedBatch ||
+				typeof embedder.embedBatch !== 'function'
+			) {
+				throw new Error(
+					'Embedder is not properly initialized or missing embed() or embedBatch() method'
+				);
+			}
 
-            // Generate embedding for the search query
-            const embeddingStartTime = Date.now();
-            logger.debug('MemorySearch: Generating embedding for query', {
-                originalQueryLength: originalQuery.length,
-                originalQueryPreview: originalQuery.substring(0, 50),
-            });
+			// Generate embedding for the search query
+			const embeddingStartTime = Date.now();
+			logger.debug('MemorySearch: Generating embedding for query', {
+				originalQueryLength: originalQuery.length,
+				originalQueryPreview: originalQuery.substring(0, 50),
+			});
 
 			let finalQuery: string[] = [originalQuery];
-            let queryEmbeddings: number[][];
+			let queryEmbeddings: number[][];
 			// Rewrite query if enabled
 			try {
 				if (enableQueryRefinement) {
-					const rewrittenQueries = await rewriteUserQuery(originalQuery, context.services.llmService);
+					const rewrittenQueries = await rewriteUserQuery(
+						originalQuery,
+						context.services.llmService
+					);
 					finalQuery = rewrittenQueries.queries;
 				}
-			logger.info('Embedding final query:', finalQuery);
-			queryEmbeddings = await embedder.embedBatch(finalQuery);
-            } catch (embedError) {
-                logger.error('MemorySearch: Failed to generate embedding, disabling embeddings globally', {
-                    error: embedError instanceof Error ? embedError.message : String(embedError),
-                    provider: embedder.getConfig().type,
-                });
+				logger.info('Embedding final query:', finalQuery);
+				queryEmbeddings = await embedder.embedBatch(finalQuery);
+			} catch (embedError) {
+				logger.error('MemorySearch: Failed to generate embedding, disabling embeddings globally', {
+					error: embedError instanceof Error ? embedError.message : String(embedError),
+					provider: embedder.getConfig().type,
+				});
 
-                // Immediately disable embeddings globally on first failure
-                if (context?.services?.embeddingManager && embedError instanceof Error) {
-                    context.services.embeddingManager.handleRuntimeFailure(
-                        embedError,
-                        embedder.getConfig().type
-                    );
-                }
+				// Immediately disable embeddings globally on first failure
+				if (context?.services?.embeddingManager && embedError instanceof Error) {
+					context.services.embeddingManager.handleRuntimeFailure(
+						embedError,
+						embedder.getConfig().type
+					);
+				}
 
-                // Return empty results since embeddings are now disabled
-                return {
-                    success: true,
-                    query: args.query || '',
-                    results: [],
-                    metadata: {
-                        totalResults: 0,
-                        searchTime: Date.now() - startTime,
-                        embeddingTime: 0,
-                        maxSimilarity: 0,
-                        minSimilarity: 0,
-                        averageSimilarity: 0,
-                        knowledgeResults: 0,
-                        reflectionResults: 0,
-                        searchMode: 'knowledge',
-                        usedFallback: true,
-                    },
-                    timestamp: new Date().toISOString(),
-                };
-            }
+				// Return empty results since embeddings are now disabled
+				return {
+					success: true,
+					query: args.query || '',
+					results: [],
+					metadata: {
+						totalResults: 0,
+						searchTime: Date.now() - startTime,
+						embeddingTime: 0,
+						maxSimilarity: 0,
+						minSimilarity: 0,
+						averageSimilarity: 0,
+						knowledgeResults: 0,
+						reflectionResults: 0,
+						searchMode: 'knowledge',
+						usedFallback: true,
+					},
+					timestamp: new Date().toISOString(),
+				};
+			}
 
-            const embeddingTime = Date.now() - embeddingStartTime;
+			const embeddingTime = Date.now() - embeddingStartTime;
 
-            logger.debug('MemorySearch: Embedding generated successfully', {
-                embeddingTime: `${embeddingTime}ms`,
-                embeddingDimensions: Array.isArray(queryEmbeddings[0]) ? queryEmbeddings[0].length : 'unknown',
-            });
-            // Search knowledge memory only
-            const searchStartTime = Date.now();
-            let allResults: any[] = [];
-            let knowledgeResultCount = 0;
-            // let reflectionResultCount = 0; // Always 0 for knowledge-only search
-            let usedFallback = false;
+			logger.debug('MemorySearch: Embedding generated successfully', {
+				embeddingTime: `${embeddingTime}ms`,
+				embeddingDimensions: Array.isArray(queryEmbeddings[0])
+					? queryEmbeddings[0].length
+					: 'unknown',
+			});
+			// Search knowledge memory only
+			const searchStartTime = Date.now();
+			let allResults: any[] = [];
+			let knowledgeResultCount = 0;
+			// let reflectionResultCount = 0; // Always 0 for knowledge-only search
+			let usedFallback = false;
 
-            // Check if we have a DualCollectionVectorManager
-            const isDualManager =
-                vectorStoreManager.constructor.name === 'DualCollectionVectorManager' ||
-                (typeof vectorStoreManager.getStore === 'function' &&
-                    vectorStoreManager.getStore.length === 1); // getStore(type) signature
+			// Check if we have a DualCollectionVectorManager
+			const isDualManager =
+				vectorStoreManager.constructor.name === 'DualCollectionVectorManager' ||
+				(typeof vectorStoreManager.getStore === 'function' &&
+					vectorStoreManager.getStore.length === 1); // getStore(type) signature
 
-            let knowledgeStore = null;
-            if (isDualManager) {
-                logger.debug('MemorySearch: Using DualCollectionVectorManager for knowledge search', {
-                    isDualManager: true,
-                });
+			let knowledgeStore = null;
+			if (isDualManager) {
+				logger.debug('MemorySearch: Using DualCollectionVectorManager for knowledge search', {
+					isDualManager: true,
+				});
 
-                try {
-                    // Try dual manager API first for knowledge collection
-                    knowledgeStore = (vectorStoreManager as any).getStore('knowledge');
-                } catch {
-                    // Fallback to default store
-                    try {
-                        knowledgeStore = vectorStoreManager.getStore();
-                        usedFallback = true;
-                    } catch (fallbackError) {
-                        throw new Error(
-                            `Knowledge collection failed and fallback to default store also failed: ${fallbackError instanceof Error ? fallbackError.message : String(fallbackError)}`
-                        );
-                    }
-                }
-            } else {
-                // Single collection manager - get default store
-                logger.debug('MemorySearch: Using single collection manager for knowledge search', {
-                    isDualManager: false,
-                });
+				try {
+					// Try dual manager API first for knowledge collection
+					knowledgeStore = (vectorStoreManager as any).getStore('knowledge');
+				} catch {
+					// Fallback to default store
+					try {
+						knowledgeStore = vectorStoreManager.getStore();
+						usedFallback = true;
+					} catch (fallbackError) {
+						throw new Error(
+							`Knowledge collection failed and fallback to default store also failed: ${fallbackError instanceof Error ? fallbackError.message : String(fallbackError)}`
+						);
+					}
+				}
+			} else {
+				// Single collection manager - get default store
+				logger.debug('MemorySearch: Using single collection manager for knowledge search', {
+					isDualManager: false,
+				});
 
-                knowledgeStore = vectorStoreManager.getStore();
-            }
+				knowledgeStore = vectorStoreManager.getStore();
+			}
 
-            if (!knowledgeStore) {
-                throw new Error('Knowledge vector store not available');
-            }
+			if (!knowledgeStore) {
+				throw new Error('Knowledge vector store not available');
+			}
 			// Retrieve knowledge for each query embedding
 			for (const queryEmbedding of queryEmbeddings) {
 				// Search knowledge collection
 				const knowledgeResults = await knowledgeStore.search(queryEmbedding, topK * 2);
-				
+
 				// Mark results with source and add to allResults
 				const markedResults = knowledgeResults.map((result: any) => ({
 					...result,
@@ -343,147 +354,143 @@ export const searchMemoryTool: InternalTool = {
 				knowledgeResults: knowledgeResultCount,
 			});
 
-            // Filter, rank, and format knowledge memory results
-            const filteredResults = allResults
-                .filter(result => (result.score || 0) >= similarityThreshold)
-                .sort((a, b) => (b.score || 0) - (a.score || 0)) // Sort by similarity score descending
-                .slice(0, topK) // Take top K results overall
-                .map(result => {
-                    const rawPayload = result.payload || {};
+			// Filter, rank, and format knowledge memory results
+			const filteredResults = allResults
+				.filter(result => (result.score || 0) >= similarityThreshold)
+				.sort((a, b) => (b.score || 0) - (a.score || 0)) // Sort by similarity score descending
+				.slice(0, topK) // Take top K results overall
+				.map(result => {
+					const rawPayload = result.payload || {};
 
-                    // All data is V2 format after collection cleanup - no migration needed
-                    const payload = rawPayload as KnowledgePayload;
+					// All data is V2 format after collection cleanup - no migration needed
+					const payload = rawPayload as KnowledgePayload;
 
-                    // Return unified result format with V2 payload data
-                    const baseResult = {
-                        id: result.id || payload.id || 'unknown',
-                        text: payload.text || 'No content available',
-                        tags: payload.tags || [],
-                        timestamp: payload.timestamp || new Date().toISOString(),
-                        similarity: result.score || 0,
-                        version: payload.version || 2, // All data is V2 after cleanup
-                        source: 'knowledge' as const,
-                        memoryType: 'knowledge' as const,
-                    };
+					// Return unified result format with V2 payload data
+					const baseResult = {
+						id: result.id || payload.id || 'unknown',
+						text: payload.text || 'No content available',
+						tags: payload.tags || [],
+						timestamp: payload.timestamp || new Date().toISOString(),
+						similarity: result.score || 0,
+						version: payload.version || 2, // All data is V2 after cleanup
+						source: 'knowledge' as const,
+						memoryType: 'knowledge' as const,
+					};
 
-                    // Add knowledge-specific fields
-                    const knowledgePayload = payload as KnowledgePayload;
-                    return {
-                        ...baseResult,
-                        confidence: knowledgePayload.confidence || 0,
-                        reasoning: knowledgePayload.reasoning || 'No reasoning available',
-                        event: knowledgePayload.event,
-                        ...(knowledgePayload.domain && { domain: knowledgePayload.domain }),
-                        qualitySource: knowledgePayload.qualitySource,
-                        ...(knowledgePayload.sourceSessionId && {
-                            sourceSessionId: knowledgePayload.sourceSessionId,
-                        }),
-                        ...(knowledgePayload.code_pattern && { code_pattern: knowledgePayload.code_pattern }),
-                        ...(knowledgePayload.old_memory && { old_memory: knowledgePayload.old_memory }),
-                    };
-                });
+					// Add knowledge-specific fields
+					const knowledgePayload = payload as KnowledgePayload;
+					return {
+						...baseResult,
+						confidence: knowledgePayload.confidence || 0,
+						reasoning: knowledgePayload.reasoning || 'No reasoning available',
+						event: knowledgePayload.event,
+						...(knowledgePayload.domain && { domain: knowledgePayload.domain }),
+						qualitySource: knowledgePayload.qualitySource,
+						...(knowledgePayload.sourceSessionId && {
+							sourceSessionId: knowledgePayload.sourceSessionId,
+						}),
+						...(knowledgePayload.code_pattern && { code_pattern: knowledgePayload.code_pattern }),
+						...(knowledgePayload.old_memory && { old_memory: knowledgePayload.old_memory }),
+					};
+				});
 
-            // Calculate statistics for knowledge search results
-            const totalResults = filteredResults.length;
-            const similarities = filteredResults.map(r => r.similarity);
-            const maxSimilarity = similarities.length > 0 ? Math.max(...similarities) : 0;
-            const minSimilarity = similarities.length > 0 ? Math.min(...similarities) : 0;
-            const averageSimilarity =
-                similarities.length > 0 ? similarities.reduce((a, b) => a + b, 0) / similarities.length : 0;
+			// Calculate statistics for knowledge search results
+			const totalResults = filteredResults.length;
+			const similarities = filteredResults.map(r => r.similarity);
+			const maxSimilarity = similarities.length > 0 ? Math.max(...similarities) : 0;
+			const minSimilarity = similarities.length > 0 ? Math.min(...similarities) : 0;
+			const averageSimilarity =
+				similarities.length > 0 ? similarities.reduce((a, b) => a + b, 0) / similarities.length : 0;
 
-            const totalTime = Date.now() - startTime;
+			const totalTime = Date.now() - startTime;
 
-            // Prepare result
-            const result: MemorySearchResult = {
-                success: true,
-                query: originalQuery,
-                results: filteredResults,
-                metadata: {
-                    totalResults,
-                    searchTime: totalTime,
-                    embeddingTime,
-                    maxSimilarity,
-                    minSimilarity,
-                    averageSimilarity,
-                    knowledgeResults: totalResults, // All results are knowledge results
-                    reflectionResults: 0, // No reflection results in knowledge-only search
-                    searchMode: 'knowledge',
-                    usedFallback,
-                },
-                timestamp: new Date().toISOString(),
-            };
+			// Prepare result
+			const result: MemorySearchResult = {
+				success: true,
+				query: originalQuery,
+				results: filteredResults,
+				metadata: {
+					totalResults,
+					searchTime: totalTime,
+					embeddingTime,
+					maxSimilarity,
+					minSimilarity,
+					averageSimilarity,
+					knowledgeResults: totalResults, // All results are knowledge results
+					reflectionResults: 0, // No reflection results in knowledge-only search
+					searchMode: 'knowledge',
+					usedFallback,
+				},
+				timestamp: new Date().toISOString(),
+			};
 
-            logger.debug('MemorySearch: Knowledge search completed successfully', {
-                query: originalQuery.substring(0, 50),
-                resultsFound: totalResults,
-                knowledgeResults: totalResults,
-                maxSimilarity: maxSimilarity.toFixed(3),
-                averageSimilarity: averageSimilarity.toFixed(3),
-                totalTime: `${totalTime}ms`,
-                usedFallback,
-            });
-			// Return result to agent 
-            return result;
-        } catch (error) {
-            const errorMessage = error instanceof Error ? error.message : String(error);
-            const totalTime = Date.now() - startTime;
+			logger.debug('MemorySearch: Knowledge search completed successfully', {
+				query: originalQuery.substring(0, 50),
+				resultsFound: totalResults,
+				knowledgeResults: totalResults,
+				maxSimilarity: maxSimilarity.toFixed(3),
+				averageSimilarity: averageSimilarity.toFixed(3),
+				totalTime: `${totalTime}ms`,
+				usedFallback,
+			});
+			// Return result to agent
+			return result;
+		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : String(error);
+			const totalTime = Date.now() - startTime;
 
-            logger.error('MemorySearch: Search failed', {
-                error: errorMessage,
-                query: args.query?.substring(0, 50) || 'undefined',
-                processingTime: `${totalTime}ms`,
-            });
+			logger.error('MemorySearch: Search failed', {
+				error: errorMessage,
+				query: args.query?.substring(0, 50) || 'undefined',
+				processingTime: `${totalTime}ms`,
+			});
 
-            // Check if this is a runtime failure that should disable embeddings globally
-            if (context?.services?.embeddingManager && error instanceof Error) {
-                const embeddingManager = context.services.embeddingManager;
-                if (embeddingManager && typeof embeddingManager.handleRuntimeFailure === 'function') {
-                    const embedder = embeddingManager.getEmbedder('default');
-                    const providerType = embedder?.getConfig()?.type || 'unknown';
-                    embeddingManager.handleRuntimeFailure(error, providerType);
-                }
-            }
+			// Check if this is a runtime failure that should disable embeddings globally
+			if (context?.services?.embeddingManager && error instanceof Error) {
+				const embeddingManager = context.services.embeddingManager;
+				if (embeddingManager && typeof embeddingManager.handleRuntimeFailure === 'function') {
+					const embedder = embeddingManager.getEmbedder('default');
+					const providerType = embedder?.getConfig()?.type || 'unknown';
+					embeddingManager.handleRuntimeFailure(error, providerType);
+				}
+			}
 
-            return {
-                success: false,
-                query: args.query || 'undefined',
-                results: [],
-                metadata: {
-                    totalResults: 0,
-                    searchTime: totalTime,
-                    embeddingTime: 0,
-                    maxSimilarity: 0,
-                    minSimilarity: 0,
-                    averageSimilarity: 0,
-                    knowledgeResults: 0,
-                    reflectionResults: 0,
-                    searchMode: 'knowledge',
-                    usedFallback: true,
-                },
-                timestamp: new Date().toISOString(),
-            };
-        }
-    },
+			return {
+				success: false,
+				query: args.query || 'undefined',
+				results: [],
+				metadata: {
+					totalResults: 0,
+					searchTime: totalTime,
+					embeddingTime: 0,
+					maxSimilarity: 0,
+					minSimilarity: 0,
+					averageSimilarity: 0,
+					knowledgeResults: 0,
+					reflectionResults: 0,
+					searchMode: 'knowledge',
+					usedFallback: true,
+				},
+				timestamp: new Date().toISOString(),
+			};
+		}
+	},
 };
 
 /**
  * Step 1: Rewrite user query into sub-queries and disambiguate ambiguous terms
  * Uses LLM to generate more targeted queries for better retrieval
- * 
+ *
  * @param originalInput - The original user query to rewrite
  * @param llmService - The LLM service to use for rewriting
  * @returns An object containing the rewritten queries
-*/
+ */
 export async function rewriteUserQuery(
-    originalInput: string,
-    llmService: any,
-): Promise<{queries: string[]}> {
-    // Add debugging to track function calls
-    const callId = Math.random().toString(36).substring(7);
-    // console.log(`🔄 [${callId}] rewriteUserQuery called with: "${originalInput}"`);
-    
-    try {
-        const rewritePrompt = `
+	originalInput: string,
+	llmService: any
+): Promise<{ queries: string[] }> {
+	try {
+		const rewritePrompt = `
         You are a query decomposition and disambiguation expert. Break down this question into search queries for a knowledge base while handling ambiguous terms.
 
         QUESTION: "${originalInput}"
@@ -521,44 +528,45 @@ export async function rewriteUserQuery(
 
         Now decompose and disambiguate: "${originalInput}"
         `;
-        const rewriteResponse = await llmService.directGenerate(rewritePrompt);
-        
-        // Parse the response to extract individual queries
-        const queries = rewriteResponse
-            .split('\n')
-            .map(line => line.trim())
-            .filter(line => line.length > 0)
-            .map(line => {
-                // Extract query content after "Query X:" prefix
-                const match = line.match(/^Query\s*\d+:\s*(.+)$/i);
-                return match ? match[1].trim() : null;
-            })
-            .filter(query => query !== null && query.length >= 3)
-            .filter((query, index, array) => array.indexOf(query) === index); // Remove duplicates
-        
-		logger.info(`Parsed queries:`,{ 
-								queries: queries,
-								queryCount: queries.length,
-							});
-        // Ensure we have at least one query (fallback to original)
-        if (queries.length === 0) {
-            return {
-                queries: [originalInput]
-            };
-        }
+		const rewriteResponse = await llmService.directGenerate(rewritePrompt);
 
-        return {
-            queries: queries
-        };
+		// Parse the response to extract individual queries
+		const queries = rewriteResponse
+			.split('\n')
+			.map((line: string) => line.trim())
+			.filter((line: string) => line.length > 0)
+			.map((line: string) => {
+				// Extract query content after "Query X:" prefix
+				const match = line.match(/^Query\s*\d+:\s*(.+)$/i);
+				return match && match[1] ? match[1].trim() : null;
+			})
+			.filter((query: string | null) => query !== null && query.length >= 3)
+			.filter(
+				(query: string | null, index: number, array: (string | null)[]) =>
+					array.indexOf(query) === index
+			); // Remove duplicates
 
-    } catch (error) {
-        logger.warn('MemorySearch: Query rewriting failed', {
-            originalInput: originalInput.substring(0, 100),
-            error: error instanceof Error ? error.message : String(error)
-        });
-        return {
-            queries: [originalInput]
-        };
-    }
+		logger.info(`Parsed queries:`, {
+			queries: queries,
+			queryCount: queries.length,
+		});
+		// Ensure we have at least one query (fallback to original)
+		if (queries.length === 0) {
+			return {
+				queries: [originalInput],
+			};
+		}
+
+		return {
+			queries: queries,
+		};
+	} catch (error) {
+		logger.warn('MemorySearch: Query rewriting failed', {
+			originalInput: originalInput.substring(0, 100),
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return {
+			queries: [originalInput],
+		};
+	}
 }
-

--- a/src/core/brain/tools/definitions/memory/search_memory.ts
+++ b/src/core/brain/tools/definitions/memory/search_memory.ts
@@ -95,8 +95,8 @@ export const searchMemoryTool: InternalTool = {
             },
             enable_query_refinement: {
                 type: 'boolean',
-                description: 'Whether to apply query refinement for better search results (default: true)',
-                default: true,
+                description: 'Whether to apply query refinement for better search results (default: false)',
+                default: false,
             },
         },
         required: ['query'],
@@ -187,7 +187,7 @@ export const searchMemoryTool: InternalTool = {
             const originalQuery = args.query.trim();
             const topK = Math.max(1, Math.min(50, args.top_k || 5));
             const similarityThreshold = Math.max(0.0, Math.min(1.0, args.similarity_threshold || 0.3));
-            const enableQueryRefinement = args.enable_query_refinement !== false && env.ENABLE_QUERY_REFINEMENT !== false;
+            const enableQueryRefinement = (args.enable_query_refinement === true) || (env.ENABLE_QUERY_REFINEMENT === true);
 
             // Get required services from context
             if (!context?.services) {

--- a/src/core/brain/tools/definitions/memory/store_reasoning_memory.ts
+++ b/src/core/brain/tools/definitions/memory/store_reasoning_memory.ts
@@ -729,7 +729,7 @@ export const storeReasoningMemoryTool: InternalTool = {
 					payloads: `[Object with ${Object.keys(payload).length} keys]`,
 				},
 			});
-
+			// console.log('Store Reasoning Memory Payload:', payload);
 			// Store in reflection vector database using exact same pattern as successful function
 			try {
 				await reflectionStore.insert([embedding], [vectorId], [payload]);

--- a/src/core/brain/tools/definitions/memory/workspace_search.ts
+++ b/src/core/brain/tools/definitions/memory/workspace_search.ts
@@ -129,6 +129,11 @@ export const workspaceSearchTool: InternalTool = {
 				description: 'Whether to include detailed metadata in results (default: true)',
 				default: true,
 			},
+			enable_query_refinement: {
+				type: 'boolean',
+				description: 'Whether to apply query refinement for better search results (default: false)',
+				default: false,
+			},
 		},
 		required: ['query'],
 	},
@@ -255,7 +260,8 @@ export const workspaceSearchTool: InternalTool = {
 				queryPreview: originalQuery.substring(0, 50),
 			});
 			let queries: string[] = [originalQuery];
-			if (env.ENABLE_QUERY_REFINEMENT) {
+			const enableQueryRefinement = (args.enable_query_refinement === true) || (env.ENABLE_QUERY_REFINEMENT === true);
+			if (enableQueryRefinement) {
 				const rewrittenQueries = await rewriteUserQuery(originalQuery, context?.services?.llmService);
 				logger.debug('WorkspaceSearch: Rewritten queries', {
 					rewrittenQueries,

--- a/src/core/brain/tools/definitions/memory/workspace_search.ts
+++ b/src/core/brain/tools/definitions/memory/workspace_search.ts
@@ -260,9 +260,13 @@ export const workspaceSearchTool: InternalTool = {
 				queryPreview: originalQuery.substring(0, 50),
 			});
 			let queries: string[] = [originalQuery];
-			const enableQueryRefinement = (args.enable_query_refinement === true) || (env.ENABLE_QUERY_REFINEMENT === true);
+			const enableQueryRefinement =
+				args.enable_query_refinement === true || env.ENABLE_QUERY_REFINEMENT === true;
 			if (enableQueryRefinement) {
-				const rewrittenQueries = await rewriteUserQuery(originalQuery, context?.services?.llmService);
+				const rewrittenQueries = await rewriteUserQuery(
+					originalQuery,
+					context?.services?.llmService
+				);
 				logger.debug('WorkspaceSearch: Rewritten queries', {
 					rewrittenQueries,
 				});
@@ -312,7 +316,9 @@ export const workspaceSearchTool: InternalTool = {
 
 			logger.debug('WorkspaceSearch: Embedding generated successfully', {
 				embeddingTime: `${embeddingTime}ms`,
-				embeddingDimensions: Array.isArray(queryEmbeddings[0]) ? queryEmbeddings[0].length : 'unknown',
+				embeddingDimensions: Array.isArray(queryEmbeddings[0])
+					? queryEmbeddings[0].length
+					: 'unknown',
 			});
 
 			// Search workspace memory

--- a/src/core/brain/tools/unified-tool-manager.ts
+++ b/src/core/brain/tools/unified-tool-manager.ts
@@ -521,7 +521,7 @@ export class UnifiedToolManager {
 				return !!tool;
 			}
 			return false;
-		} catch (error) {
+		} catch {
 			return false;
 		}
 	}

--- a/src/core/env.ts
+++ b/src/core/env.ts
@@ -114,6 +114,8 @@ const envSchema = z.object({
 		.default('Cosine'),
 	WORKSPACE_VECTOR_STORE_ON_DISK: z.boolean().default(false),
 	WORKSPACE_VECTOR_STORE_MAX_VECTORS: z.number().default(10000),
+	// Query Refinement Configuration
+	ENABLE_QUERY_REFINEMENT: z.boolean().default(true),
 });
 
 type EnvSchema = z.infer<typeof envSchema>;

--- a/src/core/session/coversation-session.ts
+++ b/src/core/session/coversation-session.ts
@@ -923,15 +923,9 @@ export class ConversationSession {
 				return;
 			}
 
-			// Check if reflection memory tools are available for execution (not for agent access)
-			// These tools are background-only (agentAccessible: false) so they won't be in allTools in CLI mode
-			// We need to check their existence directly for background execution
+			// Check if reflection memory tools are available (using pre-loaded tools)
 			const reflectionToolsAvailable =
-				this.services.unifiedToolManager.isBackgroundToolAvailable(
-					'cipher_extract_reasoning_steps'
-				) &&
-				this.services.unifiedToolManager.isBackgroundToolAvailable('cipher_store_reasoning_memory');
-
+				allTools['cipher_extract_reasoning_steps'] && allTools['cipher_store_reasoning_memory'];
 			if (embeddingsDisabled || !reflectionToolsAvailable) {
 				logger.debug('ConversationSession: Reflection memory processing skipped', {
 					embeddingsDisabled,


### PR DESCRIPTION
# Add Input Refinement Feature to Search Tools

## Overview
This PR builds upon and refines the original input refinement implementation from [PR #170](https://github.com/campfirein/cipher/pull/170) by @willingWill17, standardizing the feature across all search tools and improving the overall implementation.

## Environment Variable
Set `ENABLE_QUERY_REFINEMENT=true` to globally enable input refinement across all search tools.

## Tools Equipped with Input Refinement
- **`cipher_memory_search`** - Knowledge memory search tool
- **`cipher_workspace_search`** - Workspace memory search tool  
- **`cipher_search_reasoning_patterns`** - Reasoning patterns search tool

## How It Works
When enabled, the feature uses LLM to decompose user queries into 2-5 focused sub-queries, improving search coverage and relevance. Each tool includes an `enable_query_refinement` parameter (defaults to `false`) that can be set per-request, with the environment variable serving as a global override.

## Example
**Input:** "How to implement authentication with JWT and OAuth?"
**Refined Queries:** 
- "JWT authentication implementation"
- "OAuth authentication flow"
- "authentication security best practices"

**Credit:** Original implementation by @willingWill17 in [PR #170](https://github.com/campfirein/cipher/pull/170)