### PR TITLE
feat: add --timeout flag to curate and query commands

### DIFF
--- a/src/oclif/commands/curate/index.ts
+++ b/src/oclif/commands/curate/index.ts
@@ -310,7 +310,7 @@ Bad examples:
     }
 
     if (flags.detach) {
-      if (flags.timeout !== 300) {
+      if (flags.timeout !== 300 && format !== 'json') {
         this.log('Note: --timeout has no effect with --detach')
       }
 

--- a/src/oclif/commands/curate/index.ts
+++ b/src/oclif/commands/curate/index.ts
@@ -89,7 +89,8 @@ Bad examples:
     }),
     timeout: Flags.integer({
       default: 300,
-      description: 'Task completion timeout in seconds (default: 300)',
+      description: 'Maximum seconds to wait for task completion',
+      max: 3600,
       min: 10,
     }),
   }
@@ -309,6 +310,10 @@ Bad examples:
     }
 
     if (flags.detach) {
+      if (flags.timeout !== 300) {
+        this.log('Note: --timeout has no effect with --detach')
+      }
+
       const ack = await client.requestWithAck<TaskAck>(TaskEvents.CREATE, taskPayload)
       const {logId} = ack
 

--- a/src/oclif/commands/curate/index.ts
+++ b/src/oclif/commands/curate/index.ts
@@ -18,7 +18,7 @@ import {
   withDaemonRetry,
 } from '../../lib/daemon-client.js'
 import {writeJsonResponse} from '../../lib/json-response.js'
-import {type ToolCallRecord, waitForTaskCompletion} from '../../lib/task-client.js'
+import {DEFAULT_TIMEOUT_SECONDS, MAX_TIMEOUT_SECONDS, MIN_TIMEOUT_SECONDS, type ToolCallRecord, waitForTaskCompletion} from '../../lib/task-client.js'
 
 /** Parsed flags type */
 type CurateFlags = {
@@ -88,10 +88,10 @@ Bad examples:
       options: ['text', 'json'],
     }),
     timeout: Flags.integer({
-      default: 300,
+      default: DEFAULT_TIMEOUT_SECONDS,
       description: 'Maximum seconds to wait for task completion',
-      max: 3600,
-      min: 10,
+      max: MAX_TIMEOUT_SECONDS,
+      min: MIN_TIMEOUT_SECONDS,
     }),
   }
 
@@ -310,7 +310,7 @@ Bad examples:
     }
 
     if (flags.detach) {
-      if (flags.timeout !== 300 && format !== 'json') {
+      if (flags.timeout !== DEFAULT_TIMEOUT_SECONDS && format !== 'json') {
         this.log('Note: --timeout has no effect with --detach')
       }
 
@@ -381,7 +381,7 @@ Bad examples:
             }
           },
           taskId,
-          timeoutMs: (flags.timeout ?? 300) * 1000,
+          timeoutMs: (flags.timeout ?? DEFAULT_TIMEOUT_SECONDS) * 1000,
         },
         (msg) => this.log(msg),
       )

--- a/src/oclif/commands/curate/index.ts
+++ b/src/oclif/commands/curate/index.ts
@@ -26,6 +26,7 @@ type CurateFlags = {
   files?: string[]
   folder?: string[]
   format?: 'json' | 'text'
+  timeout?: number
 }
 
 export default class Curate extends Command {
@@ -59,6 +60,9 @@ Bad examples:
     '# Folder pack with context',
     '<%= config.bin %> <%= command.id %> "Analyze authentication module" -d src/auth/',
     '',
+    '# Increase timeout for slow models (in seconds)',
+    '<%= config.bin %> <%= command.id %> "context here" --timeout 600',
+    '',
     '# View curate history',
     '<%= config.bin %> curate view',
     '<%= config.bin %> curate view --status completed --since 1h',
@@ -83,6 +87,11 @@ Bad examples:
       description: 'Output format (text or json)',
       options: ['text', 'json'],
     }),
+    timeout: Flags.integer({
+      default: 300,
+      description: 'Task completion timeout in seconds (default: 300)',
+      min: 10,
+    }),
   }
 
   protected getDaemonClientOptions(): DaemonClientOptions {
@@ -96,6 +105,7 @@ Bad examples:
       files: rawFlags.files,
       folder: rawFlags.folder,
       format: rawFlags.format === 'json' ? 'json' : rawFlags.format === 'text' ? 'text' : undefined,
+      timeout: rawFlags.timeout,
     }
     const format: 'json' | 'text' = flags.format ?? 'text'
 
@@ -366,6 +376,7 @@ Bad examples:
             }
           },
           taskId,
+          timeoutMs: (flags.timeout ?? 300) * 1000,
         },
         (msg) => this.log(msg),
       )

--- a/src/oclif/commands/query.ts
+++ b/src/oclif/commands/query.ts
@@ -14,7 +14,7 @@ import {
   withDaemonRetry,
 } from '../lib/daemon-client.js'
 import {writeJsonResponse} from '../lib/json-response.js'
-import {waitForTaskCompletion} from '../lib/task-client.js'
+import {DEFAULT_TIMEOUT_SECONDS, MAX_TIMEOUT_SECONDS, MIN_TIMEOUT_SECONDS, waitForTaskCompletion} from '../lib/task-client.js'
 
 /** Parsed flags type */
 type QueryFlags = {
@@ -52,10 +52,10 @@ Bad:
       options: ['text', 'json'],
     }),
     timeout: Flags.integer({
-      default: 300,
+      default: DEFAULT_TIMEOUT_SECONDS,
       description: 'Maximum seconds to wait for task completion',
-      max: 3600,
-      min: 10,
+      max: MAX_TIMEOUT_SECONDS,
+      min: MIN_TIMEOUT_SECONDS,
     }),
   }
   public static strict = false
@@ -91,7 +91,14 @@ Bad:
             throw new Error(providerMissingMessage(active.activeProvider, active.authMethod))
           }
 
-          await this.submitTask({client, format, projectRoot, query: args.query, timeoutMs: (flags.timeout ?? 300) * 1000, worktreeRoot})
+          await this.submitTask({
+            client,
+            format,
+            projectRoot,
+            query: args.query,
+            timeoutMs: (flags.timeout ?? DEFAULT_TIMEOUT_SECONDS) * 1000,
+            worktreeRoot,
+          })
         },
         {
           ...this.getDaemonClientOptions(),

--- a/src/oclif/commands/query.ts
+++ b/src/oclif/commands/query.ts
@@ -19,6 +19,7 @@ import {waitForTaskCompletion} from '../lib/task-client.js'
 /** Parsed flags type */
 type QueryFlags = {
   format?: 'json' | 'text'
+  timeout?: number
 }
 
 export default class Query extends Command {
@@ -49,6 +50,11 @@ Bad:
       default: 'text',
       description: 'Output format (text or json)',
       options: ['text', 'json'],
+    }),
+    timeout: Flags.integer({
+      default: 300,
+      description: 'Task completion timeout in seconds (default: 300)',
+      min: 10,
     }),
   }
   public static strict = false
@@ -84,7 +90,7 @@ Bad:
             throw new Error(providerMissingMessage(active.activeProvider, active.authMethod))
           }
 
-          await this.submitTask({client, format, projectRoot, query: args.query, worktreeRoot})
+          await this.submitTask({client, format, projectRoot, query: args.query, timeoutMs: (flags.timeout ?? 300) * 1000, worktreeRoot})
         },
         {
           ...this.getDaemonClientOptions(),
@@ -120,9 +126,10 @@ Bad:
     format: 'json' | 'text'
     projectRoot?: string
     query: string
+    timeoutMs?: number
     worktreeRoot?: string
   }): Promise<void> {
-    const {client, format, projectRoot, query, worktreeRoot} = props
+    const {client, format, projectRoot, query, timeoutMs, worktreeRoot} = props
     const taskId = randomUUID()
     const taskPayload = {
       clientCwd: process.cwd(),
@@ -199,6 +206,7 @@ Bad:
           }
         },
         taskId,
+        timeoutMs,
       },
       (msg) => this.log(msg),
     )

--- a/src/oclif/commands/query.ts
+++ b/src/oclif/commands/query.ts
@@ -53,7 +53,8 @@ Bad:
     }),
     timeout: Flags.integer({
       default: 300,
-      description: 'Task completion timeout in seconds (default: 300)',
+      description: 'Maximum seconds to wait for task completion',
+      max: 3600,
       min: 10,
     }),
   }

