### PR TITLE
feat: [ENG-2066] LLM response parser and dream response schemas

### DIFF
--- a/src/server/infra/dream/dream-response-schemas.ts
+++ b/src/server/infra/dream/dream-response-schemas.ts
@@ -1,0 +1,55 @@
+import {z} from 'zod'
+
+// ── Consolidate ──────────────────────────────────────────────────────────────
+
+export const ConsolidationActionSchema = z.object({
+  files: z.array(z.string()).min(1),
+  mergedContent: z.string().optional(),
+  outputFile: z.string().optional(),
+  reason: z.string(),
+  type: z.enum(['MERGE', 'TEMPORAL_UPDATE', 'CROSS_REFERENCE', 'SKIP']),
+  updatedContent: z.string().optional(),
+})
+
+export const ConsolidateResponseSchema = z.object({
+  actions: z.array(ConsolidationActionSchema),
+})
+
+export type ConsolidationAction = z.infer<typeof ConsolidationActionSchema>
+export type ConsolidateResponse = z.infer<typeof ConsolidateResponseSchema>
+
+// ── Synthesize ───────────────────────────────────────────────────────────────
+
+export const SynthesisCandidateSchema = z.object({
+  claim: z.string(),
+  confidence: z.number().min(0).max(1),
+  evidence: z.array(z.object({
+    domain: z.string(),
+    fact: z.string(),
+  })),
+  placement: z.string(),
+  title: z.string(),
+})
+
+export const SynthesizeResponseSchema = z.object({
+  syntheses: z.array(SynthesisCandidateSchema),
+})
+
+export type SynthesisCandidate = z.infer<typeof SynthesisCandidateSchema>
+export type SynthesizeResponse = z.infer<typeof SynthesizeResponseSchema>
+
+// ── Prune ────────────────────────────────────────────────────────────────────
+
+export const PruneDecisionSchema = z.object({
+  decision: z.enum(['ARCHIVE', 'KEEP', 'MERGE_INTO']),
+  file: z.string(),
+  mergeTarget: z.string().optional(),
+  reason: z.string(),
+})
+
+export const PruneResponseSchema = z.object({
+  decisions: z.array(PruneDecisionSchema),
+})
+
+export type PruneDecision = z.infer<typeof PruneDecisionSchema>
+export type PruneResponse = z.infer<typeof PruneResponseSchema>

--- a/src/server/infra/dream/parse-dream-response.ts
+++ b/src/server/infra/dream/parse-dream-response.ts
@@ -1,0 +1,37 @@
+import type {z} from 'zod'
+
+/**
+ * Extract and validate a JSON response from LLM output.
+ *
+ * Tries two strategies in order:
+ * 1. JSON inside a ```json code fence (first match, non-greedy)
+ * 2. Raw JSON (first { to last })
+ *
+ * Returns null if no valid JSON matching the schema is found.
+ */
+export function parseDreamResponse<T>(response: string, schema: z.ZodType<T>): null | T {
+  // Strategy 1: JSON in code fence
+  const fenceMatch = response.match(/```json\s*([\s\S]*?)```/)
+  if (fenceMatch) {
+    const result = tryParse(fenceMatch[1], schema)
+    if (result !== null) return result
+  }
+
+  // Strategy 2: Raw JSON (first { to last })
+  const jsonMatch = response.match(/\{[\s\S]*\}/)
+  if (jsonMatch) {
+    const result = tryParse(jsonMatch[0], schema)
+    if (result !== null) return result
+  }
+
+  return null
+}
+
+function tryParse<T>(raw: string, schema: z.ZodType<T>): null | T {
+  try {
+    const parsed = JSON.parse(raw)
+    return schema.parse(parsed)
+  } catch {
+    return null
+  }
+}

