### PR TITLE
Release/3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable user-facing changes to ByteRover CLI will be documented in this file.
 
+## [3.0.0]
+
+### Added
+- **`brv vc` — Git version control commands** — A full suite of Git-like commands (`init`, `clone`, `status`, `commit`, `push`, `pull`, `branch`, `checkout`, `merge`, `reset`, `remote`, `log`, `fetch`) that sync context alongside code through ByteRover's remote.
+- **Human-in-the-loop review system** — Review pending curate operations before they are applied. Use `brv review pending` to list, `brv review approve` to accept, and `brv review reject` to discard.
+
+### Changed
+- **Legacy commands show `brv vc` hints** — Running `brv status`, `brv pull`, or `brv push` now displays a tip about the corresponding `brv vc` command.
+- **Name-based remote URLs** — Remote URLs now use human-readable names.
+- **Team and space persisted on remote add** — `brv vc remote add` and `brv vc remote set-url` now persist team and space identifiers to `config.json`.
+- **(Deprecated) `brv space list` and `brv space switch`** — These commands still work but show a deprecation notice directing users to the web dashboard.
+
+### Fixed
+- **Provider error messages** — CLI text-mode commands now show the actual backend error message instead of a misleading "API key is missing or invalid" fallback.
+- **Security dependency updates** — Patched `hono`, `@hono/node-server`, `@xmldom/xmldom`, `lodash`, and `lodash-es` to address known vulnerabilities.
+
 ## [2.6.0]
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,9 +50,9 @@ npm run typecheck                    # TypeScript type checking
 ### Source Layout (`src/`)
 
 - `agent/` — LLM agent: `core/` (interfaces/domain), `infra/` (22 modules), `resources/` (prompt YAML, tool `.txt`)
-- `server/` — Daemon infrastructure: `config/`, `core/` (domain/interfaces), `infra/` (27 modules), `utils/`
+- `server/` — Daemon infrastructure: `config/`, `core/` (domain/interfaces), `infra/` (29 modules), `utils/`
 - `shared/` — Cross-module: constants, types, transport events, utils
-- `tui/` — React/Ink TUI: app (router/pages), components, features (20 modules), hooks, lib, providers, stores
+- `tui/` — React/Ink TUI: app (router/pages), components, features (21 modules), hooks, lib, providers, stores
 - `oclif/` — Commands, hooks, lib (daemon-client, JSON response utils)
 
 **Import boundary** (ESLint-enforced): `tui/` must not import from `server/`, `agent/`, or `oclif/`. Use transport events or `shared/`.
@@ -71,7 +71,7 @@ npm run typecheck                    # TypeScript type checking
 ### Agent (`src/agent/`)
 
 - Tools: definitions in `resources/tools/*.txt`, implementations in `infra/tools/implementations/`, registry in `infra/tools/tool-registry.ts`
-- LLM: 18 providers in `infra/llm/providers/`; 6 compression strategies in `infra/llm/context/compression/`
+- LLM: 18 providers in `infra/llm/providers/`; 7 compression strategies in `infra/llm/context/compression/`
 - System prompts: contributor pattern (XML sections) in `infra/system-prompt/`
 - Map/memory: `infra/map/` (agentic map, context-tree store, LLM map memory, worker pool)
 - Storage: file-based blob (`infra/blob/`) and key storage (`infra/storage/`) — no SQLite

