### PR TITLE
fix: [ENG-1948] treat identical OIDs as ancestor in branch -d merge check

### DIFF
--- a/src/server/infra/git/isomorphic-git-service.ts
+++ b/src/server/infra/git/isomorphic-git-service.ts
@@ -424,6 +424,7 @@ export class IsomorphicGitService implements IGitService {
     const dir = this.requireDirectory(params)
     const commitOid = await git.resolveRef({dir, fs, ref: params.commit})
     const ancestorOid = await git.resolveRef({dir, fs, ref: params.ancestor})
+    if (commitOid === ancestorOid) return true
     return git.isDescendent({ancestor: ancestorOid, depth: -1, dir, fs, oid: commitOid})
   }
 


### PR DESCRIPTION
Summary

- **Problem:** When running `vc branch -d <branch>` to delete a branch that points to the exact same commit as HEAD, the operation incorrectly fails with "branch is not fully merged" error.
- **Why it matters:** Users are unable to delete branches that are trivially merged (same commit as HEAD), forcing them to use force-delete (`-D`) as a workaround, which bypasses the safety check entirely.
- **What changed:** Added an early-return in `IsomorphicGitService.isAncestor()` — when both refs resolve to the same OID, return `true` immediately instead of falling through to `git.isDescendent()`, which uses a strict proper-ancestor test that excludes self-equality.
- **What did NOT change (scope boundary):** No changes to `isDescendent` itself, branch delete logic in `vc-handler`, or any other git operations.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [ ] Agent / Tools
- [ ] LLM Providers
- [x] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes #
- Related #

## Root cause (bug fixes only, otherwise write `N/A`)

- **Root cause:** `isomorphic-git`'s `isDescendent()` performs a strict proper-ancestor check — it walks the commit graph looking for `ancestor` in the history of `oid`, but does not consider a commit to be a descendant of itself. When the branch-to-delete and HEAD point to the same commit, `isAncestor()` returned `false`, causing the delete guard in `vc-handler` to reject the operation.
- **Why this was not caught earlier:** The `isAncestor` integration tests did not include a test case where both refs resolve to the same OID; all existing tests used distinct commits.

## Test plan

- Coverage added:
  - [ ] Unit test
  - [ ] Integration test
  - [x] Manual verification only
- Test file(s): N/A
- Key scenario(s) covered: `vc branch -d <branch>` where `<branch>` points to the same commit as HEAD now succeeds instead of erroring.

## User-visible changes

`vc branch -d <branch>` no longer incorrectly rejects deletion of a branch that points to the same commit as the current branch.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording

## Checklist

- [ ] Tests added or updated and passing (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented above)
- [ ] Branch is up to date with `main`

## Risks and mitigations

- **Risk:** The early-return could mask a bug where two different refs are incorrectly resolved to the same OID.
 - **Mitigation:** OID resolution is handled by `isomorphic-git`'s `resolveRef`, which is well-tested. The equality check is strictly on the resolved SHA, so a false positive here would require a bug in ref resolution itself, not in this change.