### PR TITLE
Fix/fix UI tool display streamable http

### DIFF
--- a/memAgent/cipher.yml
+++ b/memAgent/cipher.yml
@@ -13,10 +13,10 @@ mcpServers: {}
 
 # Choose ONLY ONE of the following LLM providers
 llm:
-  # provider: openai
-  # model: gpt-4.1-mini
-  # apiKey: $OPENAI_API_KEY
-  # maxIterations: 50
+  provider: openai
+  model: gpt-4.1-mini
+  apiKey: $OPENAI_API_KEY
+  maxIterations: 50
 
   # provider: gemini
   # model: gemini-2.5-flash
@@ -43,14 +43,14 @@ llm:
 
 
 # --- AWS Bedrock LLM Configuration ---
-  provider: aws
-  model: us.anthropic.claude-3-5-sonnet-20241022-v2:0  # Or another Bedrock-supported model
-  maxIterations: 50
-  aws:
-    region: $AWS_REGION
-    accessKeyId: $AWS_ACCESS_KEY_ID
-    secretAccessKey: $AWS_SECRET_ACCESS_KEY
-    sessionToken: $AWS_SESSION_TOKEN   # Optional, for temporary credentials
+  # provider: aws
+  # model: us.anthropic.claude-3-5-sonnet-20241022-v2:0  # Or another Bedrock-supported model
+  # maxIterations: 50
+  # aws:
+  #   region: $AWS_REGION
+  #   accessKeyId: $AWS_ACCESS_KEY_ID
+  #   secretAccessKey: $AWS_SECRET_ACCESS_KEY
+  #   sessionToken: $AWS_SESSION_TOKEN   # Optional, for temporary credentials
 
 # --- Azure OpenAI LLM Configuration ---
 #   provider: azure

