### PR TITLE
fix: redact sensitive data in MCP resource endpoints

### DIFF
--- a/src/app/mcp/mcp_handler.ts
+++ b/src/app/mcp/mcp_handler.ts
@@ -16,6 +16,7 @@ import * as path from 'path';
 import type { AggregatorConfig } from '@core/mcp/types.js';
 import { McpSseServer } from './mcp_sse_server.js';
 import { McpStreamableHttpServer } from './mcp_streamable_http_server.js';
+import { redactSensitiveData } from '../api/utils/security.js';
 
 // Derive the AgentCard type from the schema
 export type AgentCard = z.infer<typeof AgentCardSchema>;
@@ -370,7 +371,7 @@ async function getAgentCardResource(agentCard: AgentCard): Promise<any> {
 			{
 				uri: 'cipher://agent/card',
 				mimeType: 'application/json',
-				text: JSON.stringify(agentCard, null, 2),
+				text: JSON.stringify(redactSensitiveData(agentCard), null, 2),
 			},
 		],
 	};
@@ -395,7 +396,9 @@ async function getAgentStatsResource(agent: MemAgent): Promise<any> {
 				connectedClients: mcpClients.size,
 				failedConnections: Object.keys(failedConnections).length,
 				clientNames: Array.from(mcpClients.keys()),
-				failures: failedConnections,
+				failures: Object.fromEntries(
+					Object.keys(failedConnections).map(name => [name, 'Connection failed'])
+				),
 			},
 			uptime: process.uptime(),
 			memoryUsage: process.memoryUsage(),
