### PR TITLE
 Fix AWS LLM provider not recognized at startup

### DIFF
--- a/memAgent/cipher.yml
+++ b/memAgent/cipher.yml
@@ -13,10 +13,10 @@ mcpServers: {}
 
 # Choose ONLY ONE of the following LLM providers
 llm:
-  provider: openai
-  model: gpt-4.1-mini
-  apiKey: $OPENAI_API_KEY
-  maxIterations: 50
+  # provider: openai
+  # model: gpt-4.1-mini
+  # apiKey: $OPENAI_API_KEY
+  # maxIterations: 50
 
   # provider: gemini
   # model: gemini-2.5-flash
@@ -43,14 +43,14 @@ llm:
 
 
 # --- AWS Bedrock LLM Configuration ---
-  # provider: aws
-  # model: us.anthropic.claude-3-5-sonnet-20241022-v2:0  # Or another Bedrock-supported model
-  # maxIterations: 50
-  # aws:
-  #   region: $AWS_REGION
-  #   accessKeyId: $AWS_ACCESS_KEY_ID
-  #   secretAccessKey: $AWS_SECRET_ACCESS_KEY
-  #   sessionToken: $AWS_SESSION_TOKEN   # Optional, for temporary credentials
+  provider: aws
+  model: us.anthropic.claude-3-5-sonnet-20241022-v2:0  # Or another Bedrock-supported model
+  maxIterations: 50
+  aws:
+    region: $AWS_REGION
+    accessKeyId: $AWS_ACCESS_KEY_ID
+    secretAccessKey: $AWS_SECRET_ACCESS_KEY
+    sessionToken: $AWS_SESSION_TOKEN   # Optional, for temporary credentials
 
 # --- Azure OpenAI LLM Configuration ---
 #   provider: azure
@@ -81,11 +81,11 @@ llm:
 #   model: text-embedding-3-small
 #   apiKey: $OPENAI_API_KEY
 
