### PR TITLE
feat: [ENG-1896] Implement QueryLogUseCase with list and detail views

### DIFF
--- a/src/server/core/domain/entities/query-log-entry.ts
+++ b/src/server/core/domain/entities/query-log-entry.ts
@@ -1,6 +1,3 @@
-// Stub: domain types driven by brv query-log view command (ENG-1897).
-// Full QueryLogEntry discriminated union will be added in ENG-1887.
-
 // ── Single source of truth: runtime arrays → derived types ───────────────────
 // Tiers originate from QueryExecutor (src/server/infra/executor/query-executor.ts).
 // Statuses track the entry lifecycle. Both are domain concepts.
@@ -9,6 +6,42 @@
 export const QUERY_LOG_TIERS = [0, 1, 2, 3, 4] as const
 export type QueryLogTier = (typeof QUERY_LOG_TIERS)[number]
 
+/** Human-readable labels for each resolution tier. */
+export const QUERY_LOG_TIER_LABELS: Record<QueryLogTier, string> = {
+  0: 'exact cache hit',
+  1: 'fuzzy cache match',
+  2: 'direct search',
+  3: 'optimized LLM',
+  4: 'full agentic',
+}
+
 /** Valid query log statuses. Add/remove here — the type updates automatically. */
 export const QUERY_LOG_STATUSES = ['cancelled', 'completed', 'error', 'processing'] as const
 export type QueryLogStatus = (typeof QUERY_LOG_STATUSES)[number]
+
+// ── Entity types ─────────────────────────────────────────────────────────────
+
+export type QueryLogMatchedDoc = {
+  path: string
+  score: number
+}
+
+export type QueryLogSearchMetadata = {
+  cacheFingerprint?: string
+  resultsFound: number
+  topScore: number
+  totalResults: number
+}
+
+type QueryLogBase = {
+  id: string
+  query: string
+  startedAt: number
+  tier: QueryLogTier
+}
+
+export type QueryLogEntry =
+  | (QueryLogBase & {completedAt: number; error: string; status: 'error'})
+  | (QueryLogBase & {completedAt: number; matchedDocs: QueryLogMatchedDoc[]; response?: string; searchMetadata: QueryLogSearchMetadata; status: 'completed'})
+  | (QueryLogBase & {completedAt: number; status: 'cancelled'})
+  | (QueryLogBase & {status: 'processing'})

--- a/src/server/core/interfaces/i-terminal.ts
+++ b/src/server/core/interfaces/i-terminal.ts
@@ -1,0 +1,3 @@
+export interface ITerminal {
+  log(msg?: string): void
+}

--- a/src/server/core/interfaces/storage/i-query-log-store.ts
+++ b/src/server/core/interfaces/storage/i-query-log-store.ts
@@ -1,6 +1,22 @@
-// Stub: types driven by brv query-log view command (ENG-1897).
-// Full IQueryLogStore interface will be added in ENG-1888.
+import type {QueryLogEntry, QueryLogStatus, QueryLogTier} from '../../domain/entities/query-log-entry.js'
 
 // Re-export domain types — single source of truth is in the entity.
 export {QUERY_LOG_STATUSES, QUERY_LOG_TIERS} from '../../domain/entities/query-log-entry.js'
 export type {QueryLogStatus, QueryLogTier} from '../../domain/entities/query-log-entry.js'
+
+export interface IQueryLogStore {
+  /** Retrieve an entry by ID. Returns null if not found or if the file is corrupt. */
+  getById(id: string): Promise<null | QueryLogEntry>
+  /** List entries sorted newest-first. Filters are applied before limit. */
+  list(options?: {
+    /** Include only entries with startedAt >= after (ms timestamp). */
+    after?: number
+    /** Include only entries with startedAt <= before (ms timestamp). */
+    before?: number
+    limit?: number
+    /** Include only entries matching these statuses. */
+    status?: QueryLogStatus[]
+    /** Include only entries matching these tiers. */
+    tier?: QueryLogTier[]
+  }): Promise<QueryLogEntry[]>
+}

