### PR TITLE
fix: address review feedback for multi-repo knowledge sharing

### DIFF
--- a/src/agent/infra/tools/implementations/search-knowledge-service.ts
+++ b/src/agent/infra/tools/implementations/search-knowledge-service.ts
@@ -517,9 +517,7 @@ async function buildFreshIndex(
 
   // Build symbolic structures using symbolPath for tree paths
   // Create a view where doc.path is replaced by doc.symbolPath for tree construction
-  const treeDocMap = new Map(
-    allDocuments.map((doc) => [doc.id, {...doc, path: doc.symbolPath}]),
-  )
+  const treeDocMap = new Map(allDocuments.map((doc) => [doc.id, {...doc, path: doc.symbolPath}]))
   const symbolTree = buildSymbolTree(treeDocMap, summaryMap)
 
   // Reference index only tracks local-to-local references

--- a/src/agent/infra/tools/write-guard.ts
+++ b/src/agent/infra/tools/write-guard.ts
@@ -1,5 +1,5 @@
 import {existsSync, realpathSync} from 'node:fs'
-import {basename, dirname, join, resolve} from 'node:path'
+import {basename, dirname, isAbsolute, join, relative, resolve} from 'node:path'
 
 import {BRV_DIR, CONTEXT_TREE_DIR} from '../../../server/constants.js'
 import {loadKnowledgeSources} from '../../../server/core/domain/knowledge/load-knowledge-sources.js'
@@ -68,7 +68,6 @@ function tryRealpath(p: string): string {
 }
 
 function isWithin(target: string, parent: string): boolean {
-  const sep = '/'
-  const normalizedParent = parent.endsWith(sep) ? parent : parent + sep
-  return target === parent || target.startsWith(normalizedParent)
+  const rel = relative(parent, target)
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel))
 }

