### PR TITLE
feat(server): add root and health endpoints for API and MCP servers

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -8,7 +8,7 @@ startCommand:
     [
       'sh',
       '-c',
-      'node dist/src/app/index.cjs --mode mcp --mcp-transport-type http --port $PORT --host 0.0.0.0 --agent ${CONFIG_FILE:-/app/memAgent/cipher.yml}',
+      'node dist/src/app/index.cjs --mode api --port $PORT --host 0.0.0.0 --agent ${CONFIG_FILE:-/app/memAgent/cipher.yml}',
     ]
   configSchema:
     type: object

--- a/src/app/api/server.ts
+++ b/src/app/api/server.ts
@@ -532,6 +532,29 @@ export class ApiServer {
 	}
 
 	private setupRoutes(): void {
+		// Root endpoint for server discovery (Smithery scanning)
+		this.app.get('/', (_req: Request, res: Response) => {
+			res.json({
+				name: 'Cipher API Server',
+				description: 'Memory-powered AI agent framework with MCP integration',
+				version: process.env.npm_package_version || '0.3.0',
+				mode: 'api',
+				endpoints: {
+					health: '/health',
+					mcp: '/api/mcp',
+					mcpSse: '/api/mcp/sse',
+					websocket: '/ws',
+				},
+				capabilities: {
+					mcp: true,
+					websocket: this.config.enableWebSocket || false,
+					tools: true,
+					resources: true,
+					prompts: true,
+				},
+			});
+		});
+
 		// Health check endpoint
 		this.app.get('/health', (_req: Request, res: Response) => {
 			const healthData: any = {

--- a/src/app/mcp/mcp_streamable_http_server.ts
+++ b/src/app/mcp/mcp_streamable_http_server.ts
@@ -244,6 +244,40 @@ export class McpStreamableHttpServer {
 		// Map to store transports by session ID (following MCP SDK example)
 		const transports: { [sessionId: string]: StreamableHTTPServerTransport } = {};
 
+		// Health check endpoint for deployment platforms like Smithery
+		this.app.get('/health', (_req: Request, res: Response) => {
+			res.json({
+				status: 'healthy',
+				timestamp: new Date().toISOString(),
+				uptime: process.uptime(),
+				mode: 'mcp-http',
+				version: process.env.npm_package_version || 'unknown',
+				endpoints: {
+					mcp: '/http',
+				},
+			});
+		});
+
+		// Root endpoint to provide MCP server information for discovery
+		this.app.get('/', (_req: Request, res: Response) => {
+			res.json({
+				name: 'Cipher MCP Server',
+				description: 'Memory-powered AI agent framework with MCP integration',
+				version: process.env.npm_package_version || '0.3.0',
+				transport: 'streamable-http',
+				endpoints: {
+					mcp: '/http',
+					health: '/health',
+				},
+				capabilities: {
+					tools: true,
+					resources: true,
+					prompts: true,
+					logging: true,
+				},
+			});
+		});
+
 		// POST /http - Main endpoint for streamable-HTTP requests (initialization and messages)
 		this.app.post('/http', async (req: Request, res: Response) => {
 			logger.debug('[MCP Streamable-HTTP Server] POST request received');


### PR DESCRIPTION
- Add root `/` endpoint in ApiServer for service discovery with metadata and capabilities
- Add `/health` endpoint in MCP Streamable HTTP server for deployment health checks
- Implement root `/` endpoint in MCP server to provide server info and supported endpoints
- Update smithery.yaml to switch start command mode to `api` from `mcp` with corresponding config changes