### PR TITLE
feat: [ENG-1919] persist team/space to config.json on vc remote add/s…

### DIFF
--- a/src/server/infra/transport/handlers/vc-handler.ts
+++ b/src/server/infra/transport/handlers/vc-handler.ts
@@ -981,15 +981,29 @@ export class VcHandler {
 
     if (data.subcommand === 'add') {
       await this.gitService.addRemote({directory, remote: 'origin', url: resolved.url})
-      return {action: 'add', url: resolved.url}
+    } else {
+      // set-url
+      await this.gitService.removeRemote({directory, remote: 'origin'}).catch(() => {
+        // ignore if remote doesn't exist
+      })
+      await this.gitService.addRemote({directory, remote: 'origin', url: resolved.url})
     }
 
-    // set-url
-    await this.gitService.removeRemote({directory, remote: 'origin'}).catch(() => {
-      // ignore if remote doesn't exist
-    })
-    await this.gitService.addRemote({directory, remote: 'origin', url: resolved.url})
-    return {action: 'set-url', url: resolved.url}
+    // Persist space/team to config (same pattern as handleClone)
+    if (resolved.spaceId && resolved.spaceName && resolved.teamId && resolved.teamName) {
+      const space = new Space({
+        id: resolved.spaceId,
+        isDefault: false,
+        name: resolved.spaceName,
+        teamId: resolved.teamId,
+        teamName: resolved.teamName,
+      })
+      const existing = await this.projectConfigStore.read(projectPath)
+      const updated = existing ? existing.withSpace(space) : BrvConfig.partialFromSpace({space})
+      await this.projectConfigStore.write(updated, projectPath)
+    }
+
+    return {action: data.subcommand === 'add' ? 'add' : 'set-url', url: resolved.url}
   }
 
   private async handleReset(data: IVcResetRequest, clientId: string): Promise<IVcResetResponse> {

--- a/test/unit/infra/transport/handlers/vc-handler.test.ts
+++ b/test/unit/infra/transport/handlers/vc-handler.test.ts
@@ -24,6 +24,7 @@ import type {IVcGitConfigStore} from '../../../../../src/server/core/interfaces/
 
 import {BRV_DIR, CONTEXT_TREE_DIR, CONTEXT_TREE_GITIGNORE} from '../../../../../src/server/constants.js'
 import {AuthToken} from '../../../../../src/server/core/domain/entities/auth-token.js'
+import {BrvConfig} from '../../../../../src/server/core/domain/entities/brv-config.js'
 import {GitAuthError, GitError} from '../../../../../src/server/core/domain/errors/git-error.js'
 import {NotAuthenticatedError} from '../../../../../src/server/core/domain/errors/task-error.js'
 import {VcError} from '../../../../../src/server/core/domain/errors/vc-error.js'
@@ -2272,6 +2273,90 @@ describe('VcHandler', () => {
           expect(error.code).to.equal(VcErrorCode.INVALID_REMOTE_URL)
         }
       }
+    })
+
+    it('should persist space/team to config on remote add with name-based URL', async () => {
+      const deps = makeDeps(sandbox, projectPath)
+      deps.gitService.isInitialized.resolves(true)
+      deps.gitService.getRemoteUrl.resolves()
+      const mockToken = new AuthToken({
+        accessToken: 'test-acc',
+        expiresAt: new Date(Date.now() + 3_600_000),
+        refreshToken: 'test-ref',
+        sessionKey: 'sess-123',
+        userEmail: 'test@example.com',
+        userId: 'u1',
+      })
+      deps.tokenStore.load.resolves(mockToken)
+      deps.teamService.getTeams.resolves({
+        teams: [{displayName: 'Acme', id: 'tid-1', isActive: true, isDefault: false, name: 'acme'}],
+        total: 1,
+      })
+      deps.spaceService.getSpaces.resolves({
+        spaces: [{id: 'sid-1', isDefault: false, name: 'project', teamId: 'tid-1', teamName: 'acme'}],
+        total: 1,
+      })
+      makeVcHandler(deps).setup()
+
+      await deps.requestHandlers[VcEvents.REMOTE](
+        {subcommand: 'add', url: 'https://byterover.dev/acme/project.git'},
+        CLIENT_ID,
+      )
+
+      expect(deps.projectConfigStore.write.calledOnce).to.be.true
+      const writtenConfig: BrvConfig = deps.projectConfigStore.write.firstCall.args[0]
+      expect(writtenConfig.spaceId).to.equal('sid-1')
+      expect(writtenConfig.teamId).to.equal('tid-1')
+      expect(writtenConfig.spaceName).to.equal('project')
+      expect(writtenConfig.teamName).to.equal('acme')
+    })
+
+    it('should persist space/team to config on remote set-url with name-based URL', async () => {
+      const deps = makeDeps(sandbox, projectPath)
+      deps.gitService.isInitialized.resolves(true)
+      const mockToken = new AuthToken({
+        accessToken: 'test-acc',
+        expiresAt: new Date(Date.now() + 3_600_000),
+        refreshToken: 'test-ref',
+        sessionKey: 'sess-123',
+        userEmail: 'test@example.com',
+        userId: 'u1',
+      })
+      deps.tokenStore.load.resolves(mockToken)
+      deps.teamService.getTeams.resolves({
+        teams: [{displayName: 'Acme', id: 'tid-1', isActive: true, isDefault: false, name: 'acme'}],
+        total: 1,
+      })
+      deps.spaceService.getSpaces.resolves({
+        spaces: [{id: 'sid-1', isDefault: false, name: 'project', teamId: 'tid-1', teamName: 'acme'}],
+        total: 1,
+      })
+      makeVcHandler(deps).setup()
+
+      await deps.requestHandlers[VcEvents.REMOTE](
+        {subcommand: 'set-url', url: 'https://byterover.dev/acme/project.git'},
+        CLIENT_ID,
+      )
+
+      expect(deps.projectConfigStore.write.calledOnce).to.be.true
+      const writtenConfig: BrvConfig = deps.projectConfigStore.write.firstCall.args[0]
+      expect(writtenConfig.spaceId).to.equal('sid-1')
+      expect(writtenConfig.teamId).to.equal('tid-1')
+      expect(writtenConfig.spaceName).to.equal('project')
+      expect(writtenConfig.teamName).to.equal('acme')
+    })
+
+    it('should not write config when URL has UUIDs only (no space/team names)', async () => {
+      const deps = makeDeps(sandbox, projectPath)
+      deps.gitService.isInitialized.resolves(true)
+      deps.gitService.getRemoteUrl.resolves()
+      makeVcHandler(deps).setup()
+
+      const url =
+        'https://test-cogit.byterover.dev/git/019b0001-0000-0000-0000-000000000001/019b0002-0000-0000-0000-000000000002.git'
+      await deps.requestHandlers[VcEvents.REMOTE]({subcommand: 'add', url}, CLIENT_ID)
+
+      expect(deps.projectConfigStore.write.called).to.be.false
     })
   })
 


### PR DESCRIPTION
…et-url

## Summary

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [ ] Agent / Tools
- [ ] LLM Providers
- [ ] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes #
- Related #

## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause:
- Why this was not caught earlier:

## Test plan

- Coverage added:
  - [ ] Unit test
  - [ ] Integration test
  - [ ] Manual verification only
- Test file(s):
- Key scenario(s) covered:

## User-visible changes

List user-visible changes (including defaults, config, or CLI output).
If none, write `None`.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording

## Checklist

- [ ] Tests added or updated and passing (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Type check passes (`npm run typecheck`)
- [ ] Build succeeds (`npm run build`)
- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or clearly documented above)
- [ ] Branch is up to date with `main`

## Risks and mitigations

List real risks for this PR. If none, write `None`.

- Risk:
  - Mitigation:
