### PR TITLE
Release/3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable user-facing changes to ByteRover CLI will be documented in this file.
 
+## [3.1.0]
+
+### Added
+- **Adaptive knowledge scoring** — The knowledge base now prioritizes content based on usage patterns. Frequently accessed knowledge ranks higher in search results through hotness scoring and hierarchical score propagation.
+- **Knowledge abstracts** — Knowledge entries automatically generate compressed summaries (abstracts and overviews), reducing token usage while preserving key information for the agent.
+- **Session learning** — The agent extracts patterns, preferences, decisions, and skills from your sessions and stores them as durable knowledge, improving responses over time.
+- **Resource ingestion tool** — The agent can now ingest external files and resources directly into your knowledge base.
+
+### Fixed
+- **Stale CLI cache after upgrades** — Install and uninstall scripts now clean the oclif client cache, preventing issues caused by cached data from previous versions.
+- **Knowledge search accuracy** — Fixed double compound scoring in parent propagation, improved maturity filtering, and corrected result truncation for more relevant search results.
+
 ## [3.0.0]
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,11 +51,11 @@ npm run typecheck                    # TypeScript type checking
 
 ### Source Layout (`src/`)
 
-- `agent/` — LLM agent: `core/` (interfaces/domain), `infra/` (22 modules), `resources/` (prompt YAML, tool `.txt`)
-- `server/` — Daemon infrastructure: `config/`, `core/` (domain/interfaces), `infra/` (29 modules), `utils/`
+- `agent/` — LLM agent: `core/` (interfaces/domain), `infra/` (22 modules, including memory, document-parser), `resources/` (prompts YAML, tools `.txt`)
+- `server/` — Daemon infrastructure: `config/`, `core/` (domain/interfaces), `infra/` (29 modules, including vc, hub, mcp, cogit), `utils/`
 - `shared/` — Cross-module: constants, types, transport events, utils
-- `tui/` — React/Ink TUI: app (router/pages), components, features (21 modules), hooks, lib, providers, stores
-- `oclif/` — Commands, hooks, lib (daemon-client, JSON response utils)
+- `tui/` — React/Ink TUI: app (router/pages), components, features (21 modules, including vc, hub, curate), hooks, lib, providers, stores
+- `oclif/` — Commands (`vc/`, `review/`, top-level), hooks, lib (daemon-client, JSON response utils)
 
 **Import boundary** (ESLint-enforced): `tui/` must not import from `server/`, `agent/`, or `oclif/`. Use transport events or `shared/`.
 
@@ -69,13 +69,21 @@ npm run typecheck                    # TypeScript type checking
 
 - Global daemon (`server/infra/daemon/`) hosts Socket.IO transport; clients connect via `@campfirein/brv-transport-client`
 - Agent pool manages forked child processes per project; task routing in `server/infra/process/`
+- MCP server in `server/infra/mcp/` exposes tools via Model Context Protocol
+
+### VC (Version Control)
+
+- `brv vc` — isomorphic-git-based version control (add, branch, checkout, clone, commit, config, fetch, init, log, merge, pull, push, remote, reset, status)
+- Oclif commands: `src/oclif/commands/vc/`, TUI feature: `src/tui/features/vc/`, server infra: `src/server/infra/vc/`
+- Slash commands: `vc-*` definitions in `src/tui/features/commands/definitions/`
 
 ### Agent (`src/agent/`)
 
 - Tools: definitions in `resources/tools/*.txt`, implementations in `infra/tools/implementations/`, registry in `infra/tools/tool-registry.ts`
-- LLM: 18 providers in `infra/llm/providers/`; 7 compression strategies in `infra/llm/context/compression/`
+- Tool categories: file ops (read/write/glob/grep), knowledge (create/expand/search), memory (read/write/edit/delete/list), curate, code exec, map
+- LLM: 18 providers in `infra/llm/providers/`; 6 compression strategies in `infra/llm/context/compression/`
 - System prompts: contributor pattern (XML sections) in `infra/system-prompt/`
-- Map/memory: `infra/map/` (agentic map, context-tree store, LLM map memory, worker pool)
+- Map/memory: `infra/map/` (agentic map, context-tree store, LLM map memory, worker pool); `infra/memory/` (memory-manager, deduplicator)
 - Storage: file-based blob (`infra/blob/`) and key storage (`infra/storage/`) — no SQLite
 
 ## Testing Gotchas
@@ -95,4 +103,4 @@ npm run typecheck                    # TypeScript type checking
 
 ## Stack
 
-oclif v4, TypeScript (ES2022, Node16 modules, strict), React/Ink (TUI), Zustand, axios, socket.io, Mocha + Chai + Sinon + Nock
+oclif v4, TypeScript (ES2022, Node16 modules, strict), React/Ink (TUI), Zustand, axios, socket.io, isomorphic-git, Mocha + Chai + Sinon + Nock

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "coding-assistant",
     "knowledge-management"
   ],
-  "version": "3.0.1",
+  "version": "3.1.0",
   "author": "ByteRover",
   "bin": {
     "brv": "./bin/run.js"


### PR DESCRIPTION
## Summary

- **Problem:** Version, changelog, and developer docs need to be updated to cut the 3.1.0 release.
- **Why it matters:** Marks the official 3.1.0 release point with proper versioning, user-facing changelog, and up-to-date CLAUDE.md for contributors.
- **What changed:** Bumped `package.json` version from 3.0.1 to 3.1.0, added 3.1.0 changelog entry, enriched CLAUDE.md architecture docs (VC section, module details, stack additions).
- **What did NOT change (scope boundary):** No source code, tests, or runtime behavior changes. All features/fixes in 3.1.0 are already on `main`.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [x] Documentation
- [ ] Test
- [x] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [ ] Agent / Tools
- [ ] LLM Providers
- [ ] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

N/A

## Root cause (bug fixes only, otherwise write `N/A`)

N/A

## Test plan

- Coverage added:
  - [ ] Unit test
  - [ ] Integration test
  - [x] Manual verification only
- Test file(s): N/A
- Key scenario(s) covered: Version string in `package.json` is correct; CHANGELOG.md and CLAUDE.md render properly.

## User-visible changes

- `brv --version` now reports `3.1.0`.
- CHANGELOG.md documents the 3.1.0 release (adaptive knowledge, session learning, resource ingestion, oclif cache fix, search accuracy fixes).

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording

_(Release prep — no runtime changes to evidence)_

## Checklist

- [ ] Tests added or updated and passing (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Type check passes (`npm run typecheck`)
- [ ] Build succeeds (`npm run build`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented above)
- [ ] Branch is up to date with `main`

## Risks and mitigations

None — documentation and version bump only.