### PR TITLE
feat(config): add schema for Cipher MCP server configuration

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -8,8 +8,44 @@ startCommand:
     [
       'sh',
       '-c',
-      'node dist/src/app/index.cjs --mode mcp --transport http --port $PORT --host 0.0.0.0 --agent $CONFIG_FILE',
+      'node dist/src/app/index.cjs --mode mcp --mcp-transport-type http --port $PORT --host 0.0.0.0 --agent ${CONFIG_FILE:-/app/memAgent/cipher.yml}',
     ]
+  configSchema:
+    type: object
+    description: 'Configuration for Cipher MCP server - memory-powered AI agent framework'
+    properties:
+      llmProvider:
+        type: string
+        description: 'LLM provider to use (openai, anthropic, gemini, etc.)'
+        default: 'openai'
+      llmModel:
+        type: string
+        description: 'LLM model name'
+        default: 'gpt-4o-mini'
+      llmApiKey:
+        type: string
+        description: 'API key for the LLM provider'
+      embeddingProvider:
+        type: string
+        description: 'Embedding provider (openai, gemini, ollama, etc.)'
+        default: 'openai'
+      embeddingModel:
+        type: string
+        description: 'Embedding model name'
+        default: 'text-embedding-3-small'
+      embeddingApiKey:
+        type: string
+        description: 'API key for embedding provider'
+    required:
+      - llmApiKey
+      - embeddingApiKey
+    exampleConfig:
+      llmProvider: 'openai'
+      llmModel: 'gpt-4o-mini'
+      llmApiKey: 'sk-...'
+      embeddingProvider: 'openai'
+      embeddingModel: 'text-embedding-3-small'
+      embeddingApiKey: 'sk-...'
 http:
   port: 3000
   healthCheckPath: '/health'


### PR DESCRIPTION
- Define config schema with object type and description
- Add properties for LLM and embedding providers, models, and API keys
- Set default values for providers and models
- Mark llmApiKey and embeddingApiKey as required fields
- Provide an example configuration for reference
- Update startCommand with improved environment variable usage and parameters