### PR TITLE
Feat/eng 2043

### DIFF
--- a/src/oclif/commands/status.ts
+++ b/src/oclif/commands/status.ts
@@ -166,6 +166,11 @@ export default class Status extends Command {
         break
       }
 
+      case 'no_vc': {
+        this.log('Context Tree: Managed by Byterover version control (use brv vc commands)')
+        break
+      }
+
       case 'not_initialized': {
         this.log('Context Tree: Not initialized')
         break

--- a/src/server/infra/transport/handlers/status-handler.ts
+++ b/src/server/infra/transport/handlers/status-handler.ts
@@ -111,13 +111,14 @@ export class StatusHandler {
     }
 
     // Project status — use effectiveProjectPath for consistency with resolved root
+    let projectConfig: Awaited<ReturnType<IProjectConfigStore['read']>> | undefined
     try {
       const isInitialized = await this.projectConfigStore.exists(effectiveProjectPath)
       if (isInitialized) {
-        const config = await this.projectConfigStore.read(effectiveProjectPath)
-        if (config) {
-          result.teamName = config.teamName
-          result.spaceName = config.spaceName
+        projectConfig = await this.projectConfigStore.read(effectiveProjectPath)
+        if (projectConfig) {
+          result.teamName = projectConfig.teamName
+          result.spaceName = projectConfig.spaceName
         }
       }
     } catch {}
@@ -142,23 +143,29 @@ export class StatusHandler {
           result.contextTreeDir = join(effectiveProjectPath, BRV_DIR, CONTEXT_TREE_DIR)
           result.contextTreeRelativeDir = join(BRV_DIR, CONTEXT_TREE_DIR)
 
-          const hasSnapshot = await this.contextTreeSnapshotService.hasSnapshot(effectiveProjectPath)
-          if (!hasSnapshot) {
-            await this.contextTreeSnapshotService.initEmptySnapshot(effectiveProjectPath)
-          }
+          const hasLegacySyncConfig = Boolean(projectConfig?.teamId && projectConfig?.spaceId)
 
-          const changes = await this.contextTreeSnapshotService.getChanges(effectiveProjectPath)
-          const hasChanges = changes.added.length > 0 || changes.modified.length > 0 || changes.deleted.length > 0
+          if (hasLegacySyncConfig) {
+            const hasSnapshot = await this.contextTreeSnapshotService.hasSnapshot(effectiveProjectPath)
+            if (!hasSnapshot) {
+              await this.contextTreeSnapshotService.initEmptySnapshot(effectiveProjectPath)
+            }
 
-          if (hasChanges) {
-            result.contextTreeStatus = 'has_changes'
-            result.contextTreeChanges = {
-              added: changes.added,
-              deleted: changes.deleted,
-              modified: changes.modified,
+            const changes = await this.contextTreeSnapshotService.getChanges(effectiveProjectPath)
+            const hasChanges = changes.added.length > 0 || changes.modified.length > 0 || changes.deleted.length > 0
+
+            if (hasChanges) {
+              result.contextTreeStatus = 'has_changes'
+              result.contextTreeChanges = {
+                added: changes.added,
+                deleted: changes.deleted,
+                modified: changes.modified,
+              }
+            } else {
+              result.contextTreeStatus = 'no_changes'
             }
           } else {
-            result.contextTreeStatus = 'no_changes'
+            result.contextTreeStatus = 'no_vc'
           }
         }
       } else {

--- a/src/shared/transport/types/dto.ts
+++ b/src/shared/transport/types/dto.ts
@@ -163,7 +163,7 @@ export interface StatusDTO {
   contextTreeDir?: string
   /** Relative path to the context tree directory from project root (e.g., '.brv/context-tree') */
   contextTreeRelativeDir?: string
-  contextTreeStatus: 'git_vc' | 'has_changes' | 'no_changes' | 'not_initialized' | 'unknown'
+  contextTreeStatus: 'git_vc' | 'has_changes' | 'no_changes' | 'no_vc' | 'not_initialized' | 'unknown'
   /** @deprecated Use projectRoot instead. Kept for backward compatibility. */
   currentDirectory: string
   /** Number of files with pending HITL review (0 if none or unavailable). */

--- a/src/tui/features/status/utils/format-status.ts
+++ b/src/tui/features/status/utils/format-status.ts
@@ -94,6 +94,11 @@ export function formatStatus(status: StatusDTO, version?: string): string {
       break
     }
 
+    case 'no_vc': {
+      lines.push('Context Tree: Managed by Byterover version control (use /vc commands)')
+      break
+    }
+
     case 'not_initialized': {
       lines.push('Context Tree: Not initialized')
       break
@@ -111,6 +116,8 @@ export function formatStatus(status: StatusDTO, version?: string): string {
         (status.reviewUrl ? `\n  Review: ${chalk.blue(status.reviewUrl)}` : ''),
     )
   }
+
+  lines.push('', 'Tip: Version control is now available for your context tree.', 'Learn more: https://docs.byterover.dev/git-semantic/overview')
 
   return lines.join('\n')
 }

--- a/test/unit/infra/transport/handlers/status-handler.test.ts
+++ b/test/unit/infra/transport/handlers/status-handler.test.ts
@@ -192,6 +192,8 @@ describe('StatusHandler', () => {
 
     it('should return no_changes when context tree exists with no changes', async () => {
       deps.contextTreeService.exists.resolves(true)
+      deps.projectConfigStore.exists.resolves(true)
+      deps.projectConfigStore.read.resolves({spaceId: 's1', spaceName: 'space-1', teamId: 't1', teamName: 'team-1'})
       deps.contextTreeSnapshotService.getChanges.resolves({added: [], deleted: [], modified: []})
       createHandler()
       const result = await callGetHandler()
@@ -200,10 +202,90 @@ describe('StatusHandler', () => {
 
     it('should return has_changes when there are changes', async () => {
       deps.contextTreeService.exists.resolves(true)
+      deps.projectConfigStore.exists.resolves(true)
+      deps.projectConfigStore.read.resolves({spaceId: 's1', spaceName: 'space-1', teamId: 't1', teamName: 'team-1'})
       deps.contextTreeSnapshotService.getChanges.resolves({added: ['new.md'], deleted: [], modified: []})
       createHandler()
       const result = await callGetHandler()
       expect(result.status.contextTreeStatus).to.equal('has_changes')
+    })
+
+    describe('legacy sync config gating (ENG-2043)', () => {
+      it('new user (no teamId/spaceId) should return no_vc and never touch snapshot', async () => {
+        deps.contextTreeService.exists.resolves(true)
+        deps.projectConfigStore.exists.resolves(true)
+        deps.projectConfigStore.read.resolves({})
+        createHandler()
+
+        const result = await callGetHandler()
+        expect(result.status.contextTreeStatus).to.equal('no_vc')
+        expect(deps.contextTreeSnapshotService.hasSnapshot.called).to.be.false
+        expect(deps.contextTreeSnapshotService.initEmptySnapshot.called).to.be.false
+        expect(deps.contextTreeSnapshotService.getChanges.called).to.be.false
+      })
+
+      it('orphan user (stale snapshot, no legacy config) should return no_vc and leave file untouched', async () => {
+        deps.contextTreeService.exists.resolves(true)
+        deps.projectConfigStore.exists.resolves(true)
+        deps.projectConfigStore.read.resolves({})
+        deps.contextTreeSnapshotService.hasSnapshot.resolves(true)
+        createHandler()
+
+        const result = await callGetHandler()
+        expect(result.status.contextTreeStatus).to.equal('no_vc')
+        expect(deps.contextTreeSnapshotService.hasSnapshot.called).to.be.false
+        expect(deps.contextTreeSnapshotService.initEmptySnapshot.called).to.be.false
+        expect(deps.contextTreeSnapshotService.getChanges.called).to.be.false
+      })
+
+      it('partial config (teamId only) should return no_vc', async () => {
+        deps.contextTreeService.exists.resolves(true)
+        deps.projectConfigStore.exists.resolves(true)
+        deps.projectConfigStore.read.resolves({teamId: 't1'})
+        createHandler()
+
+        const result = await callGetHandler()
+        expect(result.status.contextTreeStatus).to.equal('no_vc')
+        expect(deps.contextTreeSnapshotService.hasSnapshot.called).to.be.false
+        expect(deps.contextTreeSnapshotService.initEmptySnapshot.called).to.be.false
+        expect(deps.contextTreeSnapshotService.getChanges.called).to.be.false
+      })
+
+      it('partial config (spaceId only) should return no_vc', async () => {
+        deps.contextTreeService.exists.resolves(true)
+        deps.projectConfigStore.exists.resolves(true)
+        deps.projectConfigStore.read.resolves({spaceId: 's1'})
+        createHandler()
+
+        const result = await callGetHandler()
+        expect(result.status.contextTreeStatus).to.equal('no_vc')
+        expect(deps.contextTreeSnapshotService.initEmptySnapshot.called).to.be.false
+      })
+
+      it('legacy user (teamId + spaceId) should create missing snapshot and compute diffs', async () => {
+        deps.contextTreeService.exists.resolves(true)
+        deps.projectConfigStore.exists.resolves(true)
+        deps.projectConfigStore.read.resolves({spaceId: 's1', spaceName: 'space-1', teamId: 't1', teamName: 'team-1'})
+        deps.contextTreeSnapshotService.hasSnapshot.resolves(false)
+        deps.contextTreeSnapshotService.getChanges.resolves({added: [], deleted: [], modified: []})
+        createHandler()
+
+        const result = await callGetHandler()
+        expect(result.status.contextTreeStatus).to.equal('no_changes')
+        expect(deps.contextTreeSnapshotService.hasSnapshot.called).to.be.true
+        expect(deps.contextTreeSnapshotService.initEmptySnapshot.called).to.be.true
+        expect(deps.contextTreeSnapshotService.getChanges.called).to.be.true
+      })
+
+      it('no project config file at all should return no_vc', async () => {
+        deps.contextTreeService.exists.resolves(true)
+        deps.projectConfigStore.exists.resolves(false)
+        createHandler()
+
+        const result = await callGetHandler()
+        expect(result.status.contextTreeStatus).to.equal('no_vc')
+        expect(deps.contextTreeSnapshotService.initEmptySnapshot.called).to.be.false
+      })
     })
 
     it('should return unknown when contextTreeService.exists throws', async () => {


### PR DESCRIPTION
## Summary

- Problem: `brv status` unconditionally created the legacy sync `.snapshot.json` file for any initialized project, even ones that have no team/space configured and no intention of using `brv push` / `brv pull`. That wrote legacy-sync state into projects that should be on ByteRover VC.
- Why it matters: The snapshot file is an artifact of the deprecated push/pull flow. Auto-creating it on `status` quietly opts projects into legacy sync tracking and pollutes `.brv/` for users who only use `brv vc`.
- What changed: `StatusHandler` now only initializes the snapshot and computes added/modified/deleted changes when the project has a `teamId` and `spaceId` configured. Projects without legacy sync config report a new `contextTreeStatus: 'no_vc'`, which oclif and the TUI render as "Managed by Byterover version control (use brv vc commands / /vc commands)". A tip pointing users at the VC docs is appended to the TUI status output.
- What did NOT change (scope boundary): `brv push` / `brv pull` behavior, snapshot format, and `ContextTreeSnapshotService` are unchanged. `git_vc`, `has_changes`, `no_changes`, `not_initialized`, and `unknown` branches all keep their existing semantics. No changes to VC, worktree, source, or space commands.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [x] TUI / REPL
- [ ] Agent / Tools
- [ ] LLM Providers
- [x] Server / Daemon
- [x] Shared (constants, types, transport events)
- [x] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes ENG-2043
- Related #

## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause: `StatusHandler.handleStatus` called `contextTreeSnapshotService.initEmptySnapshot` whenever a project was initialized, with no gate on whether legacy sync (team+space) was actually configured. The snapshot was a prerequisite for the subsequent `getChanges` call, so it was created as a side effect of any status read.
- Why this was not caught earlier: The snapshot was harmless for projects that did use legacy sync, and status was silent about its creation, so no user-visible signal flagged the unintended file. Only after deprecating push/pull (ENG-2012) did auto-creating legacy-sync state on a VC-only project become clearly wrong.

## Test plan

- Coverage added:
  - [x] Unit test
  - [ ] Integration test
  - [ ] Manual verification only
- Test file(s):
  - `test/unit/infra/transport/handlers/status-handler.test.ts`
- Key scenario(s) covered:
  - Initialized project with no `teamId`/`spaceId` returns `contextTreeStatus: 'no_vc'` and does NOT call `initEmptySnapshot` or `getChanges`.
  - Initialized project with `teamId` + `spaceId` and no snapshot still initializes the snapshot and reports `no_changes` / `has_changes` as before.
  - `git_vc`, `not_initialized`, and `unknown` branches remain unaffected.

## User-visible changes

- `brv status` on a project without a configured team/space now prints:
  > Context Tree: Managed by Byterover version control (use brv vc commands)
  instead of silently creating `.brv/context-tree/.snapshot.json` and reporting `no_changes`.
- TUI `/status` renders the same message (with `/vc` command hint) and appends:
  > Tip: Version control is now available for your context tree.
  > Learn more: https://docs.byterover.dev/git-semantic/overview
- `StatusDTO.contextTreeStatus` gains a new `'no_vc'` variant (additive union change).

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after (`npx mocha --forbid-only "test/unit/infra/transport/handlers/status-handler.test.ts"`)
- [ ] Trace/log snippets
- [ ] Screenshot/recording

## Checklist

- [x] Tests added or updated and passing (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented above)
- [x] Branch is up to date with `main`

## Risks and mitigations

- Risk: Consumers that exhaustively switch on `StatusDTO.contextTreeStatus` will hit the new `'no_vc'` variant.
  - Mitigation: Both in-repo consumers (`src/oclif/commands/status.ts`, `src/tui/features/status/utils/format-status.ts`) handle the new case in this PR; the union is additive so no existing case is removed.
- Risk: Users who were relying on `.snapshot.json` being auto-created by `brv status` before running `brv push` will see push fail with the legacy-sync deprecation error (from ENG-2012) instead.
  - Mitigation: That is the intended redirect — push/pull are deprecated and the error message points to `brv vc init`.