--- a/src/server/infra/storage/file-query-log-store.ts
+++ b/src/server/infra/storage/file-query-log-store.ts
@@ -1,10 +1,21 @@
 // Stub: minimal FileQueryLogStore for compilation (ENG-1897).
 // Full implementation with Zod validation, atomic writes, and pruning in ENG-1889.
 
-export class FileQueryLogStore {
+import type {QueryLogEntry} from '../../core/domain/entities/query-log-entry.js'
+import type {IQueryLogStore} from '../../core/interfaces/storage/i-query-log-store.js'
+
+export class FileQueryLogStore implements IQueryLogStore {
   readonly baseDir: string
 
   constructor(opts: {baseDir: string}) {
     this.baseDir = opts.baseDir
+  }
+
+  async getById(_id: string): Promise<null | QueryLogEntry> {
+    return null // Stub: real implementation in ENG-1889
+  }
+
+  async list(_options?: Parameters<IQueryLogStore['list']>[0]): Promise<QueryLogEntry[]> {
+    return [] // Stub: real implementation in ENG-1889
   }
 }

--- a/src/server/infra/usecase/query-log-use-case.ts
+++ b/src/server/infra/usecase/query-log-use-case.ts
@@ -1,19 +1,186 @@
-// Stub: minimal QueryLogUseCase for compilation (ENG-1897).
-// Full implementation with list/detail views in ENG-1896.
-
+import type {ITerminal} from '../../core/interfaces/i-terminal.js'
+import type {IQueryLogStore, QueryLogStatus, QueryLogTier} from '../../core/interfaces/storage/i-query-log-store.js'
 import type {IQueryLogUseCase} from '../../core/interfaces/usecase/i-query-log-use-case.js'
 
-type Terminal = {log(msg?: string): void}
+import {QUERY_LOG_TIER_LABELS} from '../../core/domain/entities/query-log-entry.js'
+import {formatDuration, formatEntryDuration, formatTimestamp, truncate} from '../../utils/log-format-utils.js'
 
 type QueryLogUseCaseDeps = {
-  queryLogStore: unknown
-  terminal: Terminal
+  queryLogStore: IQueryLogStore
+  terminal: ITerminal
 }
 
+type ListOptions = {
+  after?: number
+  before?: number
+  detail?: boolean
+  format?: 'json' | 'text'
+  limit?: number
+  status?: QueryLogStatus[]
+  tier?: QueryLogTier[]
+}
+
+/**
+ * Use case for displaying query log entries.
+ *
+ * Reads directly from FileQueryLogStore — no daemon connection required.
+ */
 export class QueryLogUseCase implements IQueryLogUseCase {
   constructor(private readonly deps: QueryLogUseCaseDeps) {}
 
-  async run(_options: Parameters<IQueryLogUseCase['run']>[0]): Promise<void> {
-    // Stub: real implementation in ENG-1896
+  async run({
+    after,
+    before,
+    detail = false,
+    format = 'text',
+    id,
+    limit = 10,
+    status,
+    tier,
+  }: {
+    after?: number
+    before?: number
+    detail?: boolean
+    format?: 'json' | 'text'
+    id?: string
+    limit?: number
+    status?: QueryLogStatus[]
+    tier?: QueryLogTier[]
+  }): Promise<void> {
+    await (id
+      ? this.showDetail(id, format)
+      : this.showList({after, before, detail, format, limit, status, tier}))
+  }
+
+  private log(msg?: string): void {
+    this.deps.terminal.log(msg)
+  }
+
+  private logJson(payload: {data: unknown; success: boolean}): void {
+    this.log(JSON.stringify({command: 'query view', ...payload, retrievedAt: new Date().toISOString()}, null, 2))
+  }
+
+  private async showDetail(id: string, format: 'json' | 'text'): Promise<void> {
+    const entry = await this.deps.queryLogStore.getById(id)
+
+    if (!entry) {
+      if (format === 'json') {
+        this.logJson({data: {error: `Log entry not found: ${id}`}, success: false})
+      } else {
+        this.log(`No query log entry found with ID: ${id}`)
+      }
+
+      return
+    }
+
+    if (format === 'json') {
+      this.logJson({data: entry, success: true})
+      return
+    }
+
+    this.log(`ID:       ${entry.id}`)
+    this.log(`Status:   ${entry.status}`)
+    this.log(`Tier:     ${entry.tier} (${QUERY_LOG_TIER_LABELS[entry.tier]})`)
+    this.log(`Started:  ${formatTimestamp(entry.startedAt)}`)
+
+    if (entry.status !== 'processing') {
+      this.log(`Finished: ${formatTimestamp(entry.completedAt)}`)
+      this.log(`Duration: ${formatDuration(entry.startedAt, entry.completedAt)}`)
+    }
+
+    this.log()
+    this.log(`Query: ${entry.query}`)
+
+    if (entry.status === 'completed' && entry.matchedDocs.length > 0) {
+      this.log()
+      this.log('Matched Documents:')
+      for (const doc of entry.matchedDocs) {
+        this.log(`  [${doc.score.toFixed(2)}] ${doc.path}`)
+      }
+    }
+
+    if (entry.status === 'completed') {
+      this.log()
+      this.log('Search Metadata:')
+      this.log(`  Results: ${entry.searchMetadata.resultsFound} of ${entry.searchMetadata.totalResults} found`)
+      this.log(`  Top Score: ${entry.searchMetadata.topScore}`)
+      if (entry.searchMetadata.cacheFingerprint) {
+        this.log(`  Cache Fingerprint: ${entry.searchMetadata.cacheFingerprint}`)
+      }
+    }
+
+    if (entry.status === 'error') {
+      this.log()
+      this.log(`Error: ${entry.error}`)
+    }
+
+    if (entry.status === 'completed' && entry.response) {
+      this.log()
+      this.log('Response (truncated):')
+      this.log(`  ${truncate(entry.response, 500)}`)
+    }
+  }
+
+  private async showList({after, before, detail, format, limit, status, tier}: ListOptions): Promise<void> {
+    const hasFilters = Boolean(after !== undefined || before !== undefined || status?.length || tier?.length)
+    const entries = await this.deps.queryLogStore.list({
+      ...(after === undefined ? {} : {after}),
+      ...(before === undefined ? {} : {before}),
+      limit,
+      ...(status?.length ? {status} : {}),
+      ...(tier?.length ? {tier} : {}),
+    })
+
+    if (format === 'json') {
+      this.logJson({data: entries, success: true})
+      return
+    }
+
+    if (entries.length === 0) {
+      if (hasFilters) {
+        this.log('No query log entries found matching your filters.')
+      } else {
+        this.log('No query log entries found.')
+      }
+
+      return
+    }
+
+    const idWidth = 22
+    const tierWidth = 6
+    const statusWidth = 12
+    const timeWidth = 8
+    const queryWidth = 40
+
+    const header = [
+      'ID'.padEnd(idWidth),
+      'Tier'.padEnd(tierWidth),
+      'Status'.padEnd(statusWidth),
+      'Time'.padEnd(timeWidth),
+      'Query',
+    ].join('  ')
+
+    this.log(header)
+    this.log('─'.repeat(idWidth + tierWidth + statusWidth + timeWidth + queryWidth + 8))
+
+    for (const entry of entries) {
+      const duration = formatEntryDuration(entry)
+      const tierBadge = `T${entry.tier}`
+      const query = truncate(entry.query, queryWidth)
+      const row = [
+        entry.id.padEnd(idWidth),
+        tierBadge.padEnd(tierWidth),
+        entry.status.padEnd(statusWidth),
+        duration.padEnd(timeWidth),
+        query,
+      ].join('  ')
+      this.log(row)
+
+      if (detail && entry.status === 'completed' && entry.matchedDocs.length > 0) {
+        for (const doc of entry.matchedDocs) {
+          this.log(`  [${doc.score.toFixed(2)}] ${doc.path}`)
+        }
+      }
+    }
   }
 }

--- a/src/server/infra/usecase/query-log-use-case.ts
+++ b/src/server/infra/usecase/query-log-use-case.ts
@@ -3,7 +3,7 @@ import type {IQueryLogStore, QueryLogStatus, QueryLogTier} from '../../core/inte
 import type {IQueryLogUseCase} from '../../core/interfaces/usecase/i-query-log-use-case.js'
 
 import {QUERY_LOG_TIER_LABELS} from '../../core/domain/entities/query-log-entry.js'
-import {formatDuration, formatEntryDuration, formatTimestamp, truncate} from '../../utils/log-format-utils.js'
+import {formatEntryDuration, formatTimestamp, truncate} from '../../utils/log-format-utils.js'
 
 type QueryLogUseCaseDeps = {
   queryLogStore: IQueryLogStore
@@ -85,7 +85,10 @@ export class QueryLogUseCase implements IQueryLogUseCase {
 
     if (entry.status !== 'processing') {
       this.log(`Finished: ${formatTimestamp(entry.completedAt)}`)
-      this.log(`Duration: ${formatDuration(entry.startedAt, entry.completedAt)}`)
+    }
+
+    if (entry.status === 'completed') {
+      this.log(`Duration: ${formatEntryDuration(entry)}`)
     }
 
     this.log()

--- a/src/server/utils/log-format-utils.ts
+++ b/src/server/utils/log-format-utils.ts
@@ -1,0 +1,22 @@
+import type {QueryLogEntry} from '../core/domain/entities/query-log-entry.js'
+
+export function formatDuration(startedAt: number, completedAt?: number): string {
+  if (completedAt === undefined) return '—'
+  const delta = completedAt - startedAt
+  if (delta < 1000) return `${delta}ms`
+  return `${(delta / 1000).toFixed(1)}s`
+}
+
+export function formatEntryDuration(entry: QueryLogEntry): string {
+  if (entry.status !== 'completed') return '—'
+  return formatDuration(entry.startedAt, entry.completedAt)
+}
+
+export function formatTimestamp(ms: number): string {
+  return new Date(ms).toISOString().replace('T', ' ').slice(0, 19)
+}
+
+export function truncate(text: string, max: number): string {
+  if (text.length <= max) return text
+  return text.slice(0, max) + '...'
+}

--- a/test/unit/infra/usecase/query-log-use-case.test.ts
+++ b/test/unit/infra/usecase/query-log-use-case.test.ts
@@ -13,6 +13,7 @@ import {QueryLogUseCase} from '../../../../src/server/infra/usecase/query-log-us
 type ProcessingEntry = Extract<QueryLogEntry, {status: 'processing'}>
 type CompletedEntry = Extract<QueryLogEntry, {status: 'completed'}>
 type ErrorEntry = Extract<QueryLogEntry, {status: 'error'}>
+type CancelledEntry = Extract<QueryLogEntry, {status: 'cancelled'}>
 
 function makeProcessingEntry(overrides: Partial<ProcessingEntry> = {}): ProcessingEntry {
   return {
@@ -57,6 +58,18 @@ function makeErrorEntry(overrides: Partial<ErrorEntry> = {}): ErrorEntry {
     startedAt: 1_712_345_678_700,
     status: 'error',
     tier: 2,
+    ...overrides,
+  }
+}
+
+function makeCancelledEntry(overrides: Partial<CancelledEntry> = {}): CancelledEntry {
+  return {
+    completedAt: 1_712_345_679_500,
+    id: 'qry-1712345678500',
+    query: 'explain the auth module',
+    startedAt: 1_712_345_678_500,
+    status: 'cancelled',
+    tier: 1,
     ...overrides,
   }
 }
@@ -194,6 +207,17 @@ describe('QueryLogUseCase', () => {
       expect(output).to.include('error')
       expect(output).to.include('—')
     })
+
+    // Test: Cancelled entries show dash for Time in list view
+    it('should show dash for Time column on cancelled entries', async () => {
+      store.list.resolves([makeCancelledEntry()])
+      await useCase.run({})
+
+      const output = logs.join('\n')
+      expect(output).to.include('T1')
+      expect(output).to.include('cancelled')
+      expect(output).to.include('—')
+    })
   })
 
   // ==========================================================================
@@ -226,6 +250,27 @@ describe('QueryLogUseCase', () => {
 
       const output = logs.join('\n')
       expect(output).to.include('Error: Search index unavailable')
+    })
+
+    // Test: Cancelled entry in detail shows Finished but not Duration
+    it('should show Finished but not Duration for cancelled entry', async () => {
+      store.getById.resolves(makeCancelledEntry())
+      await useCase.run({id: 'qry-1712345678500'})
+
+      const output = logs.join('\n')
+      expect(output).to.include('cancelled')
+      expect(output).to.include('Finished:')
+      expect(output).to.not.include('Duration:')
+    })
+
+    // Test: Error entry in detail shows Finished but not Duration
+    it('should show Finished but not Duration for error entry', async () => {
+      store.getById.resolves(makeErrorEntry())
+      await useCase.run({id: 'qry-1712345678700'})
+
+      const output = logs.join('\n')
+      expect(output).to.include('Finished:')
+      expect(output).to.not.include('Duration:')
     })
 
     // Test 12: Non-existent ID shows not-found message

--- a/test/unit/infra/usecase/query-log-use-case.test.ts
+++ b/test/unit/infra/usecase/query-log-use-case.test.ts
@@ -1,0 +1,292 @@
+import {expect} from 'chai'
+import {createSandbox, type SinonSandbox, type SinonStub} from 'sinon'
+
+import type {QueryLogEntry} from '../../../../src/server/core/domain/entities/query-log-entry.js'
+import type {IQueryLogStore} from '../../../../src/server/core/interfaces/storage/i-query-log-store.js'
+
+import {QueryLogUseCase} from '../../../../src/server/infra/usecase/query-log-use-case.js'
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+type ProcessingEntry = Extract<QueryLogEntry, {status: 'processing'}>
+type CompletedEntry = Extract<QueryLogEntry, {status: 'completed'}>
+type ErrorEntry = Extract<QueryLogEntry, {status: 'error'}>
+
+function makeProcessingEntry(overrides: Partial<ProcessingEntry> = {}): ProcessingEntry {
+  return {
+    id: 'qry-1712345678901',
+    query: 'How is auth implemented?',
+    startedAt: 1_712_345_678_901,
+    status: 'processing',
+    tier: 0,
+    ...overrides,
+  }
+}
+
+function makeCompletedEntry(overrides: Partial<CompletedEntry> = {}): CompletedEntry {
+  return {
+    completedAt: 1_712_345_678_913,
+    id: 'qry-1712345678901',
+    matchedDocs: [
+      {path: 'authentication/oauth_flow.md', score: 0.92},
+      {path: 'authentication/token_storage.md', score: 0.87},
+    ],
+    query: 'How is user authentication implemented?',
+    response: 'Based on the curated knowledge, authentication uses OAuth2 with JWT tokens.',
+    searchMetadata: {
+      cacheFingerprint: 'a1b2c3d4e5f6g7h8',
+      resultsFound: 2,
+      topScore: 0.92,
+      totalResults: 5,
+    },
+    startedAt: 1_712_345_678_901,
+    status: 'completed',
+    tier: 0,
+    ...overrides,
+  }
+}
+
+function makeErrorEntry(overrides: Partial<ErrorEntry> = {}): ErrorEntry {
+  return {
+    completedAt: 1_712_345_679_000,
+    error: 'Search index unavailable',
+    id: 'qry-1712345678700',
+    query: 'show me the deployment flow',
+    startedAt: 1_712_345_678_700,
+    status: 'error',
+    tier: 2,
+    ...overrides,
+  }
+}
+
+function makeStore(sandbox: SinonSandbox): IQueryLogStore & {
+  getById: SinonStub
+  list: SinonStub
+} {
+  return {
+    getById: sandbox.stub().resolves(null),
+    list: sandbox.stub().resolves([]),
+  }
+}
+
+describe('QueryLogUseCase', () => {
+  let sandbox: SinonSandbox
+  let store: ReturnType<typeof makeStore>
+  let logs: string[]
+  let useCase: QueryLogUseCase
+
+  beforeEach(() => {
+    sandbox = createSandbox()
+    store = makeStore(sandbox)
+    logs = []
+    useCase = new QueryLogUseCase({
+      queryLogStore: store,
+      terminal: {
+        log(msg?: string) {
+          logs.push(msg ?? '')
+        },
+      },
+    })
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  // ==========================================================================
+  // List mode (no id)
+  // ==========================================================================
+
+  describe('list mode', () => {
+    // Test 1: List with entries shows aligned table
+    it('should show aligned table with ID, Tier, Status, Time, Query columns', async () => {
+      store.list.resolves([makeCompletedEntry()])
+      await useCase.run({})
+
+      const output = logs.join('\n')
+      expect(output).to.include('ID')
+      expect(output).to.include('Tier')
+      expect(output).to.include('Status')
+      expect(output).to.include('Time')
+      expect(output).to.include('Query')
+      expect(output).to.include('qry-1712345678901')
+      expect(output).to.include('T0')
+      expect(output).to.include('completed')
+      expect(output).to.include('12ms')
+    })
+
+    // Test 2: Empty list shows message
+    it('should show empty state message when no entries', async () => {
+      store.list.resolves([])
+      await useCase.run({})
+
+      expect(logs.join('\n')).to.include('No query log entries found.')
+    })
+
+    // Test 3: Empty list + filters shows filter-specific message
+    it('should show filter-specific empty message when no entries match filters', async () => {
+      store.list.resolves([])
+      await useCase.run({status: ['completed']})
+
+      expect(logs.join('\n')).to.include('No query log entries found matching your filters.')
+    })
+
+    // Test 4: Query text truncated at 40 chars
+    it('should truncate query text at 40 chars in list view', async () => {
+      const longQuery = 'This is a very long query that exceeds forty characters limit for display'
+      store.list.resolves([makeCompletedEntry({query: longQuery})])
+      await useCase.run({})
+
+      const output = logs.join('\n')
+      // First 40 chars: "This is a very long query that exceeds f" + "..."
+      expect(output).to.include('This is a very long query that exceeds f...')
+      expect(output).to.not.include(longQuery)
+    })
+
+    // Test 5: JSON format outputs valid JSON
+    it('should output valid JSON with all fields', async () => {
+      store.list.resolves([makeCompletedEntry()])
+      await useCase.run({format: 'json'})
+
+      const output = logs.join('\n')
+      const parsed = JSON.parse(output)
+      expect(parsed.command).to.equal('query view')
+      expect(parsed.success).to.be.true
+      expect(Array.isArray(parsed.data)).to.be.true
+      expect(parsed.retrievedAt).to.be.a('string')
+    })
+
+    // Test 6: Tier filter passed through to store
+    it('should pass tier filter to store.list', async () => {
+      await useCase.run({tier: [0, 1]})
+      expect(store.list.calledWith({limit: 10, tier: [0, 1]})).to.be.true
+    })
+
+    // Test 7: Status filter passed through to store
+    it('should pass status filter to store.list', async () => {
+      await useCase.run({status: ['completed', 'error']})
+      expect(store.list.calledWith({limit: 10, status: ['completed', 'error']})).to.be.true
+    })
+
+    // Test 8: Time filters passed through to store
+    it('should pass after and before filters to store.list', async () => {
+      const after = 1_700_000_000_000
+      const before = 1_700_000_001_000
+      await useCase.run({after, before})
+      expect(store.list.calledWith({after, before, limit: 10})).to.be.true
+    })
+
+    // Test 9: Limit passed through to store
+    it('should pass limit to store.list', async () => {
+      await useCase.run({limit: 5})
+      expect(store.list.calledWith({limit: 5})).to.be.true
+    })
+
+    // Test: Error entries show dash for Time in list view
+    it('should show dash for Time column on error entries', async () => {
+      store.list.resolves([makeErrorEntry()])
+      await useCase.run({})
+
+      const output = logs.join('\n')
+      expect(output).to.include('T2')
+      expect(output).to.include('error')
+      expect(output).to.include('—')
+    })
+  })
+
+  // ==========================================================================
+  // Detail mode (with id)
+  // ==========================================================================
+
+  describe('detail mode', () => {
+    // Test 10: Detail shows all fields for completed entry
+    it('should show all fields for completed entry', async () => {
+      store.getById.resolves(makeCompletedEntry())
+      await useCase.run({id: 'qry-1712345678901'})
+
+      const output = logs.join('\n')
+      expect(output).to.include('qry-1712345678901')
+      expect(output).to.include('completed')
+      expect(output).to.include('0 (exact cache hit)')
+      expect(output).to.include('How is user authentication implemented?')
+      expect(output).to.include('authentication/oauth_flow.md')
+      expect(output).to.include('[0.92]')
+      expect(output).to.include('authentication/token_storage.md')
+      expect(output).to.include('[0.87]')
+      expect(output).to.include('a1b2c3d4e5f6g7h8')
+      expect(output).to.include('Based on the curated knowledge')
+    })
+
+    // Test 11: Detail shows error message for error entry
+    it('should show error message for error entry', async () => {
+      store.getById.resolves(makeErrorEntry())
+      await useCase.run({id: 'qry-1712345678700'})
+
+      const output = logs.join('\n')
+      expect(output).to.include('Error: Search index unavailable')
+    })
+
+    // Test 12: Non-existent ID shows not-found message
+    it('should show not-found message for non-existent ID', async () => {
+      store.getById.resolves(null)
+      await useCase.run({id: 'qry-missing'})
+
+      expect(logs.join('\n')).to.include('No query log entry found with ID: qry-missing')
+    })
+
+    // Test 13: Duration formatted correctly
+    it('should format duration correctly: ms for <1s, seconds for >=1s, dash for missing', async () => {
+      // 12ms duration
+      store.getById.resolves(makeCompletedEntry({
+        completedAt: 1_712_345_678_913,
+        startedAt: 1_712_345_678_901,
+      }))
+      await useCase.run({id: 'qry-1712345678901'})
+
+      let output = logs.join('\n')
+      expect(output).to.include('12ms')
+
+      // 3.2s duration
+      logs = []
+      store.getById.resolves(makeCompletedEntry({
+        completedAt: 1_712_345_682_101,
+        startedAt: 1_712_345_678_901,
+      }))
+      await useCase.run({id: 'qry-1712345678901'})
+
+      output = logs.join('\n')
+      expect(output).to.include('3.2s')
+
+      // processing (no completedAt) → no Finished line
+      logs = []
+      store.getById.resolves(makeProcessingEntry())
+      await useCase.run({id: 'qry-1712345678901'})
+
+      output = logs.join('\n')
+      expect(output).to.not.include('Finished')
+    })
+
+    // Test 14: Matched docs displayed with scores
+    it('should display matched docs with scores in detail view', async () => {
+      store.getById.resolves(makeCompletedEntry())
+      await useCase.run({id: 'qry-1712345678901'})
+
+      const output = logs.join('\n')
+      expect(output).to.include('[0.92] authentication/oauth_flow.md')
+      expect(output).to.include('[0.87] authentication/token_storage.md')
+    })
+
+    // Test 15: Response truncated at 500 chars
+    it('should truncate response at 500 chars in detail view', async () => {
+      const longResponse = 'A'.repeat(600)
+      store.getById.resolves(makeCompletedEntry({response: longResponse}))
+      await useCase.run({id: 'qry-1712345678901'})
+
+      const output = logs.join('\n')
+      expect(output).to.include('A'.repeat(500) + '...')
+      expect(output).to.not.include('A'.repeat(501))
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- **Problem:** `brv query-log view` command (ENG-1897) has a stub `QueryLogUseCase` that produces no output — the use case, entity, and store interface are empty shells.
- **Why it matters:** Without the use case implementation, the command is non-functional. Users cannot view query log history, filter by tier/status, or inspect individual entries.
- **What changed:** Implemented `QueryLogUseCase` with list view (aligned table) and detail view (full entry display). Defined `QueryLogEntry` discriminated union, `IQueryLogStore` interface, and `ITerminal` output port. Extracted shared formatting utilities to `log-format-utils.ts`. Updated `FileQueryLogStore` stub to satisfy the interface.
- **What did NOT change (scope boundary):** No changes to the oclif command (ENG-1897), no store implementation (ENG-1889), no daemon integration. The store still returns empty data — this PR only implements the formatting/presentation layer.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [ ] Agent / Tools
- [ ] LLM Providers
- [x] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes ENG-1896
- Related ENG-1897, ENG-1887, ENG-1888, ENG-1889

## Root cause (bug fixes only, otherwise write `N/A`)

N/A

## Test plan

- Coverage added:
  - [x] Unit test
  - [ ] Integration test
  - [ ] Manual verification only
- Test file(s): `test/unit/infra/usecase/query-log-use-case.test.ts`
- Key scenario(s) covered:
  - List view: aligned table, empty states (with/without filters), query truncation (40 chars), JSON output, filter passthrough (tier, status, after/before, limit), error entry shows "—" for Time
  - Detail view: all fields for completed entry, error message display, not-found message, duration formatting (ms/<1s, seconds/>=1s, dash/missing), matched docs with scores, response truncation (500 chars)
  - 16 test cases total (15 from ticket + 1 for error entry list view duration)

## User-visible changes

None yet — `FileQueryLogStore` is still a stub returning empty data. Once the store is implemented (ENG-1889), `brv query-log view` will display:

- **List view:** Table with ID, Tier badge (T0-T4), Status, Duration, Query (truncated)
- **Detail view:** Full entry with tier label, timestamps, duration, query, matched docs with scores, search metadata, response (truncated)
- **JSON mode:** Machine-parseable output with `command`, `success`, `data`, `retrievedAt` fields

## Evidence

- [x] Failing test/log before + passing after

Before (stub): 16 failing, 0 passing
After (implementation): 0 failing, 16 passing

```
  QueryLogUseCase
    list mode
      ✔ should show aligned table with ID, Tier, Status, Time, Query columns
      ✔ should show empty state message when no entries
      ✔ should show filter-specific empty message when no entries match filters
      ✔ should truncate query text at 40 chars in list view
      ✔ should output valid JSON with all fields
      ✔ should pass tier filter to store.list
      ✔ should pass status filter to store.list
      ✔ should pass after and before filters to store.list
      ✔ should pass limit to store.list
      ✔ should show dash for Time column on error entries
    detail mode
      ✔ should show all fields for completed entry
      ✔ should show error message for error entry
      ✔ should show not-found message for non-existent ID
      ✔ should format duration correctly: ms for <1s, seconds for >=1s, dash for missing
      ✔ should display matched docs with scores in detail view
      ✔ should truncate response at 500 chars in detail view

  16 passing (10ms)
```

## Checklist

- [x] Tests added or updated and passing (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented above)
- [x] Branch is up to date with `main`

## Risks and mitigations

- **Risk:** `QueryLogEntry` discriminated union fields may not match what `FileQueryLogStore` (ENG-1889) actually persists.
  - **Mitigation:** Entity was designed Outside-In from the use case's display needs. The store implementation will validate with Zod against this same shape. Any mismatch will surface as type errors at compile time.
