### PR TITLE
feat:[ENG-2073] add short-lived result cache in SwarmCoordinator

### DIFF
--- a/src/agent/infra/swarm/config/swarm-config-schema.ts
+++ b/src/agent/infra/swarm/config/swarm-config-schema.ts
@@ -312,6 +312,7 @@ const PerformanceSchema = z.preprocess(
       index_cache_ttl_seconds: 'indexCacheTtlSeconds',
       max_concurrent_providers: 'maxConcurrentProviders',
       max_query_latency_ms: 'maxQueryLatencyMs',
+      result_cache_ttl_ms: 'resultCacheTtlMs',
     })
   },
   z.object({
@@ -319,6 +320,7 @@ const PerformanceSchema = z.preprocess(
     indexCacheTtlSeconds: z.number().int().optional().default(300),
     maxConcurrentProviders: z.number().int().positive().optional().default(4),
     maxQueryLatencyMs: z.number().int().positive().optional().default(2000),
+    resultCacheTtlMs: z.number().int().min(0).optional().default(10_000),
   })
 )
 

--- a/src/agent/infra/swarm/swarm-coordinator.ts
+++ b/src/agent/infra/swarm/swarm-coordinator.ts
@@ -154,10 +154,10 @@ function resolveEndpoint(endpoint: string, providerIds: string[]): string[] {
 export class SwarmCoordinator implements ISwarmCoordinator {
   private readonly config: SwarmConfig
   private readonly graph: SwarmGraph
-  private healthCache: Map<string, boolean> = new Map()
+  private readonly healthCache: Map<string, boolean> = new Map()
   private readonly maxCacheSize = 20
   private readonly providers: IMemoryProvider[]
-  private resultCache: Map<string, {result: SwarmQueryResult; timestamp: number}> = new Map()
+  private readonly resultCache: Map<string, {result: SwarmQueryResult; timestamp: number}> = new Map()
   private readonly resultCacheTtlMs: number
   private totalQueries = 0
 
@@ -198,7 +198,7 @@ export class SwarmCoordinator implements ISwarmCoordinator {
         this.resultCache.delete(cacheKey)
         this.resultCache.set(cacheKey, cached)
         this.totalQueries++
-        return {...cached.result, results: [...cached.result.results]}
+        return {...cached.result, results: cached.result.results.map((r) => ({...r, metadata: {...r.metadata}}))}
       }
 
       // Expired — clean up stale entry
@@ -275,12 +275,14 @@ export class SwarmCoordinator implements ISwarmCoordinator {
       results: merged,
     }
 
-    // Cache store — clone to prevent mutation of cached data via returned reference
-    this.resultCache.set(cacheKey, {
-      result: {...result, results: [...result.results]},
-      timestamp: Date.now(),
-    })
-    this.evictIfOverSize()
+    // Cache store — deep-clone to prevent mutation of cached data via returned references
+    if (this.resultCacheTtlMs > 0) {
+      this.resultCache.set(cacheKey, {
+        result: {...result, results: result.results.map((r) => ({...r, metadata: {...r.metadata}}))},
+        timestamp: Date.now(),
+      })
+      this.evictIfOverSize()
+    }
 
     return result
   }
@@ -416,7 +418,7 @@ export class SwarmCoordinator implements ISwarmCoordinator {
     const q = request.query.toLowerCase().trim().replaceAll(/\s+/g, ' ')
     const scope = request.scope ?? ''
     const max = request.maxResults ?? this.config.routing.defaultMaxResults
-    return JSON.stringify([q, scope, max])
+    return JSON.stringify([q, scope, max, request.type, request.timeRange])
   }
 
   private evictIfOverSize(): void {

--- a/src/agent/infra/swarm/swarm-coordinator.ts
+++ b/src/agent/infra/swarm/swarm-coordinator.ts
@@ -155,12 +155,16 @@ export class SwarmCoordinator implements ISwarmCoordinator {
   private readonly config: SwarmConfig
   private readonly graph: SwarmGraph
   private healthCache: Map<string, boolean> = new Map()
+  private readonly maxCacheSize = 20
   private readonly providers: IMemoryProvider[]
+  private resultCache: Map<string, {result: SwarmQueryResult; timestamp: number}> = new Map()
+  private readonly resultCacheTtlMs: number
   private totalQueries = 0
 
   constructor(providers: IMemoryProvider[], config: SwarmConfig) {
     this.providers = providers
     this.config = config
+    this.resultCacheTtlMs = config.performance.resultCacheTtlMs ?? 10_000
     this.graph = new SwarmGraph(providers, {
       timeoutMs: config.performance.maxQueryLatencyMs,
     })
@@ -185,6 +189,22 @@ export class SwarmCoordinator implements ISwarmCoordinator {
    * Execute a swarm query: classify → select providers → execute in parallel → fuse results.
    */
   public async execute(request: QueryRequest): Promise<SwarmQueryResult> {
+    // Cache check — return early if identical query was recently executed
+    const cacheKey = this.buildCacheKey(request)
+    const cached = this.resultCache.get(cacheKey)
+    if (cached) {
+      if (Date.now() - cached.timestamp < this.resultCacheTtlMs) {
+        // Move to end for LRU semantics
+        this.resultCache.delete(cacheKey)
+        this.resultCache.set(cacheKey, cached)
+        this.totalQueries++
+        return {...cached.result, results: [...cached.result.results]}
+      }
+
+      // Expired — clean up stale entry
+      this.resultCache.delete(cacheKey)
+    }
+
     const start = Date.now()
 
     // 1. Classify query type
@@ -245,7 +265,7 @@ export class SwarmCoordinator implements ISwarmCoordinator {
 
     this.totalQueries++
 
-    return {
+    const result: SwarmQueryResult = {
       meta: {
         costCents,
         providers: providerMeta,
@@ -254,6 +274,15 @@ export class SwarmCoordinator implements ISwarmCoordinator {
       },
       results: merged,
     }
+
+    // Cache store — clone to prevent mutation of cached data via returned reference
+    this.resultCache.set(cacheKey, {
+      result: {...result, results: [...result.results]},
+      timestamp: Date.now(),
+    })
+    this.evictIfOverSize()
+
+    return result
   }
 
   /**
@@ -314,6 +343,7 @@ export class SwarmCoordinator implements ISwarmCoordinator {
       })
     )
 
+    this.resultCache.clear()
     return results
   }
 
@@ -361,6 +391,10 @@ export class SwarmCoordinator implements ISwarmCoordinator {
         },
       })
 
+      if (result.success) {
+        this.resultCache.clear()
+      }
+
       return {
         id: result.id,
         latencyMs: Date.now() - start,
@@ -375,6 +409,21 @@ export class SwarmCoordinator implements ISwarmCoordinator {
         provider: target.id,
         success: false,
       }
+    }
+  }
+
+  private buildCacheKey(request: QueryRequest): string {
+    const q = request.query.toLowerCase().trim().replaceAll(/\s+/g, ' ')
+    const scope = request.scope ?? ''
+    const max = request.maxResults ?? this.config.routing.defaultMaxResults
+    return JSON.stringify([q, scope, max])
+  }
+
+  private evictIfOverSize(): void {
+    if (this.resultCache.size <= this.maxCacheSize) return
+    const firstKey = this.resultCache.keys().next().value
+    if (firstKey !== undefined) {
+      this.resultCache.delete(firstKey)
     }
   }
 }

--- a/test/unit/agent/swarm/provider-factory.test.ts
+++ b/test/unit/agent/swarm/provider-factory.test.ts
@@ -16,6 +16,7 @@ function createMinimalConfig(overrides?: Partial<SwarmConfig>): SwarmConfig {
       indexCacheTtlSeconds: 300,
       maxConcurrentProviders: 4,
       maxQueryLatencyMs: 2000,
+      resultCacheTtlMs: 10_000,
     },
     provenance: {enabled: true, fullRetentionDays: 30, keepSummaries: true, storagePath: 'swarm/provenance'},
     providers: {byterover: {enabled: true}},

--- a/test/unit/agent/swarm/swarm-coordinator.test.ts
+++ b/test/unit/agent/swarm/swarm-coordinator.test.ts
@@ -60,6 +60,7 @@ function createMinimalConfig(overrides?: Partial<SwarmConfig>): SwarmConfig {
       indexCacheTtlSeconds: 300,
       maxConcurrentProviders: 4,
       maxQueryLatencyMs: 2000,
+      resultCacheTtlMs: 10_000,
     },
     provenance: {enabled: true, fullRetentionDays: 30, keepSummaries: true, storagePath: 'swarm/provenance'},
     providers: {byterover: {enabled: true}},
@@ -412,6 +413,163 @@ describe('SwarmCoordinator', () => {
       expect(summary.activeCount).to.equal(1)
       expect(summary.monthlyBudgetCents).to.equal(5000)
       expect(summary.providers).to.have.length(1)
+    })
+  })
+
+  describe('result cache', () => {
+    it('returns cached result for identical query', async () => {
+      const p1 = createMockProvider('byterover', 'byterover', [makeResult('byterover', 'Auth')])
+      const config = createMinimalConfig()
+      const coordinator = new SwarmCoordinator([p1], config)
+
+      const r1 = await coordinator.execute({query: 'auth tokens'})
+      const r2 = await coordinator.execute({query: 'auth tokens'})
+
+      expect(r1).to.deep.equal(r2)
+      expect(r1).to.not.equal(r2) // Different object references (clone)
+      expect((p1.query as sinon.SinonStub).callCount).to.equal(1)
+    })
+
+    it('cached result is mutation-safe', async () => {
+      const p1 = createMockProvider('byterover', 'byterover', [makeResult('byterover', 'Auth')])
+      const config = createMinimalConfig()
+      const coordinator = new SwarmCoordinator([p1], config)
+
+      const r1 = await coordinator.execute({query: 'auth'})
+      r1.results.length = 0 // Mutate the returned results
+      const r2 = await coordinator.execute({query: 'auth'})
+
+      expect(r2.results).to.have.length(1) // Cache unaffected by mutation
+    })
+
+    it('cache hit is case insensitive', async () => {
+      const p1 = createMockProvider('byterover', 'byterover', [makeResult('byterover', 'Auth')])
+      const config = createMinimalConfig()
+      const coordinator = new SwarmCoordinator([p1], config)
+
+      await coordinator.execute({query: 'JWT Refresh'})
+      await coordinator.execute({query: 'jwt refresh'})
+
+      expect((p1.query as sinon.SinonStub).callCount).to.equal(1)
+    })
+
+    it('cache hit normalizes whitespace', async () => {
+      const p1 = createMockProvider('byterover', 'byterover', [makeResult('byterover', 'Auth')])
+      const config = createMinimalConfig()
+      const coordinator = new SwarmCoordinator([p1], config)
+
+      await coordinator.execute({query: 'jwt  refresh'})
+      await coordinator.execute({query: 'jwt refresh'})
+
+      expect((p1.query as sinon.SinonStub).callCount).to.equal(1)
+    })
+
+    it('cache miss for different query', async () => {
+      const p1 = createMockProvider('byterover', 'byterover', [makeResult('byterover', 'Auth')])
+      const config = createMinimalConfig()
+      const coordinator = new SwarmCoordinator([p1], config)
+
+      await coordinator.execute({query: 'JWT refresh'})
+      await coordinator.execute({query: 'JWT expiry'})
+
+      expect((p1.query as sinon.SinonStub).callCount).to.equal(2)
+    })
+
+    it('cache miss for different scope', async () => {
+      const p1 = createMockProvider('byterover', 'byterover', [makeResult('byterover', 'Auth')])
+      const config = createMinimalConfig()
+      const coordinator = new SwarmCoordinator([p1], config)
+
+      await coordinator.execute({query: 'auth', scope: 'frontend'})
+      await coordinator.execute({query: 'auth', scope: 'backend'})
+
+      expect((p1.query as sinon.SinonStub).callCount).to.equal(2)
+    })
+
+    it('cache miss for different maxResults', async () => {
+      const p1 = createMockProvider('byterover', 'byterover', [makeResult('byterover', 'Auth')])
+      const config = createMinimalConfig()
+      const coordinator = new SwarmCoordinator([p1], config)
+
+      await coordinator.execute({maxResults: 5, query: 'auth'})
+      await coordinator.execute({maxResults: 10, query: 'auth'})
+
+      expect((p1.query as sinon.SinonStub).callCount).to.equal(2)
+    })
+
+    it('cache expires after TTL', async () => {
+      const p1 = createMockProvider('byterover', 'byterover', [makeResult('byterover', 'Auth')])
+      const config = createMinimalConfig({
+        performance: {fileWatcherDebounceMs: 1000, indexCacheTtlSeconds: 300, maxConcurrentProviders: 4, maxQueryLatencyMs: 2000, resultCacheTtlMs: 1},
+      })
+      const coordinator = new SwarmCoordinator([p1], config)
+
+      await coordinator.execute({query: 'auth'})
+      await new Promise<void>((r) => { setTimeout(r, 10) })
+      await coordinator.execute({query: 'auth'})
+
+      expect((p1.query as sinon.SinonStub).callCount).to.equal(2)
+    })
+
+    it('TTL 0 disables caching', async () => {
+      const p1 = createMockProvider('byterover', 'byterover', [makeResult('byterover', 'Auth')])
+      const config = createMinimalConfig({
+        performance: {fileWatcherDebounceMs: 1000, indexCacheTtlSeconds: 300, maxConcurrentProviders: 4, maxQueryLatencyMs: 2000, resultCacheTtlMs: 0},
+      })
+      const coordinator = new SwarmCoordinator([p1], config)
+
+      await coordinator.execute({query: 'auth'})
+      await coordinator.execute({query: 'auth'})
+
+      expect((p1.query as sinon.SinonStub).callCount).to.equal(2)
+    })
+
+    it('store() invalidates cache', async () => {
+      const p1 = createMockProvider('byterover', 'byterover', [makeResult('byterover', 'Auth')])
+      p1.capabilities.writeSupported = true;
+      (p1.store as sinon.SinonStub).resolves({id: 'note-1', provider: 'byterover', success: true})
+      const config = createMinimalConfig()
+      const coordinator = new SwarmCoordinator([p1], config)
+
+      await coordinator.execute({query: 'auth'})
+      await coordinator.store({content: 'new knowledge'})
+      await coordinator.execute({query: 'auth'})
+
+      expect((p1.query as sinon.SinonStub).callCount).to.equal(2)
+    })
+
+    it('refreshHealth() invalidates cache', async () => {
+      const p1 = createMockProvider('byterover', 'byterover', [makeResult('byterover', 'Auth')])
+      const config = createMinimalConfig()
+      const coordinator = new SwarmCoordinator([p1], config)
+
+      await coordinator.execute({query: 'auth'})
+      await coordinator.refreshHealth()
+      await coordinator.execute({query: 'auth'})
+
+      expect((p1.query as sinon.SinonStub).callCount).to.equal(2)
+    })
+
+    it('evicts oldest entry when cache exceeds max size', async () => {
+      const p1 = createMockProvider('byterover', 'byterover', [makeResult('byterover', 'Auth')])
+      const config = createMinimalConfig()
+      const coordinator = new SwarmCoordinator([p1], config)
+
+      // Fill cache with 21 distinct queries (max is 20)
+      for (let i = 0; i < 21; i++) {
+        // eslint-disable-next-line no-await-in-loop -- sequential execution needed for deterministic cache order
+        await coordinator.execute({query: `query ${i}`})
+      }
+
+      // query 0 should have been evicted — re-executing should call graph
+      const callsBefore = (p1.query as sinon.SinonStub).callCount
+      await coordinator.execute({query: 'query 0'})
+      expect((p1.query as sinon.SinonStub).callCount).to.equal(callsBefore + 1)
+
+      // query 20 should still be cached
+      const callsAfter = (p1.query as sinon.SinonStub).callCount
+      await coordinator.execute({query: 'query 20'})
+      expect((p1.query as sinon.SinonStub).callCount).to.equal(callsAfter)
     })
   })
 })


### PR DESCRIPTION
Problem:** The agent calls `swarm_query` multiple times during a single conversation, and each call re-queries all providers from scratch (340ms+). GBrain subprocess alone takes 200-300ms. Identical queries seconds apart produce identical results — wasted work.
- **Why it matters:** Agent conversations involve bursts of tool calls. A 3-query burst takes 1s+ when the results are already known. This is noticeable latency in the agent's response loop.
- **What changed:** Added a short-lived, in-memory LRU result cache in `SwarmCoordinator`. Identical queries within a 10-second TTL window return instantly from cache. Cache is invalidated on `store()` (content changed) and `refreshHealth()` (provider availability changed). Configurable via `performance.result_cache_ttl_ms` (default 10s, 0 disables).
- **What did NOT change (scope boundary):** No changes to the query pipeline, provider adapters, search precision, result merging, write routing, CLI output formatting, or agent tool interface. The cache is fully transparent — same `SwarmQueryResult` type, same JSON output structure.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [x] Agent / Tools
- [ ] LLM Providers
- [ ] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes ENG-2073

## Root cause (bug fixes only, otherwise write `N/A`)

N/A

## Test plan

- Coverage added:
  - [x] Unit test
  - [ ] Integration test
  - [x] Manual verification only
- Test file(s):
  - `test/unit/agent/swarm/swarm-coordinator.test.ts` (+12 tests)
  - `test/unit/agent/swarm/provider-factory.test.ts` (type alignment)
- Key scenario(s) covered:
  - Cache hit: identical query → graph not called, result returned in 0ms
  - Cache hit: case insensitive ("JWT Refresh" → "jwt refresh")
  - Cache hit: whitespace normalized ("jwt  refresh" → "jwt refresh")
  - Cache miss: different query, different scope, different maxResults
  - TTL expiry: wait > TTL → cache miss, full re-execution
  - TTL 0: disables caching entirely
  - Invalidation: `store()` clears cache on successful write
  - Invalidation: `refreshHealth()` clears cache
  - LRU eviction: 21 queries → oldest entry evicted, newest retained
  - Mutation safety: mutating returned result doesn't corrupt cache
  - Clone verification: cached results are different object references
- Manual verification (in-process):
  - First query: 417ms → cached: 0ms → after store invalidation: 248ms

## User-visible changes

- New config option: `performance.result_cache_ttl_ms` (default: 10000, 0 to disable)
- Agent tool `swarm_query` returns faster on repeated identical queries within 10s
- No change to CLI behavior (each CLI invocation creates a new coordinator)
- No change to output format or structure

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

**In-process manual test:**
```
Test 1: First query        417ms, 7 results
Test 2: Cached (same)        0ms, 7 results  PASS
Test 3: Cached (CAPS)        0ms, 7 results  PASS
Test 4: Cache miss (new)   256ms, 1 results  PASS
Test 5: Mutation safety    results intact     PASS
Test 6: After store()     248ms, re-executed  PASS
```

## Checklist

- [x] Tests added or updated and passing (`npm test`) — 5892 passing
- [x] Lint passes (`npm run lint`) — pre-commit hook verified
- [ ] Type check passes (`npm run typecheck`)
- [ ] Build succeeds (`npm run build`)
- [x] Commits follow Conventional Commits format
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented above)
- [ ] Branch is up to date with `main`

## Risks and mitigations

- **Risk:** Cached result returned by reference could be mutated by downstream consumers, corrupting the cache.
  - **Mitigation:** Both cache store and cache hit clone the result object (`{...result, results: [...result.results]}`). Verified by `mutation-safe` test.

- **Risk:** Cache key collision if query text contains the delimiter character.
  - **Mitigation:** Cache key uses `JSON.stringify([query, scope, maxResults])` — no delimiter ambiguity.

- **Risk:** Stale TTL-expired entries could accumulate in memory.
  - **Mitigation:** Expired entries are deleted on access. Max 20 entries with LRU eviction. Cache dies with the coordinator instance (one per agent session).

- **Risk:** `totalQueries` counter could undercount when cache hits bypass the main execute path.
  - **Mitigation:** `totalQueries++` is called on both cache hit and cache miss paths.