### PR TITLE
Feat/eng 2020

### DIFF
--- a/examples/code-review-swarm/.swarm.yaml
+++ b/examples/code-review-swarm/.swarm.yaml
@@ -1,0 +1,51 @@
+schema: byterover-swarm/v1
+
+agents:
+  analyzer:
+    adapter:
+      type: claude_code
+      config:
+        model: claude-sonnet-4-20250514
+    cwd: ./src
+    timeoutSec: 120
+    budgetMaxCostUsd: 0.50
+
+  researcher:
+    adapter:
+      type: claude_code
+      config:
+        model: claude-sonnet-4-20250514
+    timeoutSec: 90
+    budgetMaxCostUsd: 0.30
+
+  synthesizer:
+    adapter:
+      type: claude_code
+      config:
+        model: claude-sonnet-4-20250514
+    timeoutSec: 120
+    budgetMaxCostUsd: 0.40
+    output: true
+
+# Fixed edges: analyzer and researcher both feed into synthesizer
+edges:
+  - from: analyzer
+    to: synthesizer
+  - from: researcher
+    to: synthesizer
+
+# Potential edge: optimizer can decide if analyzer should feed researcher
+potential_edges:
+  - from: analyzer
+    to: researcher
+
+optimization:
+  edge:
+    enabled: true
+    lr: 0.1
+    initialProbability: 0.5
+    batchSize: 4
+  node:
+    enabled: true
+    historyWindow: 4
+  evaluator: llm_judge

--- a/examples/code-review-swarm/SWARM.md
+++ b/examples/code-review-swarm/SWARM.md
@@ -1,0 +1,25 @@
+---
+name: Code Review Pipeline
+description: Three-agent code review with static analysis, doc research, and synthesis
+slug: code-review-pipeline
+schema: byterover-swarm/v1
+version: 1.0.0
+goals:
+  - Catch bugs and security vulnerabilities before they ship
+  - Produce actionable, prioritized code review feedback
+  - Cross-reference findings with project documentation
+includes:
+  - agents/analyzer/AGENT.md
+  - agents/researcher/AGENT.md
+  - agents/synthesizer/AGENT.md
+---
+
+A three-agent pipeline for comprehensive code reviews:
+
+1. **Analyzer** performs static code analysis (bugs, security, performance)
+2. **Researcher** cross-references findings with docs and known patterns
+3. **Synthesizer** merges all inputs into a single prioritized review report
+
+The analyzer and researcher run in parallel (both feed into synthesizer).
+An optional potential edge from analyzer→researcher lets the optimizer
+decide if feeding analysis results into research improves output quality.

--- a/examples/code-review-swarm/agents/analyzer/AGENT.md
+++ b/examples/code-review-swarm/agents/analyzer/AGENT.md
@@ -1,0 +1,24 @@
+---
+name: Analyzer
+slug: analyzer
+description: Static code analysis agent that finds bugs, security issues, and performance problems
+role: worker
+skills:
+  - code-review
+  - security-audit
+---
+
+You are a senior code reviewer specializing in static analysis.
+
+Given a code diff or file, produce a structured list of findings. For each finding include:
+
+- **Severity**: critical | high | medium | low | info
+- **Category**: bug | security | performance | style | maintainability
+- **Location**: file path and line range
+- **Description**: What the issue is and why it matters
+- **Suggestion**: Concrete fix or improvement
+
+Focus on issues that would block a production deploy. Ignore trivial style nits
+unless they indicate a deeper structural problem.
+
+Output your findings as a markdown list sorted by severity (critical first).

--- a/examples/code-review-swarm/agents/researcher/AGENT.md
+++ b/examples/code-review-swarm/agents/researcher/AGENT.md
@@ -1,0 +1,20 @@
+---
+name: Researcher
+slug: researcher
+description: Documentation and pattern research agent
+role: worker
+---
+
+You are a technical researcher who cross-references code changes with
+project documentation, API specs, and known patterns.
+
+Given code or analysis findings from other agents, research:
+
+1. **Breaking changes**: Does this code violate any documented API contracts?
+2. **Known patterns**: Does the project have established patterns for this type of code?
+3. **Dependencies**: Are there upstream/downstream impacts not obvious from the diff?
+4. **Prior incidents**: Has similar code caused issues before?
+
+Output a research brief with sections for each area. Be specific — cite file paths,
+doc references, and prior commit messages where relevant. Say "no findings" for
+sections with nothing noteworthy.

--- a/examples/code-review-swarm/agents/synthesizer/AGENT.md
+++ b/examples/code-review-swarm/agents/synthesizer/AGENT.md
@@ -1,0 +1,28 @@
+---
+name: Synthesizer
+slug: synthesizer
+description: Review synthesis agent that produces the final actionable report
+role: worker
+---
+
+You are a staff engineer producing the final code review report.
+
+You receive inputs from:
+- **Analyzer**: structured list of bugs, security issues, and performance problems
+- **Researcher**: documentation cross-references, pattern violations, dependency impacts
+
+Synthesize these into a single review report:
+
+## Required Sections
+
+1. **Summary** (2-3 sentences): Overall assessment — is this safe to merge?
+2. **Must Fix** (blocking): Issues that must be resolved before merge
+3. **Should Fix** (non-blocking): Issues worth addressing but not blocking
+4. **Observations**: Patterns, documentation gaps, or suggestions for follow-up
+
+## Rules
+
+- Deduplicate findings that appear in both analyzer and researcher output
+- Elevate issues where both agents flagged the same area (cross-confirmed = higher confidence)
+- Be direct and actionable — every "Must Fix" item should have a clear next step
+- If analyzer and researcher disagree, note the disagreement and your recommendation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "byterover-cli",
-  "version": "2.6.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "byterover-cli",
-      "version": "2.6.0",
+      "version": "3.1.0",
       "bundleDependencies": [
         "@campfirein/brv-transport-client"
       ],