--- a/src/app/api/websocket/event-subscriber.ts
+++ b/src/app/api/websocket/event-subscriber.ts
@@ -5,6 +5,7 @@ import { WebSocketResponse, WebSocketEventType, WebSocketEventData } from './typ
 
 export class WebSocketEventSubscriber {
 	private abortController: AbortController | null = null;
+	private sessionAbortControllers = new Map<string, AbortController>();
 	private subscribedSessions = new Set<string>();
 	private subscriptionStats = {
 		totalEventsReceived: 0,
@@ -173,7 +174,11 @@ export class WebSocketEventSubscriber {
 
 		activeSessions.forEach(sessionId => {
 			if (!this.subscribedSessions.has(sessionId)) {
-				this.subscribeToSingleSessionEvents(sessionId, signal);
+				// Create session-specific abort controller for existing sessions too
+				const sessionAbortController = new AbortController();
+				this.sessionAbortControllers.set(sessionId, sessionAbortController);
+				
+				this.subscribeToSingleSessionEvents(sessionId, sessionAbortController.signal);
 				this.subscribedSessions.add(sessionId);
 			}
 		});
@@ -190,7 +195,12 @@ export class WebSocketEventSubscriber {
 	public subscribeToSession(sessionId: string): void {
 		if (this.abortController && !this.subscribedSessions.has(sessionId)) {
 			logger.debug('Dynamically subscribing to session events', { sessionId });
-			this.subscribeToSingleSessionEvents(sessionId, this.abortController.signal);
+			
+			// Create session-specific abort controller to prevent memory leaks
+			const sessionAbortController = new AbortController();
+			this.sessionAbortControllers.set(sessionId, sessionAbortController);
+			
+			this.subscribeToSingleSessionEvents(sessionId, sessionAbortController.signal);
 			this.subscribedSessions.add(sessionId);
 		} else if (this.subscribedSessions.has(sessionId)) {
 			logger.debug('Session already subscribed, skipping', { sessionId });
@@ -202,8 +212,15 @@ export class WebSocketEventSubscriber {
 	 */
 	public unsubscribeFromSession(sessionId: string): void {
 		if (this.subscribedSessions.has(sessionId)) {
+			// Abort session-specific events to clean up listeners
+			const sessionAbortController = this.sessionAbortControllers.get(sessionId);
+			if (sessionAbortController) {
+				sessionAbortController.abort();
+				this.sessionAbortControllers.delete(sessionId);
+			}
+			
 			this.subscribedSessions.delete(sessionId);
-			logger.debug('Session removed from subscription tracking', { sessionId });
+			logger.debug('Session removed from subscription tracking and listeners cleaned up', { sessionId });
 		}
 	}
 
@@ -332,6 +349,8 @@ export class WebSocketEventSubscriber {
 					toolName: data.toolName,
 					sessionId: data.sessionId,
 					executionId: data.executionId,
+					argsKeys: data.args ? Object.keys(data.args) : [],
+					args: data.args,
 				});
 
 				// Send the specific tool execution started event
@@ -342,6 +361,7 @@ export class WebSocketEventSubscriber {
 						sessionId: data.sessionId,
 						callId: data.executionId,
 						executionId: data.executionId,
+						args: data.args || {}, // Pass through tool arguments
 					},
 					signal
 				);
@@ -361,6 +381,7 @@ export class WebSocketEventSubscriber {
 						sessionId: data.sessionId,
 						callId: data.executionId,
 						executionId: data.executionId,
+						result: data.result, // Include tool result in WebSocket event
 					},
 					signal
 				);
@@ -541,9 +562,16 @@ export class WebSocketEventSubscriber {
 		if (this.abortController) {
 			this.abortController.abort();
 			this.abortController = null;
-			this.subscribedSessions.clear();
-			logger.info('WebSocket event subscriptions terminated');
 		}
+		
+		// Clean up all session-specific abort controllers
+		this.sessionAbortControllers.forEach((controller, sessionId) => {
+			controller.abort();
+		});
+		this.sessionAbortControllers.clear();
+		this.subscribedSessions.clear();
+		
+		logger.info('WebSocket event subscriptions terminated and all session controllers cleaned up');
 	}
 
 	/**

--- a/src/app/api/websocket/event-subscriber.ts
+++ b/src/app/api/websocket/event-subscriber.ts
@@ -363,7 +363,7 @@ export class WebSocketEventSubscriber {
 						sessionId: data.sessionId,
 						callId: data.executionId,
 						executionId: data.executionId,
-						args: data.args || {}, // Pass through tool arguments
+						args: data.args || {},
 					},
 					signal
 				);
@@ -383,7 +383,7 @@ export class WebSocketEventSubscriber {
 						sessionId: data.sessionId,
 						callId: data.executionId,
 						executionId: data.executionId,
-						result: data.result, // Include tool result in WebSocket event
+						result: data.result,
 					},
 					signal
 				);

--- a/src/app/api/websocket/event-subscriber.ts
+++ b/src/app/api/websocket/event-subscriber.ts
@@ -177,7 +177,7 @@ export class WebSocketEventSubscriber {
 				// Create session-specific abort controller for existing sessions too
 				const sessionAbortController = new AbortController();
 				this.sessionAbortControllers.set(sessionId, sessionAbortController);
-				
+
 				this.subscribeToSingleSessionEvents(sessionId, sessionAbortController.signal);
 				this.subscribedSessions.add(sessionId);
 			}
@@ -195,11 +195,11 @@ export class WebSocketEventSubscriber {
 	public subscribeToSession(sessionId: string): void {
 		if (this.abortController && !this.subscribedSessions.has(sessionId)) {
 			logger.debug('Dynamically subscribing to session events', { sessionId });
-			
+
 			// Create session-specific abort controller to prevent memory leaks
 			const sessionAbortController = new AbortController();
 			this.sessionAbortControllers.set(sessionId, sessionAbortController);
-			
+
 			this.subscribeToSingleSessionEvents(sessionId, sessionAbortController.signal);
 			this.subscribedSessions.add(sessionId);
 		} else if (this.subscribedSessions.has(sessionId)) {
@@ -218,9 +218,11 @@ export class WebSocketEventSubscriber {
 				sessionAbortController.abort();
 				this.sessionAbortControllers.delete(sessionId);
 			}
-			
+
 			this.subscribedSessions.delete(sessionId);
-			logger.debug('Session removed from subscription tracking and listeners cleaned up', { sessionId });
+			logger.debug('Session removed from subscription tracking and listeners cleaned up', {
+				sessionId,
+			});
 		}
 	}
 
@@ -563,14 +565,14 @@ export class WebSocketEventSubscriber {
 			this.abortController.abort();
 			this.abortController = null;
 		}
-		
+
 		// Clean up all session-specific abort controllers
 		this.sessionAbortControllers.forEach((controller, sessionId) => {
 			controller.abort();
 		});
 		this.sessionAbortControllers.clear();
 		this.subscribedSessions.clear();
-		
+
 		logger.info('WebSocket event subscriptions terminated and all session controllers cleaned up');
 	}
 

--- a/src/app/api/websocket/types.ts
+++ b/src/app/api/websocket/types.ts
@@ -89,6 +89,7 @@ export interface WebSocketEventData {
 		sessionId: string;
 		callId?: string;
 		executionId?: string;
+		args?: Record<string, any>;
 	};
 	toolExecutionProgress: {
 		toolName: string;
@@ -110,6 +111,7 @@ export interface WebSocketEventData {
 		sessionId: string;
 		callId?: string;
 		executionId?: string;
+		result?: any;
 	};
 	toolExecutionFailed: {
 		toolName: string;

--- a/src/app/ui/src/hooks/use-chat.ts
+++ b/src/app/ui/src/hooks/use-chat.ts
@@ -327,13 +327,6 @@ export function useChat(wsUrl: string, options: UseChatOptions = {}) {
 		const name = payload.toolName;
 		const callId = payload.callId || payload.executionId;
 
-		console.log('Frontend: Received toolExecutionStarted WebSocket event', {
-			toolName: name,
-			callId,
-			argsKeys: payload.args ? Object.keys(payload.args) : [],
-			args: payload.args,
-			payload,
-		});
 
 		// Add a tool message to show tool execution started
 		const startMessage: ChatMessage = {

--- a/src/app/ui/src/hooks/use-chat.ts
+++ b/src/app/ui/src/hooks/use-chat.ts
@@ -359,10 +359,10 @@ export function useChat(wsUrl: string, options: UseChatOptions = {}) {
 			setMessages(ms => {
 				const idx = ms.findIndex(m => m.toolExecutionId === callId && m.role === 'tool');
 				if (idx !== -1) {
-					const updatedMsg: ChatMessage = { 
-						...ms[idx], 
+					const updatedMsg: ChatMessage = {
+						...ms[idx],
 						content: `⏳ ${progress}`,
-						createdAt: Date.now()
+						createdAt: Date.now(),
 					};
 					return [...ms.slice(0, idx), updatedMsg, ...ms.slice(idx + 1)];
 				}
@@ -385,7 +385,7 @@ export function useChat(wsUrl: string, options: UseChatOptions = {}) {
 						...msg,
 						content: null, // Clear progress content
 						toolResult: result,
-						createdAt: Date.now()
+						createdAt: Date.now(),
 					};
 				}
 				return msg;

--- a/src/app/ui/src/hooks/use-chat.ts
+++ b/src/app/ui/src/hooks/use-chat.ts
@@ -327,7 +327,6 @@ export function useChat(wsUrl: string, options: UseChatOptions = {}) {
 		const name = payload.toolName;
 		const callId = payload.callId || payload.executionId;
 
-
 		// Add a tool message to show tool execution started
 		const startMessage: ChatMessage = {
 			id: generateUniqueId(),

--- a/src/core/brain/tools/unified-tool-manager.ts
+++ b/src/core/brain/tools/unified-tool-manager.ts
@@ -388,7 +388,7 @@ export class UnifiedToolManager {
 					executionId,
 					duration: Date.now() - startTime,
 					success: true,
-					result: result, // Include the actual tool result
+					result: result,
 					timestamp: Date.now(),
 				});
 			}

--- a/src/core/brain/tools/unified-tool-manager.ts
+++ b/src/core/brain/tools/unified-tool-manager.ts
@@ -331,7 +331,7 @@ export class UnifiedToolManager {
 				argsKeys: args ? Object.keys(args) : [],
 				args: args,
 			});
-			
+
 			this.eventManager.emitSessionEvent(sessionId, SessionEvents.TOOL_EXECUTION_STARTED, {
 				toolName,
 				toolType,
@@ -446,7 +446,7 @@ export class UnifiedToolManager {
 				argsKeys: args ? Object.keys(args) : [],
 				args: args,
 			});
-			
+
 			this.eventManager.emitSessionEvent(sessionId, SessionEvents.TOOL_EXECUTION_STARTED, {
 				toolName,
 				toolType,

--- a/src/core/brain/tools/unified-tool-manager.ts
+++ b/src/core/brain/tools/unified-tool-manager.ts
@@ -323,12 +323,22 @@ export class UnifiedToolManager {
 
 		// Emit tool execution started event
 		if (this.eventManager && sessionId) {
+			logger.debug('UnifiedToolManager: Emitting tool execution started event', {
+				toolName,
+				toolType,
+				sessionId,
+				executionId,
+				argsKeys: args ? Object.keys(args) : [],
+				args: args,
+			});
+			
 			this.eventManager.emitSessionEvent(sessionId, SessionEvents.TOOL_EXECUTION_STARTED, {
 				toolName,
 				toolType,
 				sessionId,
 				executionId,
 				timestamp: startTime,
+				args: args, // Include tool arguments
 			});
 		}
 
@@ -378,6 +388,7 @@ export class UnifiedToolManager {
 					executionId,
 					duration: Date.now() - startTime,
 					success: true,
+					result: result, // Include the actual tool result
 					timestamp: Date.now(),
 				});
 			}
@@ -427,12 +438,22 @@ export class UnifiedToolManager {
 
 		// Emit tool execution started event
 		if (this.eventManager && sessionId) {
+			logger.debug('UnifiedToolManager: Emitting tool execution started event', {
+				toolName,
+				toolType,
+				sessionId,
+				executionId,
+				argsKeys: args ? Object.keys(args) : [],
+				args: args,
+			});
+			
 			this.eventManager.emitSessionEvent(sessionId, SessionEvents.TOOL_EXECUTION_STARTED, {
 				toolName,
 				toolType,
 				sessionId,
 				executionId,
 				timestamp: startTime,
+				args: args, // Include tool arguments
 			});
 		}
 

--- a/src/core/events/event-types.ts
+++ b/src/core/events/event-types.ts
@@ -78,6 +78,7 @@ export interface SessionEventMap {
 		sessionId: string;
 		executionId: string;
 		timestamp: number;
+		args?: any; // Tool arguments
 	};
 	'tool:executionCompleted': {
 		toolName: string;

--- a/src/core/mcp/client.ts
+++ b/src/core/mcp/client.ts
@@ -244,16 +244,7 @@ export class MCPClient implements IMCPClient {
 			? { requestInit: { headers: config.headers } }
 			: undefined;
 		const transport = new StreamableHTTPClientTransport(new URL(config.url), transportOptions);
-		// Ensure sessionId is always a string to satisfy Transport interface
-		if (transport.sessionId === undefined) {
-			Object.defineProperty(transport, 'sessionId', {
-				value: '',
-				writable: true,
-				enumerable: true,
-				configurable: true,
-			});
-		}
-		return transport as Transport;
+		return transport;
 	}
 
 	/**

--- a/src/core/mcp/client.ts
+++ b/src/core/mcp/client.ts
@@ -244,8 +244,8 @@ export class MCPClient implements IMCPClient {
 			? { requestInit: { headers: config.headers } }
 			: undefined;
 		const transport = new StreamableHTTPClientTransport(new URL(config.url), transportOptions);
-		// Satisfy Transport typing (sessionId is optional in SDK transport); no runtime change
-		return transport as unknown as Transport;
+		// Fix type compatibility with exact optional property types
+		return transport as Transport;
 	}
 
 	/**

--- a/src/core/mcp/client.ts
+++ b/src/core/mcp/client.ts
@@ -244,7 +244,8 @@ export class MCPClient implements IMCPClient {
 			? { requestInit: { headers: config.headers } }
 			: undefined;
 		const transport = new StreamableHTTPClientTransport(new URL(config.url), transportOptions);
-		return transport;
+		// Satisfy Transport typing (sessionId is optional in SDK transport); no runtime change
+		return transport as unknown as Transport;
 	}
 
 	/**

--- a/src/core/storage/backend/sqlite.ts
+++ b/src/core/storage/backend/sqlite.ts
@@ -81,7 +81,7 @@ export class SqliteBackend implements DatabaseBackend {
 			// Ensure directory exists
 			const dir = dirname(this.dbPath);
 			this.logger.debug('Ensuring database directory exists', { dir, dbPath: this.dbPath });
-			
+
 			if (!existsSync(dir)) {
 				await mkdir(dir, { recursive: true });
 				this.logger.debug('Created database directory', { dir });
@@ -90,7 +90,7 @@ export class SqliteBackend implements DatabaseBackend {
 			// Open database with enhanced error handling
 			this.logger.debug('Opening SQLite database', { path: this.dbPath });
 			this.db = new Database(this.dbPath);
-			
+
 			if (!this.db) {
 				throw new Error('Failed to create SQLite database connection - database instance is null');
 			}
@@ -110,9 +110,9 @@ export class SqliteBackend implements DatabaseBackend {
 			this.prepareStatements();
 
 			this.connected = true;
-			this.logger.info('SQLite backend connected successfully', { 
+			this.logger.info('SQLite backend connected successfully', {
 				path: this.dbPath,
-				dbSize: this.getDbInfo()
+				dbSize: this.getDbInfo(),
 			});
 		} catch (error) {
 			const errorDetails = {
@@ -123,11 +123,11 @@ export class SqliteBackend implements DatabaseBackend {
 				stack: error instanceof Error ? error.stack : undefined,
 				nodeVersion: process.version,
 				platform: process.platform,
-				arch: process.arch
+				arch: process.arch,
 			};
 
 			this.logger.error('Failed to connect to SQLite database', errorDetails);
-			
+
 			throw new StorageConnectionError(
 				`Failed to connect to SQLite database: ${error instanceof Error ? error.message : String(error)}`,
 				BACKEND_TYPES.SQLITE,


### PR DESCRIPTION
### Title
Fix: Streamable-HTTP MCP transport + Tool Panel payloads

### Summary
- Streamable-HTTP: remove nonstandard sessionId override; return SDK transport via safe cast; fixes post-connect listTools failures.
- Tool Panel: add `args` to `toolExecutionStarted` and `result` to `toolExecutionCompleted` for real-time display.

### Changes
- `src/core/mcp/client.ts`: use `StreamableHTTPClientTransport` as-is; type-safe cast; preserve headers.
- `src/app/api/websocket/types.ts`: add optional `args` and `result`.