### PR TITLE
fix: Ignore all node_modules folders in .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 # Node.js
-node_modules/
+**/node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*


### PR DESCRIPTION


 What problem this solves

Docker builds were including unnecessary nested node_modules folders, leading to larger image sizes and slower build times.

 How this solves it

Updated .dockerignore to use a recursive pattern **/node_modules/ instead of node_modules/, ensuring all nested node_modules folders across the repository are ignored during Docker builds.

 Tests performed

Built Docker image locally to confirm all nested node_modules folders are ignored.

Verified that no required files were excluded and build completes successfully.

⚠️ Breaking changes

None.

🔗 Related issues

Fixes #266

✅ Pull Request Checklist

 Code follows project style guidelines

 Self-review completed

 Tests added/updated and passing (not applicable for this small fix)

 No breaking changes (or clearly documented)

 Commits follow conventional format

 Branch is up to date with main