### PR TITLE
feat: update MiniMax API endpoint to China region (api.minimaxi.com)

### DIFF
--- a/src/agent/infra/llm/providers/minimax.ts
+++ b/src/agent/infra/llm/providers/minimax.ts
@@ -13,12 +13,12 @@ import {AiSdkContentGenerator} from '../generators/ai-sdk-content-generator.js'
 export const minimaxProvider: ProviderModule = {
   apiKeyUrl: 'https://platform.minimax.io',
   authType: 'api-key',
-  baseUrl: 'https://api.minimax.io/v1',
+  baseUrl: 'https://api.minimaxi.com/v1',
   category: 'other',
   createGenerator(config: GeneratorFactoryConfig) {
     const provider = createOpenAICompatible({
       apiKey: config.apiKey!,
-      baseURL: 'https://api.minimax.io/v1',
+      baseURL: 'https://api.minimaxi.com/v1',
       name: 'minimax',
     })
 

--- a/src/server/core/domain/entities/provider-registry.ts
+++ b/src/server/core/domain/entities/provider-registry.ts
@@ -185,7 +185,7 @@ export const PROVIDER_REGISTRY: Readonly<Record<string, ProviderDefinition>> = {
   },
   minimax: {
     apiKeyUrl: 'https://platform.minimax.io',
-    baseUrl: 'https://api.minimax.io/v1',
+    baseUrl: 'https://api.minimaxi.com/v1',
     category: 'other',
     defaultModel: 'MiniMax-M2',
     description: 'MiniMax AI models',

--- a/src/server/infra/http/provider-model-fetcher-registry.ts
+++ b/src/server/infra/http/provider-model-fetcher-registry.ts
@@ -93,7 +93,7 @@ export async function getModelFetcher(providerId: string): Promise<IProviderMode
 
     case 'minimax': {
       fetcher = new ChatBasedModelFetcher(
-        'https://api.minimax.io/v1',
+        'https://api.minimaxi.com/v1',
         'MiniMax',
         ['MiniMax-M2', 'MiniMax-M2-Stable'],
       )


### PR DESCRIPTION
## Summary
Update MiniMax API base URL from `api.minimax.io` to `api.minimaxi.com` to support China region access.

## Changes
- `src/agent/infra/llm/providers/minimax.ts`: Update baseUrl in provider config and createGenerator
- `src/server/core/domain/entities/provider-registry.ts`: Update baseUrl in PROVIDER_REGISTRY
- `src/server/infra/http/provider-model-fetcher-registry.ts`: Update baseUrl in model fetcher

## Testing
- [ ] Verify MiniMax provider connection with new endpoint
- [ ] Confirm model list fetching works