### PR TITLE
feat: [ENG-2067] dream trigger — four-gate eligibility check

### DIFF
--- a/src/server/infra/dream/dream-trigger.ts
+++ b/src/server/infra/dream/dream-trigger.ts
@@ -34,7 +34,7 @@ export class DreamTrigger {
     this.options = options
   }
 
-  async shouldDream(projectPath: string, force = false): Promise<DreamEligibility> {
+  async tryStartDream(projectPath: string, force = false): Promise<DreamEligibility> {
     const minHours = this.options.minHours ?? DEFAULT_MIN_HOURS
     const minCurations = this.options.minCurations ?? DEFAULT_MIN_CURATIONS
 

--- a/src/server/infra/dream/dream-trigger.ts
+++ b/src/server/infra/dream/dream-trigger.ts
@@ -1,0 +1,76 @@
+import type {DreamLockService} from './dream-lock-service.js'
+import type {DreamStateService} from './dream-state-service.js'
+
+type DreamTriggerDeps = {
+  dreamLockService: Pick<DreamLockService, 'tryAcquire'>
+  dreamStateService: Pick<DreamStateService, 'read'>
+  getQueueLength: (projectPath: string) => number
+}
+
+type DreamTriggerOptions = {
+  minCurations?: number
+  minHours?: number
+}
+
+export type DreamEligibility =
+  | {eligible: false; reason: string}
+  | {eligible: true; priorMtime: number}
+
+const DEFAULT_MIN_HOURS = 12
+const DEFAULT_MIN_CURATIONS = 3
+
+/**
+ * Four-gate trigger for dream eligibility.
+ *
+ * Gates 1-3 (time, activity, queue) are skipped with force=true.
+ * Gate 4 (lock) always runs — prevents concurrent dreams.
+ */
+export class DreamTrigger {
+  private readonly deps: DreamTriggerDeps
+  private readonly options: DreamTriggerOptions
+
+  constructor(deps: DreamTriggerDeps, options: DreamTriggerOptions = {}) {
+    this.deps = deps
+    this.options = options
+  }
+
+  async shouldDream(projectPath: string, force = false): Promise<DreamEligibility> {
+    const minHours = this.options.minHours ?? DEFAULT_MIN_HOURS
+    const minCurations = this.options.minCurations ?? DEFAULT_MIN_CURATIONS
+
+    if (!force) {
+      // Gates 1+2: time and activity (share one file read)
+      const state = await this.deps.dreamStateService.read()
+
+      // Gate 1: Time
+      if (state.lastDreamAt !== null) {
+        const hoursSince = (Date.now() - new Date(state.lastDreamAt).getTime()) / (1000 * 60 * 60)
+        if (hoursSince < minHours) {
+          return {eligible: false, reason: `Too recent (${hoursSince.toFixed(1)}h < ${minHours}h)`}
+        }
+      }
+
+      // Gate 2: Activity
+      if (state.curationsSinceDream < minCurations) {
+        return {
+          eligible: false,
+          reason: `Not enough activity (${state.curationsSinceDream} < ${minCurations} curations)`,
+        }
+      }
+
+      // Gate 3: Queue
+      const queueLength = this.deps.getQueueLength(projectPath)
+      if (queueLength > 0) {
+        return {eligible: false, reason: `Queue not empty (${queueLength} tasks pending)`}
+      }
+    }
+
+    // Gate 4: Lock (NEVER skipped, even with force)
+    const lockResult = await this.deps.dreamLockService.tryAcquire()
+    if (!lockResult.acquired) {
+      return {eligible: false, reason: 'Lock held by another dream process'}
+    }
+
+    return {eligible: true, priorMtime: lockResult.priorMtime}
+  }
+}

--- a/test/unit/infra/dream/dream-trigger.test.ts
+++ b/test/unit/infra/dream/dream-trigger.test.ts
@@ -1,0 +1,215 @@
+import {expect} from 'chai'
+import sinon from 'sinon'
+
+import type {DreamState} from '../../../../src/server/infra/dream/dream-state-schema.js'
+
+import {DreamTrigger} from '../../../../src/server/infra/dream/dream-trigger.js'
+
+function makeState(overrides: Partial<DreamState> = {}): DreamState {
+  return {
+    curationsSinceDream: 5,
+    lastDreamAt: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+    lastDreamLogId: null,
+    pendingMerges: [],
+    totalDreams: 0,
+    version: 1,
+    ...overrides,
+  }
+}
+
+function makeDeps(overrides: {
+  lockAcquired?: boolean
+  priorMtime?: number
+  queueLength?: number
+  state?: DreamState
+} = {}) {
+  const state = overrides.state ?? makeState()
+  return {
+    dreamLockService: {
+      tryAcquire: sinon.stub().resolves(
+        overrides.lockAcquired === false
+          ? {acquired: false}
+          : {acquired: true, priorMtime: overrides.priorMtime ?? 0},
+      ),
+    },
+    dreamStateService: {
+      read: sinon.stub().resolves(state),
+    },
+    getQueueLength: sinon.stub().returns(overrides.queueLength ?? 0),
+  }
+}
+
+describe('DreamTrigger', () => {
+  describe('shouldDream', () => {
+    it('should return eligible when all gates pass', async () => {
+      const deps = makeDeps()
+      const trigger = new DreamTrigger(deps)
+
+      const result = await trigger.shouldDream('/project')
+      expect(result.eligible).to.be.true
+      if (result.eligible) {
+        expect(result.priorMtime).to.equal(0)
+      }
+    })
+
+    it('should fail when time gate fails (too recent)', async () => {
+      const deps = makeDeps({
+        state: makeState({lastDreamAt: new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString()}),
+      })
+      const trigger = new DreamTrigger(deps)
+
+      const result = await trigger.shouldDream('/project')
+      expect(result.eligible).to.be.false
+      if (!result.eligible) {
+        expect(result.reason).to.include('recent')
+      }
+    })
+
+    it('should fail when activity gate fails (not enough curations)', async () => {
+      const deps = makeDeps({
+        state: makeState({curationsSinceDream: 1}),
+      })
+      const trigger = new DreamTrigger(deps)
+
+      const result = await trigger.shouldDream('/project')
+      expect(result.eligible).to.be.false
+      if (!result.eligible) {
+        expect(result.reason).to.include('activity')
+      }
+    })
+
+    it('should fail when queue is not empty', async () => {
+      const deps = makeDeps({queueLength: 3})
+      const trigger = new DreamTrigger(deps)
+
+      const result = await trigger.shouldDream('/project')
+      expect(result.eligible).to.be.false
+      if (!result.eligible) {
+        expect(result.reason).to.include('Queue')
+      }
+    })
+
+    it('should fail when lock is held', async () => {
+      const deps = makeDeps({lockAcquired: false})
+      const trigger = new DreamTrigger(deps)
+
+      const result = await trigger.shouldDream('/project')
+      expect(result.eligible).to.be.false
+      if (!result.eligible) {
+        expect(result.reason).to.include('Lock')
+      }
+    })
+
+    // ── Force mode ─────────────────────────────────────────────────────────
+
+    it('should skip time gate when force=true', async () => {
+      const deps = makeDeps({
+        state: makeState({lastDreamAt: new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString()}),
+      })
+      const trigger = new DreamTrigger(deps)
+
+      const result = await trigger.shouldDream('/project', true)
+      expect(result.eligible).to.be.true
+    })
+
+    it('should skip activity gate when force=true', async () => {
+      const deps = makeDeps({
+        state: makeState({curationsSinceDream: 0}),
+      })
+      const trigger = new DreamTrigger(deps)
+
+      const result = await trigger.shouldDream('/project', true)
+      expect(result.eligible).to.be.true
+    })
+
+    it('should skip queue gate when force=true', async () => {
+      const deps = makeDeps({queueLength: 3})
+      const trigger = new DreamTrigger(deps)
+
+      const result = await trigger.shouldDream('/project', true)
+      expect(result.eligible).to.be.true
+    })
+
+    it('should NOT skip lock gate even when force=true', async () => {
+      const deps = makeDeps({lockAcquired: false})
+      const trigger = new DreamTrigger(deps)
+
+      const result = await trigger.shouldDream('/project', true)
+      expect(result.eligible).to.be.false
+      if (!result.eligible) {
+        expect(result.reason).to.include('Lock')
+      }
+    })
+
+    // ── First dream ────────────────────────────────────────────────────────
+
+    it('should fail on first dream (no state) due to activity gate', async () => {
+      const deps = makeDeps({
+        state: makeState({curationsSinceDream: 0, lastDreamAt: null}),
+      })
+      const trigger = new DreamTrigger(deps)
+
+      const result = await trigger.shouldDream('/project')
+      expect(result.eligible).to.be.false
+      if (!result.eligible) {
+        expect(result.reason).to.include('activity')
+      }
+    })
+
+    it('should pass first dream with force=true', async () => {
+      const deps = makeDeps({
+        state: makeState({curationsSinceDream: 0, lastDreamAt: null}),
+      })
+      const trigger = new DreamTrigger(deps)
+
+      const result = await trigger.shouldDream('/project', true)
+      expect(result.eligible).to.be.true
+    })
+
+    // ── Gate order ─────────────────────────────────────────────────────────
+
+    it('should not check queue or lock when time fails', async () => {
+      const deps = makeDeps({
+        state: makeState({lastDreamAt: new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString()}),
+      })
+      const trigger = new DreamTrigger(deps)
+
+      await trigger.shouldDream('/project')
+      expect(deps.getQueueLength.called).to.be.false
+      expect(deps.dreamLockService.tryAcquire.called).to.be.false
+    })
+
+    it('should not check queue or lock when activity fails', async () => {
+      const deps = makeDeps({
+        state: makeState({curationsSinceDream: 1}),
+      })
+      const trigger = new DreamTrigger(deps)
+
+      await trigger.shouldDream('/project')
+      expect(deps.getQueueLength.called).to.be.false
+      expect(deps.dreamLockService.tryAcquire.called).to.be.false
+    })
+
+    // ── Custom thresholds ──────────────────────────────────────────────────
+
+    it('should respect custom minHours', async () => {
+      const deps = makeDeps({
+        state: makeState({lastDreamAt: new Date(Date.now() - 5 * 60 * 60 * 1000).toISOString()}),
+      })
+      const trigger = new DreamTrigger(deps, {minHours: 4})
+
+      const result = await trigger.shouldDream('/project')
+      expect(result.eligible).to.be.true
+    })
+
+    it('should respect custom minCurations', async () => {
+      const deps = makeDeps({
+        state: makeState({curationsSinceDream: 1}),
+      })
+      const trigger = new DreamTrigger(deps, {minCurations: 1})
+
+      const result = await trigger.shouldDream('/project')
+      expect(result.eligible).to.be.true
+    })
+  })
+})

--- a/test/unit/infra/dream/dream-trigger.test.ts
+++ b/test/unit/infra/dream/dream-trigger.test.ts
@@ -40,12 +40,12 @@ function makeDeps(overrides: {
 }
 
 describe('DreamTrigger', () => {
-  describe('shouldDream', () => {
+  describe('tryStartDream', () => {
     it('should return eligible when all gates pass', async () => {
       const deps = makeDeps()
       const trigger = new DreamTrigger(deps)
 
-      const result = await trigger.shouldDream('/project')
+      const result = await trigger.tryStartDream('/project')
       expect(result.eligible).to.be.true
       if (result.eligible) {
         expect(result.priorMtime).to.equal(0)
@@ -58,7 +58,7 @@ describe('DreamTrigger', () => {
       })
       const trigger = new DreamTrigger(deps)
 
-      const result = await trigger.shouldDream('/project')
+      const result = await trigger.tryStartDream('/project')
       expect(result.eligible).to.be.false
       if (!result.eligible) {
         expect(result.reason).to.include('recent')
@@ -71,7 +71,7 @@ describe('DreamTrigger', () => {
       })
       const trigger = new DreamTrigger(deps)
 
-      const result = await trigger.shouldDream('/project')
+      const result = await trigger.tryStartDream('/project')
       expect(result.eligible).to.be.false
       if (!result.eligible) {
         expect(result.reason).to.include('activity')
@@ -82,7 +82,7 @@ describe('DreamTrigger', () => {
       const deps = makeDeps({queueLength: 3})
       const trigger = new DreamTrigger(deps)
 
-      const result = await trigger.shouldDream('/project')
+      const result = await trigger.tryStartDream('/project')
       expect(result.eligible).to.be.false
       if (!result.eligible) {
         expect(result.reason).to.include('Queue')
@@ -93,7 +93,7 @@ describe('DreamTrigger', () => {
       const deps = makeDeps({lockAcquired: false})
       const trigger = new DreamTrigger(deps)
 
-      const result = await trigger.shouldDream('/project')
+      const result = await trigger.tryStartDream('/project')
       expect(result.eligible).to.be.false
       if (!result.eligible) {
         expect(result.reason).to.include('Lock')
@@ -108,7 +108,7 @@ describe('DreamTrigger', () => {
       })
       const trigger = new DreamTrigger(deps)
 
-      const result = await trigger.shouldDream('/project', true)
+      const result = await trigger.tryStartDream('/project', true)
       expect(result.eligible).to.be.true
     })
 
@@ -118,7 +118,7 @@ describe('DreamTrigger', () => {
       })
       const trigger = new DreamTrigger(deps)
 
-      const result = await trigger.shouldDream('/project', true)
+      const result = await trigger.tryStartDream('/project', true)
       expect(result.eligible).to.be.true
     })
 
@@ -126,7 +126,7 @@ describe('DreamTrigger', () => {
       const deps = makeDeps({queueLength: 3})
       const trigger = new DreamTrigger(deps)
 
-      const result = await trigger.shouldDream('/project', true)
+      const result = await trigger.tryStartDream('/project', true)
       expect(result.eligible).to.be.true
     })
 
@@ -134,7 +134,7 @@ describe('DreamTrigger', () => {
       const deps = makeDeps({lockAcquired: false})
       const trigger = new DreamTrigger(deps)
 
-      const result = await trigger.shouldDream('/project', true)
+      const result = await trigger.tryStartDream('/project', true)
       expect(result.eligible).to.be.false
       if (!result.eligible) {
         expect(result.reason).to.include('Lock')
@@ -149,7 +149,7 @@ describe('DreamTrigger', () => {
       })
       const trigger = new DreamTrigger(deps)
 
-      const result = await trigger.shouldDream('/project')
+      const result = await trigger.tryStartDream('/project')
       expect(result.eligible).to.be.false
       if (!result.eligible) {
         expect(result.reason).to.include('activity')
@@ -162,7 +162,7 @@ describe('DreamTrigger', () => {
       })
       const trigger = new DreamTrigger(deps)
 
-      const result = await trigger.shouldDream('/project', true)
+      const result = await trigger.tryStartDream('/project', true)
       expect(result.eligible).to.be.true
     })
 
@@ -174,7 +174,7 @@ describe('DreamTrigger', () => {
       })
       const trigger = new DreamTrigger(deps)
 
-      await trigger.shouldDream('/project')
+      await trigger.tryStartDream('/project')
       expect(deps.getQueueLength.called).to.be.false
       expect(deps.dreamLockService.tryAcquire.called).to.be.false
     })
@@ -185,8 +185,16 @@ describe('DreamTrigger', () => {
       })
       const trigger = new DreamTrigger(deps)
 
-      await trigger.shouldDream('/project')
+      await trigger.tryStartDream('/project')
       expect(deps.getQueueLength.called).to.be.false
+      expect(deps.dreamLockService.tryAcquire.called).to.be.false
+    })
+
+    it('should not check lock when queue fails', async () => {
+      const deps = makeDeps({queueLength: 3})
+      const trigger = new DreamTrigger(deps)
+
+      await trigger.tryStartDream('/project')
       expect(deps.dreamLockService.tryAcquire.called).to.be.false
     })
 
@@ -198,7 +206,7 @@ describe('DreamTrigger', () => {
       })
       const trigger = new DreamTrigger(deps, {minHours: 4})
 
-      const result = await trigger.shouldDream('/project')
+      const result = await trigger.tryStartDream('/project')
       expect(result.eligible).to.be.true
     })
 
@@ -208,7 +216,7 @@ describe('DreamTrigger', () => {
       })
       const trigger = new DreamTrigger(deps, {minCurations: 1})
 
-      const result = await trigger.shouldDream('/project')
+      const result = await trigger.tryStartDream('/project')
       expect(result.eligible).to.be.true
     })
   })


### PR DESCRIPTION
## Summary

- Problem: No mechanism to determine whether a dream should run — need to check time, activity, queue, and lock gates before executing.
- Why it matters: The trigger is the entry point for both automatic (agent idle) and manual (`brv dream`) dream execution. Without it, dreams would either run unconditionally or not at all.
- What changed: Added `dream-trigger.ts` with `DreamTrigger.shouldDream()` — four gates (time >= 12h, activity >= 3 curations, queue empty, PID lock free). Gates 1-3 skipped with `force=true`, lock never skipped. Exported `DreamEligibility` discriminated union type.
- What did NOT change (scope boundary): No daemon wiring. No CLI integration. Pure eligibility logic with injected dependencies.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [ ] Agent / Tools
- [ ] LLM Providers
- [x] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes ENG-2067
- Related ENG-2059, ENG-2065

## Root cause (bug fixes only, otherwise write `N/A`)

N/A

## Test plan

- Coverage added:
  - [x] Unit test
  - [ ] Integration test
  - [ ] Manual verification only
- Test file(s):
  - `test/unit/infra/dream/dream-trigger.test.ts`
- Key scenario(s) covered:
  - All four gates passing and failing individually
  - Force mode: skips gates 1-3, never skips lock
  - First dream (no state): activity gate blocks, force overrides
  - Gate ordering: early gate failure prevents later gate checks
  - Custom thresholds (minHours, minCurations)

## User-visible changes

None

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording

15 new tests, 120 total dream tests passing, 0 type errors, lint clean.

## Checklist

- [x] Tests added or updated and passing (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented above)
- [x] Branch is up to date with `main`

## Risks and mitigations

None — pure eligibility logic with no side effects beyond lock acquisition (which is the intended behavior).