-# Gemini:
-# embedding:
-#   type: gemini
-#   model: gemini-embedding-001
-#   apiKey: $GEMINI_API_KEY
+Gemini:
+embedding:
+  type: gemini
+  model: gemini-embedding-001
+  apiKey: $GEMINI_API_KEY
 
 # Ollama:
 # embedding:

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -191,13 +191,13 @@ program
 			!env.OPENROUTER_API_KEY &&
 			!env.OLLAMA_BASE_URL
 		) {
-			// Not good, need to check if AWS or Azure is configured 
-			console.log('AWS access key',process.env.AWS_ACCESS_KEY_ID)
-			console.log('AWS secret access key',process.env.AWS_SECRET_ACCESS_KEY)
-			console.log('AWS region',process.env.AWS_REGION)
-			console.log('AWS inference profile ARN',process.env.AWS_INFERENCE_PROFILE_ARN)
+			// Not good, need to check if AWS or Azure is configured
+			console.log('AWS access key', process.env.AWS_ACCESS_KEY_ID);
+			console.log('AWS secret access key', process.env.AWS_SECRET_ACCESS_KEY);
+			console.log('AWS region', process.env.AWS_REGION);
+			console.log('AWS inference profile ARN', process.env.AWS_INFERENCE_PROFILE_ARN);
 			if (
-				!process.env.AWS_ACCESS_KEY_ID || 
+				!process.env.AWS_ACCESS_KEY_ID ||
 				!process.env.AWS_SECRET_ACCESS_KEY ||
 				!process.env.AWS_REGION ||
 				!process.env.AWS_INFERENCE_PROFILE_ARN

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -191,17 +191,30 @@ program
 			!env.OPENROUTER_API_KEY &&
 			!env.OLLAMA_BASE_URL
 		) {
-			// Use MCP-safe error reporting
-			const errorMsg =
-				'No API key or Ollama configuration found, please set at least one of OPENAI_API_KEY, ANTHROPIC_API_KEY, OPENROUTER_API_KEY, or OLLAMA_BASE_URL in your environment variables \nAvailable providers: OpenAI, Anthropic, OpenRouter, Ollama, Qwen, Gemini, Azure, AWS, LM Studio';
+			// Not good, need to check if AWS or Azure is configured 
+			console.log('AWS access key',process.env.AWS_ACCESS_KEY_ID)
+			console.log('AWS secret access key',process.env.AWS_SECRET_ACCESS_KEY)
+			console.log('AWS region',process.env.AWS_REGION)
+			console.log('AWS inference profile ARN',process.env.AWS_INFERENCE_PROFILE_ARN)
+			if (
+				!process.env.AWS_ACCESS_KEY_ID || 
+				!process.env.AWS_SECRET_ACCESS_KEY ||
+				!process.env.AWS_REGION ||
+				!process.env.AWS_INFERENCE_PROFILE_ARN
+			) {
+				// Use MCP-safe error reporting
+				const errorMsg =
+					'No API key or Ollama configuration found, please set at least one of OPENAI_API_KEY, ANTHROPIC_API_KEY, OPENROUTER_API_KEY, OLLAMA_BASE_URL, or AWS credentials (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION) in your environment variables \nAvailable providers: OpenAI, Anthropic, OpenRouter, Ollama, Qwen, Gemini, Azure, AWS, LM Studio';
 
-			if (opts.mode === 'mcp') {
-				process.stderr.write(`[CIPHER-MCP] ERROR: ${errorMsg}\n`);
-			} else {
-				logger.error(errorMsg);
+				if (opts.mode === 'mcp') {
+					process.stderr.write(`[CIPHER-MCP] ERROR: ${errorMsg}\n`);
+				} else {
+					logger.error(errorMsg);
+				}
+				process.exit(1);
 			}
-			process.exit(1);
 		}
+		// Passed AWS credentials check, need to initialize AWS service to make it works.
 
 		// validate cli options
 		try {
@@ -244,7 +257,7 @@ program
 					serverConfig.connectionMode = 'strict';
 				}
 			}
-
+			// console.log('Agent config',cfg)
 			agent = new MemAgent(cfg, opts.mode);
 
 			// Start the agent (initialize async services)

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -191,11 +191,6 @@ program
 			!env.OPENROUTER_API_KEY &&
 			!env.OLLAMA_BASE_URL
 		) {
-			// Not good, need to check if AWS or Azure is configured
-			console.log('AWS access key', process.env.AWS_ACCESS_KEY_ID);
-			console.log('AWS secret access key', process.env.AWS_SECRET_ACCESS_KEY);
-			console.log('AWS region', process.env.AWS_REGION);
-			console.log('AWS inference profile ARN', process.env.AWS_INFERENCE_PROFILE_ARN);
 			if (
 				!process.env.AWS_ACCESS_KEY_ID ||
 				!process.env.AWS_SECRET_ACCESS_KEY ||

--- a/src/core/brain/embedding/backend/aws.ts
+++ b/src/core/brain/embedding/backend/aws.ts
@@ -28,10 +28,10 @@ export interface AWSBedrockEmbeddingConfig extends EmbeddingConfig {
 }
 
 interface BedrockError {
-  message: string;
-  code?: string;
-  statusCode?: number;
-  requestId?: string;
+	message: string;
+	code?: string;
+	statusCode?: number;
+	requestId?: string;
 }
 
 /**
@@ -136,7 +136,9 @@ export class AWSBedrockEmbedder implements Embedder {
 			if (error instanceof EmbeddingError) {
 				throw error;
 			}
-			throw new EmbeddingError(`Failed to generate AWS Bedrock batch embeddings: ${bedrockError.message}`);
+			throw new EmbeddingError(
+				`Failed to generate AWS Bedrock batch embeddings: ${bedrockError.message}`
+			);
 		}
 	}
 

--- a/src/core/brain/embedding/backend/aws.ts
+++ b/src/core/brain/embedding/backend/aws.ts
@@ -64,19 +64,40 @@ export class AWSBedrockEmbedder implements Embedder {
 
 	async embed(text: string): Promise<number[]> {
 		try {
+			console.log('aws bedrock embedder received: ',text)
 			const body = this.buildRequestBody(text);
+			// Logging to debug
+			console.log('aws bedrock embedder body: ', JSON.stringify(body, null, 2))
 			const command = new InvokeModelCommand({
 				modelId: this.model,
 				body: JSON.stringify(body),
 				contentType: 'application/json',
 				accept: 'application/json',
 			});
-
+			console.log('aws bedrock embedder calling: ',command)
+			console.log('aws bedrock embedder model: ', this.model)
+			console.log('aws bedrock embedder region: ', this.config.region)
+			console.log('aws bedrock embedder client config: ', JSON.stringify({
+				region: this.config.region,
+				credentials: {
+					accessKeyId: this.config.accessKeyId ? 'SET' : 'NOT SET',
+					secretAccessKey: this.config.secretAccessKey ? 'SET' : 'NOT SET'
+				}
+			}, null, 2))
+			
 			const response = await this.client.send(command);
 			const responseBody = JSON.parse(new TextDecoder().decode(response.body));
-
+			console.log('aws bedrock embedder responsed: ',responseBody)
 			return this.extractEmbedding(responseBody);
 		} catch (error) {
+			console.error('AWS Bedrock embedding error details:', {
+				error: error.message,
+				code: error.code,
+				statusCode: error.statusCode,
+				requestId: error.requestId,
+				model: this.model,
+				region: this.config.region
+			});
 			if (error instanceof EmbeddingError) {
 				throw error;
 			}

--- a/src/core/brain/embedding/backend/aws.ts
+++ b/src/core/brain/embedding/backend/aws.ts
@@ -27,6 +27,13 @@ export interface AWSBedrockEmbeddingConfig extends EmbeddingConfig {
 	dimensions?: 1024 | 512 | 256; // For Titan V2
 }
 
+interface BedrockError {
+  message: string;
+  code?: string;
+  statusCode?: number;
+  requestId?: string;
+}
+
 /**
  * AWS Bedrock embedding provider implementation
  */
@@ -64,39 +71,47 @@ export class AWSBedrockEmbedder implements Embedder {
 
 	async embed(text: string): Promise<number[]> {
 		try {
-			console.log('aws bedrock embedder received: ',text)
+			console.log('aws bedrock embedder received: ', text);
 			const body = this.buildRequestBody(text);
 			// Logging to debug
-			console.log('aws bedrock embedder body: ', JSON.stringify(body, null, 2))
+			console.log('aws bedrock embedder body: ', JSON.stringify(body, null, 2));
 			const command = new InvokeModelCommand({
 				modelId: this.model,
 				body: JSON.stringify(body),
 				contentType: 'application/json',
 				accept: 'application/json',
 			});
-			console.log('aws bedrock embedder calling: ',command)
-			console.log('aws bedrock embedder model: ', this.model)
-			console.log('aws bedrock embedder region: ', this.config.region)
-			console.log('aws bedrock embedder client config: ', JSON.stringify({
-				region: this.config.region,
-				credentials: {
-					accessKeyId: this.config.accessKeyId ? 'SET' : 'NOT SET',
-					secretAccessKey: this.config.secretAccessKey ? 'SET' : 'NOT SET'
-				}
-			}, null, 2))
-			
+			console.log('aws bedrock embedder calling: ', command);
+			console.log('aws bedrock embedder model: ', this.model);
+			console.log('aws bedrock embedder region: ', this.config.region);
+			console.log(
+				'aws bedrock embedder client config: ',
+				JSON.stringify(
+					{
+						region: this.config.region,
+						credentials: {
+							accessKeyId: this.config.accessKeyId ? 'SET' : 'NOT SET',
+							secretAccessKey: this.config.secretAccessKey ? 'SET' : 'NOT SET',
+						},
+					},
+					null,
+					2
+				)
+			);
+
 			const response = await this.client.send(command);
 			const responseBody = JSON.parse(new TextDecoder().decode(response.body));
-			console.log('aws bedrock embedder responsed: ',responseBody)
+			console.log('aws bedrock embedder responsed: ', responseBody);
 			return this.extractEmbedding(responseBody);
-		} catch (error) {
+		} catch (error: unknown) {
+			const bedrockError = error as BedrockError;
 			console.error('AWS Bedrock embedding error details:', {
-				error: error.message,
-				code: error.code,
-				statusCode: error.statusCode,
-				requestId: error.requestId,
+				error: bedrockError.message,
+				code: bedrockError.code,
+				statusCode: bedrockError.statusCode,
+				requestId: bedrockError.requestId,
 				model: this.model,
-				region: this.config.region
+				region: this.config.region,
 			});
 			if (error instanceof EmbeddingError) {
 				throw error;
@@ -116,11 +131,12 @@ export class AWSBedrockEmbedder implements Embedder {
 			}
 
 			return results;
-		} catch (error) {
+		} catch (error: unknown) {
+			const bedrockError = error as BedrockError;
 			if (error instanceof EmbeddingError) {
 				throw error;
 			}
-			throw new EmbeddingError(`Failed to generate AWS Bedrock batch embeddings: ${error}`);
+			throw new EmbeddingError(`Failed to generate AWS Bedrock batch embeddings: ${bedrockError.message}`);
 		}
 	}
 

--- a/src/core/brain/embedding/factory.ts
+++ b/src/core/brain/embedding/factory.ts
@@ -239,6 +239,7 @@ export async function createEmbedder(config: BackendConfig): Promise<Embedder> {
  * Create embedder from environment configuration
  */
 export async function createEmbedderFromEnv(): Promise<{ embedder: Embedder; info: any } | null> {
+	console.log('Attempting to parse embedding config from environment variables...');
 	const envConfig = parseEmbeddingConfigFromEnv();
 	if (!envConfig) {
 		logger.debug('No embedding configuration found in environment');

--- a/src/core/brain/llm/services/aws.ts
+++ b/src/core/brain/llm/services/aws.ts
@@ -211,7 +211,6 @@ export class AwsService implements ILLMService {
 		try {
 			while (iterationCount < this.maxIterations) {
 				iterationCount++;
-
 				// Get AI response
 				const response = await this.getAIResponse(formattedTools);
 				const { textContent, toolCalls } = this.parseResponse(response);

--- a/src/core/brain/memAgent/agent.ts
+++ b/src/core/brain/memAgent/agent.ts
@@ -90,7 +90,7 @@ export class MemAgent {
 				appMode: this.appMode || undefined,
 			});
 			let services: AgentServices | LazyAgentServices;
-			
+
 			// console.log('this.config',this.config)
 			// console.log('useLazyLoading',useLazyLoading)
 

--- a/src/core/brain/memAgent/agent.ts
+++ b/src/core/brain/memAgent/agent.ts
@@ -90,6 +90,9 @@ export class MemAgent {
 				appMode: this.appMode || undefined,
 			});
 			let services: AgentServices | LazyAgentServices;
+			
+			// console.log('this.config',this.config)
+			// console.log('useLazyLoading',useLazyLoading)
 
 			if (useLazyLoading) {
 				logger.debug('MemAgent: Using enhanced services with lazy loading');

--- a/src/core/utils/service-initializer.ts
+++ b/src/core/utils/service-initializer.ts
@@ -147,8 +147,11 @@ async function createEmbeddingFromLLMProvider(
 
 			case 'aws': {
 				// AWS Bedrock has native embeddings via Amazon Titan and Cohere
+				// Here we are 
 				const accessKeyId = llmConfig.accessKeyId || process.env.AWS_ACCESS_KEY_ID;
 				const secretAccessKey = llmConfig.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY;
+				console.log('AWS access key',accessKeyId)
+				console.log('AWS service',accessKeyId)
 				if (
 					!accessKeyId ||
 					accessKeyId.trim() === '' ||
@@ -409,11 +412,13 @@ export async function createAgentServices(
 
 				// Validate API key for explicit embedding config
 				const embeddingConfig = config.embedding as any;
+				console.log('embeddingConfig',embeddingConfig)
 				const needsApiKey = ['openai', 'gemini', 'anthropic', 'voyage', 'qwen'].includes(
 					embeddingConfig.type
 				);
 				const needsAwsCredentials = embeddingConfig.type === 'aws-bedrock';
-
+				console.log('needsApiKey',needsApiKey)
+				console.log('needsAwsCredentials',needsAwsCredentials)
 				if (needsApiKey) {
 					const apiKey =
 						embeddingConfig.apiKey || process.env[`${embeddingConfig.type.toUpperCase()}_API_KEY`];
@@ -441,9 +446,12 @@ export async function createAgentServices(
 						);
 					}
 				} else if (needsAwsCredentials) {
+					
 					const accessKeyId = embeddingConfig.accessKeyId || process.env.AWS_ACCESS_KEY_ID;
 					const secretAccessKey =
 						embeddingConfig.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY;
+					console.log('accessKeyId',accessKeyId)
+					console.log('secretAccessKey',secretAccessKey)
 					if (
 						!accessKeyId ||
 						accessKeyId.trim() === '' ||
@@ -469,7 +477,7 @@ export async function createAgentServices(
 					);
 				}
 			}
-
+			console.log('embeddingResult',embeddingResult)
 			// Priority 2: If no explicit embedding config (undefined) or disabled:false, fallback to LLM provider's embedding
 			if (!embeddingResult) {
 				if (config.llm?.provider) {

--- a/src/core/utils/service-initializer.ts
+++ b/src/core/utils/service-initializer.ts
@@ -147,11 +147,11 @@ async function createEmbeddingFromLLMProvider(
 
 			case 'aws': {
 				// AWS Bedrock has native embeddings via Amazon Titan and Cohere
-				// Here we are 
+				// Here we are
 				const accessKeyId = llmConfig.accessKeyId || process.env.AWS_ACCESS_KEY_ID;
 				const secretAccessKey = llmConfig.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY;
-				console.log('AWS access key',accessKeyId)
-				console.log('AWS service',accessKeyId)
+				console.log('AWS access key', accessKeyId);
+				console.log('AWS service', accessKeyId);
 				if (
 					!accessKeyId ||
 					accessKeyId.trim() === '' ||
@@ -412,13 +412,13 @@ export async function createAgentServices(
 
 				// Validate API key for explicit embedding config
 				const embeddingConfig = config.embedding as any;
-				console.log('embeddingConfig',embeddingConfig)
+				console.log('embeddingConfig', embeddingConfig);
 				const needsApiKey = ['openai', 'gemini', 'anthropic', 'voyage', 'qwen'].includes(
 					embeddingConfig.type
 				);
 				const needsAwsCredentials = embeddingConfig.type === 'aws-bedrock';
-				console.log('needsApiKey',needsApiKey)
-				console.log('needsAwsCredentials',needsAwsCredentials)
+				console.log('needsApiKey', needsApiKey);
+				console.log('needsAwsCredentials', needsAwsCredentials);
 				if (needsApiKey) {
 					const apiKey =
 						embeddingConfig.apiKey || process.env[`${embeddingConfig.type.toUpperCase()}_API_KEY`];
@@ -446,12 +446,11 @@ export async function createAgentServices(
 						);
 					}
 				} else if (needsAwsCredentials) {
-					
 					const accessKeyId = embeddingConfig.accessKeyId || process.env.AWS_ACCESS_KEY_ID;
 					const secretAccessKey =
 						embeddingConfig.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY;
-					console.log('accessKeyId',accessKeyId)
-					console.log('secretAccessKey',secretAccessKey)
+					console.log('accessKeyId', accessKeyId);
+					console.log('secretAccessKey', secretAccessKey);
 					if (
 						!accessKeyId ||
 						accessKeyId.trim() === '' ||
@@ -477,7 +476,7 @@ export async function createAgentServices(
 					);
 				}
 			}
-			console.log('embeddingResult',embeddingResult)
+			console.log('embeddingResult', embeddingResult);
 			// Priority 2: If no explicit embedding config (undefined) or disabled:false, fallback to LLM provider's embedding
 			if (!embeddingResult) {
 				if (config.llm?.provider) {

--- a/src/core/utils/service-initializer.ts
+++ b/src/core/utils/service-initializer.ts
@@ -150,8 +150,6 @@ async function createEmbeddingFromLLMProvider(
 				// Here we are
 				const accessKeyId = llmConfig.accessKeyId || process.env.AWS_ACCESS_KEY_ID;
 				const secretAccessKey = llmConfig.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY;
-				console.log('AWS access key', accessKeyId);
-				console.log('AWS service', accessKeyId);
 				if (
 					!accessKeyId ||
 					accessKeyId.trim() === '' ||
@@ -412,13 +410,11 @@ export async function createAgentServices(
 
 				// Validate API key for explicit embedding config
 				const embeddingConfig = config.embedding as any;
-				console.log('embeddingConfig', embeddingConfig);
 				const needsApiKey = ['openai', 'gemini', 'anthropic', 'voyage', 'qwen'].includes(
 					embeddingConfig.type
 				);
 				const needsAwsCredentials = embeddingConfig.type === 'aws-bedrock';
-				console.log('needsApiKey', needsApiKey);
-				console.log('needsAwsCredentials', needsAwsCredentials);
+
 				if (needsApiKey) {
 					const apiKey =
 						embeddingConfig.apiKey || process.env[`${embeddingConfig.type.toUpperCase()}_API_KEY`];
@@ -476,7 +472,7 @@ export async function createAgentServices(
 					);
 				}
 			}
-			console.log('embeddingResult', embeddingResult);
+
 			// Priority 2: If no explicit embedding config (undefined) or disabled:false, fallback to LLM provider's embedding
 			if (!embeddingResult) {
 				if (config.llm?.provider) {

--- a/src/core/utils/service-initializer.ts
+++ b/src/core/utils/service-initializer.ts
@@ -737,7 +737,6 @@ export async function createAgentServices(
 			logger.debug('Initializing LLM service...');
 		}
 		const llmConfig = stateManager.getLLMConfig();
-
 		// Use ServiceCache for ContextManager to prevent duplicate creation
 		const serviceCache = getServiceCache();
 		const contextManagerKey = createServiceKey('contextManager', {
@@ -751,9 +750,7 @@ export async function createAgentServices(
 		contextManager = await serviceCache.getOrCreate(contextManagerKey, async () => {
 			return createContextManager(llmConfig, promptManager, undefined, undefined);
 		});
-
 		llmService = createLLMService(llmConfig, mcpManager, contextManager);
-
 		if (appMode !== 'cli') {
 			logger.info('LLM service initialized successfully', {
 				provider: llmConfig.provider,


### PR DESCRIPTION
### PR Description

This pull request resolves **#206** 

#### Example Configuration

```yaml
provider: aws
model: us.anthropic.claude-3-5-sonnet-20241022-v2:0  # Or another Bedrock-supported model
maxIterations: 50
aws:
  region: $AWS_REGION
  accessKeyId: $AWS_ACCESS_KEY_ID
  secretAccessKey: $AWS_SECRET_ACCESS_KEY
  sessionToken: $AWS_SESSION_TOKEN   # Optional, for temporary credentials
```

#### Notes

* `sessionToken` is optional and can be used for temporary AWS credentials.
* This change ensures better flexibility when integrating with AWS Bedrock.