--- a/src/oclif/commands/hub/uninstall.ts
+++ b/src/oclif/commands/hub/uninstall.ts
@@ -1,4 +1,4 @@
-import {Args, Command} from '@oclif/core'
+import {Args, Command, Flags} from '@oclif/core'
 
 import {
   HubEvents,
@@ -6,6 +6,7 @@ import {
   type HubUninstallResponse,
 } from '../../../shared/transport/events/hub-events.js'
 import {formatConnectionError, withDaemonRetry} from '../../lib/daemon-client.js'
+import {writeJsonResponse} from '../../lib/json-response.js'
 
 export default class HubUninstall extends Command {
   public static args = {
@@ -16,18 +17,35 @@ export default class HubUninstall extends Command {
   }
   public static description = 'Uninstall a bundle and remove it from dependencies'
   public static examples = ['<%= config.bin %> hub uninstall react-patterns']
+  public static flags = {
+    format: Flags.string({
+      char: 'f',
+      default: 'text',
+      description: 'Output format',
+      options: ['text', 'json'],
+    }),
+  }
 
   public async run(): Promise<void> {
-    const {args} = await this.parse(HubUninstall)
+    const {args, flags} = await this.parse(HubUninstall)
+    const format = flags.format as 'json' | 'text'
 
     try {
       const result = await withDaemonRetry<HubUninstallResponse>(async (client) =>
         client.requestWithAck<HubUninstallResponse, HubUninstallRequest>(HubEvents.UNINSTALL, {entryId: args.id}),
       )
 
-      this.log(result.message)
+      if (format === 'json') {
+        writeJsonResponse({command: 'hub uninstall', data: result, success: result.success})
+      } else {
+        this.log(result.message)
+      }
     } catch (error) {
-      this.log(formatConnectionError(error))
+      if (format === 'json') {
+        writeJsonResponse({command: 'hub uninstall', data: {error: formatConnectionError(error)}, success: false})
+      } else {
+        this.log(formatConnectionError(error))
+      }
     }
   }
 }

--- a/src/server/core/domain/knowledge/dependencies-schema.ts
+++ b/src/server/core/domain/knowledge/dependencies-schema.ts
@@ -23,11 +23,13 @@ export function loadDependenciesFile(projectRoot: string): null | Record<string,
   try {
     raw = JSON.parse(readFileSync(filePath, 'utf8'))
   } catch {
+    console.warn(`Warning: ${filePath} contains invalid JSON — ignoring dependencies`)
     return {}
   }
 
   const result = DependenciesFileSchema.safeParse(raw)
   if (!result.success) {
+    console.warn(`Warning: ${filePath} has invalid schema (expected {name: version} object) — ignoring dependencies`)
     return {}
   }
 

--- a/src/server/core/domain/knowledge/workspaces-resolver.ts
+++ b/src/server/core/domain/knowledge/workspaces-resolver.ts
@@ -32,8 +32,15 @@ export function resolveWorkspaces(projectRoot: string, workspaces: string[]): Kn
 }
 
 function resolveEntry(projectRoot: string, entry: string): string[] {
+  // Only prefix/* globs are supported
   if (entry.endsWith('/*')) {
     return expandGlob(projectRoot, entry)
+  }
+
+  // Warn on unsupported glob patterns that would silently resolve to a literal path
+  if (entry.includes('*')) {
+    console.warn(`Warning: unsupported glob pattern "${entry}" in workspaces.json — only "prefix/*" is supported`)
+    return []
   }
 
   return [resolve(projectRoot, entry)]

--- a/src/server/core/domain/knowledge/workspaces-schema.ts
+++ b/src/server/core/domain/knowledge/workspaces-schema.ts
@@ -23,11 +23,13 @@ export function loadWorkspacesFile(projectRoot: string): null | string[] {
   try {
     raw = JSON.parse(readFileSync(filePath, 'utf8'))
   } catch {
+    console.warn(`Warning: ${filePath} contains invalid JSON — ignoring workspaces`)
     return []
   }
 
   const result = WorkspacesFileSchema.safeParse(raw)
   if (!result.success) {
+    console.warn(`Warning: ${filePath} has invalid schema (expected string array) — ignoring workspaces`)
     return []
   }
 

--- a/src/server/infra/transport/handlers/hub-handler.ts
+++ b/src/server/infra/transport/handlers/hub-handler.ts
@@ -8,7 +8,6 @@ import type {IHubKeychainStore} from '../../../core/interfaces/hub/i-hub-keychai
 import type {IHubRegistryConfigStore} from '../../../core/interfaces/hub/i-hub-registry-config-store.js'
 import type {IHubRegistryService} from '../../../core/interfaces/hub/i-hub-registry-service.js'
 import type {ITransportServer} from '../../../core/interfaces/transport/i-transport-server.js'
-import type {ProjectPathResolver} from './handler-types.js'
 
 import {
   HubEvents,
@@ -30,6 +29,7 @@ import {type Agent, isAgent} from '../../../core/domain/entities/agent.js'
 import {loadDependenciesFile, writeDependenciesFile} from '../../../core/domain/knowledge/dependencies-schema.js'
 import {CompositeHubRegistryService} from '../../hub/composite-hub-registry-service.js'
 import {HubRegistryService} from '../../hub/hub-registry-service.js'
+import {type ProjectPathResolver, resolveRequiredProjectPath} from './handler-types.js'
 
 const OFFICIAL_REGISTRY_NAME = 'official'
 
@@ -141,7 +141,7 @@ export class HubHandler {
   }
 
   private async handleInstallAll(clientId: string): Promise<HubInstallAllResponse> {
-    const projectPath = this.resolveEffectivePath(clientId)
+    const projectPath = resolveRequiredProjectPath(this.resolveProjectPath, clientId)
 
     const deps = loadDependenciesFile(projectPath)
     if (!deps || Object.keys(deps).length === 0) {
@@ -150,33 +150,55 @@ export class HubHandler {
 
     const entries = Object.keys(deps)
 
-    // Check which are already installed
-    const toInstall = entries.filter((id) => {
+    // Partition into already-installed and to-install
+    const toInstall: string[] = []
+    const skipped: string[] = []
+    for (const id of entries) {
       const bundleDir = join(projectPath, BRV_DIR, CONTEXT_TREE_DIR, BUNDLES_DIR, id)
-      return !existsSync(bundleDir)
-    })
-
-    if (toInstall.length === 0) {
-      return {message: `All ${entries.length} dependencies already installed.`, results: [], success: true}
+      if (existsSync(bundleDir)) {
+        skipped.push(id)
+      } else {
+        toInstall.push(id)
+      }
     }
 
-    const settled = await Promise.allSettled(
-      toInstall.map(async (entryId) => {
-        const installResult = await this.handleInstall({entryId}, clientId)
-        return {entryId, message: installResult.message, success: installResult.success}
-      }),
-    )
+    // Build results — include skipped as already-installed entries
+    const results: HubInstallAllResponse['results'] = skipped.map((entryId) => ({
+      entryId,
+      message: 'Already installed',
+      success: true,
+    }))
 
-    const results: HubInstallAllResponse['results'] = settled.map((s, i) =>
-      s.status === 'fulfilled'
-        ? s.value
-        : {entryId: toInstall[i], message: s.reason instanceof Error ? s.reason.message : 'Unknown error', success: false},
-    )
+    if (toInstall.length > 0) {
+      const settled = await Promise.allSettled(
+        toInstall.map(async (entryId) => {
+          const installResult = await this.handleInstall({entryId}, clientId)
+          return {entryId, message: installResult.message, success: installResult.success}
+        }),
+      )
 
+      for (const [i, s] of settled.entries()) {
+        results.push(
+          s.status === 'fulfilled'
+            ? s.value
+            : {
+                entryId: toInstall[i],
+                message: s.reason instanceof Error ? s.reason.message : 'Unknown error',
+                success: false,
+              },
+        )
+      }
+    }
+
+    const installed = results.filter((r) => r.success && r.message !== 'Already installed').length
     const allSuccess = results.every((r) => r.success)
-    const installed = results.filter((r) => r.success).length
+    const summary =
+      toInstall.length === 0
+        ? `All ${entries.length} dependencies already installed.`
+        : `Installed ${installed}/${toInstall.length} new (${skipped.length} already installed).`
+
     return {
-      message: `Installed ${installed}/${toInstall.length} dependencies.`,
+      message: summary,
       results,
       success: allSuccess,
     }
@@ -289,7 +311,7 @@ export class HubHandler {
   }
 
   private handleUninstall(data: HubUninstallRequest, clientId: string): HubUninstallResponse {
-    const projectPath = this.resolveEffectivePath(clientId)
+    const projectPath = resolveRequiredProjectPath(this.resolveProjectPath, clientId)
 
     // Remove from dependencies.json
     const deps = loadDependenciesFile(projectPath)


### PR DESCRIPTION
- Use node:path relative() for cross-platform path containment check in write-guard instead of hardcoded '/' separator
- Add --format json flag to hub uninstall for scripting consistency
- Warn on malformed workspaces.json/dependencies.json instead of silent empty fallback
- Use resolveRequiredProjectPath in hub install-all and uninstall handlers instead of falling back to daemon's process.cwd()
- Report skipped (already installed) bundles in install-all results
- Warn on unsupported glob patterns in workspaces.json
- Wire WorkspaceHandler into daemon feature-handlers
- Fix bundle install path to bundles/{id}/ subdirectory
- Fix dependencies.json to store entry id instead of name
- Move install-all logic from oclif to server via INSTALL_ALL event
- Add TUI /hub install and /hub uninstall commands
- Fix lint errors (import ordering, no-await-in-loop, scoping