--- a/package.json
+++ b/package.json
@@ -163,6 +163,9 @@
       },
       "space": {
         "description": "Manage ByteRover spaces"
+      },
+      "swarm": {
+        "description": "Multi-agent swarm orchestration"
       }
     },
     "update": {

--- a/src/agent/infra/swarm/engine/edge-distribution.ts
+++ b/src/agent/infra/swarm/engine/edge-distribution.ts
@@ -18,7 +18,7 @@ export class EdgeDistribution {
 
   constructor(props: {initialProbability?: number; potentialConnections: Array<[string, string]>}) {
     this.potentialConnections = props.potentialConnections
-    const p = props.initialProbability ?? 0.5
+    const p = Math.max(1e-7, Math.min(1 - 1e-7, props.initialProbability ?? 0.5))
     const initLogit = Math.log(p / (1 - p))
     this.edgeLogits = new Float64Array(props.potentialConnections.length)
     this.edgeLogits.fill(initLogit)

--- a/src/agent/infra/swarm/engine/edge-distribution.ts
+++ b/src/agent/infra/swarm/engine/edge-distribution.ts
@@ -1,0 +1,93 @@
+import {SwarmGraph} from './swarm-graph.js'
+import {SwarmNode} from './swarm-node.js'
+
+function sigmoid(x: number): number {
+  return 1 / (1 + Math.exp(-x))
+}
+
+/**
+ * EdgeWise distribution over potential connections.
+ * Ported from GPTSwarm's EdgeWiseDistribution (parameterization.py).
+ *
+ * Each potential edge has a logit parameter. realize() samples a concrete
+ * DAG by including/excluding each edge stochastically via Bernoulli sampling.
+ */
+export class EdgeDistribution {
+  readonly edgeLogits: Float64Array
+  readonly potentialConnections: ReadonlyArray<[string, string]>
+
+  constructor(props: {initialProbability?: number; potentialConnections: Array<[string, string]>}) {
+    this.potentialConnections = props.potentialConnections
+    const p = props.initialProbability ?? 0.5
+    const initLogit = Math.log(p / (1 - p))
+    this.edgeLogits = new Float64Array(props.potentialConnections.length)
+    this.edgeLogits.fill(initLogit)
+  }
+
+  realize(props: {
+    graph: SwarmGraph
+    random?: () => number
+    temperature?: number
+    threshold?: number
+  }): {graph: SwarmGraph; logProb: number} {
+    const {graph, random = Math.random, temperature = 1, threshold} = props
+
+    if (this.potentialConnections.length === 0) {
+      return {graph, logProb: 0}
+    }
+
+    // Deep-clone graph nodes so we don't mutate the original
+    const clonedNodes = new Map<string, SwarmNode>()
+    for (const [id, node] of graph.nodes) {
+      clonedNodes.set(id, new SwarmNode({id, slug: node.slug}))
+    }
+
+    // Rebuild existing edges on cloned nodes
+    for (const [, original] of graph.nodes) {
+      const cloned = clonedNodes.get(original.id)!
+      for (const successor of original.successors) {
+        const clonedSuccessor = clonedNodes.get(successor.id)
+        if (clonedSuccessor) {
+          cloned.addSuccessor(clonedSuccessor)
+        }
+      }
+    }
+
+    const newGraph = new SwarmGraph()
+    for (const node of clonedNodes.values()) {
+      newGraph.addNode(node)
+    }
+
+    // Copy output nodes
+    const outputSlugs = graph.outputNodes.map((n) => n.slug)
+    if (outputSlugs.length > 0) {
+      newGraph.setOutputNodes(outputSlugs)
+    }
+
+    let logProb = 0
+
+    for (let i = 0; i < this.potentialConnections.length; i++) {
+      const [fromId, toId] = this.potentialConnections[i]
+      const fromNode = clonedNodes.get(fromId)
+      const toNode = clonedNodes.get(toId)
+
+      if (!fromNode || !toNode) continue
+
+      // Check if adding this edge would create a cycle
+      if (SwarmGraph.checkCycle(toNode, fromNode)) continue
+
+      const edgeProb = threshold === undefined
+        ? sigmoid(this.edgeLogits[i] / temperature)
+        : (sigmoid(this.edgeLogits[i] / temperature) > threshold ? 1 : 0)
+
+      if (random() < edgeProb) {
+        fromNode.addSuccessor(toNode)
+        logProb += Math.log(edgeProb)
+      } else {
+        logProb += Math.log(1 - edgeProb)
+      }
+    }
+
+    return {graph: newGraph, logProb}
+  }
+}

--- a/src/agent/infra/swarm/engine/swarm-graph.ts
+++ b/src/agent/infra/swarm/engine/swarm-graph.ts
@@ -1,0 +1,131 @@
+import type {SwarmNode} from './swarm-node.js'
+
+/**
+ * Error thrown when the graph contains a cycle.
+ */
+export class CycleDetectedError extends Error {
+  constructor(message?: string) {
+    super(message ?? 'Cycle detected in swarm graph')
+    this.name = 'CycleDetectedError'
+  }
+}
+
+/**
+ * Directed acyclic graph of SwarmNodes.
+ * Ported from GPTSwarm's Graph class (swarm/graph/graph.py).
+ */
+export class SwarmGraph {
+  readonly nodes = new Map<string, SwarmNode>()
+  private _outputNodes: SwarmNode[] = []
+
+  /**
+   * DFS-based cycle check: returns true if target is reachable from source
+   * via successor edges. Ported from GPTSwarm's CompositeGraph.check_cycle().
+   */
+  static checkCycle(source: SwarmNode, target: SwarmNode): boolean {
+    const visited = new Set<string>()
+
+    function dfs(node: SwarmNode): boolean {
+      if (node === target) return true
+      if (visited.has(node.id)) return false
+      visited.add(node.id)
+
+      for (const successor of node.successors) {
+        if (dfs(successor)) return true
+      }
+
+      return false
+    }
+
+    for (const successor of source.successors) {
+      if (dfs(successor)) return true
+    }
+
+    return false
+  }
+
+  get edgeCount(): number {
+    let count = 0
+    for (const node of this.nodes.values()) {
+      count += node.successors.length
+    }
+
+    return count
+  }
+
+  get nodeCount(): number {
+    return this.nodes.size
+  }
+
+  get outputNodes(): SwarmNode[] {
+    return this._outputNodes
+  }
+
+  addNode(node: SwarmNode): void {
+    if (this.nodes.has(node.id)) {
+      throw new Error(`Duplicate node id: "${node.id}"`)
+    }
+
+    this.nodes.set(node.id, node)
+  }
+
+  computeInDegrees(): Map<string, number> {
+    const degrees = new Map<string, number>()
+    for (const id of this.nodes.keys()) {
+      degrees.set(id, 0)
+    }
+
+    for (const node of this.nodes.values()) {
+      for (const successor of node.successors) {
+        degrees.set(successor.id, (degrees.get(successor.id) ?? 0) + 1)
+      }
+    }
+
+    return degrees
+  }
+
+  setOutputNodes(slugs: string[]): void {
+    this._outputNodes = []
+    for (const slug of slugs) {
+      for (const node of this.nodes.values()) {
+        if (node.slug === slug) {
+          this._outputNodes.push(node)
+
+          break
+        }
+      }
+    }
+  }
+
+  /**
+   * Kahn's algorithm for topological sort.
+   * Throws CycleDetectedError if the graph contains a cycle.
+   */
+  topologicalSort(): string[] {
+    const inDegrees = this.computeInDegrees()
+    const queue: string[] = []
+    const result: string[] = []
+
+    for (const [id, deg] of inDegrees) {
+      if (deg === 0) queue.push(id)
+    }
+
+    while (queue.length > 0) {
+      const current = queue.shift()!
+      result.push(current)
+      const node = this.nodes.get(current)!
+
+      for (const successor of node.successors) {
+        const newDeg = (inDegrees.get(successor.id) ?? 1) - 1
+        inDegrees.set(successor.id, newDeg)
+        if (newDeg === 0) queue.push(successor.id)
+      }
+    }
+
+    if (result.length !== this.nodes.size) {
+      throw new CycleDetectedError()
+    }
+
+    return result
+  }
+}

--- a/src/agent/infra/swarm/engine/swarm-node.ts
+++ b/src/agent/infra/swarm/engine/swarm-node.ts
@@ -1,0 +1,48 @@
+/**
+ * A node in the swarm DAG.
+ * Ported from GPTSwarm's Node class (swarm/graph/node.py).
+ * Manages bidirectional predecessor/successor links.
+ */
+export class SwarmNode {
+  readonly id: string
+  readonly predecessors: SwarmNode[] = []
+  readonly slug: string
+  readonly successors: SwarmNode[] = []
+
+  constructor(props: {id: string; slug: string}) {
+    this.id = props.id
+    this.slug = props.slug
+  }
+
+  addPredecessor(node: SwarmNode): void {
+    if (!this.predecessors.includes(node)) {
+      this.predecessors.push(node)
+      node.successors.push(this)
+    }
+  }
+
+  addSuccessor(node: SwarmNode): void {
+    if (!this.successors.includes(node)) {
+      this.successors.push(node)
+      node.predecessors.push(this)
+    }
+  }
+
+  removePredecessor(node: SwarmNode): void {
+    const idx = this.predecessors.indexOf(node)
+    if (idx !== -1) {
+      this.predecessors.splice(idx, 1)
+      const sIdx = node.successors.indexOf(this)
+      if (sIdx !== -1) node.successors.splice(sIdx, 1)
+    }
+  }
+
+  removeSuccessor(node: SwarmNode): void {
+    const idx = this.successors.indexOf(node)
+    if (idx !== -1) {
+      this.successors.splice(idx, 1)
+      const pIdx = node.predecessors.indexOf(this)
+      if (pIdx !== -1) node.predecessors.splice(pIdx, 1)
+    }
+  }
+}

--- a/src/agent/infra/swarm/errors.ts
+++ b/src/agent/infra/swarm/errors.ts
@@ -1,0 +1,18 @@
+/**
+ * Thrown when swarm spec validation finds one or more errors.
+ * Carries all errors and warnings collected during validation,
+ * plus an optional info note for cascade context.
+ */
+export class SwarmValidationError extends Error {
+  readonly errors: string[]
+  readonly note: null | string
+  readonly warnings: string[]
+
+  constructor(errors: string[], warnings: string[] = [], note: null | string = null) {
+    super(errors.join('\n'))
+    this.name = 'SwarmValidationError'
+    this.errors = errors
+    this.note = note
+    this.warnings = warnings
+  }
+}

--- a/src/agent/infra/swarm/frontmatter.ts
+++ b/src/agent/infra/swarm/frontmatter.ts
@@ -1,0 +1,42 @@
+import {load as yamlLoad} from 'js-yaml'
+
+/**
+ * Parse YAML frontmatter from markdown content.
+ * Returns the parsed frontmatter object and the markdown body, or null if
+ * no valid frontmatter is found.
+ *
+ * Follows the pattern from summary-frontmatter.ts.
+ */
+export function parseFrontmatter<T = Record<string, unknown>>(
+  content: string,
+): null | {body: string; frontmatter: T} {
+  if (!content.startsWith('---\n') && !content.startsWith('---\r\n')) {
+    return null
+  }
+
+  const lfEnd = content.indexOf('\n---\n', 4)
+  const crlfEnd = content.indexOf('\r\n---\r\n', 5)
+
+  const result = findDelimiter(content, lfEnd, crlfEnd)
+  if (!result) return null
+
+  try {
+    const parsed = yamlLoad(result.yamlBlock) as null | T
+    if (!parsed || typeof parsed !== 'object') return null
+
+    return {body: content.slice(result.bodyStart), frontmatter: parsed}
+  } catch {
+    return null
+  }
+}
+
+function findDelimiter(
+  content: string,
+  lfEnd: number,
+  crlfEnd: number,
+): null | {bodyStart: number; yamlBlock: string} {
+  if (lfEnd === -1 && crlfEnd === -1) return null
+  if (lfEnd === -1) return {bodyStart: crlfEnd + 7, yamlBlock: content.slice(5, crlfEnd)}
+
+  return {bodyStart: lfEnd + 5, yamlBlock: content.slice(4, lfEnd)}
+}

--- a/src/agent/infra/swarm/index.ts
+++ b/src/agent/infra/swarm/index.ts
@@ -1,0 +1,20 @@
+export {SwarmValidationError} from './errors.js'
+export {buildSwarmGraph} from './swarm-graph-builder.js'
+export {SwarmLoader} from './swarm-loader.js'
+export type {ScaffoldInput} from './swarm-scaffolder.js'
+export {scaffoldSwarm} from './swarm-scaffolder.js'
+export type {WizardPrompts} from './swarm-wizard.js'
+export {runWizard} from './swarm-wizard.js'
+export type {
+  AdapterType,
+  AgentFrontmatter,
+  AgentRuntimeConfig,
+  AgentSpec,
+  EdgeDef,
+  LoadedSwarm,
+  SwarmFileReader,
+  SwarmFrontmatter,
+  SwarmRuntimeConfig,
+  SwarmSummary,
+} from './types.js'
+export {KNOWN_ADAPTER_TYPES} from './types.js'

--- a/src/agent/infra/swarm/swarm-graph-builder.ts
+++ b/src/agent/infra/swarm/swarm-graph-builder.ts
@@ -24,8 +24,12 @@ export function buildSwarmGraph(loaded: LoadedSwarm): {
 
   // Wire fixed edges
   for (const edge of runtimeConfig.edges) {
-    const from = graph.nodes.get(edge.from)!
-    const to = graph.nodes.get(edge.to)!
+    const from = graph.nodes.get(edge.from)
+    const to = graph.nodes.get(edge.to)
+    if (!from || !to) {
+      throw new Error(`Internal: node missing for edge ${edge.from} -> ${edge.to}`)
+    }
+
     from.addSuccessor(to)
   }
 

--- a/src/agent/infra/swarm/swarm-graph-builder.ts
+++ b/src/agent/infra/swarm/swarm-graph-builder.ts
@@ -1,0 +1,66 @@
+import type {LoadedSwarm, SwarmSummary} from './types.js'
+
+import {EdgeDistribution} from './engine/edge-distribution.js'
+import {SwarmGraph} from './engine/swarm-graph.js'
+import {SwarmNode} from './engine/swarm-node.js'
+
+/**
+ * Build a validated SwarmGraph + EdgeDistribution from a LoadedSwarm.
+ * Returns a summary DTO for CLI display.
+ * Throws CycleDetectedError if fixed edges form a cycle.
+ */
+export function buildSwarmGraph(loaded: LoadedSwarm): {
+  edgeDistribution: EdgeDistribution
+  graph: SwarmGraph
+  summary: SwarmSummary
+} {
+  const graph = new SwarmGraph()
+  const {agents, frontmatter, runtimeConfig} = loaded
+
+  // Create nodes (keyed by slug)
+  for (const agent of agents) {
+    graph.addNode(new SwarmNode({id: agent.frontmatter.slug, slug: agent.frontmatter.slug}))
+  }
+
+  // Wire fixed edges
+  for (const edge of runtimeConfig.edges) {
+    const from = graph.nodes.get(edge.from)!
+    const to = graph.nodes.get(edge.to)!
+    from.addSuccessor(to)
+  }
+
+  // Validate DAG (throws CycleDetectedError if cyclic)
+  graph.topologicalSort()
+
+  // Set output nodes
+  const outputSlugs = Object.entries(runtimeConfig.agents)
+    .filter(([, config]) => config.output === true)
+    .map(([slug]) => slug)
+  graph.setOutputNodes(outputSlugs)
+
+  // Build edge distribution
+  const potentialConnections: Array<[string, string]> = runtimeConfig.potentialEdges.map(
+    (e) => [e.from, e.to],
+  )
+  const initialProbability = runtimeConfig.optimization?.edge?.initialProbability
+  const edgeDistribution = new EdgeDistribution({
+    initialProbability,
+    potentialConnections,
+  })
+
+  // Build summary
+  const summary: SwarmSummary = {
+    agentCount: agents.length,
+    agents: agents.map((a) => ({
+      adapterType: runtimeConfig.agents[a.frontmatter.slug].adapter.type,
+      slug: a.frontmatter.slug,
+    })),
+    fixedEdgeCount: runtimeConfig.edges.length,
+    name: frontmatter.name,
+    outputNodes: outputSlugs,
+    potentialEdgeCount: runtimeConfig.potentialEdges.length,
+    slug: frontmatter.slug,
+  }
+
+  return {edgeDistribution, graph, summary}
+}

--- a/src/agent/infra/swarm/swarm-loader.ts
+++ b/src/agent/infra/swarm/swarm-loader.ts
@@ -82,6 +82,7 @@ const defaultFileReader: SwarmFileReader = {
       return false
     }
   },
+  // Only supports "**/<suffix>" patterns; full glob not implemented.
   async glob(dir: string, pattern: string) {
     const suffix = pattern.replace('**/', '')
     const entries = await fs.readdir(dir, {recursive: true})
@@ -151,7 +152,11 @@ export class SwarmLoader {
     const normalizedIncludes = this.validateIncludes(frontmatter.includes, sourceDir)
 
     const yamlContent = await this.reader.readFile(yamlPath)
-    const rawYaml = yamlLoad(yamlContent) as Record<string, unknown>
+    const rawYaml = yamlLoad(yamlContent)
+    if (!rawYaml || typeof rawYaml !== 'object' || Array.isArray(rawYaml)) {
+      throw new Error('.swarm.yaml must be a YAML object (got empty or non-object content)')
+    }
+
     const parsed = SwarmRuntimeConfigSchema.parse(rawYaml)
     const runtimeConfig: SwarmRuntimeConfig = {
       agents: parsed.agents,

--- a/src/agent/infra/swarm/swarm-loader.ts
+++ b/src/agent/infra/swarm/swarm-loader.ts
@@ -1,0 +1,359 @@
+/* eslint-disable camelcase */
+
+import {load as yamlLoad} from 'js-yaml'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import {z} from 'zod'
+
+import type {AgentSpec, EdgeDef, LoadedSwarm, SwarmFileReader, SwarmRuntimeConfig} from './types.js'
+
+import {SwarmValidationError} from './errors.js'
+import {parseFrontmatter} from './frontmatter.js'
+import {KNOWN_ADAPTER_TYPES} from './types.js'
+
+// ─── Zod Schemas ───
+
+const SwarmFrontmatterSchema = z.object({
+  description: z.string().min(1),
+  goals: z.array(z.string()).min(1),
+  includes: z.array(z.string()).min(1),
+  name: z.string().min(1),
+  schema: z.literal('byterover-swarm/v1'),
+  slug: z.string().min(1).regex(/^[a-z0-9-]+$/),
+  version: z.string().min(1),
+})
+
+const AgentFrontmatterSchema = z.object({
+  description: z.string().min(1),
+  name: z.string().min(1),
+  role: z.string().min(1),
+  skills: z.array(z.string()).default([]),
+  slug: z.string().min(1).regex(/^[a-z0-9-]+$/),
+})
+
+const AgentRuntimeConfigSchema = z.object({
+  adapter: z.object({
+    config: z.record(z.unknown()).optional(),
+    type: z.enum(KNOWN_ADAPTER_TYPES),
+  }),
+  budgetMaxCostUsd: z.number().positive().optional(),
+  cwd: z.string().optional(),
+  output: z.boolean().optional(),
+  timeoutSec: z.number().positive().optional(),
+})
+
+const EdgeDefSchema = z.object({
+  from: z.string().min(1),
+  to: z.string().min(1),
+})
+
+const SwarmRuntimeConfigSchema = z.object({
+  agents: z.record(z.string(), AgentRuntimeConfigSchema).refine(
+    (obj) => Object.keys(obj).length > 0,
+    {message: 'At least one agent must be defined'},
+  ),
+  edges: z.array(EdgeDefSchema).default([]),
+  optimization: z.object({
+    edge: z.object({
+      batchSize: z.number().positive().optional(),
+      enabled: z.boolean().optional(),
+      initialProbability: z.number().min(0).max(1).optional(),
+      lr: z.number().positive().optional(),
+    }).optional(),
+    evaluator: z.string().optional(),
+    node: z.object({
+      enabled: z.boolean().optional(),
+      historyWindow: z.number().positive().optional(),
+    }).optional(),
+  }).optional(),
+  potential_edges: z.array(EdgeDefSchema).default([]),
+  schema: z.literal('byterover-swarm/v1'),
+})
+
+// ─── Default file reader using node:fs/promises ───
+
+const defaultFileReader: SwarmFileReader = {
+  async exists(p: string) {
+    try {
+      await fs.access(p)
+
+      return true
+    } catch {
+      return false
+    }
+  },
+  async glob(dir: string, pattern: string) {
+    const suffix = pattern.replace('**/', '')
+    const entries = await fs.readdir(dir, {recursive: true})
+
+    return entries
+      .filter((entry) => typeof entry === 'string' && entry.endsWith(suffix))
+      .map((entry) => path.join(dir, entry as string))
+  },
+  async isDirectory(p: string) {
+    try {
+      const stat = await fs.stat(p)
+
+      return stat.isDirectory()
+    } catch {
+      return false
+    }
+  },
+  async readFile(p: string) {
+    return fs.readFile(p, 'utf8')
+  },
+}
+
+// ─── SwarmLoader ───
+
+export class SwarmLoader {
+  private readonly reader: SwarmFileReader
+
+  constructor(props?: {fileReader?: SwarmFileReader}) {
+    this.reader = props?.fileReader ?? defaultFileReader
+  }
+
+  async load(dirPath: string): Promise<LoadedSwarm> {
+    const sourceDir = path.resolve(dirPath)
+    const warnings: string[] = []
+
+    // ── Phase 1: File existence (fail-fast) ──
+    const exists = await this.reader.exists(sourceDir)
+    if (!exists) {
+      throw new Error(`Swarm directory does not exist: ${sourceDir}`)
+    }
+
+    const isDir = await this.reader.isDirectory(sourceDir)
+    if (!isDir) {
+      throw new Error(`Path is not a directory: ${sourceDir}`)
+    }
+
+    const swarmMdPath = path.join(sourceDir, 'SWARM.md')
+    const swarmMdExists = await this.reader.exists(swarmMdPath)
+    if (!swarmMdExists) {
+      throw new Error(`SWARM.md not found in ${sourceDir}`)
+    }
+
+    const yamlPath = path.join(sourceDir, '.swarm.yaml')
+    const yamlExists = await this.reader.exists(yamlPath)
+    if (!yamlExists) {
+      throw new Error(`.swarm.yaml not found in ${sourceDir}`)
+    }
+
+    // ── Phase 2: Schema parsing (fail-fast) ──
+    const swarmMdContent = await this.reader.readFile(swarmMdPath)
+    const swarmParsed = parseFrontmatter(swarmMdContent)
+    if (!swarmParsed) {
+      throw new Error('SWARM.md has invalid or missing frontmatter')
+    }
+
+    const frontmatter = SwarmFrontmatterSchema.parse(swarmParsed.frontmatter)
+    const normalizedIncludes = this.validateIncludes(frontmatter.includes, sourceDir)
+
+    const yamlContent = await this.reader.readFile(yamlPath)
+    const rawYaml = yamlLoad(yamlContent) as Record<string, unknown>
+    const parsed = SwarmRuntimeConfigSchema.parse(rawYaml)
+    const runtimeConfig: SwarmRuntimeConfig = {
+      agents: parsed.agents,
+      edges: parsed.edges,
+      optimization: parsed.optimization,
+      potentialEdges: parsed.potential_edges,
+      schema: parsed.schema,
+    }
+
+    // ── Phase 3: Agent loading + cross-validation (accumulate errors) ──
+    const {agents, errors: agentErrors, failedIncludeCount} = await this.loadAgents(normalizedIncludes, sourceDir)
+
+    // Discovery: warn about orphan AGENT.md files not in includes
+    const agentFilesOnDisk = await this.reader.glob(sourceDir, '**/AGENT.md')
+    const includedAbsPaths = new Set(normalizedIncludes.map((inc) => path.resolve(sourceDir, inc)))
+    for (const diskPath of agentFilesOnDisk) {
+      if (!includedAbsPaths.has(path.resolve(diskPath))) {
+        warnings.push(`Found ${path.relative(sourceDir, diskPath)} on disk but not in SWARM.md includes`)
+      }
+    }
+
+    const crossValidationErrors: string[] = []
+
+    // Slug cross-validation
+    const agentSlugs = new Set(agents.map((a) => a.frontmatter.slug))
+    const configSlugs = new Set(Object.keys(runtimeConfig.agents))
+
+    for (const configSlug of configSlugs) {
+      if (!agentSlugs.has(configSlug)) {
+        crossValidationErrors.push(`Agent "${configSlug}" in .swarm.yaml has no AGENT.md`)
+      }
+    }
+
+    for (const agentSlug of agentSlugs) {
+      if (!configSlugs.has(agentSlug)) {
+        crossValidationErrors.push(`Agent "${agentSlug}" has AGENT.md but no entry in .swarm.yaml`)
+      }
+    }
+
+    // Edge validation
+    const edgeErrors = this.validateEdges(runtimeConfig.edges, runtimeConfig.potentialEdges, agentSlugs)
+    crossValidationErrors.push(...edgeErrors)
+
+    // Check for output nodes
+    const hasOutput = Object.values(runtimeConfig.agents).some((a) => a.output === true)
+    if (!hasOutput) {
+      warnings.push('No agents have output: true. At least one output node is recommended.')
+    }
+
+    // Throw if any errors accumulated
+    const allErrors = [...agentErrors, ...crossValidationErrors]
+    if (allErrors.length > 0) {
+      const note = failedIncludeCount > 0 && crossValidationErrors.length > 0
+        ? `Note: ${failedIncludeCount} included file(s) failed to load. Some errors above may resolve after fixing those files.`
+        : null
+      throw new SwarmValidationError(allErrors, warnings, note)
+    }
+
+    return {
+      agents,
+      description: swarmParsed.body.trim(),
+      frontmatter,
+      runtimeConfig,
+      sourceDir,
+      warnings,
+    }
+  }
+
+  private async loadAgents(
+    normalizedIncludes: string[],
+    sourceDir: string,
+  ): Promise<{agents: AgentSpec[]; errors: string[]; failedIncludeCount: number}> {
+    const agents: AgentSpec[] = []
+    const errors: string[] = []
+    const slugToPath = new Map<string, string>()
+    let failedIncludeCount = 0
+
+    const readResults = await Promise.allSettled(
+      normalizedIncludes.map(async (includePath) => {
+        const agentMdPath = path.join(sourceDir, includePath)
+        const agentExists = await this.reader.exists(agentMdPath)
+        if (!agentExists) {
+          throw new Error(`Agent spec not found: ${includePath} referenced in includes but not found`)
+        }
+
+        const content = await this.reader.readFile(agentMdPath)
+
+        return {content, includePath}
+      }),
+    )
+
+    for (const result of readResults) {
+      if (result.status === 'rejected') {
+        errors.push((result.reason as Error).message)
+        failedIncludeCount++
+        continue
+      }
+
+      const {content, includePath} = result.value
+
+      const agentParsed = parseFrontmatter(content)
+      if (!agentParsed) {
+        errors.push(`${includePath} has invalid or missing frontmatter`)
+        failedIncludeCount++
+        continue
+      }
+
+      const agentFmResult = AgentFrontmatterSchema.safeParse(agentParsed.frontmatter)
+      if (!agentFmResult.success) {
+        const issues = agentFmResult.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join(', ')
+        errors.push(`${includePath}: ${issues}`)
+        failedIncludeCount++
+        continue
+      }
+
+      const agentFm = agentFmResult.data
+
+      // Check duplicate slugs
+      const existingPath = slugToPath.get(agentFm.slug)
+      if (existingPath) {
+        errors.push(`Duplicate agent slug "${agentFm.slug}" defined in both ${existingPath} and ${includePath}`)
+        continue
+      }
+
+      slugToPath.set(agentFm.slug, includePath)
+
+      agents.push({
+        frontmatter: agentFm,
+        prompt: agentParsed.body.trim(),
+        sourcePath: path.resolve(sourceDir, includePath),
+      })
+    }
+
+    return {agents, errors, failedIncludeCount}
+  }
+
+  private validateEdges(edges: EdgeDef[], potentialEdges: EdgeDef[], validSlugs: Set<string>): string[] {
+    const errors: string[] = []
+    const edgeKeys = new Set<string>()
+
+    for (const edge of edges) {
+      if (!validSlugs.has(edge.from)) {
+        errors.push(`Edge references unknown agent "${edge.from}"`)
+      }
+
+      if (!validSlugs.has(edge.to)) {
+        errors.push(`Edge references unknown agent "${edge.to}"`)
+      }
+
+      const key = `${edge.from}->${edge.to}`
+      if (edgeKeys.has(key)) {
+        errors.push(`Duplicate fixed edge: ${key}`)
+      }
+
+      edgeKeys.add(key)
+    }
+
+    const potentialKeys = new Set<string>()
+    for (const edge of potentialEdges) {
+      if (!validSlugs.has(edge.from)) {
+        errors.push(`Potential edge references unknown agent "${edge.from}"`)
+      }
+
+      if (!validSlugs.has(edge.to)) {
+        errors.push(`Potential edge references unknown agent "${edge.to}"`)
+      }
+
+      const key = `${edge.from}->${edge.to}`
+      if (potentialKeys.has(key)) {
+        errors.push(`Duplicate potential edge: ${key}`)
+      }
+
+      if (edgeKeys.has(key)) {
+        errors.push(`Edge ${key} appears in both edges and potential_edges`)
+      }
+
+      potentialKeys.add(key)
+    }
+
+    return errors
+  }
+
+  private validateIncludes(includes: string[], sourceDir: string): string[] {
+    const normalized: string[] = []
+    const seen = new Set<string>()
+
+    for (const inc of includes) {
+      const norm = path.normalize(inc)
+
+      const resolved = path.resolve(sourceDir, norm)
+      if (!resolved.startsWith(sourceDir + path.sep) && resolved !== sourceDir) {
+        throw new Error(`Include path "${inc}" escapes swarm directory`)
+      }
+
+      if (seen.has(norm)) {
+        throw new Error(`Duplicate include: "${inc}" (resolves to "${norm}")`)
+      }
+
+      seen.add(norm)
+      normalized.push(norm)
+    }
+
+    return normalized
+  }
+}

--- a/src/agent/infra/swarm/swarm-scaffolder.ts
+++ b/src/agent/infra/swarm/swarm-scaffolder.ts
@@ -1,0 +1,75 @@
+import {dump as yamlDump} from 'js-yaml'
+
+import type {AdapterType} from './types.js'
+
+// ─── Input / Output Types ───
+
+export type ScaffoldInput = {
+  agents: Array<{adapterType: AdapterType; description: string; name: string; role?: string; slug: string}>
+  description: string
+  edges: Array<{from: string; to: string}>
+  goals: string[]
+  name: string
+  outputNodeSlug: string
+  slug: string
+}
+
+// ─── Scaffolder ───
+
+/**
+ * Pure function: generates swarm spec files from structured input.
+ * Returns a map of relative file paths to file content strings.
+ * Zero I/O — caller is responsible for writing to disk.
+ */
+export function scaffoldSwarm(input: ScaffoldInput): Record<string, string> {
+  const files: Record<string, string> = {}
+
+  // SWARM.md
+  const swarmFrontmatter = {
+    description: input.description,
+    goals: input.goals,
+    includes: input.agents.map((a) => `agents/${a.slug}/AGENT.md`),
+    name: input.name,
+    schema: 'byterover-swarm/v1',
+    slug: input.slug,
+    version: '1.0.0',
+  }
+  const swarmYaml = yamlDump(swarmFrontmatter, {lineWidth: -1, sortKeys: true}).trimEnd()
+  files['SWARM.md'] = `---\n${swarmYaml}\n---\n\n${input.description}\n`
+
+  // AGENT.md per agent
+  for (const agent of input.agents) {
+    const agentFrontmatter = {
+      description: agent.description,
+      name: agent.name,
+      role: agent.role ?? 'worker',
+      slug: agent.slug,
+    }
+    const agentYaml = yamlDump(agentFrontmatter, {lineWidth: -1, sortKeys: true}).trimEnd()
+    const prompt = `Describe the behavior of the ${agent.name} agent here.`
+    files[`agents/${agent.slug}/AGENT.md`] = `---\n${agentYaml}\n---\n\n${prompt}\n`
+  }
+
+  // .swarm.yaml
+  const agentsConfig: Record<string, Record<string, unknown>> = {}
+  for (const agent of input.agents) {
+    const config: Record<string, unknown> = {
+      adapter: {type: agent.adapterType},
+    }
+    if (agent.slug === input.outputNodeSlug) {
+      config.output = true
+    }
+
+    agentsConfig[agent.slug] = config
+  }
+
+  const swarmConfig: Record<string, unknown> = {
+    agents: agentsConfig,
+    edges: input.edges.map((e) => ({from: e.from, to: e.to})),
+    potential_edges: [], // eslint-disable-line camelcase
+    schema: 'byterover-swarm/v1',
+  }
+  files['.swarm.yaml'] = yamlDump(swarmConfig, {lineWidth: -1}).trimEnd() + '\n'
+
+  return files
+}

--- a/src/agent/infra/swarm/swarm-scaffolder.ts
+++ b/src/agent/infra/swarm/swarm-scaffolder.ts
@@ -43,6 +43,7 @@ export function scaffoldSwarm(input: ScaffoldInput): Record<string, string> {
       description: agent.description,
       name: agent.name,
       role: agent.role ?? 'worker',
+      skills: [] as string[],
       slug: agent.slug,
     }
     const agentYaml = yamlDump(agentFrontmatter, {lineWidth: -1, sortKeys: true}).trimEnd()

--- a/src/agent/infra/swarm/swarm-wizard.ts
+++ b/src/agent/infra/swarm/swarm-wizard.ts
@@ -1,0 +1,171 @@
+import type {ScaffoldInput} from './swarm-scaffolder.js'
+import type {AdapterType} from './types.js'
+
+import {KNOWN_ADAPTER_TYPES} from './types.js'
+
+// ─── Injectable Prompt Interface ───
+
+export type WizardPrompts = {
+  checkbox(message: string, choices: Array<{name: string; value: string}>): Promise<string[]>
+  confirm(message: string): Promise<boolean>
+  input(message: string, opts?: {default?: string; validate?: (v: string) => boolean | string}): Promise<string>
+  select(message: string, choices: Array<{name: string; value: string}>): Promise<string>
+}
+
+// ─── Wizard State ───
+
+type WizardState = {
+  agents: Array<{adapterType: AdapterType; description: string; name: string; slug: string}>
+  description: string
+  edges: Array<{from: string; to: string}>
+  goals: string[]
+  name: string
+  outputNodeSlug: string
+  slug: string
+}
+
+function toSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/g, '-')
+    .replaceAll(/^-|-$/g, '')
+}
+
+// ─── Step Implementations ───
+// Steps are inherently sequential interactive prompts — each depends on the previous answer.
+/* eslint-disable no-await-in-loop */
+
+async function stepIdentity(prompts: WizardPrompts, state: WizardState): Promise<void> {
+  state.name = await prompts.input('Swarm name', {
+    default: state.name || undefined,
+    validate: (v) => v.trim().length > 0 || 'Name is required',
+  })
+  state.slug = await prompts.input('Slug', {
+    default: toSlug(state.name),
+    validate: (v) => /^[a-z0-9-]+$/.test(v) || 'Slug must be lowercase letters, numbers, and hyphens',
+  })
+  state.description = await prompts.input('Description', {
+    default: state.description || undefined,
+    validate: (v) => v.trim().length > 0 || 'Description is required',
+  })
+  const goalsRaw = await prompts.input('Goals (comma-separated)', {
+    default: state.goals.length > 0 ? state.goals.join(', ') : undefined,
+    validate: (v) => v.trim().length > 0 || 'At least one goal is required',
+  })
+  state.goals = goalsRaw.split(',').map((g) => g.trim()).filter(Boolean)
+}
+
+async function stepAgents(prompts: WizardPrompts, state: WizardState): Promise<void> {
+  const agents: typeof state.agents = []
+  let addMore = true
+
+  while (addMore) {
+    const name = await prompts.input(`Agent ${agents.length + 1} name`, {
+      validate(v) { return v.trim().length > 0 || 'Name is required' },
+    })
+    const slug = await prompts.input('Slug', {
+      default: toSlug(name),
+      validate(v) {
+        if (!/^[a-z0-9-]+$/.test(v)) return 'Slug must be lowercase letters, numbers, and hyphens'
+        if (agents.some((a) => a.slug === v)) return `Slug "${v}" already used`
+
+        return true
+      },
+    })
+    const description = await prompts.input('Description', {
+      validate(v) { return v.trim().length > 0 || 'Description is required' },
+    })
+    const adapterType = await prompts.select(
+      'Adapter type',
+      KNOWN_ADAPTER_TYPES.map((t) => ({name: t, value: t})),
+    ) as AdapterType
+
+    agents.push({adapterType, description, name, slug})
+
+    addMore = await prompts.confirm('Add another agent?')
+  }
+
+  state.agents = agents
+}
+
+async function stepEdges(prompts: WizardPrompts, state: WizardState): Promise<void> {
+  const edges: Array<{from: string; to: string}> = []
+
+  for (const agent of state.agents) {
+    const targets = state.agents.filter((a) => a.slug !== agent.slug)
+    if (targets.length === 0) continue
+
+    const selected = await prompts.checkbox(
+      `Which agents should receive output from "${agent.name}"?`,
+      targets.map((t) => ({name: t.name, value: t.slug})),
+    )
+
+    for (const target of selected) {
+      edges.push({from: agent.slug, to: target})
+    }
+  }
+
+  state.edges = edges
+}
+
+async function stepOutput(prompts: WizardPrompts, state: WizardState): Promise<void> {
+  state.outputNodeSlug = await prompts.select(
+    'Which agent produces the final output?',
+    state.agents.map((a) => ({name: a.name, value: a.slug})),
+  )
+}
+
+/* eslint-enable no-await-in-loop */
+
+// ─── Main Wizard ───
+
+const STEPS = [stepIdentity, stepAgents, stepEdges, stepOutput] as const
+
+/**
+ * Runs the interactive swarm scaffolding wizard.
+ * Returns ScaffoldInput on success, null if user cancels.
+ *
+ * Errors with name 'AbortPromptError' trigger back-navigation.
+ * Errors with name 'ExitPromptError' or 'CancelPromptError' cancel the wizard.
+ */
+export async function runWizard(prompts: WizardPrompts): Promise<null | ScaffoldInput> {
+  const state: WizardState = {
+    agents: [],
+    description: '',
+    edges: [],
+    goals: [],
+    name: '',
+    outputNodeSlug: '',
+    slug: '',
+  }
+
+  let stepIndex = 0
+  while (stepIndex < STEPS.length) {
+    try {
+      await STEPS[stepIndex](prompts, state) // eslint-disable-line no-await-in-loop
+      stepIndex++
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortPromptError') {
+        if (stepIndex === 0) return null
+        stepIndex--
+      } else if (
+        error instanceof Error &&
+        (error.name === 'ExitPromptError' || error.name === 'CancelPromptError')
+      ) {
+        return null
+      } else {
+        throw error
+      }
+    }
+  }
+
+  return {
+    agents: state.agents,
+    description: state.description,
+    edges: state.edges,
+    goals: state.goals,
+    name: state.name,
+    outputNodeSlug: state.outputNodeSlug,
+    slug: state.slug,
+  }
+}

--- a/src/agent/infra/swarm/swarm-wizard.ts
+++ b/src/agent/infra/swarm/swarm-wizard.ts
@@ -7,6 +7,7 @@ import {KNOWN_ADAPTER_TYPES} from './types.js'
 
 export type WizardPrompts = {
   checkbox(message: string, choices: Array<{name: string; value: string}>): Promise<string[]>
+  cleanup?(): void
   confirm(message: string): Promise<boolean>
   input(message: string, opts?: {default?: string; validate?: (v: string) => boolean | string}): Promise<string>
   select(message: string, choices: Array<{name: string; value: string}>): Promise<string>
@@ -75,10 +76,12 @@ async function stepAgents(prompts: WizardPrompts, state: WizardState): Promise<v
     const description = await prompts.input('Description', {
       validate(v) { return v.trim().length > 0 || 'Description is required' },
     })
-    const adapterType = await prompts.select(
+    const rawAdapter = await prompts.select(
       'Adapter type',
       KNOWN_ADAPTER_TYPES.map((t) => ({name: t, value: t})),
-    ) as AdapterType
+    )
+    const adapterType = KNOWN_ADAPTER_TYPES.find((t) => t === rawAdapter)
+    if (!adapterType) throw new Error(`Unknown adapter type: ${rawAdapter}`)
 
     agents.push({adapterType, description, name, slug})
 

--- a/src/agent/infra/swarm/types.ts
+++ b/src/agent/infra/swarm/types.ts
@@ -1,0 +1,88 @@
+// ─── Adapter Types (single source of truth, used by Zod schema) ───
+
+export const KNOWN_ADAPTER_TYPES = [
+  'claude_code',
+  'codex',
+  'hermes',
+  'openclaw'
+] as const
+
+export type AdapterType = (typeof KNOWN_ADAPTER_TYPES)[number]
+
+// ─── Spec Types (parsed from files) ───
+
+export type SwarmFrontmatter = {
+  description: string
+  goals: string[]
+  includes: string[]
+  name: string
+  schema: string
+  slug: string
+  version: string
+}
+
+export type AgentFrontmatter = {
+  description: string
+  name: string
+  role: string
+  skills: string[]
+  slug: string
+}
+
+export type AgentSpec = {
+  frontmatter: AgentFrontmatter
+  prompt: string
+  sourcePath: string
+}
+
+export type AgentRuntimeConfig = {
+  adapter: {config?: Record<string, unknown>; type: AdapterType}
+  budgetMaxCostUsd?: number
+  cwd?: string
+  output?: boolean
+  timeoutSec?: number
+}
+
+export type EdgeDef = {from: string; to: string}
+
+export type SwarmRuntimeConfig = {
+  agents: Record<string, AgentRuntimeConfig>
+  edges: EdgeDef[]
+  optimization?: {
+    edge?: {batchSize?: number; enabled?: boolean; initialProbability?: number; lr?: number}
+    evaluator?: string
+    node?: {enabled?: boolean; historyWindow?: number}
+  }
+  potentialEdges: EdgeDef[]
+  schema: string
+}
+
+export type LoadedSwarm = {
+  agents: AgentSpec[]
+  description: string
+  frontmatter: SwarmFrontmatter
+  runtimeConfig: SwarmRuntimeConfig
+  sourceDir: string
+  warnings: string[]
+}
+
+// ─── Summary DTO (for CLI output) ───
+
+export type SwarmSummary = {
+  agentCount: number
+  agents: Array<{adapterType: string; slug: string}>
+  fixedEdgeCount: number
+  name: string
+  outputNodes: string[]
+  potentialEdgeCount: number
+  slug: string
+}
+
+// ─── File Reader (for testability) ───
+
+export type SwarmFileReader = {
+  exists(path: string): Promise<boolean>
+  glob(dir: string, pattern: string): Promise<string[]>
+  isDirectory(path: string): Promise<boolean>
+  readFile(path: string): Promise<string>
+}

--- a/src/oclif/commands/swarm/index.ts
+++ b/src/oclif/commands/swarm/index.ts
@@ -1,0 +1,10 @@
+import {Command} from '@oclif/core'
+
+export default class Swarm extends Command {
+  public static description = 'Multi-agent swarm orchestration'
+  public static examples = ['<%= config.bin %> <%= command.id %> --help']
+
+  public async run(): Promise<void> {
+    await this.config.runCommand('help', ['swarm'])
+  }
+}

--- a/src/oclif/commands/swarm/load.ts
+++ b/src/oclif/commands/swarm/load.ts
@@ -1,0 +1,78 @@
+import {Args, Command} from '@oclif/core'
+
+import type {LoadedSwarm, SwarmSummary} from '../../../agent/infra/swarm/types.js'
+
+import {SwarmValidationError} from '../../../agent/infra/swarm/errors.js'
+import {buildSwarmGraph} from '../../../agent/infra/swarm/swarm-graph-builder.js'
+import {SwarmLoader} from '../../../agent/infra/swarm/swarm-loader.js'
+
+export default class SwarmLoad extends Command {
+  public static args = {
+    dir: Args.string({
+      description: 'Path to swarm spec directory',
+      required: true,
+    }),
+  }
+  public static description = 'Load and validate a swarm specification'
+  public static examples = [
+    '<%= config.bin %> swarm load ./my-swarm',
+  ]
+
+  protected createBuilder(): typeof buildSwarmGraph {
+    return buildSwarmGraph
+  }
+
+  protected createLoader(): SwarmLoader {
+    return new SwarmLoader()
+  }
+
+  public async run(): Promise<void> {
+    const {args} = await this.parse(SwarmLoad)
+
+    let loaded: LoadedSwarm
+    try {
+      loaded = await this.createLoader().load(args.dir)
+    } catch (error) {
+      if (error instanceof SwarmValidationError) {
+        for (const w of error.warnings) {
+          this.log(`Warning: ${w}`)
+        }
+
+        for (const e of error.errors) {
+          this.log(`Error: ${e}`)
+        }
+
+        if (error.note) {
+          this.log(`\n${error.note}`)
+        }
+
+        this.log(`\n${error.errors.length} error(s) found.`)
+        this.exit(1)
+      }
+
+      throw error
+    }
+
+    const {summary} = this.createBuilder()(loaded)
+
+    for (const w of loaded.warnings) {
+      this.log(`Warning: ${w}`)
+    }
+
+    this.printSummary(summary)
+  }
+
+  private printSummary(s: SwarmSummary): void {
+    this.log(`Swarm "${s.name}" (${s.slug})`)
+    this.log(`  Agents: ${s.agentCount}`)
+    for (const a of s.agents) {
+      this.log(`    - ${a.slug} [${a.adapterType}]`)
+    }
+
+    this.log(`  Fixed edges: ${s.fixedEdgeCount}`)
+    this.log(`  Potential edges: ${s.potentialEdgeCount}`)
+    if (s.outputNodes.length > 0) {
+      this.log(`  Output nodes: ${s.outputNodes.join(', ')}`)
+    }
+  }
+}

--- a/src/oclif/commands/swarm/onboard.ts
+++ b/src/oclif/commands/swarm/onboard.ts
@@ -1,0 +1,151 @@
+import {checkbox, confirm, input, select} from '@inquirer/prompts'
+import {Args, Command} from '@oclif/core'
+import chalk from 'chalk'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+import type {WizardPrompts} from '../../../agent/infra/swarm/swarm-wizard.js'
+
+import {SwarmLoader} from '../../../agent/infra/swarm/swarm-loader.js'
+import {scaffoldSwarm} from '../../../agent/infra/swarm/swarm-scaffolder.js'
+import {runWizard} from '../../../agent/infra/swarm/swarm-wizard.js'
+import {createEscapeSignal, isPromptCancelled, wizardInputTheme, wizardSelectTheme} from '../../lib/prompt-utils.js'
+import {createSpinner} from '../../lib/spinner.js'
+
+export default class SwarmOnboard extends Command {
+  public static args = {
+    dir: Args.string({
+      default: '.',
+      description: 'Directory to create swarm spec in (default: current directory)',
+      required: false,
+    }),
+  }
+  public static description = 'Scaffold a new swarm specification interactively'
+  public static examples = [
+    '<%= config.bin %> swarm onboard',
+    '<%= config.bin %> swarm onboard ./my-swarm',
+  ]
+
+  protected async confirmLoadExisting(): Promise<boolean> {
+    return confirm({message: 'Load existing swarm spec instead?'})
+  }
+
+  protected createLoader(): SwarmLoader {
+    return new SwarmLoader()
+  }
+
+  protected createWizardPrompts(): WizardPrompts {
+    const esc = createEscapeSignal()
+
+    const resetOnCancel = (error: unknown) => {
+      if (isPromptCancelled(error)) esc.reset()
+      throw error
+    }
+
+    const prompts: WizardPrompts & {cleanup?: () => void} = {
+      async checkbox(message, choices) {
+        return checkbox({choices: choices.map((c) => ({name: c.name, value: c.value})), message, theme: wizardSelectTheme}, {signal: esc.signal}).catch(resetOnCancel)
+      },
+      cleanup: () => esc.cleanup(),
+      async confirm(message) {
+        return confirm({message}, {signal: esc.signal}).catch(resetOnCancel)
+      },
+      async input(message, opts) {
+        return input({default: opts?.default, message, theme: wizardInputTheme, validate: opts?.validate}, {signal: esc.signal}).catch(resetOnCancel)
+      },
+      async select(message, choices) {
+        return select({choices: choices.map((c) => ({name: c.name, value: c.value})), message, theme: wizardSelectTheme}, {signal: esc.signal}).catch(resetOnCancel)
+      },
+    }
+
+    return prompts
+  }
+
+  public async run(): Promise<void> {
+    const {args} = await this.parse(SwarmOnboard)
+    const targetDir = path.resolve(args.dir ?? '.')
+
+    // Check for existing spec
+    if (await this.swarmSpecExists(targetDir)) {
+      this.log(`Found existing SWARM.md in ${targetDir}`)
+      try {
+        const shouldLoad = await this.confirmLoadExisting()
+        if (shouldLoad) {
+          await this.config.runCommand('swarm:load', [targetDir])
+
+          return
+        }
+      } catch (error) {
+        if (isPromptCancelled(error)) return
+        throw error
+      }
+
+      this.log('Aborted. Use "brv swarm load" to validate the existing spec.')
+
+      return
+    }
+
+    // Run wizard
+    const prompts = this.createWizardPrompts()
+    const result = await runWizard(prompts)
+
+    // Cleanup esc listener
+    if ('cleanup' in prompts && typeof prompts.cleanup === 'function') {
+      ;(prompts as {cleanup: () => void}).cleanup()
+    }
+
+    if (!result) {
+      return
+    }
+
+    // Generate files
+    const files = scaffoldSwarm(result)
+
+    // Write to disk
+    await this.writeFiles(targetDir, files)
+
+    this.log(`\nCreated swarm spec in ${targetDir}:`)
+    for (const filePath of Object.keys(files).sort()) {
+      this.log(`  ${filePath}`)
+    }
+
+    // Validate
+    const spinner = createSpinner('Validating...')
+    try {
+      const loaded = await this.createLoader().load(targetDir)
+      spinner.clear()
+
+      for (const w of loaded.warnings) {
+        this.log(chalk.yellow(`Warning: ${w}`))
+      }
+
+      this.log(chalk.green(`\nSwarm "${result.name}" scaffolded successfully.`))
+    } catch (error) {
+      spinner.clear()
+      this.log(chalk.red(`\nValidation failed: ${error instanceof Error ? error.message : 'Unknown error'}`))
+      this.log('Files have been left in place for debugging.')
+      this.exit(1)
+    }
+  }
+
+  protected async swarmSpecExists(dir: string): Promise<boolean> {
+    try {
+      await fs.access(path.join(dir, 'SWARM.md'))
+
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  protected async writeFiles(baseDir: string, files: Record<string, string>): Promise<void> {
+    const sorted = Object.entries(files).sort(([a], [b]) => a.localeCompare(b))
+    await Promise.all(
+      sorted.map(async ([relPath, content]) => {
+        const fullPath = path.join(baseDir, relPath)
+        await fs.mkdir(path.dirname(fullPath), {recursive: true})
+        await fs.writeFile(fullPath, content, 'utf8')
+      }),
+    )
+  }
+}

--- a/src/oclif/commands/swarm/onboard.ts
+++ b/src/oclif/commands/swarm/onboard.ts
@@ -42,11 +42,11 @@ export default class SwarmOnboard extends Command {
       throw error
     }
 
-    const prompts: WizardPrompts & {cleanup?: () => void} = {
+    const prompts: WizardPrompts = {
       async checkbox(message, choices) {
         return checkbox({choices: choices.map((c) => ({name: c.name, value: c.value})), message, theme: wizardSelectTheme}, {signal: esc.signal}).catch(resetOnCancel)
       },
-      cleanup: () => esc.cleanup(),
+      cleanup() { esc.cleanup() },
       async confirm(message) {
         return confirm({message}, {signal: esc.signal}).catch(resetOnCancel)
       },
@@ -87,11 +87,11 @@ export default class SwarmOnboard extends Command {
 
     // Run wizard
     const prompts = this.createWizardPrompts()
-    const result = await runWizard(prompts)
-
-    // Cleanup esc listener
-    if ('cleanup' in prompts && typeof prompts.cleanup === 'function') {
-      ;(prompts as {cleanup: () => void}).cleanup()
+    let result: Awaited<ReturnType<typeof runWizard>>
+    try {
+      result = await runWizard(prompts)
+    } finally {
+      prompts.cleanup?.()
     }
 
     if (!result) {

--- a/test/commands/swarm/load.test.ts
+++ b/test/commands/swarm/load.test.ts
@@ -23,14 +23,14 @@ const MOCK_LOADED_SWARM: LoadedSwarm = {
   ],
   description: 'Test',
   frontmatter: {description: 'Test', goals: ['Test'], includes: [], name: 'Test Swarm', schema: 'byterover-swarm/v1', slug: 'test-swarm', version: '1.0.0'},
-  runtimeConfig: {agents: {analyzer: {adapter: {type: 'claude_code'}}, synthesizer: {adapter: {type: 'process'}, output: true}}, edges: [{from: 'analyzer', to: 'synthesizer'}], potentialEdges: [], schema: 'byterover-swarm/v1'},
+  runtimeConfig: {agents: {analyzer: {adapter: {type: 'claude_code'}}, synthesizer: {adapter: {type: 'hermes'}, output: true}}, edges: [{from: 'analyzer', to: 'synthesizer'}], potentialEdges: [], schema: 'byterover-swarm/v1'},
   sourceDir: '/s',
   warnings: [],
 }
 
 const MOCK_SUMMARY: SwarmSummary = {
   agentCount: 2,
-  agents: [{adapterType: 'claude_code', slug: 'analyzer'}, {adapterType: 'process', slug: 'synthesizer'}],
+  agents: [{adapterType: 'claude_code', slug: 'analyzer'}, {adapterType: 'hermes', slug: 'synthesizer'}],
   fixedEdgeCount: 1,
   name: 'Test Swarm',
   outputNodes: ['synthesizer'],
@@ -101,7 +101,7 @@ describe('SwarmLoad Command', () => {
       expect(loggedMessages.some((m) => m.includes('Test Swarm'))).to.be.true
       expect(loggedMessages.some((m) => m.includes('Agents: 2'))).to.be.true
       expect(loggedMessages.some((m) => m.includes('analyzer [claude_code]'))).to.be.true
-      expect(loggedMessages.some((m) => m.includes('synthesizer [process]'))).to.be.true
+      expect(loggedMessages.some((m) => m.includes('synthesizer [hermes]'))).to.be.true
       expect(loggedMessages.some((m) => m.includes('Fixed edges: 1'))).to.be.true
       expect(loggedMessages.some((m) => m.includes('Output nodes: synthesizer'))).to.be.true
     })

--- a/test/commands/swarm/load.test.ts
+++ b/test/commands/swarm/load.test.ts
@@ -1,0 +1,230 @@
+/// <reference types="mocha" />
+
+import type {Config} from '@oclif/core'
+
+import {Config as OclifConfig} from '@oclif/core'
+import {expect} from 'chai'
+import {restore, stub} from 'sinon'
+
+import type {buildSwarmGraph} from '../../../src/agent/infra/swarm/swarm-graph-builder.js'
+import type {LoadedSwarm, SwarmSummary} from '../../../src/agent/infra/swarm/types.js'
+
+import {CycleDetectedError} from '../../../src/agent/infra/swarm/engine/swarm-graph.js'
+import {SwarmValidationError} from '../../../src/agent/infra/swarm/errors.js'
+import {SwarmLoader} from '../../../src/agent/infra/swarm/swarm-loader.js'
+import SwarmLoad from '../../../src/oclif/commands/swarm/load.js'
+
+// ─── Mock data ───
+
+const MOCK_LOADED_SWARM: LoadedSwarm = {
+  agents: [
+    {frontmatter: {description: 'Analyzer', name: 'Analyzer', role: 'worker', skills: [], slug: 'analyzer'}, prompt: 'Analyze.', sourcePath: '/s/agents/analyzer/AGENT.md'},
+    {frontmatter: {description: 'Synth', name: 'Synth', role: 'worker', skills: [], slug: 'synthesizer'}, prompt: 'Synth.', sourcePath: '/s/agents/synthesizer/AGENT.md'},
+  ],
+  description: 'Test',
+  frontmatter: {description: 'Test', goals: ['Test'], includes: [], name: 'Test Swarm', schema: 'byterover-swarm/v1', slug: 'test-swarm', version: '1.0.0'},
+  runtimeConfig: {agents: {analyzer: {adapter: {type: 'claude_code'}}, synthesizer: {adapter: {type: 'process'}, output: true}}, edges: [{from: 'analyzer', to: 'synthesizer'}], potentialEdges: [], schema: 'byterover-swarm/v1'},
+  sourceDir: '/s',
+  warnings: [],
+}
+
+const MOCK_SUMMARY: SwarmSummary = {
+  agentCount: 2,
+  agents: [{adapterType: 'claude_code', slug: 'analyzer'}, {adapterType: 'process', slug: 'synthesizer'}],
+  fixedEdgeCount: 1,
+  name: 'Test Swarm',
+  outputNodes: ['synthesizer'],
+  potentialEdgeCount: 0,
+  slug: 'test-swarm',
+}
+
+// ─── Testable subclass ───
+
+class TestableSwarmLoad extends SwarmLoad {
+  private mockBuilder?: typeof buildSwarmGraph
+  private mockLoader?: SwarmLoader
+
+  protected override createBuilder(): typeof buildSwarmGraph {
+    return this.mockBuilder ?? super.createBuilder()
+  }
+
+  protected override createLoader(): SwarmLoader {
+    return this.mockLoader ?? super.createLoader()
+  }
+
+  setMockBuilder(builder: typeof buildSwarmGraph): void {
+    this.mockBuilder = builder
+  }
+
+  setMockLoader(loader: SwarmLoader): void {
+    this.mockLoader = loader
+  }
+}
+
+describe('SwarmLoad Command', () => {
+  let config: Config
+  let loggedMessages: string[]
+
+  before(async () => {
+    config = await OclifConfig.load(import.meta.url)
+  })
+
+  afterEach(() => {
+    restore()
+  })
+
+  function createCommand(...argv: string[]): TestableSwarmLoad {
+    const command = new TestableSwarmLoad(argv, config)
+    loggedMessages = []
+    stub(command, 'log').callsFake((msg?: string) => {
+      if (msg) loggedMessages.push(msg)
+    })
+
+    return command
+  }
+
+  describe('happy path', () => {
+    it('should log swarm summary on success', async () => {
+      const command = createCommand('./my-swarm')
+
+      const mockLoader = new SwarmLoader()
+      stub(mockLoader, 'load').resolves(MOCK_LOADED_SWARM)
+      command.setMockLoader(mockLoader)
+      command.setMockBuilder(() => ({
+        edgeDistribution: {} as never,
+        graph: {} as never,
+        summary: MOCK_SUMMARY,
+      }))
+
+      await command.run()
+
+      expect(loggedMessages.some((m) => m.includes('Test Swarm'))).to.be.true
+      expect(loggedMessages.some((m) => m.includes('Agents: 2'))).to.be.true
+      expect(loggedMessages.some((m) => m.includes('analyzer [claude_code]'))).to.be.true
+      expect(loggedMessages.some((m) => m.includes('synthesizer [process]'))).to.be.true
+      expect(loggedMessages.some((m) => m.includes('Fixed edges: 1'))).to.be.true
+      expect(loggedMessages.some((m) => m.includes('Output nodes: synthesizer'))).to.be.true
+    })
+
+    it('should log warnings before summary', async () => {
+      const loadedWithWarnings = {...MOCK_LOADED_SWARM, warnings: ['No agents have output: true.']}
+      const command = createCommand('./my-swarm')
+
+      const mockLoader = new SwarmLoader()
+      stub(mockLoader, 'load').resolves(loadedWithWarnings)
+      command.setMockLoader(mockLoader)
+      command.setMockBuilder(() => ({
+        edgeDistribution: {} as never,
+        graph: {} as never,
+        summary: MOCK_SUMMARY,
+      }))
+
+      await command.run()
+
+      const warningIdx = loggedMessages.findIndex((m) => m.includes('Warning:'))
+      const summaryIdx = loggedMessages.findIndex((m) => m.includes('Test Swarm'))
+      expect(warningIdx).to.be.greaterThanOrEqual(0)
+      expect(warningIdx).to.be.lessThan(summaryIdx)
+    })
+  })
+
+  describe('error handling', () => {
+    it('should throw on loader validation error', async () => {
+      const command = createCommand('./bad-swarm')
+
+      const mockLoader = new SwarmLoader()
+      stub(mockLoader, 'load').rejects(new Error('SWARM.md not found'))
+      command.setMockLoader(mockLoader)
+
+      try {
+        await command.run()
+        expect.fail('should have thrown')
+      } catch (error) {
+        expect((error as Error).message).to.include('SWARM.md not found')
+      }
+    })
+
+    it('should throw on cycle error from builder', async () => {
+      const command = createCommand('./cycle-swarm')
+
+      const mockLoader = new SwarmLoader()
+      stub(mockLoader, 'load').resolves(MOCK_LOADED_SWARM)
+      command.setMockLoader(mockLoader)
+      command.setMockBuilder(() => {
+        throw new CycleDetectedError()
+      })
+
+      try {
+        await command.run()
+        expect.fail('should have thrown')
+      } catch (error) {
+        expect(error).to.be.instanceOf(CycleDetectedError)
+      }
+    })
+
+    it('should throw on missing required dir arg', async () => {
+      const command = createCommand()
+
+      try {
+        await command.run()
+        expect.fail('should have thrown')
+      } catch (error) {
+        expect((error as Error).message).to.include('Missing')
+      }
+    })
+
+    it('should log all errors from SwarmValidationError and exit 1', async () => {
+      const command = createCommand('./bad-swarm')
+      const exitStub = stub(command, 'exit').callsFake((code?: number) => {
+        throw Object.assign(new Error('EXIT'), {oclif: {exit: code ?? 0}})
+      })
+
+      const mockLoader = new SwarmLoader()
+      stub(mockLoader, 'load').rejects(
+        new SwarmValidationError(['err1: bad slug', 'err2: bad edge', 'err3: duplicate'], ['warn1']),
+      )
+      command.setMockLoader(mockLoader)
+
+      try {
+        await command.run()
+        expect.fail('should have thrown')
+      } catch {
+        // exit(1) throws the sentinel
+      }
+
+      expect(loggedMessages.some((m) => m.includes('warn1'))).to.be.true
+      expect(loggedMessages.some((m) => m.includes('err1: bad slug'))).to.be.true
+      expect(loggedMessages.some((m) => m.includes('err2: bad edge'))).to.be.true
+      expect(loggedMessages.some((m) => m.includes('err3: duplicate'))).to.be.true
+      expect(loggedMessages.some((m) => m.includes('3 error(s) found'))).to.be.true
+      expect(exitStub.calledOnceWithExactly(1)).to.be.true
+    })
+
+    it('should log note after errors when present', async () => {
+      const command = createCommand('./bad-swarm')
+      stub(command, 'exit').callsFake((code?: number) => {
+        throw Object.assign(new Error('EXIT'), {oclif: {exit: code ?? 0}})
+      })
+
+      const mockLoader = new SwarmLoader()
+      stub(mockLoader, 'load').rejects(
+        new SwarmValidationError(['err1'], [], 'Note: 1 file failed'),
+      )
+      command.setMockLoader(mockLoader)
+
+      try {
+        await command.run()
+        expect.fail('should have thrown')
+      } catch {
+        // exit(1) throws sentinel
+      }
+
+      const errIdx = loggedMessages.findIndex((m) => m.includes('err1'))
+      const noteIdx = loggedMessages.findIndex((m) => m.includes('Note: 1 file failed'))
+      expect(errIdx).to.be.greaterThanOrEqual(0)
+      expect(noteIdx).to.be.greaterThan(errIdx)
+      // Note should NOT inflate error count
+      expect(loggedMessages.some((m) => m.includes('1 error(s) found'))).to.be.true
+    })
+  })
+})

--- a/test/commands/swarm/onboard.test.ts
+++ b/test/commands/swarm/onboard.test.ts
@@ -68,7 +68,7 @@ function mockWizardPrompts(): WizardPrompts {
     // Step 1: Identity
     'Test Swarm', 'test-swarm', 'Test description', 'Goal one',
     // Step 2: Agents (1 agent)
-    'Agent', 'agent', 'Test agent', 'process',
+    'Agent', 'agent', 'Test agent', 'hermes',
     false, // don't add another
     // Step 3: Edges (single agent, no targets, checkbox not called)
     // Step 4: Output

--- a/test/commands/swarm/onboard.test.ts
+++ b/test/commands/swarm/onboard.test.ts
@@ -1,0 +1,225 @@
+/// <reference types="mocha" />
+
+import type {Config} from '@oclif/core'
+
+import {Config as OclifConfig} from '@oclif/core'
+import {expect} from 'chai'
+import {restore, stub} from 'sinon'
+
+import type {WizardPrompts} from '../../../src/agent/infra/swarm/swarm-wizard.js'
+
+import {SwarmLoader} from '../../../src/agent/infra/swarm/swarm-loader.js'
+import SwarmOnboard from '../../../src/oclif/commands/swarm/onboard.js'
+
+// ─── Testable subclass ───
+
+class TestableSwarmOnboard extends SwarmOnboard {
+  public writtenFiles: Record<string, string> = {}
+  private mockConfirmLoadExisting?: boolean
+  private mockLoader?: SwarmLoader
+  private mockSwarmSpecExists?: boolean
+  private mockWizardPrompts?: WizardPrompts
+
+  protected override async confirmLoadExisting(): Promise<boolean> {
+    if (this.mockConfirmLoadExisting !== undefined) return this.mockConfirmLoadExisting
+
+    return super.confirmLoadExisting()
+  }
+
+  protected override createLoader(): SwarmLoader {
+    return this.mockLoader ?? super.createLoader()
+  }
+
+  protected override createWizardPrompts(): WizardPrompts {
+    return this.mockWizardPrompts ?? super.createWizardPrompts()
+  }
+
+  setMockConfirmLoadExisting(value: boolean): void {
+    this.mockConfirmLoadExisting = value
+  }
+
+  setMockLoader(loader: SwarmLoader): void {
+    this.mockLoader = loader
+  }
+
+  setMockSwarmSpecExists(value: boolean): void {
+    this.mockSwarmSpecExists = value
+  }
+
+  setMockWizardPrompts(prompts: WizardPrompts): void {
+    this.mockWizardPrompts = prompts
+  }
+
+  protected override async swarmSpecExists(...args: [string]): Promise<boolean> {
+    if (this.mockSwarmSpecExists !== undefined) return this.mockSwarmSpecExists
+
+    return super.swarmSpecExists(args[0])
+  }
+
+  protected override async writeFiles(_baseDir: string, files: Record<string, string>): Promise<void> {
+    this.writtenFiles = files
+  }
+}
+
+// ─── Mock wizard prompts that return a simple 1-agent swarm ───
+
+function mockWizardPrompts(): WizardPrompts {
+  const answers: Array<boolean | string | string[]> = [
+    // Step 1: Identity
+    'Test Swarm', 'test-swarm', 'Test description', 'Goal one',
+    // Step 2: Agents (1 agent)
+    'Agent', 'agent', 'Test agent', 'process',
+    false, // don't add another
+    // Step 3: Edges (single agent, no targets, checkbox not called)
+    // Step 4: Output
+    'agent',
+  ]
+  let idx = 0
+  const next = () => answers[idx++]
+
+  return {
+    async checkbox() { return next() as string[] },
+    async confirm() { return next() as boolean },
+    async input(_msg: string, opts?: {default?: string}) {
+      const val = next() as string
+      return val === '' && opts?.default ? opts.default : val
+    },
+    async select() { return next() as string },
+  }
+}
+
+function cancellingPrompts(): WizardPrompts {
+  const err = new Error('CancelPromptError')
+  err.name = 'CancelPromptError'
+  return {
+    async checkbox() { throw err },
+    async confirm() { throw err },
+    async input() { throw err },
+    async select() { throw err },
+  }
+}
+
+describe('SwarmOnboard Command', () => {
+  let config: Config
+  let loggedMessages: string[]
+
+  before(async () => {
+    config = await OclifConfig.load(import.meta.url)
+  })
+
+  afterEach(() => {
+    restore()
+  })
+
+  function createCommand(...argv: string[]): TestableSwarmOnboard {
+    const command = new TestableSwarmOnboard(argv.length > 0 ? argv : ['.'], config)
+    loggedMessages = []
+    stub(command, 'log').callsFake((msg?: string) => {
+      if (msg) loggedMessages.push(msg)
+    })
+
+    return command
+  }
+
+  describe('existing SWARM.md', () => {
+    it('should delegate to swarm:load when user confirms', async () => {
+      const command = createCommand('./my-swarm')
+      command.setMockSwarmSpecExists(true)
+      command.setMockConfirmLoadExisting(true)
+      const runCommandStub = stub(command.config, 'runCommand').resolves()
+
+      await command.run()
+
+      expect(runCommandStub.calledOnce).to.be.true
+      const [cmdName, cmdArgs] = runCommandStub.firstCall.args
+      expect(cmdName).to.equal('swarm:load')
+      expect(cmdArgs).to.be.an('array')
+    })
+
+    it('should exit without writing files when user declines', async () => {
+      const command = createCommand('./my-swarm')
+      command.setMockSwarmSpecExists(true)
+      command.setMockConfirmLoadExisting(false)
+
+      await command.run()
+
+      expect(command.writtenFiles).to.deep.equal({})
+      expect(loggedMessages.some((m) => m.includes('Aborted'))).to.be.true
+    })
+  })
+
+  describe('wizard flow', () => {
+    it('should write scaffolded files on successful wizard', async () => {
+      const command = createCommand('./new-swarm')
+      command.setMockSwarmSpecExists(false)
+      command.setMockWizardPrompts(mockWizardPrompts())
+
+      const mockLoader = new SwarmLoader()
+      stub(mockLoader, 'load').resolves({
+        agents: [],
+        description: '',
+        frontmatter: {} as never,
+        runtimeConfig: {} as never,
+        sourceDir: '/test',
+        warnings: [],
+      })
+      command.setMockLoader(mockLoader)
+
+      await command.run()
+
+      expect(command.writtenFiles).to.have.property('SWARM.md')
+      expect(command.writtenFiles).to.have.property('.swarm.yaml')
+      expect(command.writtenFiles).to.have.property('agents/agent/AGENT.md')
+      expect(loggedMessages.some((m) => m.includes('scaffolded successfully'))).to.be.true
+    })
+
+    it('should not write files when wizard is cancelled', async () => {
+      const command = createCommand('./new-swarm')
+      command.setMockSwarmSpecExists(false)
+      command.setMockWizardPrompts(cancellingPrompts())
+
+      await command.run()
+
+      expect(command.writtenFiles).to.deep.equal({})
+    })
+
+    it('should exit 1 when final validation fails', async () => {
+      const command = createCommand('./new-swarm')
+      command.setMockSwarmSpecExists(false)
+      command.setMockWizardPrompts(mockWizardPrompts())
+
+      const mockLoader = new SwarmLoader()
+      stub(mockLoader, 'load').rejects(new Error('Validation failed'))
+      command.setMockLoader(mockLoader)
+
+      const exitStub = stub(command, 'exit').callsFake((code?: number) => {
+        throw Object.assign(new Error('EXIT'), {oclif: {exit: code ?? 0}})
+      })
+
+      try {
+        await command.run()
+        expect.fail('should have thrown')
+      } catch {
+        // exit(1) throws sentinel
+      }
+
+      expect(exitStub.calledOnceWithExactly(1)).to.be.true
+      // Files were still written (left in place for debugging)
+      expect(Object.keys(command.writtenFiles).length).to.be.greaterThan(0)
+      expect(loggedMessages.some((m) => m.includes('Validation failed'))).to.be.true
+    })
+  })
+
+  describe('args', () => {
+    it('should default dir to current directory', async () => {
+      const command = createCommand()
+      command.setMockSwarmSpecExists(false)
+      command.setMockWizardPrompts(cancellingPrompts())
+
+      await command.run()
+
+      // Command ran without error — dir defaulted to '.'
+      expect(command.writtenFiles).to.deep.equal({})
+    })
+  })
+})

--- a/test/fixtures/swarm/cycle-swarm/.swarm.yaml
+++ b/test/fixtures/swarm/cycle-swarm/.swarm.yaml
@@ -1,0 +1,23 @@
+schema: byterover-swarm/v1
+
+agents:
+  a:
+    adapter:
+      type: process
+      config:
+        command: echo
+    timeoutSec: 60
+
+  b:
+    adapter:
+      type: process
+      config:
+        command: echo
+    timeoutSec: 60
+    output: true
+
+edges:
+  - from: a
+    to: b
+  - from: b
+    to: a

--- a/test/fixtures/swarm/cycle-swarm/.swarm.yaml
+++ b/test/fixtures/swarm/cycle-swarm/.swarm.yaml
@@ -3,14 +3,14 @@ schema: byterover-swarm/v1
 agents:
   a:
     adapter:
-      type: process
+      type: claude_code
       config:
         command: echo
     timeoutSec: 60
 
   b:
     adapter:
-      type: process
+      type: claude_code
       config:
         command: echo
     timeoutSec: 60

--- a/test/fixtures/swarm/cycle-swarm/SWARM.md
+++ b/test/fixtures/swarm/cycle-swarm/SWARM.md
@@ -1,0 +1,14 @@
+---
+name: Cycle Test
+description: Swarm with a cycle in fixed edges
+slug: cycle-test
+schema: byterover-swarm/v1
+version: 1.0.0
+goals:
+  - Test cycle detection
+includes:
+  - agents/a/AGENT.md
+  - agents/b/AGENT.md
+---
+
+This swarm has a cycle in its fixed edges and should fail validation.

--- a/test/fixtures/swarm/cycle-swarm/agents/a/AGENT.md
+++ b/test/fixtures/swarm/cycle-swarm/agents/a/AGENT.md
@@ -1,0 +1,8 @@
+---
+name: Agent A
+slug: a
+description: First agent in cycle
+role: worker
+---
+
+Agent A prompt.

--- a/test/fixtures/swarm/cycle-swarm/agents/b/AGENT.md
+++ b/test/fixtures/swarm/cycle-swarm/agents/b/AGENT.md
@@ -1,0 +1,8 @@
+---
+name: Agent B
+slug: b
+description: Second agent in cycle
+role: worker
+---
+
+Agent B prompt.

--- a/test/fixtures/swarm/valid-swarm/.swarm.yaml
+++ b/test/fixtures/swarm/valid-swarm/.swarm.yaml
@@ -1,0 +1,26 @@
+schema: byterover-swarm/v1
+
+agents:
+  analyzer:
+    adapter:
+      type: claude_code
+      config:
+        model: claude-sonnet-4-20250514
+    timeoutSec: 120
+    budgetMaxCostUsd: 0.50
+
+  synthesizer:
+    adapter:
+      type: claude_code
+      config:
+        model: claude-sonnet-4-20250514
+    timeoutSec: 120
+    output: true
+
+edges:
+  - from: analyzer
+    to: synthesizer
+
+potential_edges:
+  - from: synthesizer
+    to: analyzer

--- a/test/fixtures/swarm/valid-swarm/SWARM.md
+++ b/test/fixtures/swarm/valid-swarm/SWARM.md
@@ -1,0 +1,16 @@
+---
+name: Code Review Pipeline
+description: Multi-agent code review with analysis and synthesis
+slug: code-review-pipeline
+schema: byterover-swarm/v1
+version: 1.0.0
+goals:
+  - Produce comprehensive code reviews
+  - Catch bugs before they ship
+includes:
+  - agents/analyzer/AGENT.md
+  - agents/synthesizer/AGENT.md
+---
+
+A two-agent pipeline that analyzes code and synthesizes findings
+into actionable review feedback.

--- a/test/fixtures/swarm/valid-swarm/agents/analyzer/AGENT.md
+++ b/test/fixtures/swarm/valid-swarm/agents/analyzer/AGENT.md
@@ -1,0 +1,12 @@
+---
+name: Analyzer
+slug: analyzer
+description: Static code analysis agent
+role: worker
+skills:
+  - code-review
+---
+
+Analyze the provided code for bugs, security vulnerabilities, and
+performance problems. Report findings as a structured list with
+severity, location, and suggested fix for each issue.

--- a/test/fixtures/swarm/valid-swarm/agents/synthesizer/AGENT.md
+++ b/test/fixtures/swarm/valid-swarm/agents/synthesizer/AGENT.md
@@ -1,0 +1,10 @@
+---
+name: Synthesizer
+slug: synthesizer
+description: Review synthesis agent
+role: worker
+skills: []
+---
+
+Synthesize all analysis findings into a single, actionable code review
+report. Prioritize issues by severity and group by file.

--- a/test/unit/agent/swarm/engine/edge-distribution.test.ts
+++ b/test/unit/agent/swarm/engine/edge-distribution.test.ts
@@ -1,0 +1,125 @@
+import {expect} from 'chai'
+
+import {EdgeDistribution} from '../../../../../src/agent/infra/swarm/engine/edge-distribution.js'
+import {SwarmGraph} from '../../../../../src/agent/infra/swarm/engine/swarm-graph.js'
+import {SwarmNode} from '../../../../../src/agent/infra/swarm/engine/swarm-node.js'
+
+function buildChainGraph(): SwarmGraph {
+  const graph = new SwarmGraph()
+  const a = new SwarmNode({id: 'a', slug: 'a'})
+  const b = new SwarmNode({id: 'b', slug: 'b'})
+  const c = new SwarmNode({id: 'c', slug: 'c'})
+
+  a.addSuccessor(b)
+  b.addSuccessor(c)
+  graph.addNode(a)
+  graph.addNode(b)
+  graph.addNode(c)
+
+  return graph
+}
+
+describe('EdgeDistribution', () => {
+  describe('constructor', () => {
+    it('should initialize logits to 0 for initialProbability=0.5', () => {
+      const dist = new EdgeDistribution({
+        potentialConnections: [['a', 'b']],
+      })
+
+      expect(dist.edgeLogits.length).to.equal(1)
+      expect(dist.edgeLogits[0]).to.be.closeTo(0, 1e-6)
+    })
+
+    it('should initialize logits correctly for initialProbability=0.9', () => {
+      const dist = new EdgeDistribution({
+        initialProbability: 0.9,
+        potentialConnections: [['a', 'b']],
+      })
+
+      const expected = Math.log(0.9 / 0.1) // ~2.197
+      expect(dist.edgeLogits[0]).to.be.closeTo(expected, 1e-4)
+    })
+
+    it('should have edgeLogits.length equal to potentialConnections.length', () => {
+      const dist = new EdgeDistribution({
+        potentialConnections: [
+          ['a', 'b'],
+          ['b', 'c'],
+          ['c', 'a'],
+        ],
+      })
+
+      expect(dist.edgeLogits.length).to.equal(3)
+    })
+  })
+
+  describe('realize', () => {
+    it('should include all edges when random returns 0.01 (below sigmoid)', () => {
+      const graph = buildChainGraph() // a->b->c
+      const dist = new EdgeDistribution({
+        potentialConnections: [['a', 'c']], // a->c is a shortcut, no cycle
+      })
+
+      // sigmoid(0) = 0.5, random=0.01 < 0.5 → include
+      const result = dist.realize({graph, random: () => 0.01})
+
+      const nodeA = result.graph.nodes.get('a')!
+      expect(nodeA.successors.some((n) => n.id === 'c')).to.be.true
+    })
+
+    it('should exclude all edges when random returns 0.99 (above sigmoid)', () => {
+      const graph = buildChainGraph() // a->b->c
+      const dist = new EdgeDistribution({
+        potentialConnections: [['a', 'c']],
+      })
+
+      // sigmoid(0) = 0.5, random=0.99 > 0.5 → exclude
+      const result = dist.realize({graph, random: () => 0.99})
+
+      const nodeA = result.graph.nodes.get('a')!
+      // a should only have its original successor b, not c
+      expect(nodeA.successors.some((n) => n.id === 'c')).to.be.false
+    })
+
+    it('should skip edges that would create a cycle', () => {
+      const graph = buildChainGraph() // a->b->c
+      const dist = new EdgeDistribution({
+        initialProbability: 0.99, // very high → sigmoid ≈ 1
+        potentialConnections: [['c', 'a']], // would create cycle c->a
+      })
+
+      // random=0.01 would include, but c->a creates cycle a->b->c->a
+      const result = dist.realize({graph, random: () => 0.01})
+
+      const nodeC = result.graph.nodes.get('c')!
+      expect(nodeC.successors.some((n) => n.id === 'a')).to.be.false
+    })
+
+    it('should return log probability of the sampled configuration', () => {
+      const graph = new SwarmGraph()
+      const a = new SwarmNode({id: 'a', slug: 'a'})
+      const b = new SwarmNode({id: 'b', slug: 'b'})
+      graph.addNode(a)
+      graph.addNode(b)
+
+      const dist = new EdgeDistribution({
+        potentialConnections: [['a', 'b']],
+      })
+
+      // sigmoid(0) = 0.5, include → log(0.5)
+      const result = dist.realize({graph, random: () => 0.01})
+
+      expect(result.logProb).to.be.closeTo(Math.log(0.5), 1e-6)
+    })
+
+    it('should return unchanged graph and logProb=0 for empty connections', () => {
+      const graph = buildChainGraph()
+      const dist = new EdgeDistribution({potentialConnections: []})
+
+      const result = dist.realize({graph})
+
+      expect(result.graph.edgeCount).to.equal(graph.edgeCount)
+      expect(result.logProb).to.equal(0)
+    })
+  })
+})

--- a/test/unit/agent/swarm/engine/swarm-graph.test.ts
+++ b/test/unit/agent/swarm/engine/swarm-graph.test.ts
@@ -1,0 +1,177 @@
+import {expect} from 'chai'
+
+import {CycleDetectedError, SwarmGraph} from '../../../../../src/agent/infra/swarm/engine/swarm-graph.js'
+import {SwarmNode} from '../../../../../src/agent/infra/swarm/engine/swarm-node.js'
+
+describe('SwarmGraph', () => {
+  it('should start empty', () => {
+    const graph = new SwarmGraph()
+
+    expect(graph.nodeCount).to.equal(0)
+    expect(graph.edgeCount).to.equal(0)
+    expect(graph.nodes.size).to.equal(0)
+  })
+
+  describe('addNode', () => {
+    it('should register a node by id', () => {
+      const graph = new SwarmGraph()
+      const node = new SwarmNode({id: 'a', slug: 'analyzer'})
+
+      graph.addNode(node)
+
+      expect(graph.nodes.get('a')).to.equal(node)
+      expect(graph.nodeCount).to.equal(1)
+    })
+
+    it('should throw on duplicate id', () => {
+      const graph = new SwarmGraph()
+      graph.addNode(new SwarmNode({id: 'a', slug: 'a'}))
+
+      expect(() => graph.addNode(new SwarmNode({id: 'a', slug: 'b'}))).to.throw('Duplicate node id')
+    })
+  })
+
+  describe('computeInDegrees', () => {
+    it('should return correct in-degrees for chain A->B->C', () => {
+      const graph = new SwarmGraph()
+      const a = new SwarmNode({id: 'a', slug: 'a'})
+      const b = new SwarmNode({id: 'b', slug: 'b'})
+      const c = new SwarmNode({id: 'c', slug: 'c'})
+
+      a.addSuccessor(b)
+      b.addSuccessor(c)
+      graph.addNode(a)
+      graph.addNode(b)
+      graph.addNode(c)
+
+      const degrees = graph.computeInDegrees()
+
+      expect(degrees.get('a')).to.equal(0)
+      expect(degrees.get('b')).to.equal(1)
+      expect(degrees.get('c')).to.equal(1)
+    })
+  })
+
+  describe('edgeCount', () => {
+    it('should count edges correctly', () => {
+      const graph = new SwarmGraph()
+      const a = new SwarmNode({id: 'a', slug: 'a'})
+      const b = new SwarmNode({id: 'b', slug: 'b'})
+      const c = new SwarmNode({id: 'c', slug: 'c'})
+
+      a.addSuccessor(b)
+      a.addSuccessor(c)
+      b.addSuccessor(c)
+      graph.addNode(a)
+      graph.addNode(b)
+      graph.addNode(c)
+
+      expect(graph.edgeCount).to.equal(3)
+    })
+  })
+
+  describe('topologicalSort', () => {
+    it('should return valid order for chain A->B->C', () => {
+      const graph = new SwarmGraph()
+      const a = new SwarmNode({id: 'a', slug: 'a'})
+      const b = new SwarmNode({id: 'b', slug: 'b'})
+      const c = new SwarmNode({id: 'c', slug: 'c'})
+
+      a.addSuccessor(b)
+      b.addSuccessor(c)
+      graph.addNode(a)
+      graph.addNode(b)
+      graph.addNode(c)
+
+      const order = graph.topologicalSort()
+
+      expect(order.indexOf('a')).to.be.lessThan(order.indexOf('b'))
+      expect(order.indexOf('b')).to.be.lessThan(order.indexOf('c'))
+    })
+
+    it('should work for diamond: A->B, A->C, B->D, C->D', () => {
+      const graph = new SwarmGraph()
+      const a = new SwarmNode({id: 'a', slug: 'a'})
+      const b = new SwarmNode({id: 'b', slug: 'b'})
+      const c = new SwarmNode({id: 'c', slug: 'c'})
+      const d = new SwarmNode({id: 'd', slug: 'd'})
+
+      a.addSuccessor(b)
+      a.addSuccessor(c)
+      b.addSuccessor(d)
+      c.addSuccessor(d)
+      graph.addNode(a)
+      graph.addNode(b)
+      graph.addNode(c)
+      graph.addNode(d)
+
+      const order = graph.topologicalSort()
+
+      expect(order.indexOf('a')).to.be.lessThan(order.indexOf('b'))
+      expect(order.indexOf('a')).to.be.lessThan(order.indexOf('c'))
+      expect(order.indexOf('b')).to.be.lessThan(order.indexOf('d'))
+      expect(order.indexOf('c')).to.be.lessThan(order.indexOf('d'))
+    })
+
+    it('should throw CycleDetectedError on cycle A->B->C->A', () => {
+      const graph = new SwarmGraph()
+      const a = new SwarmNode({id: 'a', slug: 'a'})
+      const b = new SwarmNode({id: 'b', slug: 'b'})
+      const c = new SwarmNode({id: 'c', slug: 'c'})
+
+      a.addSuccessor(b)
+      b.addSuccessor(c)
+      c.addSuccessor(a)
+      graph.addNode(a)
+      graph.addNode(b)
+      graph.addNode(c)
+
+      expect(() => graph.topologicalSort()).to.throw(CycleDetectedError)
+    })
+
+    it('should work for single node', () => {
+      const graph = new SwarmGraph()
+      graph.addNode(new SwarmNode({id: 'a', slug: 'a'}))
+
+      const order = graph.topologicalSort()
+
+      expect(order).to.deep.equal(['a'])
+    })
+  })
+
+  describe('checkCycle', () => {
+    it('should detect reachability', () => {
+      const a = new SwarmNode({id: 'a', slug: 'a'})
+      const b = new SwarmNode({id: 'b', slug: 'b'})
+      const c = new SwarmNode({id: 'c', slug: 'c'})
+
+      a.addSuccessor(b)
+      b.addSuccessor(c)
+
+      expect(SwarmGraph.checkCycle(a, c)).to.be.true
+    })
+
+    it('should return false when not reachable', () => {
+      const a = new SwarmNode({id: 'a', slug: 'a'})
+      const b = new SwarmNode({id: 'b', slug: 'b'})
+
+      a.addSuccessor(b)
+
+      expect(SwarmGraph.checkCycle(b, a)).to.be.false
+    })
+  })
+
+  describe('outputNodes', () => {
+    it('should allow setting and getting output nodes', () => {
+      const graph = new SwarmGraph()
+      const a = new SwarmNode({id: 'a', slug: 'a'})
+      const b = new SwarmNode({id: 'b', slug: 'b'})
+
+      graph.addNode(a)
+      graph.addNode(b)
+      graph.setOutputNodes(['b'])
+
+      expect(graph.outputNodes).to.deep.equal([b])
+    })
+  })
+})

--- a/test/unit/agent/swarm/engine/swarm-node.test.ts
+++ b/test/unit/agent/swarm/engine/swarm-node.test.ts
@@ -1,0 +1,95 @@
+import {expect} from 'chai'
+
+import {SwarmNode} from '../../../../../src/agent/infra/swarm/engine/swarm-node.js'
+
+describe('SwarmNode', () => {
+  it('should initialize with id, slug, and empty arrays', () => {
+    const node = new SwarmNode({id: 'n1', slug: 'analyzer'})
+
+    expect(node.id).to.equal('n1')
+    expect(node.slug).to.equal('analyzer')
+    expect(node.predecessors).to.deep.equal([])
+    expect(node.successors).to.deep.equal([])
+  })
+
+  describe('addPredecessor', () => {
+    it('should add bidirectional link', () => {
+      const a = new SwarmNode({id: 'a', slug: 'a'})
+      const b = new SwarmNode({id: 'b', slug: 'b'})
+
+      b.addPredecessor(a)
+
+      expect(b.predecessors).to.include(a)
+      expect(a.successors).to.include(b)
+    })
+
+    it('should be idempotent', () => {
+      const a = new SwarmNode({id: 'a', slug: 'a'})
+      const b = new SwarmNode({id: 'b', slug: 'b'})
+
+      b.addPredecessor(a)
+      b.addPredecessor(a)
+
+      expect(b.predecessors).to.have.lengthOf(1)
+      expect(a.successors).to.have.lengthOf(1)
+    })
+  })
+
+  describe('addSuccessor', () => {
+    it('should add bidirectional link', () => {
+      const a = new SwarmNode({id: 'a', slug: 'a'})
+      const b = new SwarmNode({id: 'b', slug: 'b'})
+
+      a.addSuccessor(b)
+
+      expect(a.successors).to.include(b)
+      expect(b.predecessors).to.include(a)
+    })
+
+    it('should be idempotent', () => {
+      const a = new SwarmNode({id: 'a', slug: 'a'})
+      const b = new SwarmNode({id: 'b', slug: 'b'})
+
+      a.addSuccessor(b)
+      a.addSuccessor(b)
+
+      expect(a.successors).to.have.lengthOf(1)
+      expect(b.predecessors).to.have.lengthOf(1)
+    })
+  })
+
+  describe('removePredecessor', () => {
+    it('should remove bidirectional link', () => {
+      const a = new SwarmNode({id: 'a', slug: 'a'})
+      const b = new SwarmNode({id: 'b', slug: 'b'})
+
+      b.addPredecessor(a)
+      b.removePredecessor(a)
+
+      expect(b.predecessors).to.deep.equal([])
+      expect(a.successors).to.deep.equal([])
+    })
+
+    it('should be safe to call when not linked', () => {
+      const a = new SwarmNode({id: 'a', slug: 'a'})
+      const b = new SwarmNode({id: 'b', slug: 'b'})
+
+      b.removePredecessor(a)
+
+      expect(b.predecessors).to.deep.equal([])
+    })
+  })
+
+  describe('removeSuccessor', () => {
+    it('should remove bidirectional link', () => {
+      const a = new SwarmNode({id: 'a', slug: 'a'})
+      const b = new SwarmNode({id: 'b', slug: 'b'})
+
+      a.addSuccessor(b)
+      a.removeSuccessor(b)
+
+      expect(a.successors).to.deep.equal([])
+      expect(b.predecessors).to.deep.equal([])
+    })
+  })
+})

--- a/test/unit/agent/swarm/errors.test.ts
+++ b/test/unit/agent/swarm/errors.test.ts
@@ -1,0 +1,44 @@
+/// <reference types="mocha" />
+
+import {expect} from 'chai'
+
+import {SwarmValidationError} from '../../../../src/agent/infra/swarm/errors.js'
+
+describe('SwarmValidationError', () => {
+  it('should be an instance of Error', () => {
+    const err = new SwarmValidationError(['bad slug'])
+    expect(err).to.be.instanceOf(Error)
+  })
+
+  it('should have name SwarmValidationError', () => {
+    const err = new SwarmValidationError(['err1'])
+    expect(err.name).to.equal('SwarmValidationError')
+  })
+
+  it('should store errors and warnings arrays', () => {
+    const err = new SwarmValidationError(['err1', 'err2'], ['warn1'])
+    expect(err.errors).to.deep.equal(['err1', 'err2'])
+    expect(err.warnings).to.deep.equal(['warn1'])
+  })
+
+  it('should default warnings to empty array', () => {
+    const err = new SwarmValidationError(['err1'])
+    expect(err.warnings).to.deep.equal([])
+  })
+
+  it('should join errors into message', () => {
+    const err = new SwarmValidationError(['err1', 'err2'])
+    expect(err.message).to.equal('err1\nerr2')
+  })
+
+  it('should not include note in message', () => {
+    const err = new SwarmValidationError(['err1'], [], 'some note')
+    expect(err.message).to.equal('err1')
+    expect(err.note).to.equal('some note')
+  })
+
+  it('should default note to null', () => {
+    const err = new SwarmValidationError(['err1'])
+    expect(err.note).to.be.null
+  })
+})

--- a/test/unit/agent/swarm/frontmatter.test.ts
+++ b/test/unit/agent/swarm/frontmatter.test.ts
@@ -1,0 +1,68 @@
+import {expect} from 'chai'
+
+import {parseFrontmatter} from '../../../../src/agent/infra/swarm/frontmatter.js'
+
+describe('parseFrontmatter', () => {
+  it('should parse valid frontmatter and body', () => {
+    const content = '---\nname: test\nvalue: 42\n---\nThis is the body.'
+    const result = parseFrontmatter<{name: string; value: number}>(content)
+
+    expect(result).to.not.be.null
+    expect(result!.frontmatter.name).to.equal('test')
+    expect(result!.frontmatter.value).to.equal(42)
+    expect(result!.body).to.equal('This is the body.')
+  })
+
+  it('should return body after closing delimiter with leading newline trimmed', () => {
+    const content = '---\nkey: val\n---\n\nLine one.\nLine two.'
+    const result = parseFrontmatter(content)
+
+    expect(result).to.not.be.null
+    expect(result!.body).to.equal('\nLine one.\nLine two.')
+  })
+
+  it('should return empty body when nothing follows closing delimiter', () => {
+    const content = '---\nkey: val\n---\n'
+    const result = parseFrontmatter(content)
+
+    expect(result).to.not.be.null
+    expect(result!.body).to.equal('')
+  })
+
+  it('should return null when content does not start with ---', () => {
+    const content = 'no frontmatter here\n---\nkey: val\n---'
+    const result = parseFrontmatter(content)
+
+    expect(result).to.be.null
+  })
+
+  it('should return null when closing --- is missing', () => {
+    const content = '---\nkey: val\nno closing delimiter'
+    const result = parseFrontmatter(content)
+
+    expect(result).to.be.null
+  })
+
+  it('should handle CRLF line endings', () => {
+    const content = '---\r\nname: crlf\r\n---\r\nBody with CRLF.'
+    const result = parseFrontmatter<{name: string}>(content)
+
+    expect(result).to.not.be.null
+    expect(result!.frontmatter.name).to.equal('crlf')
+    expect(result!.body).to.equal('Body with CRLF.')
+  })
+
+  it('should return null on YAML parse errors', () => {
+    const content = '---\n: invalid: yaml: {{{\n---\nBody.'
+    const result = parseFrontmatter(content)
+
+    expect(result).to.be.null
+  })
+
+  it('should return null when frontmatter is not an object', () => {
+    const content = '---\njust a string\n---\nBody.'
+    const result = parseFrontmatter(content)
+
+    expect(result).to.be.null
+  })
+})

--- a/test/unit/agent/swarm/swarm-graph-builder.test.ts
+++ b/test/unit/agent/swarm/swarm-graph-builder.test.ts
@@ -1,0 +1,114 @@
+/// <reference types="mocha" />
+
+import {expect} from 'chai'
+
+import type {LoadedSwarm} from '../../../../src/agent/infra/swarm/types.js'
+
+import {CycleDetectedError} from '../../../../src/agent/infra/swarm/engine/swarm-graph.js'
+import {buildSwarmGraph} from '../../../../src/agent/infra/swarm/swarm-graph-builder.js'
+
+function makeLoadedSwarm(overrides?: Partial<LoadedSwarm>): LoadedSwarm {
+  return {
+    agents: [
+      {frontmatter: {description: 'Analyzer', name: 'Analyzer', role: 'worker', skills: [], slug: 'analyzer'}, prompt: 'Analyze.', sourcePath: '/s/agents/analyzer/AGENT.md'},
+      {frontmatter: {description: 'Synthesizer', name: 'Synthesizer', role: 'worker', skills: [], slug: 'synthesizer'}, prompt: 'Synthesize.', sourcePath: '/s/agents/synthesizer/AGENT.md'},
+    ],
+    description: 'Test swarm',
+    frontmatter: {
+      description: 'Test',
+      goals: ['Test'],
+      includes: ['agents/analyzer/AGENT.md', 'agents/synthesizer/AGENT.md'],
+      name: 'Test Swarm',
+      schema: 'byterover-swarm/v1',
+      slug: 'test-swarm',
+      version: '1.0.0',
+    },
+    runtimeConfig: {
+      agents: {
+        analyzer: {adapter: {type: 'claude_code'}, timeoutSec: 120},
+        synthesizer: {adapter: {config: {command: 'echo'}, type: 'process'}, output: true, timeoutSec: 60},
+      },
+      edges: [{from: 'analyzer', to: 'synthesizer'}],
+      potentialEdges: [{from: 'synthesizer', to: 'analyzer'}],
+      schema: 'byterover-swarm/v1',
+    },
+    sourceDir: '/s',
+    warnings: [],
+    ...overrides,
+  }
+}
+
+describe('buildSwarmGraph', () => {
+  it('should create one node per agent', () => {
+    const result = buildSwarmGraph(makeLoadedSwarm())
+
+    expect(result.graph.nodeCount).to.equal(2)
+    expect(result.graph.nodes.has('analyzer')).to.be.true
+    expect(result.graph.nodes.has('synthesizer')).to.be.true
+  })
+
+  it('should wire fixed edges correctly', () => {
+    const result = buildSwarmGraph(makeLoadedSwarm())
+
+    const analyzer = result.graph.nodes.get('analyzer')!
+    expect(analyzer.successors.some((n) => n.id === 'synthesizer')).to.be.true
+  })
+
+  it('should pass potential edges to EdgeDistribution', () => {
+    const result = buildSwarmGraph(makeLoadedSwarm())
+
+    expect(result.edgeDistribution.potentialConnections).to.deep.equal([['synthesizer', 'analyzer']])
+  })
+
+  it('should set output nodes from agents with output: true', () => {
+    const result = buildSwarmGraph(makeLoadedSwarm())
+
+    expect(result.graph.outputNodes).to.have.lengthOf(1)
+    expect(result.graph.outputNodes[0].slug).to.equal('synthesizer')
+  })
+
+  it('should return correct summary', () => {
+    const result = buildSwarmGraph(makeLoadedSwarm())
+
+    expect(result.summary.name).to.equal('Test Swarm')
+    expect(result.summary.slug).to.equal('test-swarm')
+    expect(result.summary.agentCount).to.equal(2)
+    expect(result.summary.fixedEdgeCount).to.equal(1)
+    expect(result.summary.potentialEdgeCount).to.equal(1)
+    expect(result.summary.outputNodes).to.deep.equal(['synthesizer'])
+    expect(result.summary.agents).to.deep.equal([
+      {adapterType: 'claude_code', slug: 'analyzer'},
+      {adapterType: 'process', slug: 'synthesizer'},
+    ])
+  })
+
+  it('should throw CycleDetectedError if fixed edges form a cycle', () => {
+    const loaded = makeLoadedSwarm({
+      runtimeConfig: {
+        agents: {
+          a: {adapter: {type: 'process'}, timeoutSec: 60},
+          b: {adapter: {type: 'process'}, output: true, timeoutSec: 60},
+        },
+        edges: [{from: 'a', to: 'b'}, {from: 'b', to: 'a'}],
+        potentialEdges: [],
+        schema: 'byterover-swarm/v1',
+      },
+    })
+    loaded.agents = [
+      {frontmatter: {description: 'A', name: 'A', role: 'worker', skills: [], slug: 'a'}, prompt: 'A.', sourcePath: '/s/a'},
+      {frontmatter: {description: 'B', name: 'B', role: 'worker', skills: [], slug: 'b'}, prompt: 'B.', sourcePath: '/s/b'},
+    ]
+
+    expect(() => buildSwarmGraph(loaded)).to.throw(CycleDetectedError)
+  })
+
+  it('should work with zero potential edges', () => {
+    const loaded = makeLoadedSwarm()
+    loaded.runtimeConfig.potentialEdges = []
+
+    const result = buildSwarmGraph(loaded)
+
+    expect(result.edgeDistribution.potentialConnections).to.have.lengthOf(0)
+    expect(result.summary.potentialEdgeCount).to.equal(0)
+  })
+})

--- a/test/unit/agent/swarm/swarm-graph-builder.test.ts
+++ b/test/unit/agent/swarm/swarm-graph-builder.test.ts
@@ -26,7 +26,7 @@ function makeLoadedSwarm(overrides?: Partial<LoadedSwarm>): LoadedSwarm {
     runtimeConfig: {
       agents: {
         analyzer: {adapter: {type: 'claude_code'}, timeoutSec: 120},
-        synthesizer: {adapter: {config: {command: 'echo'}, type: 'process'}, output: true, timeoutSec: 60},
+        synthesizer: {adapter: {config: {command: 'echo'}, type: 'hermes'}, output: true, timeoutSec: 60},
       },
       edges: [{from: 'analyzer', to: 'synthesizer'}],
       potentialEdges: [{from: 'synthesizer', to: 'analyzer'}],
@@ -78,7 +78,7 @@ describe('buildSwarmGraph', () => {
     expect(result.summary.outputNodes).to.deep.equal(['synthesizer'])
     expect(result.summary.agents).to.deep.equal([
       {adapterType: 'claude_code', slug: 'analyzer'},
-      {adapterType: 'process', slug: 'synthesizer'},
+      {adapterType: 'hermes', slug: 'synthesizer'},
     ])
   })
 
@@ -86,8 +86,8 @@ describe('buildSwarmGraph', () => {
     const loaded = makeLoadedSwarm({
       runtimeConfig: {
         agents: {
-          a: {adapter: {type: 'process'}, timeoutSec: 60},
-          b: {adapter: {type: 'process'}, output: true, timeoutSec: 60},
+          a: {adapter: {type: 'hermes'}, timeoutSec: 60},
+          b: {adapter: {type: 'hermes'}, output: true, timeoutSec: 60},
         },
         edges: [{from: 'a', to: 'b'}, {from: 'b', to: 'a'}],
         potentialEdges: [],

--- a/test/unit/agent/swarm/swarm-loader.test.ts
+++ b/test/unit/agent/swarm/swarm-loader.test.ts
@@ -90,9 +90,7 @@ agents:
 
   synthesizer:
     adapter:
-      type: process
-      config:
-        command: echo
+      type: hermes
     output: true
     timeoutSec: 60
 

--- a/test/unit/agent/swarm/swarm-loader.test.ts
+++ b/test/unit/agent/swarm/swarm-loader.test.ts
@@ -1,0 +1,622 @@
+/// <reference types="mocha" />
+
+import {expect} from 'chai'
+import path from 'node:path'
+
+import type {SwarmFileReader} from '../../../../src/agent/infra/swarm/types.js'
+
+import {SwarmValidationError} from '../../../../src/agent/infra/swarm/errors.js'
+import {SwarmLoader} from '../../../../src/agent/infra/swarm/swarm-loader.js'
+
+// ─── In-memory file reader stub ───
+
+function createStubReader(files: Record<string, string>): SwarmFileReader {
+  const normalized = new Map<string, string>()
+  for (const [k, v] of Object.entries(files)) {
+    normalized.set(path.resolve(k), v)
+  }
+
+  return {
+    async exists(p: string) {
+      const resolved = path.resolve(p)
+      return normalized.has(resolved) || [...normalized.keys()].some((k) => k.startsWith(resolved + '/'))
+    },
+    async glob(dir: string, pattern: string) {
+      const resolvedDir = path.resolve(dir)
+      const suffix = pattern.replace('**/', '')
+      return [...normalized.keys()].filter((k) => k.startsWith(resolvedDir + '/') && k.endsWith(suffix))
+    },
+    async isDirectory(p: string) {
+      const resolved = path.resolve(p)
+      return !normalized.has(resolved) && [...normalized.keys()].some((k) => k.startsWith(resolved + '/'))
+    },
+    async readFile(p: string) {
+      const resolved = path.resolve(p)
+      const content = normalized.get(resolved)
+      if (content === undefined) throw new Error(`ENOENT: ${resolved}`)
+
+      return content
+    },
+  }
+}
+
+// ─── Valid fixture content ───
+
+const VALID_SWARM_MD = `---
+name: Test Swarm
+description: A test swarm
+slug: test-swarm
+schema: byterover-swarm/v1
+version: 1.0.0
+goals:
+  - Test goal
+includes:
+  - agents/analyzer/AGENT.md
+  - agents/synthesizer/AGENT.md
+---
+
+Test swarm description.
+`
+
+const ANALYZER_AGENT_MD = `---
+name: Analyzer
+slug: analyzer
+description: Code analyzer
+role: worker
+skills:
+  - review
+---
+
+Analyze the code.
+`
+
+const SYNTHESIZER_AGENT_MD = `---
+name: Synthesizer
+slug: synthesizer
+description: Synthesis agent
+role: worker
+---
+
+Synthesize findings.
+`
+
+const VALID_SWARM_YAML = `schema: byterover-swarm/v1
+
+agents:
+  analyzer:
+    adapter:
+      type: claude_code
+    timeoutSec: 120
+
+  synthesizer:
+    adapter:
+      type: process
+      config:
+        command: echo
+    output: true
+    timeoutSec: 60
+
+edges:
+  - from: analyzer
+    to: synthesizer
+
+potential_edges:
+  - from: synthesizer
+    to: analyzer
+`
+
+function validFiles(root = '/swarm'): Record<string, string> {
+  return {
+    [`${root}/.swarm.yaml`]: VALID_SWARM_YAML,
+    [`${root}/agents/analyzer/AGENT.md`]: ANALYZER_AGENT_MD,
+    [`${root}/agents/synthesizer/AGENT.md`]: SYNTHESIZER_AGENT_MD,
+    [`${root}/SWARM.md`]: VALID_SWARM_MD,
+  }
+}
+
+describe('SwarmLoader', () => {
+  describe('happy path', () => {
+    it('should load a valid swarm spec', async () => {
+      const reader = createStubReader(validFiles())
+      const loader = new SwarmLoader({fileReader: reader})
+
+      const loaded = await loader.load('/swarm')
+
+      expect(loaded.frontmatter.name).to.equal('Test Swarm')
+      expect(loaded.frontmatter.slug).to.equal('test-swarm')
+      expect(loaded.description).to.include('Test swarm description.')
+      expect(loaded.agents).to.have.lengthOf(2)
+      expect(loaded.agents[0].frontmatter.slug).to.equal('analyzer')
+      expect(loaded.agents[0].prompt).to.include('Analyze the code.')
+      expect(loaded.agents[1].frontmatter.slug).to.equal('synthesizer')
+      expect(loaded.runtimeConfig.edges).to.have.lengthOf(1)
+      expect(loaded.runtimeConfig.potentialEdges).to.have.lengthOf(1)
+      expect(loaded.sourceDir).to.equal(path.resolve('/swarm'))
+    })
+
+    it('should resolve sourceDir to absolute path', async () => {
+      const reader = createStubReader(validFiles())
+      const loader = new SwarmLoader({fileReader: reader})
+
+      const loaded = await loader.load('/swarm')
+
+      expect(path.isAbsolute(loaded.sourceDir)).to.be.true
+    })
+
+    it('should produce warning when no output nodes defined', async () => {
+      const files = validFiles()
+      files['/swarm/.swarm.yaml'] = VALID_SWARM_YAML.replace('output: true\n    ', '')
+      const reader = createStubReader(files)
+      const loader = new SwarmLoader({fileReader: reader})
+
+      const loaded = await loader.load('/swarm')
+
+      expect(loaded.warnings).to.have.lengthOf(1)
+      expect(loaded.warnings[0]).to.include('output')
+    })
+  })
+
+  describe('missing files', () => {
+    it('should throw when directory does not exist', async () => {
+      const reader = createStubReader({})
+      const loader = new SwarmLoader({fileReader: reader})
+
+      try {
+        await loader.load('/nonexistent')
+        expect.fail('should have thrown')
+      } catch (error) {
+        expect((error as Error).message).to.include('does not exist')
+      }
+    })
+
+    it('should throw when path is not a directory', async () => {
+      const reader = createStubReader({'/afile': 'content'})
+      const loader = new SwarmLoader({fileReader: reader})
+
+      try {
+        await loader.load('/afile')
+        expect.fail('should have thrown')
+      } catch (error) {
+        expect((error as Error).message).to.include('not a directory')
+      }
+    })
+
+    it('should throw when SWARM.md is missing', async () => {
+      const files = validFiles()
+      delete files['/swarm/SWARM.md']
+      const reader = createStubReader(files)
+      const loader = new SwarmLoader({fileReader: reader})
+
+      try {
+        await loader.load('/swarm')
+        expect.fail('should have thrown')
+      } catch (error) {
+        expect((error as Error).message).to.include('SWARM.md')
+      }
+    })
+
+    it('should throw when .swarm.yaml is missing', async () => {
+      const files = validFiles()
+      delete files['/swarm/.swarm.yaml']
+      const reader = createStubReader(files)
+      const loader = new SwarmLoader({fileReader: reader})
+
+      try {
+        await loader.load('/swarm')
+        expect.fail('should have thrown')
+      } catch (error) {
+        expect((error as Error).message).to.include('.swarm.yaml')
+      }
+    })
+
+    it('should throw SwarmValidationError when included AGENT.md is missing', async () => {
+      const files = validFiles()
+      delete files['/swarm/agents/synthesizer/AGENT.md']
+      const reader = createStubReader(files)
+      const loader = new SwarmLoader({fileReader: reader})
+
+      try {
+        await loader.load('/swarm')
+        expect.fail('should have thrown')
+      } catch (error) {
+        expect(error).to.be.instanceOf(SwarmValidationError)
+        const ve = error as SwarmValidationError
+        expect(ve.errors.some((e) => e.includes('agents/synthesizer/AGENT.md'))).to.be.true
+      }
+    })
+  })
+
+  describe('schema validation', () => {
+    it('should throw when SWARM.md schema is wrong', async () => {
+      const files = validFiles()
+      files['/swarm/SWARM.md'] = VALID_SWARM_MD.replace('byterover-swarm/v1', 'wrong/v1')
+      const reader = createStubReader(files)
+      const loader = new SwarmLoader({fileReader: reader})
+
+      try {
+        await loader.load('/swarm')
+        expect.fail('should have thrown')
+      } catch (error) {
+        expect((error as Error).message).to.include('schema')
+      }
+    })
+
+    it('should throw when SWARM.md missing required name', async () => {
+      const files = validFiles()
+      files['/swarm/SWARM.md'] = VALID_SWARM_MD.replace('name: Test Swarm\n', '')
+      const reader = createStubReader(files)
+      const loader = new SwarmLoader({fileReader: reader})
+
+      try {
+        await loader.load('/swarm')
+        expect.fail('should have thrown')
+      } catch (error) {
+        expect((error as Error).message).to.include('name')
+      }
+    })
+
+    it('should throw SwarmValidationError when AGENT.md missing required slug', async () => {
+      const files = validFiles()
+      files['/swarm/agents/analyzer/AGENT.md'] = ANALYZER_AGENT_MD.replace('slug: analyzer\n', '')
+      const reader = createStubReader(files)
+      const loader = new SwarmLoader({fileReader: reader})
+
+      try {
+        await loader.load('/swarm')
+        expect.fail('should have thrown')
+      } catch (error) {
+        expect(error).to.be.instanceOf(SwarmValidationError)
+        const ve = error as SwarmValidationError
+        expect(ve.errors.some((e) => e.includes('slug'))).to.be.true
+      }
+    })
+
+    it('should throw on invalid adapter type in .swarm.yaml', async () => {
+      const files = validFiles()
+      files['/swarm/.swarm.yaml'] = VALID_SWARM_YAML.replace('type: claude_code', 'type: unknown_type')
+      const reader = createStubReader(files)
+      const loader = new SwarmLoader({fileReader: reader})
+
+      try {
+        await loader.load('/swarm')
+        expect.fail('should have thrown')
+      } catch (error) {
+        expect((error as Error).message).to.include('unknown_type')
+      }
+    })
+  })
+
+  describe('includes validation', () => {
+    it('should throw on duplicate includes', async () => {
+      const files = validFiles()
+      files['/swarm/SWARM.md'] = VALID_SWARM_MD.replace(
+        'includes:\n  - agents/analyzer/AGENT.md\n  - agents/synthesizer/AGENT.md',
+        'includes:\n  - agents/analyzer/AGENT.md\n  - agents/analyzer/AGENT.md',
+      )
+      // Also update .swarm.yaml to only have analyzer
+      files['/swarm/.swarm.yaml'] = VALID_SWARM_YAML.replace(
+        /\n {2}synthesizer:[\s\S]*?(?=\nedges:)/,
+        '',
+      ).replace(
+        /potential_edges:[\s\S]*$/,
+        'potential_edges: []\n',
+      )
+      const reader = createStubReader(files)
+      const loader = new SwarmLoader({fileReader: reader})
+
+      try {
+        await loader.load('/swarm')
+        expect.fail('should have thrown')
+      } catch (error) {
+        expect((error as Error).message).to.include('uplicate')
+      }
+    })
+
+    it('should throw on duplicate includes after normalization', async () => {
+      const files = validFiles()
+      files['/swarm/SWARM.md'] = VALID_SWARM_MD.replace(
+        'includes:\n  - agents/analyzer/AGENT.md\n  - agents/synthesizer/AGENT.md',
+        'includes:\n  - agents/analyzer/AGENT.md\n  - ./agents/../agents/analyzer/AGENT.md',
+      )
+      files['/swarm/.swarm.yaml'] = VALID_SWARM_YAML.replace(
+        /\n {2}synthesizer:[\s\S]*?(?=\nedges:)/,
+        '',
+      ).replace(
+        /potential_edges:[\s\S]*$/,
+        'potential_edges: []\n',
+      )
+      const reader = createStubReader(files)
+      const loader = new SwarmLoader({fileReader: reader})
+
+      try {
+        await loader.load('/swarm')
+        expect.fail('should have thrown')
+      } catch (error) {
+        expect((error as Error).message).to.include('uplicate')
+      }
+    })
+
+    it('should throw on path traversal', async () => {
+      const files = validFiles()
+      files['/swarm/SWARM.md'] = VALID_SWARM_MD.replace(
+        'agents/synthesizer/AGENT.md',
+        '../../etc/passwd',
+      )
+      const reader = createStubReader(files)
+      const loader = new SwarmLoader({fileReader: reader})
+
+      try {
+        await loader.load('/swarm')
+        expect.fail('should have thrown')
+      } catch (error) {
+        expect((error as Error).message).to.include('escapes')
+      }
+    })
+  })
+
+  describe('slug/config consistency', () => {
+    it('should throw SwarmValidationError on duplicate agent slugs', async () => {
+      const files = validFiles()
+      files['/swarm/agents/synthesizer/AGENT.md'] = SYNTHESIZER_AGENT_MD.replace(
+        'slug: synthesizer',
+        'slug: analyzer',
+      )
+      const reader = createStubReader(files)
+      const loader = new SwarmLoader({fileReader: reader})
+
+      try {
+        await loader.load('/swarm')
+        expect.fail('should have thrown')
+      } catch (error) {
+        expect(error).to.be.instanceOf(SwarmValidationError)
+        const ve = error as SwarmValidationError
+        expect(ve.errors.some((e) => e.includes('uplicate') && e.includes('analyzer'))).to.be.true
+      }
+    })
+
+    it('should throw SwarmValidationError when .swarm.yaml references unknown agent slug', async () => {
+      const files = validFiles()
+      files['/swarm/.swarm.yaml'] = VALID_SWARM_YAML.replace('analyzer:', 'unknown-agent:')
+      const reader = createStubReader(files)
+      const loader = new SwarmLoader({fileReader: reader})
+
+      try {
+        await loader.load('/swarm')
+        expect.fail('should have thrown')
+      } catch (error) {
+        expect(error).to.be.instanceOf(SwarmValidationError)
+        const ve = error as SwarmValidationError
+        expect(ve.errors.some((e) => e.includes('unknown-agent'))).to.be.true
+      }
+    })
+
+    it('should throw SwarmValidationError when AGENT.md slug has no config in .swarm.yaml', async () => {
+      const files = validFiles()
+      files['/swarm/.swarm.yaml'] = VALID_SWARM_YAML.replace(
+        /\n {2}synthesizer:[\s\S]*?(?=\nedges:)/,
+        '',
+      )
+      const reader = createStubReader(files)
+      const loader = new SwarmLoader({fileReader: reader})
+
+      try {
+        await loader.load('/swarm')
+        expect.fail('should have thrown')
+      } catch (error) {
+        expect(error).to.be.instanceOf(SwarmValidationError)
+        const ve = error as SwarmValidationError
+        expect(ve.errors.some((e) => e.includes('synthesizer') && e.includes('no entry'))).to.be.true
+      }
+    })
+  })
+
+  describe('edge validation', () => {
+    it('should throw SwarmValidationError when edge references unknown agent slug', async () => {
+      const files = validFiles()
+      files['/swarm/.swarm.yaml'] = VALID_SWARM_YAML.replace('from: analyzer', 'from: ghost')
+      const reader = createStubReader(files)
+      const loader = new SwarmLoader({fileReader: reader})
+
+      try {
+        await loader.load('/swarm')
+        expect.fail('should have thrown')
+      } catch (error) {
+        expect(error).to.be.instanceOf(SwarmValidationError)
+        const ve = error as SwarmValidationError
+        expect(ve.errors.some((e) => e.includes('ghost'))).to.be.true
+      }
+    })
+
+    it('should throw SwarmValidationError on duplicate fixed edges', async () => {
+      const files = validFiles()
+      files['/swarm/.swarm.yaml'] = VALID_SWARM_YAML.replace(
+        'edges:\n  - from: analyzer\n    to: synthesizer',
+        'edges:\n  - from: analyzer\n    to: synthesizer\n  - from: analyzer\n    to: synthesizer',
+      )
+      const reader = createStubReader(files)
+      const loader = new SwarmLoader({fileReader: reader})
+
+      try {
+        await loader.load('/swarm')
+        expect.fail('should have thrown')
+      } catch (error) {
+        expect(error).to.be.instanceOf(SwarmValidationError)
+        const ve = error as SwarmValidationError
+        expect(ve.errors.some((e) => e.includes('uplicate'))).to.be.true
+      }
+    })
+
+    it('should throw SwarmValidationError on duplicate potential edges', async () => {
+      const files = validFiles()
+      files['/swarm/.swarm.yaml'] = VALID_SWARM_YAML.replace(
+        'potential_edges:\n  - from: synthesizer\n    to: analyzer',
+        'potential_edges:\n  - from: synthesizer\n    to: analyzer\n  - from: synthesizer\n    to: analyzer',
+      )
+      const reader = createStubReader(files)
+      const loader = new SwarmLoader({fileReader: reader})
+
+      try {
+        await loader.load('/swarm')
+        expect.fail('should have thrown')
+      } catch (error) {
+        expect(error).to.be.instanceOf(SwarmValidationError)
+        const ve = error as SwarmValidationError
+        expect(ve.errors.some((e) => e.includes('uplicate'))).to.be.true
+      }
+    })
+
+    it('should throw SwarmValidationError when same edge in both fixed and potential', async () => {
+      const files = validFiles()
+      files['/swarm/.swarm.yaml'] = VALID_SWARM_YAML.replace(
+        'potential_edges:\n  - from: synthesizer\n    to: analyzer',
+        'potential_edges:\n  - from: analyzer\n    to: synthesizer',
+      )
+      const reader = createStubReader(files)
+      const loader = new SwarmLoader({fileReader: reader})
+
+      try {
+        await loader.load('/swarm')
+        expect.fail('should have thrown')
+      } catch (error) {
+        expect(error).to.be.instanceOf(SwarmValidationError)
+        const ve = error as SwarmValidationError
+        expect(ve.errors.some((e) => e.includes('both'))).to.be.true
+      }
+    })
+  })
+
+  describe('error accumulation', () => {
+    it('should collect multiple slug mismatches in one throw', async () => {
+      const files = validFiles()
+      // Config has "unknown1" and "unknown2" instead of real slugs
+      files['/swarm/.swarm.yaml'] = VALID_SWARM_YAML
+        .replace('analyzer:', 'unknown1:')
+        .replace('synthesizer:', 'unknown2:')
+      const reader = createStubReader(files)
+      const loader = new SwarmLoader({fileReader: reader})
+
+      try {
+        await loader.load('/swarm')
+        expect.fail('should have thrown')
+      } catch (error) {
+        expect(error).to.be.instanceOf(SwarmValidationError)
+        const ve = error as SwarmValidationError
+        expect(ve.errors.some((e) => e.includes('unknown1'))).to.be.true
+        expect(ve.errors.some((e) => e.includes('unknown2'))).to.be.true
+        expect(ve.errors.some((e) => e.includes('analyzer') && e.includes('no entry'))).to.be.true
+        expect(ve.errors.some((e) => e.includes('synthesizer') && e.includes('no entry'))).to.be.true
+      }
+    })
+
+    it('should include cascade note when includes fail and cross-validation errors exist', async () => {
+      const files = validFiles()
+      // Remove one agent file so it fails to load
+      delete files['/swarm/agents/synthesizer/AGENT.md']
+      const reader = createStubReader(files)
+      const loader = new SwarmLoader({fileReader: reader})
+
+      try {
+        await loader.load('/swarm')
+        expect.fail('should have thrown')
+      } catch (error) {
+        expect(error).to.be.instanceOf(SwarmValidationError)
+        const ve = error as SwarmValidationError
+        expect(ve.note).to.include('1 included file(s) failed to load')
+        // The actual file error + cross-validation errors should both be present
+        expect(ve.errors.length).to.be.greaterThan(1)
+      }
+    })
+
+    it('should not include cascade note when errors are only from cross-validation (no failed includes)', async () => {
+      // Config references unknown slug, but all includes load fine → no cascade note
+      const files = validFiles()
+      files['/swarm/.swarm.yaml'] = VALID_SWARM_YAML.replace('analyzer:', 'unknown-agent:')
+      const reader = createStubReader(files)
+      const loader = new SwarmLoader({fileReader: reader})
+
+      try {
+        await loader.load('/swarm')
+        expect.fail('should have thrown')
+      } catch (error) {
+        expect(error).to.be.instanceOf(SwarmValidationError)
+        const ve = error as SwarmValidationError
+        expect(ve.errors.length).to.be.greaterThan(0)
+        expect(ve.note).to.be.null
+      }
+    })
+
+    it('should still fail-fast on missing SWARM.md (plain Error)', async () => {
+      const files = validFiles()
+      delete files['/swarm/SWARM.md']
+      const reader = createStubReader(files)
+      const loader = new SwarmLoader({fileReader: reader})
+
+      try {
+        await loader.load('/swarm')
+        expect.fail('should have thrown')
+      } catch (error) {
+        expect(error).to.not.be.instanceOf(SwarmValidationError)
+        expect((error as Error).message).to.include('SWARM.md')
+      }
+    })
+  })
+
+  describe('file discovery warnings', () => {
+    it('should warn about orphan AGENT.md not in includes', async () => {
+      const files = validFiles()
+      // Add an orphan agent file not referenced by SWARM.md includes
+      files['/swarm/agents/researcher/AGENT.md'] = `---
+name: Researcher
+slug: researcher
+description: Research agent
+role: worker
+---
+
+Research things.
+`
+      const reader = createStubReader(files)
+      const loader = new SwarmLoader({fileReader: reader})
+
+      const loaded = await loader.load('/swarm')
+
+      expect(loaded.warnings.some((w) => w.includes('researcher/AGENT.md') && w.includes('not in SWARM.md includes'))).to.be.true
+    })
+
+    it('should not warn when all AGENT.md files are in includes', async () => {
+      const files = validFiles()
+      const reader = createStubReader(files)
+      const loader = new SwarmLoader({fileReader: reader})
+
+      const loaded = await loader.load('/swarm')
+
+      expect(loaded.warnings.filter((w) => w.includes('not in SWARM.md includes'))).to.have.lengthOf(0)
+    })
+
+    it('should warn about multiple orphan AGENT.md files', async () => {
+      const files = validFiles()
+      files['/swarm/agents/researcher/AGENT.md'] = `---
+name: Researcher
+slug: researcher
+description: Research
+role: worker
+---
+Research.
+`
+      files['/swarm/agents/tester/AGENT.md'] = `---
+name: Tester
+slug: tester
+description: Test
+role: worker
+---
+Test.
+`
+      const reader = createStubReader(files)
+      const loader = new SwarmLoader({fileReader: reader})
+
+      const loaded = await loader.load('/swarm')
+
+      const discoveryWarnings = loaded.warnings.filter((w) => w.includes('not in SWARM.md includes'))
+      expect(discoveryWarnings).to.have.lengthOf(2)
+    })
+  })
+})

--- a/test/unit/agent/swarm/swarm-scaffolder.test.ts
+++ b/test/unit/agent/swarm/swarm-scaffolder.test.ts
@@ -44,7 +44,7 @@ function readerFromScaffold(files: Record<string, string>, root: string): SwarmF
 const TWO_AGENT_INPUT = {
   agents: [
     {adapterType: 'claude_code' as const, description: 'Code analyzer', name: 'Analyzer', slug: 'analyzer'},
-    {adapterType: 'process' as const, description: 'Synthesis agent', name: 'Synthesizer', slug: 'synthesizer'},
+    {adapterType: 'hermes' as const, description: 'Synthesis agent', name: 'Synthesizer', slug: 'synthesizer'},
   ],
   description: 'A two-agent code review pipeline.',
   edges: [{from: 'analyzer', to: 'synthesizer'}],
@@ -113,7 +113,7 @@ describe('scaffoldSwarm', () => {
 
   it('should handle single agent with zero edges', () => {
     const files = scaffoldSwarm({
-      agents: [{adapterType: 'process', description: 'Solo', name: 'Solo', slug: 'solo'}],
+      agents: [{adapterType: 'hermes', description: 'Solo', name: 'Solo', slug: 'solo'}],
       description: 'Single agent.',
       edges: [],
       goals: ['Do one thing'],
@@ -129,7 +129,7 @@ describe('scaffoldSwarm', () => {
 
   it('should roundtrip single agent through SwarmLoader', async () => {
     const files = scaffoldSwarm({
-      agents: [{adapterType: 'process', description: 'Solo', name: 'Solo', slug: 'solo'}],
+      agents: [{adapterType: 'hermes', description: 'Solo', name: 'Solo', slug: 'solo'}],
       description: 'Single.',
       edges: [],
       goals: ['Test'],

--- a/test/unit/agent/swarm/swarm-scaffolder.test.ts
+++ b/test/unit/agent/swarm/swarm-scaffolder.test.ts
@@ -1,0 +1,149 @@
+/// <reference types="mocha" />
+
+import {expect} from 'chai'
+import {load as yamlLoad} from 'js-yaml'
+import path from 'node:path'
+
+import type {SwarmFileReader} from '../../../../src/agent/infra/swarm/types.js'
+
+import {parseFrontmatter} from '../../../../src/agent/infra/swarm/frontmatter.js'
+import {SwarmLoader} from '../../../../src/agent/infra/swarm/swarm-loader.js'
+import {scaffoldSwarm} from '../../../../src/agent/infra/swarm/swarm-scaffolder.js'
+
+// ─── In-memory reader for roundtrip test ───
+
+function readerFromScaffold(files: Record<string, string>, root: string): SwarmFileReader {
+  const normalized = new Map<string, string>()
+  for (const [relPath, content] of Object.entries(files)) {
+    normalized.set(path.resolve(root, relPath), content)
+  }
+
+  return {
+    async exists(p: string) {
+      const resolved = path.resolve(p)
+      return normalized.has(resolved) || [...normalized.keys()].some((k) => k.startsWith(resolved + '/'))
+    },
+    async glob(dir: string, pattern: string) {
+      const resolvedDir = path.resolve(dir)
+      const suffix = pattern.replace('**/', '')
+      return [...normalized.keys()].filter((k) => k.startsWith(resolvedDir + '/') && k.endsWith(suffix))
+    },
+    async isDirectory(p: string) {
+      const resolved = path.resolve(p)
+      return !normalized.has(resolved) && [...normalized.keys()].some((k) => k.startsWith(resolved + '/'))
+    },
+    async readFile(p: string) {
+      const resolved = path.resolve(p)
+      const content = normalized.get(resolved)
+      if (content === undefined) throw new Error(`ENOENT: ${resolved}`)
+      return content
+    },
+  }
+}
+
+const TWO_AGENT_INPUT = {
+  agents: [
+    {adapterType: 'claude_code' as const, description: 'Code analyzer', name: 'Analyzer', slug: 'analyzer'},
+    {adapterType: 'process' as const, description: 'Synthesis agent', name: 'Synthesizer', slug: 'synthesizer'},
+  ],
+  description: 'A two-agent code review pipeline.',
+  edges: [{from: 'analyzer', to: 'synthesizer'}],
+  goals: ['Find bugs', 'Produce reviews'],
+  name: 'Code Review',
+  outputNodeSlug: 'synthesizer',
+  slug: 'code-review',
+}
+
+describe('scaffoldSwarm', () => {
+  it('should generate correct file keys for 2-agent input', () => {
+    const files = scaffoldSwarm(TWO_AGENT_INPUT)
+
+    expect(files).to.have.property('SWARM.md')
+    expect(files).to.have.property('agents/analyzer/AGENT.md')
+    expect(files).to.have.property('agents/synthesizer/AGENT.md')
+    expect(files).to.have.property('.swarm.yaml')
+    expect(Object.keys(files)).to.have.lengthOf(4)
+  })
+
+  it('should generate valid SWARM.md with correct frontmatter', () => {
+    const files = scaffoldSwarm(TWO_AGENT_INPUT)
+    const parsed = parseFrontmatter(files['SWARM.md'])
+
+    expect(parsed).to.not.be.null
+    expect(parsed!.frontmatter).to.have.property('name', 'Code Review')
+    expect(parsed!.frontmatter).to.have.property('slug', 'code-review')
+    expect(parsed!.frontmatter).to.have.property('schema', 'byterover-swarm/v1')
+    expect((parsed!.frontmatter as Record<string, unknown>).includes).to.deep.equal([
+      'agents/analyzer/AGENT.md',
+      'agents/synthesizer/AGENT.md',
+    ])
+  })
+
+  it('should generate valid .swarm.yaml with output flag on correct agent', () => {
+    const files = scaffoldSwarm(TWO_AGENT_INPUT)
+    const yaml = yamlLoad(files['.swarm.yaml']) as Record<string, unknown>
+
+    expect(yaml).to.have.property('schema', 'byterover-swarm/v1')
+    const agents = yaml.agents as Record<string, Record<string, unknown>>
+    expect(agents.synthesizer).to.have.property('output', true)
+    expect(agents.analyzer).to.not.have.property('output')
+  })
+
+  it('should use role: worker by default', () => {
+    const files = scaffoldSwarm(TWO_AGENT_INPUT)
+    const parsed = parseFrontmatter(files['agents/analyzer/AGENT.md'])
+
+    expect(parsed).to.not.be.null
+    expect(parsed!.frontmatter).to.have.property('role', 'worker')
+  })
+
+  it('should roundtrip through SwarmLoader without errors', async () => {
+    const files = scaffoldSwarm(TWO_AGENT_INPUT)
+    const root = '/scaffold-test'
+    const reader = readerFromScaffold(files, root)
+    const loader = new SwarmLoader({fileReader: reader})
+
+    const loaded = await loader.load(root)
+
+    expect(loaded.frontmatter.name).to.equal('Code Review')
+    expect(loaded.agents).to.have.lengthOf(2)
+    expect(loaded.runtimeConfig.edges).to.have.lengthOf(1)
+    expect(loaded.warnings).to.deep.equal([])
+  })
+
+  it('should handle single agent with zero edges', () => {
+    const files = scaffoldSwarm({
+      agents: [{adapterType: 'process', description: 'Solo', name: 'Solo', slug: 'solo'}],
+      description: 'Single agent.',
+      edges: [],
+      goals: ['Do one thing'],
+      name: 'Solo Swarm',
+      outputNodeSlug: 'solo',
+      slug: 'solo-swarm',
+    })
+
+    expect(Object.keys(files)).to.have.lengthOf(3) // SWARM.md, AGENT.md, .swarm.yaml
+    const yaml = yamlLoad(files['.swarm.yaml']) as Record<string, unknown>
+    expect((yaml as Record<string, unknown>).edges).to.deep.equal([])
+  })
+
+  it('should roundtrip single agent through SwarmLoader', async () => {
+    const files = scaffoldSwarm({
+      agents: [{adapterType: 'process', description: 'Solo', name: 'Solo', slug: 'solo'}],
+      description: 'Single.',
+      edges: [],
+      goals: ['Test'],
+      name: 'Solo',
+      outputNodeSlug: 'solo',
+      slug: 'solo',
+    })
+    const root = '/solo-test'
+    const reader = readerFromScaffold(files, root)
+    const loader = new SwarmLoader({fileReader: reader})
+
+    const loaded = await loader.load(root)
+
+    expect(loaded.agents).to.have.lengthOf(1)
+    expect(loaded.warnings).to.deep.equal([])
+  })
+})

--- a/test/unit/agent/swarm/swarm-wizard.test.ts
+++ b/test/unit/agent/swarm/swarm-wizard.test.ts
@@ -63,7 +63,7 @@ describe('runWizard', () => {
       'Synthesizer',      // agent 2 name
       'synthesizer',      // agent 2 slug
       'Merge findings',   // agent 2 description
-      'process',          // agent 2 adapter
+      'hermes',          // agent 2 adapter
       false,              // add another?
       // Step 3: Edges
       ['synthesizer'],    // analyzer outputs to synthesizer
@@ -80,7 +80,7 @@ describe('runWizard', () => {
     expect(result!.goals).to.deep.equal(['Find bugs', 'Ship safe'])
     expect(result!.agents).to.have.lengthOf(2)
     expect(result!.agents[0].slug).to.equal('analyzer')
-    expect(result!.agents[1].adapterType).to.equal('process')
+    expect(result!.agents[1].adapterType).to.equal('hermes')
     expect(result!.edges).to.deep.equal([{from: 'analyzer', to: 'synthesizer'}])
     expect(result!.outputNodeSlug).to.equal('synthesizer')
   })
@@ -161,7 +161,7 @@ describe('runWizard', () => {
     let selectCount = 0
     prompts.select = async () => {
       selectCount++
-      if (selectCount === 1) return 'process' // agent adapter
+      if (selectCount === 1) return 'hermes' // agent adapter
       return 'solo' // output node
     }
 
@@ -181,7 +181,7 @@ describe('runWizard', () => {
       // Step 1
       'Solo', 'solo', 'One agent', 'Test',
       // Step 2
-      'Agent', 'agent', 'The agent', 'process',
+      'Agent', 'agent', 'The agent', 'hermes',
       false,              // don't add another
       // Step 3 — no edges for single agent (checkbox not called since no targets)
       // Step 4
@@ -199,9 +199,9 @@ describe('runWizard', () => {
       // Step 1
       'Test', 'test', 'Desc', 'Goal',
       // Step 2: 3 agents
-      'A', 'a', 'Agent A', 'process', true,
-      'B', 'b', 'Agent B', 'process', true,
-      'C', 'c', 'Agent C', 'process', false,
+      'A', 'a', 'Agent A', 'hermes', true,
+      'B', 'b', 'Agent B', 'hermes', true,
+      'C', 'c', 'Agent C', 'hermes', false,
       // Step 3: edges
       ['b', 'c'],    // A → B, A → C
       ['c'],          // B → C

--- a/test/unit/agent/swarm/swarm-wizard.test.ts
+++ b/test/unit/agent/swarm/swarm-wizard.test.ts
@@ -1,0 +1,222 @@
+/// <reference types="mocha" />
+
+import {expect} from 'chai'
+
+import type {WizardPrompts} from '../../../../src/agent/infra/swarm/swarm-wizard.js'
+
+import {runWizard} from '../../../../src/agent/infra/swarm/swarm-wizard.js'
+
+// ─── Mock prompt helpers ───
+
+function makeAbortError(): Error {
+  const err = new Error('AbortPromptError')
+  err.name = 'AbortPromptError'
+  return err
+}
+
+function makeCancelError(): Error {
+  const err = new Error('CancelPromptError')
+  err.name = 'CancelPromptError'
+  return err
+}
+
+type AnswerQueue = Array<boolean | string | string[]>
+
+function createMockPrompts(answers: AnswerQueue): WizardPrompts {
+  let idx = 0
+  const next = () => {
+    if (idx >= answers.length) throw new Error(`Mock prompt exhausted at index ${idx}`)
+    return answers[idx++]
+  }
+
+  return {
+    async checkbox() {
+      return next() as string[]
+    },
+    async confirm() {
+      return next() as boolean
+    },
+    async input(_msg: string, opts?: {default?: string}) {
+      const val = next() as string
+      return val === '' && opts?.default ? opts.default : val
+    },
+    async select() {
+      return next() as string
+    },
+  }
+}
+
+describe('runWizard', () => {
+  it('should return complete ScaffoldInput on happy path', async () => {
+    const prompts = createMockPrompts([
+      // Step 1: Identity
+      'Code Review',      // name
+      'code-review',      // slug
+      'A review pipeline', // description
+      'Find bugs, Ship safe', // goals
+      // Step 2: Agents
+      'Analyzer',         // agent 1 name
+      'analyzer',         // agent 1 slug
+      'Code analysis',    // agent 1 description
+      'claude_code',      // agent 1 adapter
+      true,               // add another?
+      'Synthesizer',      // agent 2 name
+      'synthesizer',      // agent 2 slug
+      'Merge findings',   // agent 2 description
+      'process',          // agent 2 adapter
+      false,              // add another?
+      // Step 3: Edges
+      ['synthesizer'],    // analyzer outputs to synthesizer
+      [],                 // synthesizer outputs to nobody
+      // Step 4: Output
+      'synthesizer',      // output node
+    ])
+
+    const result = await runWizard(prompts)
+
+    expect(result).to.not.be.null
+    expect(result!.name).to.equal('Code Review')
+    expect(result!.slug).to.equal('code-review')
+    expect(result!.goals).to.deep.equal(['Find bugs', 'Ship safe'])
+    expect(result!.agents).to.have.lengthOf(2)
+    expect(result!.agents[0].slug).to.equal('analyzer')
+    expect(result!.agents[1].adapterType).to.equal('process')
+    expect(result!.edges).to.deep.equal([{from: 'analyzer', to: 'synthesizer'}])
+    expect(result!.outputNodeSlug).to.equal('synthesizer')
+  })
+
+  it('should return null when user cancels (CancelPromptError)', async () => {
+    let callCount = 0
+    const prompts: WizardPrompts = {
+      async checkbox() { throw makeCancelError() },
+      async confirm() { throw makeCancelError() },
+      async input() {
+        callCount++
+        if (callCount === 1) return 'Test'
+        throw makeCancelError()
+      },
+      async select() { throw makeCancelError() },
+    }
+
+    const result = await runWizard(prompts)
+    expect(result).to.be.null
+  })
+
+  it('should return null when ESC on first step', async () => {
+    const prompts: WizardPrompts = {
+      async checkbox() { throw makeAbortError() },
+      async confirm() { throw makeAbortError() },
+      async input() { throw makeAbortError() },
+      async select() { throw makeAbortError() },
+    }
+
+    const result = await runWizard(prompts)
+    expect(result).to.be.null
+  })
+
+  it('should go back to previous step on ESC (AbortPromptError)', async () => {
+    const stepsCalled: number[] = []
+    let step2CallCount = 0
+
+    const prompts = createMockPrompts([
+      // Step 1: Identity (first pass)
+      'Test Swarm',
+      'test-swarm',
+      'Description',
+      'Goal one',
+    ])
+
+    // Override to track step transitions and simulate ESC on step 2 first time
+    const originalInput = prompts.input.bind(prompts)
+    let inputCallCount = 0
+    prompts.input = async (msg, opts) => {
+      inputCallCount++
+      // Step 1 calls input 4 times (name, slug, desc, goals)
+      // After step 1 completes, step 2 starts and calls input for agent name
+      if (inputCallCount === 5) {
+        // First time entering step 2 — throw ESC to go back
+        step2CallCount++
+        stepsCalled.push(2)
+        throw makeAbortError()
+      }
+
+      if (inputCallCount >= 6 && inputCallCount <= 9) {
+        // Step 1 again (re-prompted after back)
+        stepsCalled.push(1)
+        // Return same identity values
+        const defaults = ['Test Swarm', 'test-swarm', 'Description', 'Goal one']
+        return defaults[inputCallCount - 6]
+      }
+
+      if (inputCallCount >= 10) {
+        // Step 2 second attempt — provide agent answers
+        const agentAnswers = ['Solo', 'solo', 'Solo agent']
+        const agentIdx = inputCallCount - 10
+        if (agentIdx < agentAnswers.length) return agentAnswers[agentIdx]
+      }
+
+      return originalInput(msg, opts)
+    }
+
+    let selectCount = 0
+    prompts.select = async () => {
+      selectCount++
+      if (selectCount === 1) return 'process' // agent adapter
+      return 'solo' // output node
+    }
+
+    prompts.confirm = async () => false // don't add more agents
+
+    prompts.checkbox = async () => [] // no edges
+
+    const result = await runWizard(prompts)
+
+    expect(result).to.not.be.null
+    expect(step2CallCount).to.equal(1) // ESC was hit once on step 2
+    expect(result!.name).to.equal('Test Swarm') // identity preserved from first pass
+  })
+
+  it('should produce 1 agent when user says no to add another', async () => {
+    const prompts = createMockPrompts([
+      // Step 1
+      'Solo', 'solo', 'One agent', 'Test',
+      // Step 2
+      'Agent', 'agent', 'The agent', 'process',
+      false,              // don't add another
+      // Step 3 — no edges for single agent (checkbox not called since no targets)
+      // Step 4
+      'agent',            // output
+    ])
+
+    const result = await runWizard(prompts)
+
+    expect(result).to.not.be.null
+    expect(result!.agents).to.have.lengthOf(1)
+  })
+
+  it('should produce correct edges from checkbox selections', async () => {
+    const prompts = createMockPrompts([
+      // Step 1
+      'Test', 'test', 'Desc', 'Goal',
+      // Step 2: 3 agents
+      'A', 'a', 'Agent A', 'process', true,
+      'B', 'b', 'Agent B', 'process', true,
+      'C', 'c', 'Agent C', 'process', false,
+      // Step 3: edges
+      ['b', 'c'],    // A → B, A → C
+      ['c'],          // B → C
+      [],             // C → nobody
+      // Step 4
+      'c',
+    ])
+
+    const result = await runWizard(prompts)
+
+    expect(result).to.not.be.null
+    expect(result!.edges).to.deep.equal([
+      {from: 'a', to: 'b'},
+      {from: 'a', to: 'c'},
+      {from: 'b', to: 'c'},
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

- **Problem:** ByteRover CLI has no way to orchestrate multiple external agents (Claude Code, Hermes, OpenClaw, Codex) as a coordinated pipeline. Users working on complex tasks must manually invoke agents one at a time and stitch results together.
- **Why it matters:** Multi-agent swarm orchestration is the foundation for automated code review pipelines, research workflows, and any task that benefits from parallel agent execution with shared context. This is the first step toward GPTSwarm-style graph optimization inside brv.
- **What changed:** Added `brv swarm load` (parse, validate, and summarize declarative swarm specs) and `brv swarm onboard` (interactive wizard to scaffold new specs). Ported DAG engine from GPTSwarm (topological sort, cycle detection, edge distribution). Implemented Paperclip-inspired error accumulation and orphan file discovery.
- **What did NOT change (scope boundary):** No agent execution, no adapter invocations, no daemon integration, no REPL commands, no optimization. This is parse + validate + scaffold only — execution is Phase 2.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [x] Agent / Tools
- [ ] LLM Providers
- [ ] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [x] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes #ENG-2020

## Root cause (bug fixes only, otherwise write `N/A`)

N/A

## Test plan

- Coverage added:
  - [x] Unit test
  - [ ] Integration test
  - [x] Manual verification only
- Test file(s):
  - `test/unit/agent/swarm/errors.test.ts`
  - `test/unit/agent/swarm/frontmatter.test.ts`
  - `test/unit/agent/swarm/engine/swarm-node.test.ts`
  - `test/unit/agent/swarm/engine/swarm-graph.test.ts`
  - `test/unit/agent/swarm/engine/edge-distribution.test.ts`
  - `test/unit/agent/swarm/swarm-loader.test.ts`
  - `test/unit/agent/swarm/swarm-graph-builder.test.ts`
  - `test/unit/agent/swarm/swarm-scaffolder.test.ts`
  - `test/unit/agent/swarm/swarm-wizard.test.ts`
  - `test/commands/swarm/load.test.ts`
  - `test/commands/swarm/onboard.test.ts`
- Key scenario(s) covered:
  - Spec parsing (frontmatter, YAML, Zod validation)
  - DAG construction (topological sort, cycle detection, edge sampling)
  - 18+ validation checks (missing files, duplicates, path traversal, slug mismatches, edge corruption)
  - Error accumulation (multiple errors in single throw, cascade note)
  - Orphan AGENT.md file discovery
  - Scaffolder roundtrip (generate → load → no errors)
  - Wizard state machine (happy path, ESC back-nav, cancel)
  - CLI command integration (summary output, validation error formatting, exit codes)

## User-visible changes

- New CLI topic: `brv swarm` with `--help` showing available subcommands
- New command: `brv swarm load <dir>` — validates a swarm spec directory and prints a summary
- New command: `brv swarm onboard [dir]` — interactive wizard to scaffold a new swarm spec
- New declarative spec format: `SWARM.md` + `agents/*/AGENT.md` + `.swarm.yaml`
- New oclif topic `swarm` registered in `package.json`
- Validation errors now show all problems at once instead of failing on the first one
- Orphan AGENT.md files on disk (not in includes) produce a warning

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

