### PR TITLE
fix: add DISABLE_SIGNIFICANCE_FILTER env var to bypass memory filtering

### DIFF
--- a/src/core/brain/tools/definitions/memory/extract_and_operate_memory.ts
+++ b/src/core/brain/tools/definitions/memory/extract_and_operate_memory.ts
@@ -20,6 +20,10 @@ function isSignificantKnowledge(content: string): boolean {
 		return false;
 	}
 
+	if (process.env.DISABLE_SIGNIFICANCE_FILTER === 'true') {
+		return true;
+	}
+
 	const text = content.toLowerCase().trim();
 
 	// Skip trivial tool results and non-technical content

--- a/src/core/brain/tools/definitions/memory/workspace_store.ts
+++ b/src/core/brain/tools/definitions/memory/workspace_store.ts
@@ -39,6 +39,10 @@ function isWorkspaceSignificantContent(content: string): boolean {
 		return false;
 	}
 
+	if (process.env.DISABLE_SIGNIFICANCE_FILTER === 'true') {
+		return true;
+	}
+
 	const text = content.toLowerCase().trim();
 
 	// Skip patterns that are not workspace-relevant

--- a/src/core/env.ts
+++ b/src/core/env.ts
@@ -117,6 +117,7 @@ const envSchema = z.object({
 	USE_WORKSPACE_MEMORY: z.boolean().default(false),
 	WORKSPACE_SEARCH_THRESHOLD: z.number().default(0.4),
 	DISABLE_DEFAULT_MEMORY: z.boolean().default(false),
+	DISABLE_SIGNIFICANCE_FILTER: z.boolean().default(false),
 	WORKSPACE_VECTOR_STORE_TYPE: z
 		.enum(['qdrant', 'milvus', 'chroma', 'pinecone', 'pgvector', 'in-memory'])
 		.optional(),
@@ -350,6 +351,8 @@ export const env: EnvSchema = new Proxy({} as EnvSchema, {
 					: 0.4;
 			case 'DISABLE_DEFAULT_MEMORY':
 				return process.env.DISABLE_DEFAULT_MEMORY === 'true';
+			case 'DISABLE_SIGNIFICANCE_FILTER':
+				return process.env.DISABLE_SIGNIFICANCE_FILTER === 'true';
 			case 'WORKSPACE_VECTOR_STORE_TYPE':
 				return process.env.WORKSPACE_VECTOR_STORE_TYPE;
 			case 'WORKSPACE_VECTOR_STORE_HOST':
@@ -553,6 +556,7 @@ export const validateEnv = () => {
 			? parseFloat(process.env.WORKSPACE_SEARCH_THRESHOLD)
 			: 0.4,
 		DISABLE_DEFAULT_MEMORY: process.env.DISABLE_DEFAULT_MEMORY === 'true',
+		DISABLE_SIGNIFICANCE_FILTER: process.env.DISABLE_SIGNIFICANCE_FILTER === 'true',
 		WORKSPACE_VECTOR_STORE_TYPE: process.env.WORKSPACE_VECTOR_STORE_TYPE,
 		WORKSPACE_VECTOR_STORE_HOST: process.env.WORKSPACE_VECTOR_STORE_HOST,
 		WORKSPACE_VECTOR_STORE_PORT: process.env.WORKSPACE_VECTOR_STORE_PORT

--- a/src/core/knowledge_graph/backend/neo4j.ts
+++ b/src/core/knowledge_graph/backend/neo4j.ts
@@ -931,70 +931,68 @@ export class Neo4jBackend implements KnowledgeGraph {
 		return converted;
 	}
 
-        private buildFilterConstraints(
-                filters: NodeFilters | EdgeFilters,
-                prefix: string,
-                params: any
-        ): string {
-                const constraints: string[] = [];
+	private buildFilterConstraints(
+		filters: NodeFilters | EdgeFilters,
+		prefix: string,
+		params: any
+	): string {
+		const constraints: string[] = [];
 
-                for (const [rawKey, filter] of Object.entries(filters)) {
-                        const propertyKey = this.escapePropertyKey(rawKey);
-                        const paramKey = `${prefix}_${Object.keys(params).length}`;
+		for (const [rawKey, filter] of Object.entries(filters)) {
+			const propertyKey = this.escapePropertyKey(rawKey);
+			const paramKey = `${prefix}_${Object.keys(params).length}`;
 
-                        if (typeof filter === 'object' && filter !== null && !Array.isArray(filter)) {
-                                // Range filters
-                                if ('gte' in filter) {
-                                        constraints.push(`${prefix}.${propertyKey} >= $${paramKey}_gte`);
-                                        params[`${paramKey}_gte`] = filter.gte;
-                                }
-                                if ('gt' in filter) {
-                                        constraints.push(`${prefix}.${propertyKey} > $${paramKey}_gt`);
-                                        params[`${paramKey}_gt`] = filter.gt;
-                                }
-                                if ('lte' in filter) {
-                                        constraints.push(`${prefix}.${propertyKey} <= $${paramKey}_lte`);
-                                        params[`${paramKey}_lte`] = filter.lte;
-                                }
-                                if ('lt' in filter) {
-                                        constraints.push(`${prefix}.${propertyKey} < $${paramKey}_lt`);
-                                        params[`${paramKey}_lt`] = filter.lt;
-                                }
+			if (typeof filter === 'object' && filter !== null && !Array.isArray(filter)) {
+				// Range filters
+				if ('gte' in filter) {
+					constraints.push(`${prefix}.${propertyKey} >= $${paramKey}_gte`);
+					params[`${paramKey}_gte`] = filter.gte;
+				}
+				if ('gt' in filter) {
+					constraints.push(`${prefix}.${propertyKey} > $${paramKey}_gt`);
+					params[`${paramKey}_gt`] = filter.gt;
+				}
+				if ('lte' in filter) {
+					constraints.push(`${prefix}.${propertyKey} <= $${paramKey}_lte`);
+					params[`${paramKey}_lte`] = filter.lte;
+				}
+				if ('lt' in filter) {
+					constraints.push(`${prefix}.${propertyKey} < $${paramKey}_lt`);
+					params[`${paramKey}_lt`] = filter.lt;
+				}
 
-                                // Array filters
-                                if ('any' in filter && Array.isArray(filter.any)) {
-                                        constraints.push(`${prefix}.${propertyKey} IN $${paramKey}`);
-                                        params[paramKey] = filter.any;
-                                }
-                                if ('all' in filter && Array.isArray(filter.all)) {
-                                        // For 'all' filter, check if the property (assumed to be array) contains all values
-                                        constraints.push(
-                                                `all(x IN $${paramKey} WHERE x IN ${prefix}.${propertyKey})`
-                                        );
-                                        params[paramKey] = filter.all;
-                                }
-                        } else {
-                                // Direct equality
-                                constraints.push(`${prefix}.${propertyKey} = $${paramKey}`);
-                                params[paramKey] = filter;
-                        }
-                }
+				// Array filters
+				if ('any' in filter && Array.isArray(filter.any)) {
+					constraints.push(`${prefix}.${propertyKey} IN $${paramKey}`);
+					params[paramKey] = filter.any;
+				}
+				if ('all' in filter && Array.isArray(filter.all)) {
+					// For 'all' filter, check if the property (assumed to be array) contains all values
+					constraints.push(`all(x IN $${paramKey} WHERE x IN ${prefix}.${propertyKey})`);
+					params[paramKey] = filter.all;
+				}
+			} else {
+				// Direct equality
+				constraints.push(`${prefix}.${propertyKey} = $${paramKey}`);
+				params[paramKey] = filter;
+			}
+		}
 
-                return constraints.join(' AND ');
-        }
+		return constraints.join(' AND ');
+	}
 
-        private escapePropertyKey(key: string): string {
-                if (key.trim().length === 0) {
-                        throw new Error('Filter property names must not be empty.');
-                }
+	private escapePropertyKey(key: string): string {
+		if (key.trim().length === 0) {
+			throw new Error('Filter property names must not be empty.');
+		}
 
-                if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
-                        return key;
-                }
+		if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+			return key;
+		}
 
-                const escapedKey = key.replace(/`/g, '``');
-                return `\`${escapedKey}\``;
-        }
+		const escapedKey = key.replace(/`/g, '``');
+		return `\`${escapedKey}\``;
+	}
 
 	private async createIndexes(): Promise<void> {
 		const session = this.getSession();


### PR DESCRIPTION
## Summary
- Add `DISABLE_SIGNIFICANCE_FILTER=true` env var to bypass the `isSignificantKnowledge()` and `isWorkspaceSignificantContent()` filters
- Default is `false` — no behavior change for existing users
- When enabled, all content passes through to embedding/storage instead of being silently rejected by regex heuristics

## Problem
The significance filter uses `skipPatterns` that match common technical terms:
```
/\b(personal|profile|identity|username|login|password|email|address|phone)\b/i
```
Content mentioning "email" (email services, SMTP), "address" (IP addresses, memory addresses), "login" (auth systems), etc. is silently discarded. The tool returns `extracted: 0, skipped: 1` with no user-facing indication that the filter was the cause — identical to a dedup skip.

Root cause analysis by @MafraAiDev in #263.

## Usage
```bash
DISABLE_SIGNIFICANCE_FILTER=true
```

## What this does NOT guarantee
Issue #263 has multiple reporters with different setups and potentially different root causes:
- @MafraAiDev confirmed the significance filter as root cause (Qdrant + OpenAI) — this fix directly addresses that
- @temporary-wanderer found a separate OpenAI SDK base64 encoding issue with LM Studio — this fix does not address that
- @Sheld0n-Cooper (original reporter, Gemini API) may have had a Gemini initialization issue — this fix may or may not help

## Test plan
- [x] All 40 memory tool tests pass
- [x] `pnpm run format:check` passes
- [x] Env var follows identical pattern to existing `DISABLE_DEFAULT_MEMORY`, `DISABLE_EMBEDDINGS`, etc.
- [x] Default `false` — zero behavior change unless explicitly opted in

Fixes #263