### PR TITLE
Feat/eng 2012

### DIFF
--- a/src/oclif/lib/daemon-client.ts
+++ b/src/oclif/lib/daemon-client.ts
@@ -39,8 +39,6 @@ const USER_FRIENDLY_MESSAGES: Record<string, string> = {
   [TaskErrorCode.PROJECT_NOT_INIT]: 'Project not initialized. Run "brv restart" to reinitialize.',
   [TaskErrorCode.PROVIDER_NOT_CONFIGURED]:
     'No provider connected. Run "brv providers connect byterover" to use the free built-in provider, or connect another provider.',
-  [TaskErrorCode.SPACE_NOT_CONFIGURED]:
-    'No space configured. Run "brv space list" to see available spaces, then "brv space switch --team <team> --name <space>" to select one.',
   [TaskErrorCode.SPACE_NOT_FOUND]: 'Space not found. Check your configuration.',
   [TaskErrorCode.VC_GIT_INITIALIZED]:
     'ByteRover version control is active. Use brv vc commands instead of legacy sync commands.',

--- a/src/server/core/domain/errors/task-error.ts
+++ b/src/server/core/domain/errors/task-error.ts
@@ -11,11 +11,13 @@ export const TaskErrorCode = {
   // Context tree errors
   CONTEXT_TREE_NOT_INITIALIZED: 'ERR_CONTEXT_TREE_NOT_INIT',
 
+  // Legacy sync (brv push/pull) no longer available because project has no team+space configured
+  LEGACY_SYNC_UNAVAILABLE: 'ERR_LEGACY_SYNC_UNAVAILABLE',
   // LLM errors
   LLM_ERROR: 'ERR_LLM_ERROR',
   LLM_RATE_LIMIT: 'ERR_LLM_RATE_LIMIT',
-  LOCAL_CHANGES_EXIST: 'ERR_LOCAL_CHANGES_EXIST',
 
+  LOCAL_CHANGES_EXIST: 'ERR_LOCAL_CHANGES_EXIST',
   // Auth/Init errors
   NOT_AUTHENTICATED: 'ERR_NOT_AUTHENTICATED',
   // OAuth errors
@@ -24,7 +26,6 @@ export const TaskErrorCode = {
   // Execution errors
   PROJECT_NOT_INIT: 'ERR_PROJECT_NOT_INIT',
   PROVIDER_NOT_CONFIGURED: 'ERR_PROVIDER_NOT_CONFIGURED',
-  SPACE_NOT_CONFIGURED: 'ERR_SPACE_NOT_CONFIGURED',
   SPACE_NOT_FOUND: 'ERR_SPACE_NOT_FOUND',
   TASK_CANCELLED: 'ERR_TASK_CANCELLED',
 
@@ -197,13 +198,13 @@ export class LocalChangesExistError extends TaskError {
   }
 }
 
-export class SpaceNotConfiguredError extends TaskError {
+export class LegacySyncUnavailableError extends TaskError {
   public constructor() {
     super(
-      'No space configured. Run "brv space list" to see available spaces, then "brv space switch --team <team> --name <space>" to select one.',
-      TaskErrorCode.SPACE_NOT_CONFIGURED,
+      'brv push and brv pull are deprecated. Run `brv vc init` to start using Byterover version control.',
+      TaskErrorCode.LEGACY_SYNC_UNAVAILABLE,
     )
-    this.name = 'SpaceNotConfiguredError'
+    this.name = 'LegacySyncUnavailableError'
   }
 }
 

--- a/src/server/core/domain/errors/task-error.ts
+++ b/src/server/core/domain/errors/task-error.ts
@@ -201,7 +201,7 @@ export class LocalChangesExistError extends TaskError {
 export class LegacySyncUnavailableError extends TaskError {
   public constructor() {
     super(
-      'brv push and brv pull are deprecated. Run `brv vc init` to start using Byterover version control.',
+      'Command brv push and brv pull are deprecated. Run `brv vc init` to start using Byterover version control.',
       TaskErrorCode.LEGACY_SYNC_UNAVAILABLE,
     )
     this.name = 'LegacySyncUnavailableError'

--- a/src/server/infra/transport/handlers/pull-handler.ts
+++ b/src/server/infra/transport/handlers/pull-handler.ts
@@ -14,10 +14,10 @@ import {
   type PullPrepareResponse,
 } from '../../../../shared/transport/events/pull-events.js'
 import {
+  LegacySyncUnavailableError,
   LocalChangesExistError,
   NotAuthenticatedError,
   ProjectNotInitError,
-  SpaceNotConfiguredError,
 } from '../../../core/domain/errors/task-error.js'
 import {
   guardAgainstGitVc,
@@ -91,7 +91,7 @@ export class PullHandler {
     }
 
     if (!config.teamId || !config.spaceId) {
-      throw new SpaceNotConfiguredError()
+      throw new LegacySyncUnavailableError()
     }
 
     // Check for local changes that would be overwritten
@@ -138,7 +138,7 @@ export class PullHandler {
     }
 
     if (!config.teamId || !config.spaceId) {
-      throw new SpaceNotConfiguredError()
+      throw new LegacySyncUnavailableError()
     }
 
     const changes = await this.contextTreeSnapshotService.getChanges(projectPath)

--- a/src/server/infra/transport/handlers/push-handler.ts
+++ b/src/server/infra/transport/handlers/push-handler.ts
@@ -18,9 +18,9 @@ import {
   type PushPrepareResponse,
 } from '../../../../shared/transport/events/push-events.js'
 import {
+  LegacySyncUnavailableError,
   NotAuthenticatedError,
   ProjectNotInitError,
-  SpaceNotConfiguredError,
 } from '../../../core/domain/errors/task-error.js'
 import {mapToPushContexts} from '../../cogit/context-tree-to-push-context-mapper.js'
 import {
@@ -154,7 +154,7 @@ export class PushHandler {
     }
 
     if (!config.teamId || !config.spaceId) {
-      throw new SpaceNotConfiguredError()
+      throw new LegacySyncUnavailableError()
     }
 
     this.broadcastToProject(projectPath, PushEvents.PROGRESS, {message: 'Reading context files...', step: 'reading'})
@@ -247,7 +247,7 @@ export class PushHandler {
     }
 
     if (!config.teamId || !config.spaceId) {
-      throw new SpaceNotConfiguredError()
+      throw new LegacySyncUnavailableError()
     }
 
     const hasSnapshot = await this.contextTreeSnapshotService.hasSnapshot(projectPath)

--- a/src/tui/utils/error-messages.ts
+++ b/src/tui/utils/error-messages.ts
@@ -17,7 +17,6 @@ const USER_FRIENDLY_MESSAGES: Record<string, string> = {
   ERR_PROJECT_NOT_INIT: "Project not initialized. Run 'brv restart' to reinitialize.",
   ERR_PROVIDER_NOT_CONFIGURED:
     'No provider connected. Run /providers connect byterover to use the free built-in provider, or connect another provider.',
-  ERR_SPACE_NOT_CONFIGURED: 'No space configured. Run /space switch to select a space first.',
   ERR_SPACE_NOT_FOUND: 'Space not found. Check your configuration.',
   ERR_VC_AUTH_FAILED: 'Authentication failed. Run /login.',
   ERR_VC_BRANCH_ALREADY_EXISTS: 'Branch already exists.',

--- a/src/tui/utils/error-messages.ts
+++ b/src/tui/utils/error-messages.ts
@@ -10,6 +10,8 @@
 const USER_FRIENDLY_MESSAGES: Record<string, string> = {
   ERR_AGENT_NOT_INITIALIZED: "Agent failed to initialize. Run 'brv restart' to force a clean restart.",
   ERR_CONTEXT_TREE_NOT_INIT: 'Context tree not initialized.',
+  ERR_LEGACY_SYNC_UNAVAILABLE:
+    'Legacy cloud sync (push/pull) is not available for this project. Use /vc init to start using version control. Learn more: https://docs.byterover.dev/git-semantic/overview',
   ERR_LOCAL_CHANGES_EXIST: 'You have local changes. Run /push to save your changes before pulling.',
   ERR_NOT_AUTHENTICATED: 'Not authenticated. This is required for cloud sync. Run /login to connect your account.',
   ERR_OAUTH_REFRESH_FAILED: 'OAuth token refresh failed. Run /providers to reconnect your provider.',
@@ -24,7 +26,8 @@ const USER_FRIENDLY_MESSAGES: Record<string, string> = {
   ERR_VC_CONFIG_KEY_NOT_SET: 'Config key is not set.',
   ERR_VC_CONFLICT_MARKERS_PRESENT:
     'Conflict markers detected. Run /vc conflicts to view them. Resolve conflicts and run /vc add before pushing.',
-  ERR_VC_GIT_INITIALIZED: 'ByteRover version control is active. Use /vc commands instead of legacy sync commands.',
+  ERR_VC_GIT_INITIALIZED:
+    'ByteRover version control is active. Use /vc commands instead of legacy sync commands. Learn more: https://docs.byterover.dev/git-semantic/overview',
   ERR_VC_GIT_NOT_INITIALIZED: 'ByteRover version control not initialized. Run /vc init first.',
   ERR_VC_INVALID_ACTION: 'Invalid action.',
   // ERR_VC_INVALID_BRANCH_NAME intentionally omitted: fall through to server's message with actual branch name

--- a/test/unit/infra/transport/handlers/pull-handler.test.ts
+++ b/test/unit/infra/transport/handlers/pull-handler.test.ts
@@ -3,21 +3,30 @@ import type {SinonStub} from 'sinon'
 import {expect} from 'chai'
 import {restore, stub} from 'sinon'
 
-import {GitVcInitializedError} from '../../../../../src/server/core/domain/errors/task-error.js'
+import {GitVcInitializedError, LegacySyncUnavailableError} from '../../../../../src/server/core/domain/errors/task-error.js'
 import {PullHandler} from '../../../../../src/server/infra/transport/handlers/pull-handler.js'
 import {PullEvents} from '../../../../../src/shared/transport/events/pull-events.js'
 import {createMockTransportServer, type MockTransportServer} from '../../../../helpers/mock-factories.js'
+
+function assertLegacySyncError(error: unknown): void {
+  expect(error).to.be.instanceOf(LegacySyncUnavailableError)
+  const msg = (error as Error).message
+  expect(msg).to.match(/brv vc init/)
+  expect(msg).to.not.match(/space\s+(switch|list)/)
+}
 
 // ==================== Tests ====================
 
 describe('PullHandler', () => {
   let contextTreeService: {hasGitRepo: SinonStub}
+  let projectConfigStore: {exists: SinonStub; getModifiedTime: SinonStub; read: SinonStub; write: SinonStub}
   let resolveProjectPath: SinonStub
   let tokenStore: {clear: SinonStub; load: SinonStub; save: SinonStub}
   let transport: MockTransportServer
 
   beforeEach(() => {
     contextTreeService = {hasGitRepo: stub().resolves(false)}
+    projectConfigStore = {exists: stub(), getModifiedTime: stub(), read: stub(), write: stub()}
     resolveProjectPath = stub().returns('/test/project')
     tokenStore = {clear: stub(), load: stub(), save: stub()}
     transport = createMockTransportServer()
@@ -42,7 +51,7 @@ describe('PullHandler', () => {
         saveSnapshotFromState: stub(),
       } as never,
       contextTreeWriterService: {sync: stub()} as never,
-      projectConfigStore: {exists: stub(), getModifiedTime: stub(), read: stub(), write: stub()} as never,
+      projectConfigStore: projectConfigStore as never,
       resolveProjectPath,
       tokenStore: tokenStore as never,
       transport,
@@ -102,6 +111,61 @@ describe('PullHandler', () => {
       }
 
       expect(contextTreeService.hasGitRepo.calledOnce).to.be.true
+    })
+  })
+
+  describe('legacy sync unavailable (ENG-2012)', () => {
+    beforeEach(() => {
+      contextTreeService.hasGitRepo.resolves(false)
+      tokenStore.load.resolves({isValid: () => true, sessionKey: 'sess'})
+    })
+
+    it('PREPARE, no team+space, no .git → throws LegacySyncUnavailableError', async () => {
+      projectConfigStore.read.resolves({})
+      createHandler()
+
+      try {
+        await callPrepareHandler()
+        expect.fail('should have thrown')
+      } catch (error) {
+        assertLegacySyncError(error)
+      }
+    })
+
+    it('EXECUTE, no team+space, no .git → throws LegacySyncUnavailableError', async () => {
+      projectConfigStore.read.resolves({})
+      createHandler()
+
+      try {
+        await callExecuteHandler()
+        expect.fail('should have thrown')
+      } catch (error) {
+        assertLegacySyncError(error)
+      }
+    })
+
+    it('PREPARE, partial config (teamId only) → throws LegacySyncUnavailableError', async () => {
+      projectConfigStore.read.resolves({teamId: 't1'})
+      createHandler()
+
+      try {
+        await callPrepareHandler()
+        expect.fail('should have thrown')
+      } catch (error) {
+        assertLegacySyncError(error)
+      }
+    })
+
+    it('PREPARE, partial config (spaceId only) → throws LegacySyncUnavailableError', async () => {
+      projectConfigStore.read.resolves({spaceId: 's1'})
+      createHandler()
+
+      try {
+        await callPrepareHandler()
+        expect.fail('should have thrown')
+      } catch (error) {
+        assertLegacySyncError(error)
+      }
     })
   })
 })

--- a/test/unit/infra/transport/handlers/push-handler.test.ts
+++ b/test/unit/infra/transport/handlers/push-handler.test.ts
@@ -17,7 +17,7 @@ import type {PushExecuteResponse, PushPrepareResponse} from '../../../../../src/
 
 import {BrvConfig} from '../../../../../src/server/core/domain/entities/brv-config.js'
 import {CogitPushResponse} from '../../../../../src/server/core/domain/entities/cogit-push-response.js'
-import {GitVcInitializedError} from '../../../../../src/server/core/domain/errors/task-error.js'
+import {GitVcInitializedError, LegacySyncUnavailableError} from '../../../../../src/server/core/domain/errors/task-error.js'
 import {PushHandler} from '../../../../../src/server/infra/transport/handlers/push-handler.js'
 import {PushEvents} from '../../../../../src/shared/transport/events/push-events.js'
 import {createMockTransportServer, type MockTransportServer} from '../../../../helpers/mock-factories.js'
@@ -50,6 +50,13 @@ function makeConfig(): BrvConfig {
     teamName: 'test-team',
     version: '1',
   })
+}
+
+function assertLegacySyncError(error: unknown): void {
+  expect(error).to.be.instanceOf(LegacySyncUnavailableError)
+  const msg = (error as Error).message
+  expect(msg).to.match(/brv vc init/)
+  expect(msg).to.not.match(/space\s+(switch|list)/)
 }
 
 // ==================== Tests ====================
@@ -195,6 +202,65 @@ describe('PushHandler', () => {
       }
 
       expect(contextTreeService.hasGitRepo.calledOnce).to.be.true
+    })
+  })
+
+  describe('legacy sync unavailable (ENG-2012)', () => {
+    beforeEach(() => {
+      contextTreeService.hasGitRepo.resolves(false)
+      tokenStore.load.resolves(makeToken() as never)
+    })
+
+    it('PREPARE, no team+space, no .git → throws LegacySyncUnavailableError', async () => {
+      projectConfigStore.read.resolves(BrvConfig.fromJson({createdAt: new Date().toISOString(), version: '1'}) as never)
+      createHandler()
+
+      try {
+        await callPrepareHandler()
+        expect.fail('should have thrown')
+      } catch (error) {
+        assertLegacySyncError(error)
+      }
+    })
+
+    it('EXECUTE, no team+space, no .git → throws LegacySyncUnavailableError', async () => {
+      projectConfigStore.read.resolves(BrvConfig.fromJson({createdAt: new Date().toISOString(), version: '1'}) as never)
+      createHandler()
+
+      try {
+        await callExecuteHandler()
+        expect.fail('should have thrown')
+      } catch (error) {
+        assertLegacySyncError(error)
+      }
+    })
+
+    it('PREPARE, partial config (teamId only) → throws LegacySyncUnavailableError', async () => {
+      projectConfigStore.read.resolves(
+        BrvConfig.fromJson({createdAt: new Date().toISOString(), teamId: 't1', version: '1'}) as never,
+      )
+      createHandler()
+
+      try {
+        await callPrepareHandler()
+        expect.fail('should have thrown')
+      } catch (error) {
+        assertLegacySyncError(error)
+      }
+    })
+
+    it('PREPARE, partial config (spaceId only) → throws LegacySyncUnavailableError', async () => {
+      projectConfigStore.read.resolves(
+        BrvConfig.fromJson({createdAt: new Date().toISOString(), spaceId: 's1', version: '1'}) as never,
+      )
+      createHandler()
+
+      try {
+        await callPrepareHandler()
+        expect.fail('should have thrown')
+      } catch (error) {
+        assertLegacySyncError(error)
+      }
     })
   })
 

--- a/test/unit/tui/utils/error-messages.test.ts
+++ b/test/unit/tui/utils/error-messages.test.ts
@@ -78,6 +78,26 @@ describe('error-messages', () => {
       expect(formatTransportError(err)).to.equal('No code here.')
     })
 
+    it('includes docs link for ERR_VC_GIT_INITIALIZED', () => {
+      const err = Object.assign(new Error('ByteRover version control is initialized'), {
+        code: 'ERR_VC_GIT_INITIALIZED',
+      })
+      const result = formatTransportError(err)
+      expect(result).to.include('/vc commands')
+      expect(result).to.include('https://docs.byterover.dev/git-semantic/overview')
+    })
+
+    it('includes docs link for ERR_LEGACY_SYNC_UNAVAILABLE', () => {
+      const err = Object.assign(new Error('brv push and brv pull are deprecated.'), {
+        code: 'ERR_LEGACY_SYNC_UNAVAILABLE',
+      })
+      const result = formatTransportError(err)
+      expect(result).to.include('/vc init')
+      expect(result).to.include('https://docs.byterover.dev/git-semantic/overview')
+      expect(result).to.not.include('space switch')
+      expect(result).to.not.include('space list')
+    })
+
     it('should return friendly message for TransportRequestTimeoutError', () => {
       const error = new Error("Request timeout for event 'provider:awaitOAuthCallback' after 300000ms")
       error.name = 'TransportRequestTimeoutError'


### PR DESCRIPTION
## Summary

- Problem: `brv push` / `brv pull` are legacy sync commands being replaced by ByteRover VC (`brv vc`), but when a project had no team+space configured the handlers still surfaced `SpaceNotConfiguredError` telling users to "run `brv space switch`" — steering them further down the deprecated path.
- Why it matters: Users hitting the "no space" branch should be redirected to the supported workflow (`brv vc init`) rather than coached into configuring legacy sync.
- What changed: The "no team/space" branch in the push/pull handlers now throws a new `LegacySyncUnavailableError` (`ERR_LEGACY_SYNC_UNAVAILABLE`) whose message points users at `brv vc init`. The old `SpaceNotConfiguredError` / `ERR_SPACE_NOT_CONFIGURED` code and its user-friendly message mappings are removed.
- What did NOT change (scope boundary): `brv push` / `brv pull` themselves are not removed; all other error codes (`SPACE_NOT_FOUND`, `PROVIDER_NOT_CONFIGURED`, `PROJECT_NOT_INIT`, etc.) are untouched; no changes to VC, worktree, or space commands.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [ ] Agent / Tools
- [ ] LLM Providers
- [x] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [x] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

Note: TUI and oclif are touched only to remove the stale `ERR_SPACE_NOT_CONFIGURED` user-message mappings.

## Linked issues

- Closes ENG-2012
- Related #

## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause: N/A (deprecation notice, not a bug fix)
- Why this was not caught earlier: N/A

## Test plan

- Coverage added:
  - [x] Unit test
  - [ ] Integration test
  - [ ] Manual verification only
- Test file(s):
  - `test/unit/infra/transport/handlers/push-handler.test.ts`
  - `test/unit/infra/transport/handlers/pull-handler.test.ts`
- Key scenario(s) covered:
  - `push.prepare` with no team/space configured throws `LegacySyncUnavailableError` (`ERR_LEGACY_SYNC_UNAVAILABLE`).
  - `push.execute` with no team/space configured throws `LegacySyncUnavailableError`.
  - `pull.prepare` with no team/space configured throws `LegacySyncUnavailableError`.
  - `pull.execute` with no team/space configured throws `LegacySyncUnavailableError`.
  - Error message surfaces the `brv vc init` guidance.

## User-visible changes

- Running `brv push` or `brv pull` in a project without a configured team/space now fails with:
  > Command brv push and brv pull are deprecated. Run `brv vc init` to start using Byterover version control.
  (error code `ERR_LEGACY_SYNC_UNAVAILABLE`)
- The previous "No space configured. Run `brv space switch` ..." message is no longer emitted from this path.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after (`npx mocha --forbid-only "test/unit/infra/transport/handlers/push-handler.test.ts" "test/unit/infra/transport/handlers/pull-handler.test.ts"`)
- [ ] Trace/log snippets
- [ ] Screenshot/recording

## Checklist

- [x] Tests added or updated and passing (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented above)
- [ ] Branch is up to date with `main`

## Risks and mitigations

- Risk: External callers that still key off `ERR_SPACE_NOT_CONFIGURED` will no longer match.
  - Mitigation: Only the daemon/TUI consumed this code; both mappings are removed in the same PR, so there are no remaining internal consumers. Any external integration should switch to `ERR_LEGACY_SYNC_UNAVAILABLE`.
- Risk: Users accustomed to "run `brv space switch`" guidance may be confused by the new deprecation wording.
  - Mitigation: New message explicitly names the replacement command (`brv vc init`).
