### PR TITLE
feat: [ENG-2060] Consolidate operation — merge, temporal update, cross-reference

### DIFF
--- a/src/server/infra/daemon/agent-process.ts
+++ b/src/server/infra/daemon/agent-process.ts
@@ -24,6 +24,7 @@ import {randomUUID} from 'node:crypto'
 import {appendFileSync} from 'node:fs'
 import {join} from 'node:path'
 
+import type {ISearchKnowledgeService} from '../../../agent/infra/sandbox/tools-sdk.js'
 import type {BrvConfig} from '../../core/domain/entities/brv-config.js'
 import type {ProviderConfigResponse, TaskExecute} from '../../core/domain/transport/schemas.js'
 
@@ -379,7 +380,7 @@ async function start(): Promise<void> {
   transport.on<TaskExecute>(TransportTaskEventNames.EXECUTE, (task) => {
     agentLog(`task:execute received taskId=${task.taskId} type=${task.type} activeTaskCount=${activeTaskCount + 1}`)
     // eslint-disable-next-line no-void
-    void executeTask(task, curateExecutor, folderPackExecutor, queryExecutor, searchExecutor)
+    void executeTask(task, curateExecutor, folderPackExecutor, queryExecutor, searchExecutor, searchService, configResult.storagePath)
   })
 
   // 8. Register with transport server (for TransportHandlers tracking)
@@ -396,6 +397,8 @@ async function executeTask(
   folderPackExecutor: FolderPackExecutor,
   queryExecutor: QueryExecutor,
   searchExecutor: SearchExecutor,
+  searchKnowledgeService: ISearchKnowledgeService,
+  storagePath: string,
 ): Promise<void> {
   const {clientCwd, clientId, content, files, folderPath, force, taskId, type, worktreeRoot} = task
   if (!transport || !agent) return
@@ -513,10 +516,11 @@ async function executeTask(
           }
 
           const dreamExecutor = new DreamExecutor({
-            curateLogStore: new FileCurateLogStore({baseDir: brvDir}),
+            curateLogStore: new FileCurateLogStore({baseDir: storagePath}),
             dreamLockService,
             dreamLogStore: new DreamLogStore({baseDir: brvDir}),
             dreamStateService,
+            searchService: searchKnowledgeService,
           })
           result = await dreamExecutor.executeWithAgent(agent, {
             priorMtime: eligibility.priorMtime,

--- a/src/server/infra/dream/dream-response-schemas.ts
+++ b/src/server/infra/dream/dream-response-schemas.ts
@@ -3,6 +3,7 @@ import {z} from 'zod'
 // ── Consolidate ──────────────────────────────────────────────────────────────
 
 export const ConsolidationActionSchema = z.object({
+  confidence: z.number().min(0).max(1).optional(),
   files: z.array(z.string()).min(1),
   mergedContent: z.string().optional(),
   outputFile: z.string().optional(),

--- a/src/server/infra/dream/operations/consolidate.ts
+++ b/src/server/infra/dream/operations/consolidate.ts
@@ -1,0 +1,467 @@
+/**
+ * Consolidate operation — merges, updates, and cross-references related context tree files.
+ *
+ * Flow:
+ * 1. Group changed files by domain (first path segment)
+ * 2. Per domain: find related files via BM25 search + path siblings
+ * 3. Per domain: LLM classifies file relationships → returns actions
+ * 4. Execute actions: MERGE (combine + delete source), TEMPORAL_UPDATE (rewrite),
+ *    CROSS_REFERENCE (add related links in frontmatter), SKIP (no-op)
+ *
+ * Never throws — returns partial results on errors.
+ */
+
+import {dump as yamlDump, load as yamlLoad} from 'js-yaml'
+import {randomUUID} from 'node:crypto'
+import {mkdir, readdir, readFile, rename, unlink, writeFile} from 'node:fs/promises'
+import {dirname, join} from 'node:path'
+
+import type {ICipherAgent} from '../../../../agent/core/interfaces/i-cipher-agent.js'
+import type {DreamOperation} from '../dream-log-schema.js'
+import type {ConsolidationAction} from '../dream-response-schemas.js'
+
+import {parseFrontmatterScoring} from '../../../core/domain/knowledge/markdown-writer.js'
+import {ConsolidateResponseSchema} from '../dream-response-schemas.js'
+import {parseDreamResponse} from '../parse-dream-response.js'
+
+export type ConsolidateDeps = {
+  agent: ICipherAgent
+  contextTreeDir: string
+  searchService: {
+    search(query: string, options?: {limit?: number; scope?: string}): Promise<{results: Array<{path: string; score: number; title: string}>}>
+  }
+  taskId: string
+}
+
+/**
+ * Run the consolidation operation on changed files.
+ * Returns DreamOperation results (never throws).
+ */
+export async function consolidate(
+  changedFiles: string[],
+  deps: ConsolidateDeps,
+): Promise<DreamOperation[]> {
+  if (changedFiles.length === 0) return []
+
+  // Step 1: Group by domain
+  const domainGroups = groupByDomain(changedFiles)
+
+  // Step 2-5: Process each domain sequentially to avoid concurrent file writes
+  const allResults: DreamOperation[] = []
+  for (const [domain, files] of domainGroups) {
+    // eslint-disable-next-line no-await-in-loop
+    const domainOps = await processDomain(domain, files, deps)
+    allResults.push(...domainOps)
+  }
+
+  return allResults
+}
+
+async function processDomain(domain: string, files: string[], deps: ConsolidateDeps): Promise<DreamOperation[]> {
+  const {agent, contextTreeDir, searchService, taskId} = deps
+  const results: DreamOperation[] = []
+  const sessionId = await agent.createTaskSession(taskId, 'dream-consolidate')
+
+  try {
+    // Step 2: Find related files for each changed file in domain
+    const fileContents = new Map<string, string>()
+    const relatedPaths = new Set<string>()
+
+    // Sequential: each file's search results may inform the next (shared fileContents map)
+    // eslint-disable-next-line no-await-in-loop
+    for (const file of files) await loadFileAndRelated(file, domain, contextTreeDir, searchService, fileContents, relatedPaths)
+
+    // Also load sibling .md files from same directories
+    await loadSiblings(files, contextTreeDir, fileContents)
+
+    if (fileContents.size === 0) return []
+
+    // Step 3: LLM classification
+    const filesPayload: Record<string, string> = Object.fromEntries(fileContents)
+
+    agent.setSandboxVariableOnSession(sessionId, '__dream_consolidate_files', filesPayload)
+
+    const prompt = buildPrompt(files, [...relatedPaths], Object.keys(filesPayload))
+    const response = await agent.executeOnSession(sessionId, prompt, {
+      executionContext: {commandType: 'curate', maxIterations: 10},
+      taskId,
+    })
+
+    const parsed = parseDreamResponse(response, ConsolidateResponseSchema)
+    if (!parsed) return []
+
+    // Step 4: Execute actions (sequential: MERGE deletes files that later actions may reference)
+    for (const action of parsed.actions) {
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        const op = await executeAction(action, contextTreeDir, fileContents)
+        if (op) results.push(op)
+      } catch {
+        // Skip failed action, continue with others
+      }
+    }
+  } catch {
+    // Skip failed domain — return whatever succeeded
+  } finally {
+    await agent.deleteTaskSession(sessionId).catch(() => {})
+  }
+
+  return results
+}
+
+async function atomicWrite(filePath: string, content: string): Promise<void> {
+  await mkdir(dirname(filePath), {recursive: true})
+  const tmpPath = `${filePath}.${randomUUID()}.tmp`
+  await writeFile(tmpPath, content, 'utf8')
+  await rename(tmpPath, filePath)
+}
+
+/** Merge extra fields into existing YAML frontmatter, or prepend new frontmatter if none exists. */
+function addFrontmatterFields(content: string, fields: Record<string, unknown>): string {
+  if (content.startsWith('---\n') || content.startsWith('---\r\n')) {
+    const endIndex = content.indexOf('\n---\n', 4)
+    const endIndexCrlf = content.indexOf('\r\n---\r\n', 5)
+    const actualEnd = endIndex === -1 ? endIndexCrlf : endIndex
+
+    if (actualEnd >= 0) {
+      const yamlBlock = content.slice(4, actualEnd)
+      const bodyStart = content.indexOf('\n', actualEnd + 1) + 1
+      const body = content.slice(bodyStart)
+
+      try {
+        const parsed = yamlLoad(yamlBlock) as null | Record<string, unknown>
+        if (parsed && typeof parsed === 'object') {
+          const merged = {...parsed, ...fields}
+          const newYaml = yamlDump(merged, {flowLevel: 2, lineWidth: -1, sortKeys: true}).trimEnd()
+          return `---\n${newYaml}\n---\n${body}`
+        }
+      } catch {
+        // YAML parse failure — prepend new frontmatter
+      }
+    }
+  }
+
+  // No valid frontmatter — prepend
+  const yaml = yamlDump(fields, {flowLevel: 2, lineWidth: -1, sortKeys: true}).trimEnd()
+  return `---\n${yaml}\n---\n${content}`
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function groupByDomain(files: string[]): Map<string, string[]> {
+  const groups = new Map<string, string[]>()
+  for (const file of files) {
+    const domain = file.split('/')[0]
+    const group = groups.get(domain) ?? []
+    group.push(file)
+    groups.set(domain, group)
+  }
+
+  return groups
+}
+
+async function loadFileAndRelated(
+  file: string,
+  domain: string,
+  contextTreeDir: string,
+  searchService: ConsolidateDeps['searchService'],
+  fileContents: Map<string, string>,
+  relatedPaths: Set<string>,
+): Promise<void> {
+  // Read changed file
+  try {
+    const content = await readFile(join(contextTreeDir, file), 'utf8')
+    fileContents.set(file, content)
+  } catch {
+    return // File missing — skip
+  }
+
+  // BM25 search for related files in same domain
+  try {
+    const query = extractSearchQuery(file, fileContents.get(file) ?? '')
+    const searchResults = await searchService.search(query, {limit: 5, scope: domain})
+    const newPaths = searchResults.results
+      .filter((r) => r.path !== file && !fileContents.has(r.path))
+      .map((r) => r.path)
+
+    for (const p of searchResults.results) {
+      if (p.path !== file) relatedPaths.add(p.path)
+    }
+
+    const loaded = await Promise.all(
+      newPaths.map(async (p) => {
+        try {
+          return {content: await readFile(join(contextTreeDir, p), 'utf8'), path: p}
+        } catch {
+          return null
+        }
+      }),
+    )
+    for (const item of loaded) {
+      if (item) fileContents.set(item.path, item.content)
+    }
+  } catch {
+    // Search failure — continue without related files
+  }
+}
+
+async function loadSiblings(
+  files: string[],
+  contextTreeDir: string,
+  fileContents: Map<string, string>,
+): Promise<void> {
+  const dirs = [...new Set(files.map((f) => dirname(f)))]
+
+  const dirResults = await Promise.all(
+    dirs.map(async (dir) => {
+      try {
+        const entries = await readdir(join(contextTreeDir, dir), {withFileTypes: true})
+        return entries
+          .filter((e) => e.isFile() && e.name.endsWith('.md') && !e.name.startsWith('_'))
+          .map((e) => join(dir, e.name))
+      } catch {
+        return []
+      }
+    }),
+  )
+
+  const allSiblings = dirResults.flat().filter((s) => !fileContents.has(s))
+  const loaded = await Promise.all(
+    allSiblings.map(async (sibling) => {
+      try {
+        return {content: await readFile(join(contextTreeDir, sibling), 'utf8'), path: sibling}
+      } catch {
+        return null
+      }
+    }),
+  )
+
+  for (const item of loaded) {
+    if (item) fileContents.set(item.path, item.content)
+  }
+}
+
+function extractSearchQuery(filePath: string, content: string): string {
+  // Use filename (without extension) + first 100 words of content
+  const name = filePath.split('/').pop()?.replace(/\.md$/, '').replaceAll(/[-_]/g, ' ') ?? ''
+  const words = content.split(/\s+/).slice(0, 100).join(' ')
+  return `${name} ${words}`.trim()
+}
+
+function buildPrompt(changedFiles: string[], relatedFiles: string[], allFiles: string[]): string {
+  return [
+    'You are consolidating a knowledge context tree. The files have been loaded into __dream_consolidate_files (a JSON object mapping path → content).',
+    '',
+    `Changed files (recently curated): ${JSON.stringify(changedFiles)}`,
+    `Related files (found via search): ${JSON.stringify(relatedFiles)}`,
+    `All available files: ${JSON.stringify(allFiles)}`,
+    '',
+    'For each pair/group of related files, classify the relationship and recommend an action:',
+    '- MERGE: Files are redundant/overlapping → combine into one, specify outputFile and mergedContent',
+    '- TEMPORAL_UPDATE: File has contradictory/outdated info → rewrite with temporal narrative, specify updatedContent',
+    '- CROSS_REFERENCE: Files are complementary → add cross-references (no content changes needed)',
+    '- SKIP: Files are unrelated → no action needed',
+    '',
+    'Respond with JSON matching this schema:',
+    '```',
+    '{ "actions": [{ "type": "MERGE"|"TEMPORAL_UPDATE"|"CROSS_REFERENCE"|"SKIP", "files": ["path1", ...], "reason": "...", "confidence?": 0.0-1.0, "mergedContent?": "...", "outputFile?": "...", "updatedContent?": "..." }] }',
+    '```',
+    '',
+    'Rules:',
+    '- Only propose MERGE when files have significant overlap (>50% shared concepts)',
+    '- For MERGE, choose the richer/more complete file as outputFile',
+    '- For TEMPORAL_UPDATE, preserve all facts and add temporal context. Include confidence (0-1) indicating certainty that the update is correct',
+    '- For CROSS_REFERENCE, just list the files — the system will add frontmatter links',
+    '- Preserve all diagrams, tables, code examples, and structured data verbatim',
+    '- Read file contents from __dream_consolidate_files via code_exec before making decisions',
+  ].join('\n')
+}
+
+async function executeAction(
+  action: ConsolidationAction,
+  contextTreeDir: string,
+  fileContents: Map<string, string>,
+): Promise<DreamOperation | undefined> {
+  switch (action.type) {
+    case 'CROSS_REFERENCE': {
+      return executeCrossReference(action, contextTreeDir, fileContents)
+    }
+
+    case 'MERGE': {
+      return executeMerge(action, contextTreeDir, fileContents)
+    }
+
+    case 'SKIP': {
+      return undefined
+    }
+
+    case 'TEMPORAL_UPDATE': {
+      return executeTemporalUpdate(action, contextTreeDir, fileContents)
+    }
+  }
+}
+
+async function executeMerge(
+  action: ConsolidationAction,
+  contextTreeDir: string,
+  fileContents: Map<string, string>,
+): Promise<DreamOperation> {
+  const outputFile = action.outputFile ?? action.files[0]
+  const mergedContent = action.mergedContent ?? ''
+
+  // Capture previous texts
+  const previousTexts: Record<string, string> = {}
+  for (const file of action.files) {
+    const content = fileContents.get(file)
+    if (content !== undefined) {
+      previousTexts[file] = content
+    }
+  }
+
+  // Add consolidation metadata frontmatter, then write atomically
+  const sourceFiles = action.files.filter((f) => f !== outputFile)
+  /* eslint-disable camelcase */
+  const consolidationFm = {
+    consolidated_at: new Date().toISOString(),
+    consolidated_from: sourceFiles.map((f) => ({date: new Date().toISOString(), path: f, reason: action.reason})),
+  }
+  /* eslint-enable camelcase */
+  const contentWithFm = addFrontmatterFields(mergedContent, consolidationFm)
+  await atomicWrite(join(contextTreeDir, outputFile), contentWithFm)
+
+  // Delete source files (except output target)
+  const toDelete = action.files.filter((f) => f !== outputFile)
+  await Promise.all(toDelete.map((f) => unlink(join(contextTreeDir, f)).catch(() => {})))
+
+  // Determine needsReview
+  const needsReview = determineNeedsReview('MERGE', action.files, fileContents)
+
+  return {
+    action: 'MERGE',
+    inputFiles: action.files,
+    needsReview,
+    outputFile,
+    previousTexts,
+    reason: action.reason,
+    type: 'CONSOLIDATE',
+  }
+}
+
+async function executeTemporalUpdate(
+  action: ConsolidationAction,
+  contextTreeDir: string,
+  fileContents: Map<string, string>,
+): Promise<DreamOperation> {
+  const targetFile = action.files[0]
+  const updatedContent = action.updatedContent ?? ''
+
+  // Capture previous text
+  const previousTexts: Record<string, string> = {}
+  const original = fileContents.get(targetFile)
+  if (original !== undefined) {
+    previousTexts[targetFile] = original
+  }
+
+  // Add consolidation timestamp, then write atomically
+  // eslint-disable-next-line camelcase
+  const contentWithFm = addFrontmatterFields(updatedContent, {consolidated_at: new Date().toISOString()})
+  await atomicWrite(join(contextTreeDir, targetFile), contentWithFm)
+
+  const needsReview = determineNeedsReview('TEMPORAL_UPDATE', action.files, fileContents, action.confidence)
+
+  return {
+    action: 'TEMPORAL_UPDATE',
+    inputFiles: action.files,
+    needsReview,
+    previousTexts,
+    reason: action.reason,
+    type: 'CONSOLIDATE',
+  }
+}
+
+async function executeCrossReference(
+  action: ConsolidationAction,
+  contextTreeDir: string,
+  fileContents: Map<string, string>,
+): Promise<DreamOperation> {
+  // For each file, add the other files to its related frontmatter
+  await Promise.all(
+    action.files.map((file) => {
+      const otherFiles = action.files.filter((f) => f !== file)
+      return addRelatedLinks(join(contextTreeDir, file), otherFiles)
+    }),
+  )
+
+  const needsReview = determineNeedsReview('CROSS_REFERENCE', action.files, fileContents)
+
+  return {
+    action: 'CROSS_REFERENCE',
+    inputFiles: action.files,
+    needsReview,
+    reason: action.reason,
+    type: 'CONSOLIDATE',
+  }
+}
+
+async function addRelatedLinks(filePath: string, relatedPaths: string[]): Promise<void> {
+  let content: string
+  try {
+    content = await readFile(filePath, 'utf8')
+  } catch {
+    return // File missing — skip
+  }
+
+  // Parse existing frontmatter
+  if (content.startsWith('---\n') || content.startsWith('---\r\n')) {
+    const endIndex = content.indexOf('\n---\n', 4)
+    const endIndexCrlf = content.indexOf('\r\n---\r\n', 5)
+    const actualEnd = endIndex === -1 ? endIndexCrlf : endIndex
+
+    if (actualEnd >= 0) {
+      const yamlBlock = content.slice(4, actualEnd)
+      const bodyStart = content.indexOf('\n', actualEnd + 1) + 1
+      const body = content.slice(bodyStart)
+
+      try {
+        const parsed = yamlLoad(yamlBlock) as null | Record<string, unknown>
+        if (parsed && typeof parsed === 'object') {
+          const existing = Array.isArray(parsed.related) ? (parsed.related as string[]) : []
+          parsed.related = [...new Set([...existing, ...relatedPaths])]
+          const newYaml = yamlDump(parsed, {flowLevel: 1, lineWidth: -1, sortKeys: true}).trimEnd()
+          await atomicWrite(filePath, `---\n${newYaml}\n---\n${body}`)
+          return
+        }
+      } catch {
+        // YAML parse failure — skip
+      }
+    }
+  }
+
+  // No existing frontmatter — add one with related field
+  const yaml = yamlDump({related: relatedPaths}, {flowLevel: 1, lineWidth: -1, sortKeys: true}).trimEnd()
+  await atomicWrite(filePath, `---\n${yaml}\n---\n${content}`)
+}
+
+function determineNeedsReview(
+  actionType: 'CROSS_REFERENCE' | 'MERGE' | 'TEMPORAL_UPDATE',
+  files: string[],
+  fileContents: Map<string, string>,
+  confidence?: number,
+): boolean {
+  // MERGE always needs review
+  if (actionType === 'MERGE') return true
+
+  // TEMPORAL_UPDATE: needs review when confidence is low or absent
+  if (actionType === 'TEMPORAL_UPDATE') return (confidence ?? 0) < 0.7
+
+  // CROSS_REFERENCE: only if any file has core maturity
+  for (const file of files) {
+    const content = fileContents.get(file)
+    if (content) {
+      const scoring = parseFrontmatterScoring(content)
+      if (scoring?.maturity === 'core') return true
+    }
+  }
+
+  return false
+}

--- a/src/server/infra/dream/operations/consolidate.ts
+++ b/src/server/infra/dream/operations/consolidate.ts
@@ -60,7 +60,12 @@ export async function consolidate(
 async function processDomain(domain: string, files: string[], deps: ConsolidateDeps): Promise<DreamOperation[]> {
   const {agent, contextTreeDir, searchService, taskId} = deps
   const results: DreamOperation[] = []
-  const sessionId = await agent.createTaskSession(taskId, 'dream-consolidate')
+  let sessionId: string
+  try {
+    sessionId = await agent.createTaskSession(taskId, 'dream-consolidate')
+  } catch {
+    return [] // Session creation failed — skip domain
+  }
 
   try {
     // Step 2: Find related files for each changed file in domain
@@ -76,8 +81,8 @@ async function processDomain(domain: string, files: string[], deps: ConsolidateD
 
     if (fileContents.size === 0) return []
 
-    // Step 3: LLM classification
-    const filesPayload: Record<string, string> = Object.fromEntries(fileContents)
+    // Step 3: LLM classification — cap payload to avoid exceeding model context limits
+    const filesPayload = capPayloadSize(Object.fromEntries(fileContents), files)
 
     agent.setSandboxVariableOnSession(sessionId, '__dream_consolidate_files', filesPayload)
 
@@ -114,6 +119,44 @@ async function atomicWrite(filePath: string, content: string): Promise<void> {
   const tmpPath = `${filePath}.${randomUUID()}.tmp`
   await writeFile(tmpPath, content, 'utf8')
   await rename(tmpPath, filePath)
+}
+
+/** Max total chars for LLM sandbox payload — matches curate task cap (MAX_CONTENT_PER_FILE × MAX_FILES). */
+const MAX_PAYLOAD_CHARS = 200_000
+
+/**
+ * Cap the total payload size by evicting non-changed files (lowest relevance) when the
+ * combined content exceeds MAX_PAYLOAD_BYTES. Changed files are always kept.
+ */
+function capPayloadSize(payload: Record<string, string>, changedFiles: string[]): Record<string, string> {
+  const changedSet = new Set(changedFiles)
+  let totalSize = 0
+  for (const content of Object.values(payload)) totalSize += content.length
+
+  if (totalSize <= MAX_PAYLOAD_CHARS) return payload
+
+  // Keep changed files, evict non-changed (siblings/search results) until under cap
+  const result: Record<string, string> = {}
+  let currentSize = 0
+
+  // Add changed files first (always kept)
+  for (const [path, content] of Object.entries(payload)) {
+    if (changedSet.has(path)) {
+      result[path] = content
+      currentSize += content.length
+    }
+  }
+
+  // Add non-changed files until cap reached
+  for (const [path, content] of Object.entries(payload)) {
+    if (!changedSet.has(path)) {
+      if (currentSize + content.length > MAX_PAYLOAD_CHARS) continue
+      result[path] = content
+      currentSize += content.length
+    }
+  }
+
+  return result
 }
 
 /** Merge extra fields into existing YAML frontmatter, or prepend new frontmatter if none exists. */
@@ -307,7 +350,11 @@ async function executeMerge(
   fileContents: Map<string, string>,
 ): Promise<DreamOperation> {
   const outputFile = action.outputFile ?? action.files[0]
-  const mergedContent = action.mergedContent ?? ''
+  if (!action.mergedContent) {
+    throw new Error(`MERGE action missing mergedContent for ${outputFile}`)
+  }
+
+  const {mergedContent} = action
 
   // Capture previous texts
   const previousTexts: Record<string, string> = {}
@@ -353,7 +400,11 @@ async function executeTemporalUpdate(
   fileContents: Map<string, string>,
 ): Promise<DreamOperation> {
   const targetFile = action.files[0]
-  const updatedContent = action.updatedContent ?? ''
+  if (!action.updatedContent) {
+    throw new Error(`TEMPORAL_UPDATE action missing updatedContent for ${targetFile}`)
+  }
+
+  const {updatedContent} = action
 
   // Capture previous text
   const previousTexts: Record<string, string> = {}

--- a/src/server/infra/dream/operations/consolidate.ts
+++ b/src/server/infra/dream/operations/consolidate.ts
@@ -30,6 +30,7 @@ export type ConsolidateDeps = {
   searchService: {
     search(query: string, options?: {limit?: number; scope?: string}): Promise<{results: Array<{path: string; score: number; title: string}>}>
   }
+  signal?: AbortSignal
   taskId: string
 }
 
@@ -49,6 +50,7 @@ export async function consolidate(
   // Step 2-5: Process each domain sequentially to avoid concurrent file writes
   const allResults: DreamOperation[] = []
   for (const [domain, files] of domainGroups) {
+    if (deps.signal?.aborted) break
     // eslint-disable-next-line no-await-in-loop
     const domainOps = await processDomain(domain, files, deps)
     allResults.push(...domainOps)

--- a/src/server/infra/executor/dream-executor.ts
+++ b/src/server/infra/executor/dream-executor.ts
@@ -110,6 +110,7 @@ export class DreamExecutor {
         agent,
         contextTreeDir,
         searchService: this.deps.searchService,
+        signal: controller.signal,
         taskId: options.taskId,
       })
       const allOperations: DreamOperation[] = [...consolidateResults]

--- a/src/server/infra/executor/dream-executor.ts
+++ b/src/server/infra/executor/dream-executor.ts
@@ -16,7 +16,7 @@
  */
 
 import {access} from 'node:fs/promises'
-import {join} from 'node:path'
+import {isAbsolute, join, sep} from 'node:path'
 
 import type {ICipherAgent} from '../../../agent/core/interfaces/i-cipher-agent.js'
 import type {FileState} from '../../core/domain/entities/context-tree-snapshot.js'
@@ -252,14 +252,25 @@ export class DreamExecutor {
   }
 }
 
-/** Convert an absolute file path to a context-tree-relative path, or null if not inside the tree. */
+/** Convert an absolute file path to a context-tree-relative path, or undefined if not inside the tree. */
 function toContextTreeRelative(absolutePath: string, contextTreeDir: string): string | undefined {
-  if (absolutePath.startsWith(contextTreeDir + '/')) {
-    return absolutePath.slice(contextTreeDir.length + 1)
+  // Normalize separators for cross-platform (Windows uses backslash)
+  const normalized = absolutePath.replaceAll('\\', '/')
+  const normalizedDir = contextTreeDir.replaceAll('\\', '/')
+
+  if (normalized.startsWith(normalizedDir + '/')) {
+    return normalized.slice(normalizedDir.length + 1)
   }
 
-  // Already relative?
-  if (!absolutePath.startsWith('/')) return absolutePath
+  // Already relative? Validate it doesn't traverse outside the context tree
+  if (!isAbsolute(normalized)) {
+    const resolved = join(contextTreeDir, normalized)
+    if (resolved.startsWith(contextTreeDir + sep) || resolved.startsWith(contextTreeDir + '/')) {
+      return normalized
+    }
+
+    return undefined // Path traversal attempt (e.g., ../../secret.md)
+  }
 
   return undefined
 }

--- a/src/server/infra/executor/dream-executor.ts
+++ b/src/server/infra/executor/dream-executor.ts
@@ -29,6 +29,7 @@ import {FileContextTreeManifestService} from '../context-tree/file-context-tree-
 import {FileContextTreeSnapshotService} from '../context-tree/file-context-tree-snapshot-service.js'
 import {FileContextTreeSummaryService} from '../context-tree/file-context-tree-summary-service.js'
 import {diffStates} from '../context-tree/snapshot-diff.js'
+import {consolidate, type ConsolidateDeps} from '../dream/operations/consolidate.js'
 
 const DREAM_TIMEOUT_MS = 5 * 60 * 1000 // 5 minutes
 
@@ -48,6 +49,7 @@ export type DreamExecutorDeps = {
     read(): Promise<import('../dream/dream-state-schema.js').DreamState>
     write(state: import('../dream/dream-state-schema.js').DreamState): Promise<void>
   }
+  searchService: ConsolidateDeps['searchService']
 }
 
 type DreamExecuteOptions = {
@@ -101,12 +103,16 @@ export class DreamExecutor {
       // Step 2: Load dream state
       const dreamState = await this.deps.dreamStateService.read()
 
-      // Step 3: Find changed files since last dream (consumed by operations in ENG-2060/2061/2062)
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      // Step 3: Find changed files since last dream
       const changedFiles = await this.findChangedFilesSinceLastDream(dreamState.lastDreamAt, contextTreeDir)
-
-      // Step 4: Run operations (NO-OP stubs — changedFiles passed to operations when implemented)
-      const allOperations: DreamOperation[] = []
+      // Step 4: Run operations (consolidate now, synthesize + prune in ENG-2061/2062)
+      const consolidateResults = await consolidate([...changedFiles], {
+        agent,
+        contextTreeDir,
+        searchService: this.deps.searchService,
+        taskId: options.taskId,
+      })
+      const allOperations: DreamOperation[] = [...consolidateResults]
 
       // Step 5: Post-dream propagation (fail-open)
       if (preState) {
@@ -206,19 +212,28 @@ export class DreamExecutor {
     lastDreamAt: null | string,
     contextTreeDir: string,
   ): Promise<Set<string>> {
-    if (lastDreamAt === null) return new Set()
+    // First dream (lastDreamAt=null): scan ALL curate logs — every curation happened "since never"
+    const afterTimestamp = lastDreamAt ? new Date(lastDreamAt).getTime() : 0
 
     const recentLogs = await this.deps.curateLogStore.list({
-      after: new Date(lastDreamAt).getTime(),
+      after: afterTimestamp,
       status: ['completed'],
     })
 
     const changedFiles = new Set<string>()
     for (const log of recentLogs) {
       for (const op of log.operations ?? []) {
-        if (op.path) changedFiles.add(op.path)
+        // op.filePath is absolute; convert to relative for context tree operations
+        if (op.filePath) {
+          const relative = toContextTreeRelative(op.filePath, contextTreeDir)
+          if (relative) changedFiles.add(relative)
+        }
+
         if (op.additionalFilePaths) {
-          for (const p of op.additionalFilePaths) changedFiles.add(p)
+          for (const p of op.additionalFilePaths) {
+            const relative = toContextTreeRelative(p, contextTreeDir)
+            if (relative) changedFiles.add(relative)
+          }
         }
       }
     }
@@ -235,4 +250,16 @@ export class DreamExecutor {
     const results = await Promise.all(checks)
     return new Set(results.filter((f): f is string => f !== null))
   }
+}
+
+/** Convert an absolute file path to a context-tree-relative path, or null if not inside the tree. */
+function toContextTreeRelative(absolutePath: string, contextTreeDir: string): string | undefined {
+  if (absolutePath.startsWith(contextTreeDir + '/')) {
+    return absolutePath.slice(contextTreeDir.length + 1)
+  }
+
+  // Already relative?
+  if (!absolutePath.startsWith('/')) return absolutePath
+
+  return undefined
 }

--- a/test/unit/infra/dream/operations/consolidate.test.ts
+++ b/test/unit/infra/dream/operations/consolidate.test.ts
@@ -351,4 +351,23 @@ describe('consolidate', () => {
     // Should include siblings (logout.md, session.md) in addition to the changed file
     expect(fileKeys.length).to.be.greaterThan(1)
   })
+
+  it('stops processing domains when signal is aborted', async () => {
+    await createMdFile(ctxDir, 'auth/login.md', '# Login')
+    await createMdFile(ctxDir, 'api/endpoints.md', '# Endpoints')
+
+    const controller = new AbortController()
+
+    // Abort after first domain finishes executing
+    agent.executeOnSession.onFirstCall().callsFake(async () => {
+      controller.abort()
+      return llmResponse([])
+    })
+    agent.executeOnSession.onSecondCall().resolves(llmResponse([]))
+
+    await consolidate(['auth/login.md', 'api/endpoints.md'], {...deps, signal: controller.signal})
+
+    // Only one domain processed — the second was skipped because signal was aborted
+    expect(agent.createTaskSession.callCount).to.equal(1)
+  })
 })

--- a/test/unit/infra/dream/operations/consolidate.test.ts
+++ b/test/unit/infra/dream/operations/consolidate.test.ts
@@ -1,0 +1,354 @@
+import {expect} from 'chai'
+import {mkdir, readFile, writeFile} from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+import {restore, type SinonStub, stub} from 'sinon'
+
+import type {ICipherAgent} from '../../../../../src/agent/core/interfaces/i-cipher-agent.js'
+import type {DreamOperation} from '../../../../../src/server/infra/dream/dream-log-schema.js'
+
+import {consolidate, type ConsolidateDeps} from '../../../../../src/server/infra/dream/operations/consolidate.js'
+
+/** Narrow DreamOperation to CONSOLIDATE variant for test assertions */
+function asConsolidate(op: DreamOperation) {
+  expect(op.type).to.equal('CONSOLIDATE')
+  return op as Extract<DreamOperation, {type: 'CONSOLIDATE'}>
+}
+
+/** Helper: create a markdown file with optional frontmatter */
+async function createMdFile(dir: string, relativePath: string, body: string, frontmatter?: Record<string, unknown>): Promise<void> {
+  const fullPath = join(dir, relativePath)
+  await mkdir(join(fullPath, '..'), {recursive: true})
+  let content = body
+  if (frontmatter) {
+    const {dump} = await import('js-yaml')
+    const yaml = dump(frontmatter, {flowLevel: 1, lineWidth: -1, sortKeys: true}).trimEnd()
+    content = `---\n${yaml}\n---\n${body}`
+  }
+
+  await writeFile(fullPath, content, 'utf8')
+}
+
+/** Helper: build a canned LLM response JSON */
+function llmResponse(actions: Array<{confidence?: number; files: string[]; mergedContent?: string; outputFile?: string; reason: string; type: string; updatedContent?: string}>): string {
+  return '```json\n' + JSON.stringify({actions}) + '\n```'
+}
+
+describe('consolidate', () => {
+  let ctxDir: string
+  let agent: {
+    createTaskSession: SinonStub
+    deleteTaskSession: SinonStub
+    executeOnSession: SinonStub
+    setSandboxVariableOnSession: SinonStub
+  }
+  let searchService: {search: SinonStub}
+  let deps: ConsolidateDeps
+
+  beforeEach(async () => {
+    ctxDir = join(tmpdir(), `brv-consolidate-test-${Date.now()}`)
+    await mkdir(ctxDir, {recursive: true})
+
+    agent = {
+      createTaskSession: stub().resolves('session-1'),
+      deleteTaskSession: stub().resolves(),
+      executeOnSession: stub().resolves('```json\n{"actions":[]}\n```'),
+      setSandboxVariableOnSession: stub(),
+    }
+
+    searchService = {
+      search: stub().resolves({message: '', results: [], totalFound: 0}),
+    }
+
+    deps = {agent: agent as unknown as ICipherAgent, contextTreeDir: ctxDir, searchService, taskId: 'test-task'}
+  })
+
+  afterEach(() => {
+    restore()
+  })
+
+  it('returns empty array when changedFiles is empty', async () => {
+    const results = await consolidate([], deps)
+    expect(results).to.deep.equal([])
+    expect(agent.createTaskSession.called).to.be.false
+  })
+
+  it('groups files by domain and creates one session per domain', async () => {
+    await createMdFile(ctxDir, 'auth/login.md', '# Login')
+    await createMdFile(ctxDir, 'auth/signup.md', '# Signup')
+    await createMdFile(ctxDir, 'api/endpoints.md', '# Endpoints')
+
+    agent.executeOnSession.resolves(llmResponse([]))
+
+    await consolidate(['auth/login.md', 'auth/signup.md', 'api/endpoints.md'], deps)
+
+    // Two domains → two sessions
+    expect(agent.createTaskSession.callCount).to.equal(2)
+    expect(agent.deleteTaskSession.callCount).to.equal(2)
+  })
+
+  it('finds related files via search service', async () => {
+    await createMdFile(ctxDir, 'auth/login.md', '# Login Flow')
+    await createMdFile(ctxDir, 'auth/session.md', '# Session Management')
+
+    searchService.search.resolves({
+      message: '',
+      results: [{path: 'auth/session.md', score: 0.8, title: 'Session Management'}],
+      totalFound: 1,
+    })
+
+    agent.executeOnSession.resolves(llmResponse([]))
+
+    await consolidate(['auth/login.md'], deps)
+
+    expect(searchService.search.calledOnce).to.be.true
+    const searchCall = searchService.search.firstCall
+    expect(searchCall.args[1]).to.have.property('scope', 'auth')
+  })
+
+  it('executes MERGE: writes merged content, deletes source', async () => {
+    await createMdFile(ctxDir, 'auth/login.md', '# Login', {title: 'Login'})
+    await createMdFile(ctxDir, 'auth/login-v2.md', '# Login V2', {title: 'Login V2'})
+
+    agent.executeOnSession.resolves(llmResponse([{
+      files: ['auth/login.md', 'auth/login-v2.md'],
+      mergedContent: '# Unified Login\nMerged content here.',
+      outputFile: 'auth/login.md',
+      reason: 'Redundant login docs',
+      type: 'MERGE',
+    }]))
+
+    const results = await consolidate(['auth/login.md', 'auth/login-v2.md'], deps)
+
+    expect(results).to.have.lengthOf(1)
+    const op = asConsolidate(results[0])
+    expect(op.action).to.equal('MERGE')
+    expect(op.inputFiles).to.deep.equal(['auth/login.md', 'auth/login-v2.md'])
+    expect(op.outputFile).to.equal('auth/login.md')
+    expect(op.needsReview).to.be.true
+
+    // Target file has merged content
+    const merged = await readFile(join(ctxDir, 'auth/login.md'), 'utf8')
+    expect(merged).to.include('Unified Login')
+
+    // Source file deleted
+    let sourceExists = true
+    try { await readFile(join(ctxDir, 'auth/login-v2.md'), 'utf8') } catch { sourceExists = false }
+    expect(sourceExists).to.be.false
+  })
+
+  it('populates previousTexts for MERGE', async () => {
+    await createMdFile(ctxDir, 'auth/a.md', 'Content A')
+    await createMdFile(ctxDir, 'auth/b.md', 'Content B')
+
+    agent.executeOnSession.resolves(llmResponse([{
+      files: ['auth/a.md', 'auth/b.md'],
+      mergedContent: 'Merged',
+      outputFile: 'auth/a.md',
+      reason: 'Merge',
+      type: 'MERGE',
+    }]))
+
+    const results = await consolidate(['auth/a.md', 'auth/b.md'], deps)
+
+    const op = asConsolidate(results[0])
+    expect(op.previousTexts).to.deep.equal({
+      'auth/a.md': 'Content A',
+      'auth/b.md': 'Content B',
+    })
+  })
+
+  it('executes TEMPORAL_UPDATE: writes updated content', async () => {
+    await createMdFile(ctxDir, 'api/rate-limits.md', '# Old rate limits')
+
+    agent.executeOnSession.resolves(llmResponse([{
+      files: ['api/rate-limits.md'],
+      reason: 'Outdated info',
+      type: 'TEMPORAL_UPDATE',
+      updatedContent: '# Updated rate limits\nNow 200 req/min.',
+    }]))
+
+    const results = await consolidate(['api/rate-limits.md'], deps)
+
+    expect(results).to.have.lengthOf(1)
+    const op = asConsolidate(results[0])
+    expect(op.action).to.equal('TEMPORAL_UPDATE')
+    expect(op.needsReview).to.be.true
+
+    const updated = await readFile(join(ctxDir, 'api/rate-limits.md'), 'utf8')
+    expect(updated).to.include('Updated rate limits')
+  })
+
+  it('populates previousTexts for TEMPORAL_UPDATE', async () => {
+    await createMdFile(ctxDir, 'api/config.md', 'Original config')
+
+    agent.executeOnSession.resolves(llmResponse([{
+      files: ['api/config.md'],
+      reason: 'Update',
+      type: 'TEMPORAL_UPDATE',
+      updatedContent: 'New config',
+    }]))
+
+    const results = await consolidate(['api/config.md'], deps)
+
+    const op = asConsolidate(results[0])
+    expect(op.previousTexts).to.deep.equal({
+      'api/config.md': 'Original config',
+    })
+  })
+
+  it('sets needsReview=false for high-confidence TEMPORAL_UPDATE', async () => {
+    await createMdFile(ctxDir, 'api/config.md', 'Old config')
+
+    agent.executeOnSession.resolves(llmResponse([{
+      confidence: 0.9,
+      files: ['api/config.md'],
+      reason: 'Clear update',
+      type: 'TEMPORAL_UPDATE',
+      updatedContent: 'New config',
+    }]))
+
+    const results = await consolidate(['api/config.md'], deps)
+    expect(results[0].needsReview).to.be.false
+  })
+
+  it('adds consolidated_at frontmatter to merged files', async () => {
+    await createMdFile(ctxDir, 'auth/a.md', 'Content A')
+    await createMdFile(ctxDir, 'auth/b.md', 'Content B')
+
+    agent.executeOnSession.resolves(llmResponse([{
+      files: ['auth/a.md', 'auth/b.md'],
+      mergedContent: '# Merged\nCombined content.',
+      outputFile: 'auth/a.md',
+      reason: 'Redundant',
+      type: 'MERGE',
+    }]))
+
+    const results = await consolidate(['auth/a.md', 'auth/b.md'], deps)
+    expect(results).to.have.lengthOf(1)
+
+    const merged = await readFile(join(ctxDir, 'auth/a.md'), 'utf8')
+    expect(merged).to.include('consolidated_at')
+    expect(merged).to.include('consolidated_from')
+    expect(merged).to.include('auth/b.md')
+  })
+
+  it('executes CROSS_REFERENCE: adds related links in frontmatter', async () => {
+    await createMdFile(ctxDir, 'auth/jwt.md', '# JWT', {keywords: [], related: [], tags: [], title: 'JWT'})
+    await createMdFile(ctxDir, 'auth/oauth.md', '# OAuth', {keywords: [], related: [], tags: [], title: 'OAuth'})
+
+    agent.executeOnSession.resolves(llmResponse([{
+      files: ['auth/jwt.md', 'auth/oauth.md'],
+      reason: 'Complementary auth topics',
+      type: 'CROSS_REFERENCE',
+    }]))
+
+    const results = await consolidate(['auth/jwt.md', 'auth/oauth.md'], deps)
+
+    expect(results).to.have.lengthOf(1)
+    const op = asConsolidate(results[0])
+    expect(op.action).to.equal('CROSS_REFERENCE')
+    expect(op.needsReview).to.be.false
+
+    const jwt = await readFile(join(ctxDir, 'auth/jwt.md'), 'utf8')
+    expect(jwt).to.include('auth/oauth.md')
+
+    const oauth = await readFile(join(ctxDir, 'auth/oauth.md'), 'utf8')
+    expect(oauth).to.include('auth/jwt.md')
+  })
+
+  it('returns empty operations for SKIP actions', async () => {
+    await createMdFile(ctxDir, 'auth/unrelated.md', '# Unrelated')
+
+    agent.executeOnSession.resolves(llmResponse([{
+      files: ['auth/unrelated.md'],
+      reason: 'Not related',
+      type: 'SKIP',
+    }]))
+
+    const results = await consolidate(['auth/unrelated.md'], deps)
+
+    expect(results).to.deep.equal([])
+  })
+
+  it('sets needsReview=true when file has core maturity', async () => {
+    await createMdFile(ctxDir, 'auth/core-auth.md', '# Core Auth', {
+      keywords: [], maturity: 'core', related: [], tags: [], title: 'Core Auth',
+    })
+    await createMdFile(ctxDir, 'auth/helper.md', '# Helper')
+
+    agent.executeOnSession.resolves(llmResponse([{
+      files: ['auth/core-auth.md', 'auth/helper.md'],
+      reason: 'Cross-reference',
+      type: 'CROSS_REFERENCE',
+    }]))
+
+    const results = await consolidate(['auth/core-auth.md', 'auth/helper.md'], deps)
+
+    // CROSS_REFERENCE is normally needsReview=false, but core maturity overrides
+    expect(results[0].needsReview).to.be.true
+  })
+
+  it('continues processing when LLM fails for one domain', async () => {
+    await createMdFile(ctxDir, 'auth/login.md', '# Login')
+    await createMdFile(ctxDir, 'api/endpoints.md', '# Endpoints')
+
+    // First domain (api) fails, second domain (auth) succeeds
+    agent.executeOnSession
+      .onFirstCall().rejects(new Error('LLM timeout'))
+      .onSecondCall().resolves(llmResponse([]))
+
+    const results = await consolidate(['api/endpoints.md', 'auth/login.md'], deps)
+
+    // Should not throw, returns whatever succeeded
+    expect(results).to.be.an('array')
+    // Both sessions still cleaned up
+    expect(agent.deleteTaskSession.callCount).to.equal(2)
+  })
+
+  it('continues processing when file read fails for an action', async () => {
+    // File doesn't exist in context tree but was in changedFiles
+    agent.executeOnSession.resolves(llmResponse([{
+      files: ['auth/missing.md', 'auth/also-missing.md'],
+      mergedContent: 'Merged',
+      outputFile: 'auth/missing.md',
+      reason: 'Merge',
+      type: 'MERGE',
+    }]))
+
+    // Create at least one valid file so the domain gets processed
+    await createMdFile(ctxDir, 'auth/exists.md', '# Exists')
+
+    const results = await consolidate(['auth/exists.md'], deps)
+
+    // Should not throw — action skipped due to file read failure
+    expect(results).to.be.an('array')
+  })
+
+  it('cleans up task session even on error', async () => {
+    await createMdFile(ctxDir, 'auth/test.md', '# Test')
+
+    agent.executeOnSession.rejects(new Error('Session error'))
+
+    await consolidate(['auth/test.md'], deps)
+
+    expect(agent.deleteTaskSession.calledOnce).to.be.true
+  })
+
+  it('includes path siblings as related files', async () => {
+    await createMdFile(ctxDir, 'auth/login.md', '# Login')
+    await createMdFile(ctxDir, 'auth/logout.md', '# Logout')
+    await createMdFile(ctxDir, 'auth/session.md', '# Session')
+
+    agent.executeOnSession.resolves(llmResponse([]))
+
+    await consolidate(['auth/login.md'], deps)
+
+    // The sandbox variable should include sibling file contents
+    expect(agent.setSandboxVariableOnSession.called).to.be.true
+    const filesPayload = agent.setSandboxVariableOnSession.firstCall.args[2]
+    const fileKeys = typeof filesPayload === 'string' ? Object.keys(JSON.parse(filesPayload)) : Object.keys(filesPayload)
+    // Should include siblings (logout.md, session.md) in addition to the changed file
+    expect(fileKeys.length).to.be.greaterThan(1)
+  })
+})

--- a/test/unit/infra/dream/operations/consolidate.test.ts
+++ b/test/unit/infra/dream/operations/consolidate.test.ts
@@ -306,8 +306,8 @@ describe('consolidate', () => {
     expect(agent.deleteTaskSession.callCount).to.equal(2)
   })
 
-  it('continues processing when file read fails for an action', async () => {
-    // File doesn't exist in context tree but was in changedFiles
+  it('does not crash when MERGE references files not in fileContents', async () => {
+    // LLM references files that weren't loaded (missing from context tree)
     agent.executeOnSession.resolves(llmResponse([{
       files: ['auth/missing.md', 'auth/also-missing.md'],
       mergedContent: 'Merged',
@@ -321,7 +321,7 @@ describe('consolidate', () => {
 
     const results = await consolidate(['auth/exists.md'], deps)
 
-    // Should not throw — action skipped due to file read failure
+    // Should not throw — MERGE writes to outputFile even if sources weren't in fileContents
     expect(results).to.be.an('array')
   })
 

--- a/test/unit/infra/executor/dream-executor.test.ts
+++ b/test/unit/infra/executor/dream-executor.test.ts
@@ -36,8 +36,19 @@ describe('DreamExecutor', () => {
     curateLogStore = {
       list: stub().resolves([]),
     }
-    agent = {} as unknown as ICipherAgent
-    deps = {curateLogStore, dreamLockService, dreamLogStore, dreamStateService}
+    agent = {
+      createTaskSession: stub().resolves('session-1'),
+      deleteTaskSession: stub().resolves(),
+      executeOnSession: stub().resolves('```json\n{"actions":[]}\n```'),
+      setSandboxVariableOnSession: stub(),
+    } as unknown as ICipherAgent
+    deps = {
+      curateLogStore,
+      dreamLockService,
+      dreamLogStore,
+      dreamStateService,
+      searchService: {search: stub().resolves({message: '', results: [], totalFound: 0})},
+    }
   })
 
   afterEach(() => {
@@ -137,13 +148,15 @@ describe('DreamExecutor', () => {
       expect(dreamLockService.release.called).to.be.false
     })
 
-    it('does not scan curate logs on first dream (lastDreamAt = null)', async () => {
+    it('scans all curate logs on first dream (lastDreamAt = null)', async () => {
       dreamStateService.read.resolves({...EMPTY_DREAM_STATE, pendingMerges: []})
 
       const executor = new DreamExecutor(deps)
       await executor.executeWithAgent(agent, defaultOptions)
 
-      expect(curateLogStore.list.called).to.be.false
+      expect(curateLogStore.list.calledOnce).to.be.true
+      const listArgs = curateLogStore.list.firstCall.args[0]
+      expect(listArgs.after).to.equal(0) // epoch 0 = scan all
     })
 
     it('scans curate logs since last dream when lastDreamAt is set', async () => {


### PR DESCRIPTION
## Summary

- Problem: Dream executor had stub operations — no actual memory consolidation happened
- Why it matters: Consolidate is the first LLM-driven operation and the foundation for synthesize and prune. Without it, dreaming produces empty results.
- What changed:
  - New `consolidate.ts` (~430 LoC): domain grouping, BM25 search + sibling discovery, LLM classification via agent sessions, action execution (MERGE, TEMPORAL_UPDATE, CROSS_REFERENCE, SKIP)
  - MERGE: writes merged content, deletes sources, adds `consolidated_from` + `consolidated_at` frontmatter programmatically
  - TEMPORAL_UPDATE: rewrites with temporal narrative, confidence-gated review (< 0.7 threshold)
  - CROSS_REFERENCE: bidirectional `related` links in YAML frontmatter
  - Wired into DreamExecutor step 4 (replaces stub)
  - Added `searchService` to DreamExecutorDeps, threaded through agent-process.ts
  - Fixed curate log store to use global `storagePath` (not `projectPath/.brv`)
  - Fixed `findChangedFilesSinceLastDream` to use `op.filePath` (absolute) and scan all logs on first dream
  - Added optional `confidence` field to `ConsolidationActionSchema`
- What did NOT change (scope boundary): Synthesize and prune remain stubs (ENG-2061/ENG-2062). No review system integration. No idle trigger wiring.

## Type of change

- [x] New feature

## Scope (select all touched areas)

- [x] Server / Daemon
- [x] Agent / Tools
- [x] CLI Commands (oclif)

## Linked issues

- Related ENG-2060 (child of ENG-2059)
- Depends on ENG-2065, ENG-2066, ENG-2067, ENG-2068

## Root cause (bug fixes only, otherwise write `N/A`)

Three bugs found during interactive testing:
- Root cause 1: `FileCurateLogStore` was instantiated with `projectPath/.brv` but curate logs are stored in global `storagePath`
- Root cause 2: `findChangedFilesSinceLastDream` used `op.path` (domain path like "security/authentication") instead of `op.filePath` (absolute file path)
- Root cause 3: First dream returned empty changed files because `lastDreamAt=null` short-circuited to empty set instead of scanning all curate logs

## Test plan

- Coverage added:
  - [x] Unit test
  - [x] Manual verification only
- Test file(s): `test/unit/infra/dream/operations/consolidate.test.ts`, `test/unit/infra/executor/dream-executor.test.ts`
- Key scenario(s) covered:
  - Unit (16 new tests): empty input, domain grouping, BM25 search, MERGE/TEMPORAL_UPDATE/CROSS_REFERENCE/SKIP execution, previousTexts, needsReview rules (MERGE=always, TEMPORAL_UPDATE=confidence, CROSS_REF=core maturity), frontmatter metadata, LLM failure resilience, file read failure, session cleanup, sibling discovery, high-confidence skip
  - Interactive (2 dream cycles): 10 curations across 4 domains, verified MERGE file deletion + frontmatter, CROSS_REFERENCE bidirectional links, TEMPORAL_UPDATE enrichment, "since last dream" scoping, gate logic, dream state lifecycle

## User-visible changes

- `brv dream` now performs actual consolidation: merges redundant files, updates contradictory content, adds cross-references
- Dream log entries contain real operation details (action, inputFiles, reason, needsReview, previousTexts)
- Merged files include `consolidated_from` and `consolidated_at` YAML frontmatter
- Cross-referenced files include bidirectional `related` links

## Evidence

- 148 dream tests passing (14 consolidate + 11 executor + 121 existing + 2 new)
- Interactive: Dream Cycle 1 (8 curations → 6 ops, 73s), Dream Cycle 2 (2 curations → 4 ops, 54s), zero errors

## Checklist

- [x] Tests added or updated and passing (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow Conventional Commits format
- [x] No breaking changes (or clearly documented above)
- [x] Branch is up to date with `proj/dreaming`

## Risks and mitigations

- Risk: LLM may merge derived artifacts (.abstract.md, .overview.md) into main files but leave orphaned derivatives from other files
  - Mitigation: Prune operation (ENG-2062) will handle cleanup of orphaned derived artifacts
- Risk: Consolidate prompt quality affects operation accuracy
  - Mitigation: All MERGE operations are flagged for human review (needsReview=true)