--- a/test/unit/infra/dream/dream-response-schemas.test.ts
+++ b/test/unit/infra/dream/dream-response-schemas.test.ts
@@ -1,0 +1,213 @@
+import {expect} from 'chai'
+
+import {
+  ConsolidateResponseSchema,
+  PruneResponseSchema,
+  SynthesizeResponseSchema,
+} from '../../../../src/server/infra/dream/dream-response-schemas.js'
+
+describe('dream-response-schemas', () => {
+  describe('ConsolidateResponseSchema', () => {
+    it('should parse a MERGE action', () => {
+      const input = {
+        actions: [{
+          files: ['a.md', 'b.md'],
+          mergedContent: 'combined text',
+          outputFile: 'a.md',
+          reason: 'duplicate',
+          type: 'MERGE',
+        }],
+      }
+      const result = ConsolidateResponseSchema.parse(input)
+      expect(result.actions).to.have.lengthOf(1)
+      expect(result.actions[0].type).to.equal('MERGE')
+    })
+
+    it('should parse a TEMPORAL_UPDATE action', () => {
+      const input = {
+        actions: [{
+          files: ['a.md'],
+          reason: 'conflicting dates',
+          type: 'TEMPORAL_UPDATE',
+          updatedContent: 'Previously X. As of 2026-04: Y.',
+        }],
+      }
+      const result = ConsolidateResponseSchema.parse(input)
+      expect(result.actions[0].type).to.equal('TEMPORAL_UPDATE')
+    })
+
+    it('should parse a CROSS_REFERENCE action', () => {
+      const input = {
+        actions: [{
+          files: ['a.md', 'b.md'],
+          reason: 'related topics',
+          type: 'CROSS_REFERENCE',
+        }],
+      }
+      const result = ConsolidateResponseSchema.parse(input)
+      expect(result.actions[0].type).to.equal('CROSS_REFERENCE')
+    })
+
+    it('should parse a SKIP action', () => {
+      const input = {
+        actions: [{
+          files: ['a.md', 'b.md'],
+          reason: 'unrelated',
+          type: 'SKIP',
+        }],
+      }
+      const result = ConsolidateResponseSchema.parse(input)
+      expect(result.actions[0].type).to.equal('SKIP')
+    })
+
+    it('should reject empty files array', () => {
+      const input = {
+        actions: [{
+          files: [],
+          reason: 'test',
+          type: 'MERGE',
+        }],
+      }
+      expect(() => ConsolidateResponseSchema.parse(input)).to.throw()
+    })
+
+    it('should accept empty actions array', () => {
+      const result = ConsolidateResponseSchema.parse({actions: []})
+      expect(result.actions).to.have.lengthOf(0)
+    })
+  })
+
+  describe('SynthesizeResponseSchema', () => {
+    it('should parse valid synthesis with all fields', () => {
+      const input = {
+        syntheses: [{
+          claim: 'Both use JWT tokens',
+          confidence: 0.85,
+          evidence: [
+            {domain: 'auth', fact: 'uses JWT for session management'},
+            {domain: 'api', fact: 'validates JWT in middleware'},
+          ],
+          placement: 'api',
+          title: 'Shared auth pattern',
+        }],
+      }
+      const result = SynthesizeResponseSchema.parse(input)
+      expect(result.syntheses).to.have.lengthOf(1)
+      expect(result.syntheses[0].confidence).to.equal(0.85)
+    })
+
+    it('should accept empty syntheses array', () => {
+      const result = SynthesizeResponseSchema.parse({syntheses: []})
+      expect(result.syntheses).to.have.lengthOf(0)
+    })
+
+    it('should reject confidence below 0', () => {
+      const input = {
+        syntheses: [{
+          claim: 'test',
+          confidence: -0.1,
+          evidence: [{domain: 'a', fact: 'f'}],
+          placement: 'a',
+          title: 'test',
+        }],
+      }
+      expect(() => SynthesizeResponseSchema.parse(input)).to.throw()
+    })
+
+    it('should reject confidence above 1', () => {
+      const input = {
+        syntheses: [{
+          claim: 'test',
+          confidence: 1.1,
+          evidence: [{domain: 'a', fact: 'f'}],
+          placement: 'a',
+          title: 'test',
+        }],
+      }
+      expect(() => SynthesizeResponseSchema.parse(input)).to.throw()
+    })
+
+    it('should accept confidence at boundary 0.0', () => {
+      const input = {
+        syntheses: [{
+          claim: 'test',
+          confidence: 0,
+          evidence: [{domain: 'a', fact: 'f'}],
+          placement: 'a',
+          title: 'test',
+        }],
+      }
+      expect(() => SynthesizeResponseSchema.parse(input)).to.not.throw()
+    })
+
+    it('should accept confidence at boundary 1.0', () => {
+      const input = {
+        syntheses: [{
+          claim: 'test',
+          confidence: 1,
+          evidence: [{domain: 'a', fact: 'f'}],
+          placement: 'a',
+          title: 'test',
+        }],
+      }
+      expect(() => SynthesizeResponseSchema.parse(input)).to.not.throw()
+    })
+  })
+
+  describe('PruneResponseSchema', () => {
+    it('should parse an ARCHIVE decision', () => {
+      const input = {
+        decisions: [{
+          decision: 'ARCHIVE',
+          file: 'domain/stale.md',
+          reason: 'superseded',
+        }],
+      }
+      const result = PruneResponseSchema.parse(input)
+      expect(result.decisions[0].decision).to.equal('ARCHIVE')
+    })
+
+    it('should parse a KEEP decision', () => {
+      const input = {
+        decisions: [{
+          decision: 'KEEP',
+          file: 'domain/important.md',
+          reason: 'still useful',
+        }],
+      }
+      const result = PruneResponseSchema.parse(input)
+      expect(result.decisions[0].decision).to.equal('KEEP')
+    })
+
+    it('should parse a MERGE_INTO decision with mergeTarget', () => {
+      const input = {
+        decisions: [{
+          decision: 'MERGE_INTO',
+          file: 'domain/old.md',
+          mergeTarget: 'domain/target.md',
+          reason: 'overlapping content',
+        }],
+      }
+      const result = PruneResponseSchema.parse(input)
+      expect(result.decisions[0].decision).to.equal('MERGE_INTO')
+      expect(result.decisions[0].mergeTarget).to.equal('domain/target.md')
+    })
+
+    it('should accept MERGE_INTO without mergeTarget (optional)', () => {
+      const input = {
+        decisions: [{
+          decision: 'MERGE_INTO',
+          file: 'domain/old.md',
+          reason: 'overlapping',
+        }],
+      }
+      const result = PruneResponseSchema.parse(input)
+      expect(result.decisions[0].mergeTarget).to.be.undefined
+    })
+
+    it('should accept empty decisions array', () => {
+      const result = PruneResponseSchema.parse({decisions: []})
+      expect(result.decisions).to.have.lengthOf(0)
+    })
+  })
+})

