### PR TITLE
Fix .dockerignore to exclude nested node_modules directories

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 # Node.js
 node_modules/
+**/node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*


### PR DESCRIPTION
## Summary
- update `.dockerignore` so that nested `node_modules` folders are excluded from Docker build contexts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e9e89832908324ab622c165b5a00cb