@@ -416,7 +419,7 @@ async function getAgentStatsResource(agent: MemAgent): Promise<any> {
 		logger.error('[MCP Handler] Error getting agent stats', { error: errorMessage });
 
 		const errorStats = {
-			error: `Failed to retrieve stats: ${errorMessage}`,
+			error: 'Failed to retrieve stats',
 			timestamp: new Date().toISOString(),
 		};
 

--- a/src/core/knowledge_graph/backend/neo4j.ts
+++ b/src/core/knowledge_graph/backend/neo4j.ts
@@ -931,70 +931,68 @@ export class Neo4jBackend implements KnowledgeGraph {
 		return converted;
 	}
 
-        private buildFilterConstraints(
-                filters: NodeFilters | EdgeFilters,
-                prefix: string,
-                params: any
-        ): string {
-                const constraints: string[] = [];
+	private buildFilterConstraints(
+		filters: NodeFilters | EdgeFilters,
+		prefix: string,
+		params: any
+	): string {
+		const constraints: string[] = [];
 
-                for (const [rawKey, filter] of Object.entries(filters)) {
-                        const propertyKey = this.escapePropertyKey(rawKey);
-                        const paramKey = `${prefix}_${Object.keys(params).length}`;
+		for (const [rawKey, filter] of Object.entries(filters)) {
+			const propertyKey = this.escapePropertyKey(rawKey);
+			const paramKey = `${prefix}_${Object.keys(params).length}`;
 
-                        if (typeof filter === 'object' && filter !== null && !Array.isArray(filter)) {
-                                // Range filters
-                                if ('gte' in filter) {
-                                        constraints.push(`${prefix}.${propertyKey} >= $${paramKey}_gte`);
-                                        params[`${paramKey}_gte`] = filter.gte;
-                                }
-                                if ('gt' in filter) {
-                                        constraints.push(`${prefix}.${propertyKey} > $${paramKey}_gt`);
-                                        params[`${paramKey}_gt`] = filter.gt;
-                                }
-                                if ('lte' in filter) {
-                                        constraints.push(`${prefix}.${propertyKey} <= $${paramKey}_lte`);
-                                        params[`${paramKey}_lte`] = filter.lte;
-                                }
-                                if ('lt' in filter) {
-                                        constraints.push(`${prefix}.${propertyKey} < $${paramKey}_lt`);
-                                        params[`${paramKey}_lt`] = filter.lt;
-                                }
+			if (typeof filter === 'object' && filter !== null && !Array.isArray(filter)) {
+				// Range filters
+				if ('gte' in filter) {
+					constraints.push(`${prefix}.${propertyKey} >= $${paramKey}_gte`);
+					params[`${paramKey}_gte`] = filter.gte;
+				}
+				if ('gt' in filter) {
+					constraints.push(`${prefix}.${propertyKey} > $${paramKey}_gt`);
+					params[`${paramKey}_gt`] = filter.gt;
+				}
+				if ('lte' in filter) {
+					constraints.push(`${prefix}.${propertyKey} <= $${paramKey}_lte`);
+					params[`${paramKey}_lte`] = filter.lte;
+				}
+				if ('lt' in filter) {
+					constraints.push(`${prefix}.${propertyKey} < $${paramKey}_lt`);
+					params[`${paramKey}_lt`] = filter.lt;
+				}
 
-                                // Array filters
-                                if ('any' in filter && Array.isArray(filter.any)) {
-                                        constraints.push(`${prefix}.${propertyKey} IN $${paramKey}`);
-                                        params[paramKey] = filter.any;
-                                }
-                                if ('all' in filter && Array.isArray(filter.all)) {
-                                        // For 'all' filter, check if the property (assumed to be array) contains all values
-                                        constraints.push(
-                                                `all(x IN $${paramKey} WHERE x IN ${prefix}.${propertyKey})`
-                                        );
-                                        params[paramKey] = filter.all;
-                                }
-                        } else {
-                                // Direct equality
-                                constraints.push(`${prefix}.${propertyKey} = $${paramKey}`);
-                                params[paramKey] = filter;
-                        }
-                }
+				// Array filters
+				if ('any' in filter && Array.isArray(filter.any)) {
+					constraints.push(`${prefix}.${propertyKey} IN $${paramKey}`);
+					params[paramKey] = filter.any;
+				}
+				if ('all' in filter && Array.isArray(filter.all)) {
+					// For 'all' filter, check if the property (assumed to be array) contains all values
+					constraints.push(`all(x IN $${paramKey} WHERE x IN ${prefix}.${propertyKey})`);
+					params[paramKey] = filter.all;
+				}
+			} else {
+				// Direct equality
+				constraints.push(`${prefix}.${propertyKey} = $${paramKey}`);
+				params[paramKey] = filter;
+			}
+		}
 
-                return constraints.join(' AND ');
-        }
+		return constraints.join(' AND ');
+	}
 
-        private escapePropertyKey(key: string): string {
-                if (key.trim().length === 0) {
-                        throw new Error('Filter property names must not be empty.');
-                }
+	private escapePropertyKey(key: string): string {
+		if (key.trim().length === 0) {
+			throw new Error('Filter property names must not be empty.');
+		}
 
-                if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
-                        return key;
-                }
+		if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+			return key;
+		}
 
-                const escapedKey = key.replace(/`/g, '``');
-                return `\`${escapedKey}\``;
-        }
+		const escapedKey = key.replace(/`/g, '``');
+		return `\`${escapedKey}\``;
+	}
 
 	private async createIndexes(): Promise<void> {
 		const session = this.getSession();


### PR DESCRIPTION
## Summary
- Apply `redactSensitiveData()` to `cipher://agent/card` resource to mask sensitive fields before serialization
- Replace raw error messages in `cipher://agent/stats` failed connections with generic "Connection failed" — prevents leaking API keys, URLs, or credentials via error strings
- Stop exposing raw error details in the stats error handler catch block

Uses the existing `redactSensitiveData()` utility from `src/app/api/utils/security.ts`, already used by the REST API `/api/config` route.

## Test plan
- [x] All 11 MCP endpoint tests pass
- [x] `pnpm run format:check` passes
- [x] TypeScript compiles (no new errors)
- [x] Response shape unchanged — same JSON keys, sanitized values only

Fixes #292