--- a/test/unit/infra/dream/parse-dream-response.test.ts
+++ b/test/unit/infra/dream/parse-dream-response.test.ts
@@ -1,0 +1,60 @@
+import {expect} from 'chai'
+
+import {ConsolidateResponseSchema} from '../../../../src/server/infra/dream/dream-response-schemas.js'
+import {parseDreamResponse} from '../../../../src/server/infra/dream/parse-dream-response.js'
+
+describe('parseDreamResponse', () => {
+  const schema = ConsolidateResponseSchema
+
+  it('should parse JSON in a code fence', () => {
+    const response = '```json\n{"actions":[]}\n```'
+    const result = parseDreamResponse(response, schema)
+    expect(result).to.deep.equal({actions: []})
+  })
+
+  it('should parse raw JSON embedded in text', () => {
+    const response = 'Here\'s my analysis: {"actions":[{"type":"MERGE","files":["a.md"],"reason":"dup"}]} Hope that helps'
+    const result = parseDreamResponse(response, schema)
+    expect(result).to.not.be.null
+    expect(result?.actions).to.have.lengthOf(1)
+  })
+
+  it('should prefer code fence over raw JSON', () => {
+    const response = '```json\n{"actions":[]}\n``` Some extra text with {"actions":[{"type":"SKIP","files":["x.md"],"reason":"r"}]}'
+    const result = parseDreamResponse(response, schema)
+    expect(result).to.deep.equal({actions: []})
+  })
+
+  it('should parse bare JSON object', () => {
+    const response = '{"actions": [{"type":"MERGE","files":["a.md"],"reason":"dup"}]}'
+    const result = parseDreamResponse(response, schema)
+    expect(result).to.not.be.null
+    expect(result?.actions[0].type).to.equal('MERGE')
+  })
+
+  it('should return null for no JSON', () => {
+    const result = parseDreamResponse('No JSON here at all', schema)
+    expect(result).to.be.null
+  })
+
+  it('should return null for valid JSON but wrong schema', () => {
+    const result = parseDreamResponse('{"not_actions": true}', schema)
+    expect(result).to.be.null
+  })
+
+  it('should return null for malformed JSON', () => {
+    const result = parseDreamResponse('{malformed json', schema)
+    expect(result).to.be.null
+  })
+
+  it('should return null for empty string', () => {
+    const result = parseDreamResponse('', schema)
+    expect(result).to.be.null
+  })
+
+  it('should use first code fence when multiple present', () => {
+    const response = '```json\n{"actions":[]}\n```\nand\n```json\n{"actions":[{"type":"SKIP","files":["x.md"],"reason":"r"}]}\n```'
+    const result = parseDreamResponse(response, schema)
+    expect(result).to.deep.equal({actions: []})
+  })
+})


### PR DESCRIPTION
## Summary

- Problem: Dream operations (consolidate, synthesize, prune) need to extract structured JSON from LLM responses and validate against operation-specific schemas.
- Why it matters: All three dream operations depend on this shared parser — it's the boundary between raw LLM output and typed domain data.
- What changed: Added `dream-response-schemas.ts` (3 Zod response schemas for consolidate/synthesize/prune) and `parse-dream-response.ts` (generic two-strategy parser: code fence first, raw JSON fallback).
- What did NOT change (scope boundary): No existing files modified. No wiring into operations. Pure standalone module.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [ ] Agent / Tools
- [ ] LLM Providers
- [x] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes ENG-2066
- Related ENG-2059

## Root cause (bug fixes only, otherwise write `N/A`)

N/A

## Test plan

- Coverage added:
  - [x] Unit test
  - [ ] Integration test
  - [ ] Manual verification only
- Test file(s):
  - `test/unit/infra/dream/dream-response-schemas.test.ts`
  - `test/unit/infra/dream/parse-dream-response.test.ts`
- Key scenario(s) covered:
  - Schema validation: all action/decision types, confidence boundaries, empty arrays, min constraints
  - Parser: code fence extraction, raw JSON fallback, fence priority, malformed/empty/wrong-schema → null

## User-visible changes

None

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording

26 new tests, 105 total dream tests passing, 0 type errors, lint clean.

## Checklist

- [x] Tests added or updated and passing (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented above)
- [x] Branch is up to date with `main`

## Risks and mitigations

None — pure parsing module with no side effects. All failure modes return null.