### PR TITLE
fix: [ENG-2023] handle stop-word-only queries and strip frontmatter from excerpts

### DIFF
--- a/src/agent/infra/tools/implementations/search-knowledge-service.ts
+++ b/src/agent/infra/tools/implementations/search-knowledge-service.ts
@@ -291,7 +291,7 @@ function getSummarySource(
 function filterStopWords(query: string): string {
   const words = query.toLowerCase().split(/\s+/)
   const filtered = removeStopwords(words)
-  return filtered.length > 0 ? filtered.join(' ') : query
+  return filtered.join(' ')
 }
 
 /**
@@ -398,11 +398,12 @@ function chunkDocument(content: string): {pos: number; text: string}[] {
 }
 
 function extractExcerpt(content: string, query: string, maxLength: number = 800): string {
-  // Strip ## Relations section and title heading
-  const relationsMatch = /^## Relations\n([\S\s]*?)(?=\n## |\n# |$)/m.exec(content)
-  let cleanContent = content
+  // Strip YAML frontmatter, ## Relations section, and title heading
+  let cleanContent = stripMarkdownFrontmatter(content)
+
+  const relationsMatch = /^## Relations\n([\S\s]*?)(?=\n## |\n# |$)/m.exec(cleanContent)
   if (relationsMatch) {
-    cleanContent = content.replace(relationsMatch[0], '').trim()
+    cleanContent = cleanContent.replace(relationsMatch[0], '').trim()
   }
 
   cleanContent = cleanContent.replace(/^# .+$/m, '').trim()
@@ -1143,6 +1144,11 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
   ): SearchKnowledgeResult {
     const filteredQuery = filterStopWords(query)
     const filteredWords = filteredQuery.split(/\s+/).filter((w) => w.length >= 2)
+
+    // Guard: if all query words were stop words, return empty results
+    if (filteredWords.length === 0) {
+      return {message: 'Query contains only common words. Try more specific terms.', results: [], totalFound: 0}
+    }
 
     // Build scope filter if a subtree is specified
     let scopeFilter: ((result: {id: string}) => boolean) | undefined

--- a/test/unit/agent/tools/search-knowledge-bugs.test.ts
+++ b/test/unit/agent/tools/search-knowledge-bugs.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tests for search knowledge service bug fixes:
+ * - BUG 2: Stop-word-only queries should return empty, not everything at 100%
+ * - BUG 3: Excerpts should not contain raw YAML frontmatter
+ */
+
+import {expect} from 'chai'
+import {createSandbox} from 'sinon'
+
+import type {IFileSystem} from '../../../../src/agent/core/interfaces/i-file-system.js'
+
+import {SearchKnowledgeService} from '../../../../src/agent/infra/tools/implementations/search-knowledge-service.js'
+
+function mockFileSystem(sandbox: ReturnType<typeof createSandbox>) {
+  const globStub = sandbox.stub()
+  const readStub = sandbox.stub()
+  const listDirStub = sandbox.stub()
+
+  listDirStub.resolves({count: 1, entries: [], tree: '', truncated: false})
+
+  globStub.resolves({
+    files: [
+      {isDirectory: false, modified: new Date('2024-01-01'), path: '/test/.brv/context-tree/auth/login.md', size: 100},
+      {
+        isDirectory: false,
+        modified: new Date('2024-01-02'),
+        path: '/test/.brv/context-tree/api/endpoints.md',
+        size: 100,
+      },
+    ],
+    ignoredCount: 0,
+    message: 'Found 2 files',
+    totalFound: 2,
+    truncated: false,
+  })
+
+  readStub.callsFake((filePath: string) => {
+    if (filePath.includes('login')) {
+      return Promise.resolve({
+        content: [
+          '---',
+          'title: Login Flow',
+          'tags: [auth, oauth]',
+          'importance: 70',
+          'maturity: validated',
+          'recency: 0.8',
+          '---',
+          '',
+          '# Login Flow',
+          '',
+          '## Raw Concept',
+          '**Task:** OAuth 2.0 login with session management',
+          '',
+          '## Narrative',
+          '### Structure',
+          'Users authenticate via OAuth provider then receive session tokens.',
+        ].join('\n'),
+        encoding: 'utf8',
+        lines: 16,
+        size: 300,
+        totalLines: 16,
+        truncated: false,
+      })
+    }
+
+    if (filePath.includes('endpoints')) {
+      return Promise.resolve({
+        content: [
+          '---',
+          'title: API Endpoints',
+          'tags: [api, rest]',
+          'importance: 60',
+          'maturity: draft',
+          '---',
+          '',
+          '# API Endpoints',
+          '',
+          '## Raw Concept',
+          '**Task:** RESTful API endpoint documentation',
+          '',
+          '## Narrative',
+          'GET /users returns user list. POST /users creates a user.',
+        ].join('\n'),
+        encoding: 'utf8',
+        lines: 14,
+        size: 250,
+        totalLines: 14,
+        truncated: false,
+      })
+    }
+
+    return Promise.reject(new Error('File not found'))
+  })
+
+  const fileSystem = {
+    editFile: sandbox.stub(),
+    globFiles: globStub,
+    initialize: sandbox.stub(),
+    listDirectory: listDirStub,
+    readFile: readStub,
+    searchContent: sandbox.stub(),
+    writeFile: sandbox.stub().resolves({message: 'ok', path: '', success: true}),
+  } as unknown as IFileSystem
+
+  return fileSystem
+}
+
+describe('Search Knowledge Service - Bug Fixes', () => {
+  const sandbox = createSandbox()
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  describe('BUG 2: Stop-word-only queries', () => {
+    it('should return 0 results for stop-word-only query "the a an"', async () => {
+      const fileSystem = mockFileSystem(sandbox)
+      const service = new SearchKnowledgeService(fileSystem, {baseDirectory: '/test', cacheTtlMs: 0})
+
+      const result = await service.search('the a an')
+
+      expect(result.results).to.have.length(0)
+      expect(result.message).to.be.a('string')
+    })
+
+    it('should return 0 results for stop-word-only query "is are was were"', async () => {
+      const fileSystem = mockFileSystem(sandbox)
+      const service = new SearchKnowledgeService(fileSystem, {baseDirectory: '/test', cacheTtlMs: 0})
+
+      const result = await service.search('is are was were')
+
+      expect(result.results).to.have.length(0)
+    })
+
+    it('should still return results for queries with non-stop words', async () => {
+      const fileSystem = mockFileSystem(sandbox)
+      const service = new SearchKnowledgeService(fileSystem, {baseDirectory: '/test', cacheTtlMs: 0})
+
+      const result = await service.search('the OAuth login')
+
+      expect(result.results.length).to.be.greaterThan(0)
+    })
+  })
+
+  describe('BUG 3: Excerpts should not show frontmatter', () => {
+    it('should not include YAML frontmatter in excerpt', async () => {
+      const fileSystem = mockFileSystem(sandbox)
+      const service = new SearchKnowledgeService(fileSystem, {baseDirectory: '/test', cacheTtlMs: 0})
+
+      const result = await service.search('OAuth login')
+
+      expect(result.results.length).to.be.greaterThan(0)
+      for (const r of result.results) {
+        expect(r.excerpt).to.not.include('---\ntitle:')
+        expect(r.excerpt).to.not.include('tags: [')
+        expect(r.excerpt).to.not.include('importance:')
+        expect(r.excerpt).to.not.include('maturity:')
+        expect(r.excerpt).to.not.include('recency:')
+      }
+    })
+
+    it('should show meaningful content in excerpt instead of frontmatter', async () => {
+      const fileSystem = mockFileSystem(sandbox)
+      const service = new SearchKnowledgeService(fileSystem, {baseDirectory: '/test', cacheTtlMs: 0})
+
+      const result = await service.search('API endpoints')
+
+      const apiResult = result.results.find((r) => r.path.includes('endpoints'))
+      if (apiResult) {
+        // Should contain actual content, not frontmatter
+        expect(apiResult.excerpt).to.not.match(/^---/)
+        // Should contain something meaningful from the document body
+        expect(apiResult.excerpt.length).to.be.greaterThan(0)
+      }
+    })
+  })
+})


### PR DESCRIPTION
Summary

- **Problem:** Two search quality bugs: (1) stop-word-only queries like "the a an" return all documents at 100% score, (2) search excerpts display raw YAML frontmatter instead of meaningful content
- **Why it matters:** Users see irrelevant results flooding search output and unreadable metadata in excerpts, making `brv search` unreliable
- **What changed:** `filterStopWords()` now returns empty string for all-stop-word queries (was falling back to original query), added empty-query guard in search pipeline, and `extractExcerpt()` now strips YAML frontmatter before chunking
- **What did NOT change (scope boundary):** No changes to indexing, scoring weights, MiniSearch config, or any other search pipeline logic

## Type of change

- [x] Bug fix

## Scope (select all touched areas)

- [x] Agent / Tools

## Linked issues

- Related ENG-2023

## Root cause (bug fixes only, otherwise write `N/A`)

- **BUG 2 root cause:** `filterStopWords()` returned the original query when `removeStopwords()` filtered all words out (`filtered.length > 0 ? filtered.join(' ') : query`). MiniSearch then received "the a an" and matched all documents via fuzzy/prefix matching. The empty-query guard checked the original query (non-empty), not the filtered one.
- **BUG 3 root cause:** `extractExcerpt()` stripped `## Relations` sections and `# Title` headings but never called the existing `stripMarkdownFrontmatter()` function. The first chunk often contained the `---` frontmatter block.
- **Why this was not caught earlier:** No unit tests existed for stop-word-only queries or frontmatter-heavy documents in excerpts.

## Test plan

- Coverage added:
  - [x] Unit test
- Test file(s): `test/unit/agent/tools/search-knowledge-bugs.test.ts`
- Key scenario(s) covered:
  - Stop-word-only query "the a an" returns 0 results
  - Stop-word-only query "is are was were" returns 0 results
  - Mixed query "the OAuth login" still returns results (non-stop words preserved)
  - Excerpts do not contain `---\ntitle:`, `tags:`, `importance:`, `maturity:`, `recency:` frontmatter
  - Excerpts show meaningful document body content

## User-visible changes

- `brv search "the a an"` → now returns empty with message "Query contains only common words. Try more specific terms." (was: all documents at 100%)
- Search result excerpts now show document content instead of YAML frontmatter metadata

## Evidence

- [x] Failing test/log before + passing after

Before fix: 3 tests failing (stop-word query returned 2 results, excerpts contained `---\ntitle:`)
After fix: all 5 new tests + all 41 existing search tests passing

## Checklist

- [x] Tests added or updated and passing (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow Conventional Commits format
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented above)
- [ ] Branch is up to date with `main`

## Risks and mitigations

- **Risk:** Queries with only short common words (e.g., "go run") might be filtered as stop words
  - **Mitigation:** The guard checks `filteredWords.length === 0` after filtering words with `length >= 2`, so short programming terms like "go" pass through the stop-word filter (the `stopword` library only removes English stop words, not programming keywords)