--- a/README.md
+++ b/README.md
@@ -32,9 +32,11 @@ Or download our self-hosted PDF version of the paper [here](https://byterover.de
 
 - 🖥️ Interactive TUI with REPL interface (React/Ink)
 - 🧠 Context tree and knowledge storage management
-- 🤖 20+ LLM providers (Anthropic, OpenAI, Google, Groq, Mistral, xAI, and more)
+- 🔀 Git-like version control for the context tree (branch, commit, merge, push/pull)
+- 🤖 18 LLM providers (Anthropic, OpenAI, Google, Groq, Mistral, xAI, and more)
 - 🛠️ 24 built-in agent tools (code exec, file ops, knowledge search, memory management)
 - 🔄 Cloud sync with push/pull
+- 👀 Review workflow for curate operations (approve/reject pending changes)
 - 🔌 MCP (Model Context Protocol) integration
 - 📦 Hub and connectors ecosystem for skills and bundles
 - 🤝 Works with 22+ AI coding agents (Cursor, Claude Code, Windsurf, Cline, and more)
@@ -130,13 +132,40 @@ brv status           # Show project and daemon status
 brv curate           # Add context to knowledge storage
 brv curate view      # View curate history
 brv query            # Query context tree and knowledge
+brv review pending   # List pending review operations
+brv review approve   # Approve curate operations
+brv review reject    # Reject curate operations
 ```
 
-### Sync
+### Sync (Legacy)
 
 ```bash
-brv push             # Sync local context to cloud
-brv pull             # Sync from cloud to local
+brv push             # Legacy — migrate or snapshot context to cloud
+brv pull             # Legacy — restore context from cloud snapshot
+```
+
+> Use `brv vc push` / `brv vc pull` for version-controlled sync going forward.
+
+### Version Control
+
+```bash
+brv vc init              # Initialize version control for context tree
+brv vc status            # Show version control status
+brv vc add               # Stage files for the next commit
+brv vc commit            # Save staged changes as a commit
+brv vc log               # Show commit history
+brv vc branch            # List, create, or delete branches
+brv vc checkout          # Switch branches
+brv vc merge             # Merge a branch into the current branch
+brv vc clone             # Clone a ByteRover space repository
+brv vc push              # Push commits to ByteRover cloud
+brv vc pull              # Pull commits from ByteRover cloud
+brv vc fetch             # Fetch refs from ByteRover cloud
+brv vc remote            # Show current remote origin
+brv vc remote add        # Add a named remote
+brv vc remote set-url    # Update a remote URL
+brv vc config            # Get or set commit author
+brv vc reset             # Unstage files or undo commits
 ```
 
 ### Providers & Models
@@ -162,11 +191,11 @@ brv connectors list      # List connectors
 brv connectors install   # Install a connector
 ```
 
-### Spaces
+### Spaces (Deprecated)
 
 ```bash
-brv space list       # List spaces
-brv space switch     # Switch active space
+brv space list       # Deprecated — use web dashboard
+brv space switch     # Deprecated — use brv vc clone
 ```
 
 ### Other
@@ -220,6 +249,7 @@ Visit [**docs.byterover.dev**](https://docs.byterover.dev) for full guides on se
 |-------|-------------|
 | [Getting Started](https://docs.byterover.dev) | Installation, first run, and basic usage |
 | [Cloud Sync](https://docs.byterover.dev) | Push/pull workflows and team sharing |
+| [Version Control](https://docs.byterover.dev) | Context tree branching, commits, and collaboration |
 | [LLM Providers](https://docs.byterover.dev) | Provider setup and model configuration |
 | [AI Agent Integrations](https://docs.byterover.dev) | Using ByteRover with Cursor, Claude Code, Windsurf, etc. |
 | [Hub & Connectors](https://docs.byterover.dev) | Skills, bundles, and the connector ecosystem |


### PR DESCRIPTION
## Summary

- **Problem:** The `release/3.0.0` branch has documentation updates (README, CHANGELOG, CLAUDE.md) that need to be merged back to `main` to reflect the v3.0.0 release notes and updated project metadata.
- **Why it matters:** Without merging, `main` lacks the v3.0.0 changelog, updated feature list (vc commands, review system), and accurate architecture counts in CLAUDE.md.
- **What changed:**
  - `CHANGELOG.md` — Added v3.0.0 section (vc commands, review system, deprecations, fixes)
  - `README.md` — Added vc commands, review commands, deprecated space commands, updated feature counts
  - `CLAUDE.md` — Updated module counts (29 server infra modules, 21 TUI features, 7 compression strategies)
- **What did NOT change (scope boundary):** No source code, tests, configuration, or build artifacts were modified. Documentation only.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [x] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [ ] Agent / Tools
- [ ] LLM Providers
- [ ] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

> None of the above — changes are limited to project-level documentation files (CHANGELOG.md, README.md, CLAUDE.md).

## Linked issues

- Closes #
- Related #

## Root cause (bug fixes only, otherwise write `N/A`)

N/A

## Test plan

- Coverage added:
  - [ ] Unit test
  - [ ] Integration test
  - [x] Manual verification only
- Test file(s): N/A
- Key scenario(s) covered: Verified diff contains only documentation text changes across 3 files (66 insertions, 10 deletions). No code changes to test.

## User-visible changes

None — these are repository documentation files, not CLI output or runtime behavior.

## Evidence

- [x] Trace/log snippets