--- a/src/oclif/lib/task-client.ts
+++ b/src/oclif/lib/task-client.ts
@@ -155,12 +155,13 @@ export function waitForTaskCompletion(options: WaitForTaskOptions, log: (msg: st
       if (!completed) {
         completed = true
         cleanup()
+        const timeoutMessage = `Task timed out after ${timeoutMs / 1000}s`
         if (isText) {
-          reject(new Error('Task timed out after 5 minutes'))
+          reject(new Error(timeoutMessage))
         } else {
           writeJsonResponse({
             command,
-            data: {event: 'error', message: 'Task timed out after 5 minutes', status: 'error'},
+            data: {event: 'error', message: timeoutMessage, status: 'error'},
             success: false,
           })
           resolve()

--- a/src/oclif/lib/task-client.ts
+++ b/src/oclif/lib/task-client.ts
@@ -78,8 +78,14 @@ export interface WaitForTaskOptions {
 
 /** Grace period before treating 'reconnecting' as daemon death (ms) */
 const DISCONNECT_GRACE_MS = 10_000
+/** Default timeout for task completion (seconds) — shared across curate/query commands. */
+export const DEFAULT_TIMEOUT_SECONDS = 300
+/** Minimum --timeout value accepted from the CLI (seconds). */
+export const MIN_TIMEOUT_SECONDS = 10
+/** Maximum --timeout value accepted from the CLI (seconds). */
+export const MAX_TIMEOUT_SECONDS = 3600
 /** Default timeout for task completion (ms) */
-const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000
+const DEFAULT_TIMEOUT_MS = DEFAULT_TIMEOUT_SECONDS * 1000
 
 /**
  * Format tool call for CLI display (simplified version of TUI formatToolDisplay).

--- a/test/commands/curate.test.ts
+++ b/test/commands/curate.test.ts
@@ -527,6 +527,18 @@ describe('Curate Command', () => {
       expect(loggedMessages).to.include('✓ Context queued for processing.')
     })
 
+    it('should warn when --timeout is used with --detach', async () => {
+      await createCommand('test context', '--detach', '--timeout', '600').run()
+
+      expect(loggedMessages).to.include('Note: --timeout has no effect with --detach')
+    })
+
+    it('should not warn about --timeout with --detach when using default', async () => {
+      await createCommand('test context', '--detach').run()
+
+      expect(loggedMessages).to.not.include('Note: --timeout has no effect with --detach')
+    })
+
     it('should accept --timeout flag in JSON mode', async () => {
       await createJsonCommand('test context', '--detach', '--timeout', '600').run()
 

--- a/test/commands/curate.test.ts
+++ b/test/commands/curate.test.ts
@@ -517,4 +517,41 @@ describe('Curate Command', () => {
       expect(json.data).to.not.have.property('pendingReview')
     })
   })
+
+  // ==================== Timeout Flag ====================
+
+  describe('timeout flag', () => {
+    it('should accept --timeout flag without error', async () => {
+      await createCommand('test context', '--detach', '--timeout', '600').run()
+
+      expect(loggedMessages).to.include('✓ Context queued for processing.')
+    })
+
+    it('should accept --timeout flag in JSON mode', async () => {
+      await createJsonCommand('test context', '--detach', '--timeout', '600').run()
+
+      const json = parseJsonOutput()
+      expect(json.success).to.be.true
+      expect(json.data).to.have.property('status', 'queued')
+    })
+
+    it('should work with default timeout when flag is not provided', async () => {
+      simulateTaskCompletion([
+        {
+          applied: [
+            {
+              needsReview: false,
+              path: 'auth/jwt.md',
+              status: 'success',
+              type: 'ADD',
+            },
+          ],
+        },
+      ])
+
+      await createCommand('test context').run()
+
+      expect(loggedMessages.some((m) => m.includes('✓ Context curated successfully'))).to.be.true
+    })
+  })
 })

--- a/test/commands/query.test.ts
+++ b/test/commands/query.test.ts
@@ -476,4 +476,80 @@ describe('Query Command', () => {
       expect(json.data).to.have.property('error')
     })
   })
+
+  // ==================== Timeout Flag ====================
+
+  describe('timeout flag', () => {
+    it('should accept --timeout flag without error', async () => {
+      const eventHandlers: Map<string, Array<(data: unknown) => void>> = new Map()
+      ;(mockClient.on as sinon.SinonStub).callsFake((event: string, handler: (data: unknown) => void) => {
+        if (!eventHandlers.has(event)) eventHandlers.set(event, [])
+        eventHandlers.get(event)!.push(handler)
+        return () => {}
+      })
+      ;(mockClient.requestWithAck as sinon.SinonStub).callsFake(async (event: string, payload: {taskId: string}) => {
+        if (event === 'state:getProviderConfig') return {activeProvider: 'anthropic'}
+        setTimeout(() => {
+          const handlers = eventHandlers.get('task:completed')
+          if (handlers) {
+            for (const handler of handlers) handler({result: 'done', taskId: payload.taskId})
+          }
+        }, 10)
+        return {taskId: payload.taskId}
+      })
+
+      await createCommand('test query', '--timeout', '600').run()
+
+      expect(loggedMessages.some((m) => m.includes('done'))).to.be.true
+    })
+
+    it('should accept --timeout flag in JSON mode', async () => {
+      const eventHandlers: Map<string, Array<(data: unknown) => void>> = new Map()
+      ;(mockClient.on as sinon.SinonStub).callsFake((event: string, handler: (data: unknown) => void) => {
+        if (!eventHandlers.has(event)) eventHandlers.set(event, [])
+        eventHandlers.get(event)!.push(handler)
+        return () => {}
+      })
+      ;(mockClient.requestWithAck as sinon.SinonStub).callsFake(async (event: string, payload: {taskId: string}) => {
+        if (event === 'state:getProviderConfig') return {activeProvider: 'anthropic'}
+        setTimeout(() => {
+          const handlers = eventHandlers.get('task:completed')
+          if (handlers) {
+            for (const handler of handlers) handler({result: 'done', taskId: payload.taskId})
+          }
+        }, 10)
+        return {taskId: payload.taskId}
+      })
+
+      await createJsonCommand('test query', '--timeout', '600').run()
+
+      const lines = parseJsonOutput()
+      const completedEvent = lines.find((l) => (l.data as Record<string, unknown>).event === 'completed')
+      expect(completedEvent).to.exist
+      expect(completedEvent!.success).to.be.true
+    })
+
+    it('should work with default timeout when flag is not provided', async () => {
+      const eventHandlers: Map<string, Array<(data: unknown) => void>> = new Map()
+      ;(mockClient.on as sinon.SinonStub).callsFake((event: string, handler: (data: unknown) => void) => {
+        if (!eventHandlers.has(event)) eventHandlers.set(event, [])
+        eventHandlers.get(event)!.push(handler)
+        return () => {}
+      })
+      ;(mockClient.requestWithAck as sinon.SinonStub).callsFake(async (event: string, payload: {taskId: string}) => {
+        if (event === 'state:getProviderConfig') return {activeProvider: 'anthropic'}
+        setTimeout(() => {
+          const handlers = eventHandlers.get('task:completed')
+          if (handlers) {
+            for (const handler of handlers) handler({result: 'done', taskId: payload.taskId})
+          }
+        }, 10)
+        return {taskId: payload.taskId}
+      })
+
+      await createCommand('test query').run()
+
+      expect(loggedMessages.some((m) => m.includes('done'))).to.be.true
+    })
+  })
 })


### PR DESCRIPTION
## What

Add a `--timeout` flag (in seconds, default: 300) to both `curate` and `query` commands, allowing users to configure the task completion timeout.

Also fixes the hardcoded "Task timed out after 5 minutes" error message in `task-client.ts` to dynamically reflect the configured timeout value.

## Why

Local models are slower than cloud providers and frequently exceed the hardcoded 5-minute timeout, causing curate and query tasks to fail before completion. This change allows users to increase the timeout as needed (e.g., `brv curate "context" --timeout 600` for 10 minutes).

## Changes

- **`src/oclif/commands/curate/index.ts`** — Add `--timeout` flag (integer, default 300, min 10), pass `timeoutMs` to `waitForTaskCompletion`
- **`src/oclif/commands/query.ts`** — Same `--timeout` flag and passthrough
- **`src/oclif/lib/task-client.ts`** — Make timeout error message dynamic instead of hardcoded "5 minutes"
- **`test/commands/curate.test.ts`** — Add tests for timeout flag acceptance and default behavior

## Backward compatible

Default timeout remains 300s (5 minutes). No behavior change unless `--timeout` is explicitly provided.

## Testing

- TDD approach: tests written first, verified they fail, then implemented
- All 5228 tests pass
- `npm run lint` — 0 errors
- `npm run typecheck` — clean
- `npm run build` — clean