### PR TITLE
feat: [ENG-2070] Dream undo — revert last dream from previousTexts

### DIFF
--- a/src/oclif/commands/dream.ts
+++ b/src/oclif/commands/dream.ts
@@ -2,8 +2,15 @@ import type {ITransportClient, TaskAck} from '@campfirein/brv-transport-client'
 
 import {Command, Flags} from '@oclif/core'
 import {randomUUID} from 'node:crypto'
+import {join} from 'node:path'
 
+import {BRV_DIR, CONTEXT_TREE_DIR} from '../../server/constants.js'
 import {type ProviderConfigResponse, TransportStateEventNames} from '../../server/core/domain/transport/schemas.js'
+import {FileContextTreeManifestService} from '../../server/infra/context-tree/file-context-tree-manifest-service.js'
+import {DreamLogStore} from '../../server/infra/dream/dream-log-store.js'
+import {DreamStateService} from '../../server/infra/dream/dream-state-service.js'
+import {undoLastDream} from '../../server/infra/dream/dream-undo.js'
+import {resolveProject} from '../../server/infra/project/resolve-project.js'
 import {TaskEvents} from '../../shared/transport/events/index.js'
 import {
   type DaemonClientOptions,
@@ -25,6 +32,9 @@ export default class Dream extends Command {
     '# Force dream (skip time/activity/queue gates, lock still checked)',
     '<%= config.bin %> <%= command.id %> --force',
     '',
+    '# Revert the last dream',
+    '<%= config.bin %> <%= command.id %> --undo',
+    '',
     '# JSON output',
     '<%= config.bin %> <%= command.id %> --format json',
   ]
@@ -45,6 +55,10 @@ export default class Dream extends Command {
       max: MAX_TIMEOUT_SECONDS,
       min: MIN_TIMEOUT_SECONDS,
     }),
+    undo: Flags.boolean({
+      default: false,
+      description: 'Revert the last dream',
+    }),
   }
 
   protected getDaemonClientOptions(): DaemonClientOptions {
@@ -54,6 +68,11 @@ export default class Dream extends Command {
   public async run(): Promise<void> {
     const {flags: rawFlags} = await this.parse(Dream)
     const format = rawFlags.format === 'json' ? 'json' : 'text'
+
+    if (rawFlags.undo) {
+      await this.runUndo(format)
+      return
+    }
 
     let providerContext: ProviderErrorContext | undefined
 
@@ -110,6 +129,43 @@ export default class Dream extends Command {
     if (hasLeakedHandles(error)) {
       // eslint-disable-next-line n/no-process-exit, unicorn/no-process-exit
       process.exit(1)
+    }
+  }
+
+  private async runUndo(format: 'json' | 'text'): Promise<void> {
+    const projectRoot = resolveProject()?.projectRoot ?? process.cwd()
+    const brvDir = join(projectRoot, BRV_DIR)
+    const contextTreeDir = join(brvDir, CONTEXT_TREE_DIR)
+
+    try {
+      const result = await undoLastDream({
+        contextTreeDir,
+        dreamLogStore: new DreamLogStore({baseDir: brvDir}),
+        dreamStateService: new DreamStateService({baseDir: brvDir}),
+        manifestService: new FileContextTreeManifestService({baseDirectory: projectRoot}),
+      })
+
+      if (format === 'json') {
+        writeJsonResponse({command: 'dream', data: {...result, status: 'undone'}, success: true})
+      } else {
+        this.log(`Undone dream ${result.dreamId}`)
+        this.log(`  Restored: ${result.restoredFiles.length} files`)
+        this.log(`  Deleted: ${result.deletedFiles.length} files`)
+        this.log(`  Restored archives: ${result.restoredArchives.length} files`)
+        if (result.errors.length > 0) {
+          this.log(`  Errors: ${result.errors.length}`)
+          for (const e of result.errors) {
+            this.log(`    - ${e}`)
+          }
+        }
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Undo failed'
+      if (format === 'json') {
+        writeJsonResponse({command: 'dream', data: {error: message, status: 'error'}, success: false})
+      } else {
+        this.log(`Undo failed: ${message}`)
+      }
     }
   }
 

--- a/src/server/infra/dream/dream-undo.ts
+++ b/src/server/infra/dream/dream-undo.ts
@@ -1,0 +1,238 @@
+/**
+ * Dream Undo — reverts the last dream's file changes using previousTexts from the dream log.
+ *
+ * Runs directly from CLI (no daemon/agent needed). Pure file I/O.
+ * Only undoes the LAST dream — not a history stack.
+ */
+
+import {mkdir, unlink, writeFile} from 'node:fs/promises'
+import {dirname, join} from 'node:path'
+
+import type {DreamLogEntry, DreamOperation} from './dream-log-schema.js'
+import type {DreamState} from './dream-state-schema.js'
+
+export type DreamUndoDeps = {
+  archiveService?: {restoreEntry(stubPath: string, directory?: string): Promise<string>}
+  contextTreeDir: string
+  dreamLogStore: {
+    getById(id: string): Promise<DreamLogEntry | null>
+    save(entry: DreamLogEntry): Promise<void>
+  }
+  dreamStateService: {
+    read(): Promise<DreamState>
+    write(state: DreamState): Promise<void>
+  }
+  manifestService: {buildManifest(dir?: string): Promise<unknown>}
+}
+
+export interface DreamUndoResult {
+  deletedFiles: string[]
+  dreamId: string
+  errors: string[]
+  restoredArchives: string[]
+  restoredFiles: string[]
+}
+
+export async function undoLastDream(deps: DreamUndoDeps): Promise<DreamUndoResult> {
+  const {contextTreeDir, dreamLogStore, dreamStateService, manifestService} = deps
+
+  // ── Precondition checks ─────────────────────────────────────────────────
+  const state = await dreamStateService.read()
+  if (!state.lastDreamLogId) {
+    throw new Error('No dream to undo')
+  }
+
+  const log = await dreamLogStore.getById(state.lastDreamLogId)
+  if (!log) {
+    throw new Error(`Dream log not found: ${state.lastDreamLogId}`)
+  }
+
+  if (log.status === 'undone') {
+    throw new Error(`Dream already undone: ${state.lastDreamLogId}`)
+  }
+
+  if (log.status !== 'completed' && log.status !== 'partial') {
+    throw new Error(`Cannot undo dream with status: ${log.status}`)
+  }
+
+  // ── Reverse operations ──────────────────────────────────────────────────
+  const result: DreamUndoResult = {
+    deletedFiles: [],
+    dreamId: log.id,
+    errors: [],
+    restoredArchives: [],
+    restoredFiles: [],
+  }
+
+  // Track pending merges to remove (for PRUNE/SUGGEST_MERGE)
+  const mergesToRemove: Array<{mergeTarget: string; sourceFile: string}> = []
+
+  const reversed = [...log.operations].reverse()
+  for (const op of reversed) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      await undoOperation(op, {contextTreeDir, deps, mergesToRemove, result})
+    } catch (error) {
+      result.errors.push(error instanceof Error ? error.message : String(error))
+    }
+  }
+
+  // ── Post-undo: rebuild manifest ─────────────────────────────────────────
+  try {
+    await manifestService.buildManifest(contextTreeDir)
+  } catch {
+    // Manifest rebuild is best-effort
+  }
+
+  // ── Post-undo: mark log as undone ───────────────────────────────────────
+  const undoneLog: DreamLogEntry = {
+    completedAt: 'completedAt' in log ? (log.completedAt as number) : Date.now(),
+    id: log.id,
+    operations: log.operations,
+    startedAt: log.startedAt,
+    status: 'undone',
+    summary: log.summary,
+    trigger: log.trigger,
+    undoneAt: Date.now(),
+  }
+  await dreamLogStore.save(undoneLog)
+
+  // ── Post-undo: rewind dream state ───────────────────────────────────────
+  let {pendingMerges} = state
+  if (mergesToRemove.length > 0) {
+    pendingMerges = (pendingMerges ?? []).filter(
+      (pm) => !mergesToRemove.some((rm) => rm.sourceFile === pm.sourceFile && rm.mergeTarget === pm.mergeTarget),
+    )
+  }
+
+  await dreamStateService.write({
+    ...state,
+    lastDreamAt: null,
+    pendingMerges,
+    totalDreams: Math.max(0, state.totalDreams - 1),
+  })
+
+  return result
+}
+
+// ── Per-operation undo handlers ───────────────────────────────────────────────
+
+type UndoContext = {
+  contextTreeDir: string
+  deps: DreamUndoDeps
+  mergesToRemove: Array<{mergeTarget: string; sourceFile: string}>
+  result: DreamUndoResult
+}
+
+async function undoOperation(op: DreamOperation, ctx: UndoContext): Promise<void> {
+  switch (op.type) {
+    case 'CONSOLIDATE': {
+      await undoConsolidate(op, ctx.contextTreeDir, ctx.result)
+      break
+    }
+
+    case 'PRUNE': {
+      await undoPrune(op, ctx)
+      break
+    }
+
+    case 'SYNTHESIZE': {
+      await undoSynthesize(op, ctx.contextTreeDir, ctx.result)
+      break
+    }
+  }
+}
+
+async function undoConsolidate(
+  op: Extract<DreamOperation, {type: 'CONSOLIDATE'}>,
+  contextTreeDir: string,
+  result: DreamUndoResult,
+): Promise<void> {
+  switch (op.action) {
+    case 'CROSS_REFERENCE': {
+      // Non-destructive — skip
+      break
+    }
+
+    case 'MERGE': {
+      if (!op.previousTexts || Object.keys(op.previousTexts).length === 0) {
+        throw new Error(`Cannot undo MERGE: missing previousTexts for ${op.outputFile ?? op.inputFiles[0]}`)
+      }
+
+      // Restore all source files from previousTexts
+      for (const [filePath, content] of Object.entries(op.previousTexts)) {
+        const fullPath = join(contextTreeDir, filePath)
+        // eslint-disable-next-line no-await-in-loop
+        await mkdir(dirname(fullPath), {recursive: true})
+        // eslint-disable-next-line no-await-in-loop
+        await writeFile(fullPath, content, 'utf8')
+        result.restoredFiles.push(filePath)
+      }
+
+      // Delete merged output if it wasn't an original source
+      if (op.outputFile && !op.previousTexts[op.outputFile]) {
+        await unlink(join(contextTreeDir, op.outputFile)).catch(() => {})
+        result.deletedFiles.push(op.outputFile)
+      }
+
+      break
+    }
+
+    case 'TEMPORAL_UPDATE': {
+      if (!op.previousTexts || Object.keys(op.previousTexts).length === 0) {
+        throw new Error(`Cannot undo TEMPORAL_UPDATE: missing previousTexts for ${op.inputFiles[0]}`)
+      }
+
+      for (const [filePath, content] of Object.entries(op.previousTexts)) {
+        const fullPath = join(contextTreeDir, filePath)
+        // eslint-disable-next-line no-await-in-loop
+        await mkdir(dirname(fullPath), {recursive: true})
+        // eslint-disable-next-line no-await-in-loop
+        await writeFile(fullPath, content, 'utf8')
+        result.restoredFiles.push(filePath)
+      }
+
+      break
+    }
+  }
+}
+
+async function undoSynthesize(
+  op: Extract<DreamOperation, {type: 'SYNTHESIZE'}>,
+  contextTreeDir: string,
+  result: DreamUndoResult,
+): Promise<void> {
+  // Delete the synthesized file
+  await unlink(join(contextTreeDir, op.outputFile)).catch(() => {})
+  result.deletedFiles.push(op.outputFile)
+}
+
+async function undoPrune(
+  op: Extract<DreamOperation, {type: 'PRUNE'}>,
+  ctx: UndoContext,
+): Promise<void> {
+  switch (op.action) {
+    case 'ARCHIVE': {
+      if (!ctx.deps.archiveService) {
+        throw new Error(`Cannot undo PRUNE/ARCHIVE: no archive service available for ${op.file}`)
+      }
+
+      const restored = await ctx.deps.archiveService.restoreEntry(op.file, ctx.contextTreeDir)
+      ctx.result.restoredArchives.push(restored)
+      break
+    }
+
+    case 'KEEP': {
+      // No-op — nothing was changed
+      break
+    }
+
+    case 'SUGGEST_MERGE': {
+      if (op.mergeTarget) {
+        ctx.mergesToRemove.push({mergeTarget: op.mergeTarget, sourceFile: op.file})
+      }
+
+      break
+    }
+  }
+}

--- a/src/server/infra/dream/dream-undo.ts
+++ b/src/server/infra/dream/dream-undo.ts
@@ -6,7 +6,7 @@
  */
 
 import {mkdir, unlink, writeFile} from 'node:fs/promises'
-import {dirname, join} from 'node:path'
+import {dirname, resolve} from 'node:path'
 
 import type {DreamLogEntry, DreamOperation} from './dream-log-schema.js'
 import type {DreamState} from './dream-state-schema.js'
@@ -80,13 +80,13 @@ export async function undoLastDream(deps: DreamUndoDeps): Promise<DreamUndoResul
   // ── Post-undo: rebuild manifest ─────────────────────────────────────────
   try {
     await manifestService.buildManifest(contextTreeDir)
-  } catch {
-    // Manifest rebuild is best-effort
+  } catch (error) {
+    result.errors.push(`Manifest rebuild failed: ${error instanceof Error ? error.message : String(error)}`)
   }
 
   // ── Post-undo: mark log as undone ───────────────────────────────────────
   const undoneLog: DreamLogEntry = {
-    completedAt: 'completedAt' in log ? (log.completedAt as number) : Date.now(),
+    completedAt: log.completedAt,
     id: log.id,
     operations: log.operations,
     startedAt: log.startedAt,
@@ -113,6 +113,25 @@ export async function undoLastDream(deps: DreamUndoDeps): Promise<DreamUndoResul
   })
 
   return result
+}
+
+/** Unlink a file, ignoring ENOENT (already gone) but rethrowing other errors. */
+async function unlinkSafe(filePath: string): Promise<void> {
+  try {
+    await unlink(filePath)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+  }
+}
+
+/** Resolve a relative path within contextTreeDir, rejecting traversal outside the tree. */
+function safePath(contextTreeDir: string, relativePath: string): string {
+  const full = resolve(contextTreeDir, relativePath)
+  if (!full.startsWith(contextTreeDir + '/') && full !== contextTreeDir) {
+    throw new Error(`Path traversal blocked: ${relativePath}`)
+  }
+
+  return full
 }
 
 // ── Per-operation undo handlers ───────────────────────────────────────────────
@@ -161,7 +180,7 @@ async function undoConsolidate(
 
       // Restore all source files from previousTexts
       for (const [filePath, content] of Object.entries(op.previousTexts)) {
-        const fullPath = join(contextTreeDir, filePath)
+        const fullPath = safePath(contextTreeDir, filePath)
         // eslint-disable-next-line no-await-in-loop
         await mkdir(dirname(fullPath), {recursive: true})
         // eslint-disable-next-line no-await-in-loop
@@ -171,7 +190,7 @@ async function undoConsolidate(
 
       // Delete merged output if it wasn't an original source
       if (op.outputFile && !op.previousTexts[op.outputFile]) {
-        await unlink(join(contextTreeDir, op.outputFile)).catch(() => {})
+        await unlinkSafe(safePath(contextTreeDir, op.outputFile))
         result.deletedFiles.push(op.outputFile)
       }
 
@@ -184,7 +203,7 @@ async function undoConsolidate(
       }
 
       for (const [filePath, content] of Object.entries(op.previousTexts)) {
-        const fullPath = join(contextTreeDir, filePath)
+        const fullPath = safePath(contextTreeDir, filePath)
         // eslint-disable-next-line no-await-in-loop
         await mkdir(dirname(fullPath), {recursive: true})
         // eslint-disable-next-line no-await-in-loop
@@ -202,8 +221,13 @@ async function undoSynthesize(
   contextTreeDir: string,
   result: DreamUndoResult,
 ): Promise<void> {
-  // Delete the synthesized file
-  await unlink(join(contextTreeDir, op.outputFile)).catch(() => {})
+  // UPDATE modified a pre-existing file — can't undo without previousTexts (not captured by SYNTHESIZE)
+  if (op.action === 'UPDATE') {
+    throw new Error(`Cannot undo SYNTHESIZE/UPDATE: previousTexts not captured for ${op.outputFile}`)
+  }
+
+  // CREATE — delete the synthesized file
+  await unlinkSafe(safePath(contextTreeDir, op.outputFile))
   result.deletedFiles.push(op.outputFile)
 }
 

--- a/test/unit/infra/dream/dream-undo.test.ts
+++ b/test/unit/infra/dream/dream-undo.test.ts
@@ -265,6 +265,30 @@ describe('undoLastDream', () => {
     expect(exists).to.be.false
   })
 
+  it('throws for SYNTHESIZE/UPDATE (no previousTexts to restore)', async () => {
+    await mkdir(join(ctxDir, 'auth'), {recursive: true})
+    await writeFile(join(ctxDir, 'auth/overview.md'), 'Updated content')
+
+    dreamLogStore.getById.resolves(completedLog([{
+      action: 'UPDATE',
+      confidence: 0.8,
+      needsReview: false,
+      outputFile: 'auth/overview.md',
+      sources: ['auth/jwt.md'],
+      type: 'SYNTHESIZE',
+    }]))
+
+    const result = await undoLastDream(deps)
+
+    // Error collected, file NOT deleted
+    expect(result.errors.length).to.be.greaterThan(0)
+    expect(result.errors[0]).to.include('SYNTHESIZE/UPDATE')
+    expect(result.deletedFiles).to.be.empty
+
+    const content = await readFile(join(ctxDir, 'auth/overview.md'), 'utf8')
+    expect(content).to.equal('Updated content')
+  })
+
   // ── PRUNE undo (forward-compatible) ───────────────────────────────────────
 
   it('undoes PRUNE/ARCHIVE: calls archiveService.restoreEntry', async () => {

--- a/test/unit/infra/dream/dream-undo.test.ts
+++ b/test/unit/infra/dream/dream-undo.test.ts
@@ -1,0 +1,452 @@
+import {expect} from 'chai'
+import {access, mkdir, readFile, writeFile} from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+import {restore, type SinonStub, stub} from 'sinon'
+
+import type {DreamLogEntry} from '../../../../src/server/infra/dream/dream-log-schema.js'
+
+import {EMPTY_DREAM_STATE} from '../../../../src/server/infra/dream/dream-state-schema.js'
+import {type DreamUndoDeps, undoLastDream} from '../../../../src/server/infra/dream/dream-undo.js'
+
+/** Build a completed dream log entry with optional operation overrides. */
+function completedLog(operations: DreamLogEntry['operations'] = []): DreamLogEntry {
+  return {
+    completedAt: Date.now(),
+    id: 'drm-1000',
+    operations,
+    startedAt: Date.now() - 1000,
+    status: 'completed',
+    summary: {consolidated: 0, errors: 0, flaggedForReview: 0, pruned: 0, synthesized: 0},
+    trigger: 'cli',
+  }
+}
+
+describe('undoLastDream', () => {
+  let ctxDir: string
+  let dreamLogStore: {getById: SinonStub; save: SinonStub}
+  let dreamStateService: {read: SinonStub; write: SinonStub}
+  let manifestService: {buildManifest: SinonStub}
+  let deps: DreamUndoDeps
+
+  beforeEach(async () => {
+    ctxDir = join(tmpdir(), `brv-undo-test-${Date.now()}`)
+    await mkdir(ctxDir, {recursive: true})
+
+    dreamLogStore = {
+      getById: stub().resolves(completedLog()),
+      save: stub().resolves(),
+    }
+    dreamStateService = {
+      read: stub().resolves({...EMPTY_DREAM_STATE, lastDreamLogId: 'drm-1000', totalDreams: 1}),
+      write: stub().resolves(),
+    }
+    manifestService = {
+      buildManifest: stub().resolves({}),
+    }
+
+    deps = {contextTreeDir: ctxDir, dreamLogStore, dreamStateService, manifestService}
+  })
+
+  afterEach(() => {
+    restore()
+  })
+
+  // ── Precondition checks ───────────────────────────────────────────────────
+
+  it('throws when no dream to undo (lastDreamLogId is null)', async () => {
+    dreamStateService.read.resolves({...EMPTY_DREAM_STATE})
+
+    try {
+      await undoLastDream(deps)
+      expect.fail('should have thrown')
+    } catch (error) {
+      expect((error as Error).message).to.include('No dream to undo')
+    }
+  })
+
+  it('throws when dream log not found', async () => {
+    dreamLogStore.getById.resolves(null)
+
+    try {
+      await undoLastDream(deps)
+      expect.fail('should have thrown')
+    } catch (error) {
+      expect((error as Error).message).to.include('not found')
+    }
+  })
+
+  it('throws when dream already undone', async () => {
+    const undoneLog: DreamLogEntry = {
+      completedAt: Date.now(),
+      id: 'drm-1000',
+      operations: [],
+      startedAt: Date.now() - 1000,
+      status: 'undone',
+      summary: {consolidated: 0, errors: 0, flaggedForReview: 0, pruned: 0, synthesized: 0},
+      trigger: 'cli',
+      undoneAt: Date.now(),
+    }
+    dreamLogStore.getById.resolves(undoneLog)
+
+    try {
+      await undoLastDream(deps)
+      expect.fail('should have thrown')
+    } catch (error) {
+      expect((error as Error).message).to.include('already undone')
+    }
+  })
+
+  it('throws when dream status is error', async () => {
+    const errorLog: DreamLogEntry = {
+      completedAt: Date.now(),
+      error: 'boom',
+      id: 'drm-1000',
+      operations: [],
+      startedAt: Date.now() - 1000,
+      status: 'error',
+      summary: {consolidated: 0, errors: 0, flaggedForReview: 0, pruned: 0, synthesized: 0},
+      trigger: 'cli',
+    }
+    dreamLogStore.getById.resolves(errorLog)
+
+    try {
+      await undoLastDream(deps)
+      expect.fail('should have thrown')
+    } catch (error) {
+      expect((error as Error).message).to.include('Cannot undo')
+    }
+  })
+
+  it('allows undo of partial dreams', async () => {
+    const partialLog: DreamLogEntry = {
+      abortReason: 'Timeout',
+      completedAt: Date.now(),
+      id: 'drm-1000',
+      operations: [],
+      startedAt: Date.now() - 1000,
+      status: 'partial',
+      summary: {consolidated: 0, errors: 0, flaggedForReview: 0, pruned: 0, synthesized: 0},
+      trigger: 'cli',
+    }
+    dreamLogStore.getById.resolves(partialLog)
+
+    const result = await undoLastDream(deps)
+    expect(result.dreamId).to.equal('drm-1000')
+  })
+
+  // ── CONSOLIDATE/MERGE undo ────────────────────────────────────────────────
+
+  it('undoes MERGE: restores source files from previousTexts', async () => {
+    await mkdir(join(ctxDir, 'auth'), {recursive: true})
+    await writeFile(join(ctxDir, 'auth/login.md'), 'Merged content')
+
+    dreamLogStore.getById.resolves(completedLog([{
+      action: 'MERGE',
+      inputFiles: ['auth/login.md', 'auth/login-v2.md'],
+      needsReview: true,
+      outputFile: 'auth/login.md',
+      previousTexts: {
+        'auth/login-v2.md': 'Original login-v2 content',
+        'auth/login.md': 'Original login content',
+      },
+      reason: 'Redundant',
+      type: 'CONSOLIDATE',
+    }]))
+
+    const result = await undoLastDream(deps)
+
+    expect(result.restoredFiles).to.include('auth/login.md')
+    expect(result.restoredFiles).to.include('auth/login-v2.md')
+
+    const login = await readFile(join(ctxDir, 'auth/login.md'), 'utf8')
+    expect(login).to.equal('Original login content')
+    const loginV2 = await readFile(join(ctxDir, 'auth/login-v2.md'), 'utf8')
+    expect(loginV2).to.equal('Original login-v2 content')
+  })
+
+  it('undoes MERGE: deletes output file when not in previousTexts', async () => {
+    await mkdir(join(ctxDir, 'auth'), {recursive: true})
+    await writeFile(join(ctxDir, 'auth/combined.md'), 'Merged content')
+
+    dreamLogStore.getById.resolves(completedLog([{
+      action: 'MERGE',
+      inputFiles: ['auth/a.md', 'auth/b.md'],
+      needsReview: true,
+      outputFile: 'auth/combined.md',
+      previousTexts: {
+        'auth/a.md': 'Content A',
+        'auth/b.md': 'Content B',
+      },
+      reason: 'Merge',
+      type: 'CONSOLIDATE',
+    }]))
+
+    const result = await undoLastDream(deps)
+
+    expect(result.deletedFiles).to.include('auth/combined.md')
+    expect(result.restoredFiles).to.include('auth/a.md')
+    expect(result.restoredFiles).to.include('auth/b.md')
+
+    let exists = true
+    try {
+      await access(join(ctxDir, 'auth/combined.md'))
+    } catch {
+      exists = false
+    }
+
+    expect(exists).to.be.false
+  })
+
+  // ── CONSOLIDATE/TEMPORAL_UPDATE undo ──────────────────────────────────────
+
+  it('undoes TEMPORAL_UPDATE: restores original content', async () => {
+    await mkdir(join(ctxDir, 'api'), {recursive: true})
+    await writeFile(join(ctxDir, 'api/rate-limits.md'), 'Updated content')
+
+    dreamLogStore.getById.resolves(completedLog([{
+      action: 'TEMPORAL_UPDATE',
+      inputFiles: ['api/rate-limits.md'],
+      needsReview: true,
+      previousTexts: {'api/rate-limits.md': 'Original rate limits'},
+      reason: 'Outdated',
+      type: 'CONSOLIDATE',
+    }]))
+
+    const result = await undoLastDream(deps)
+
+    expect(result.restoredFiles).to.include('api/rate-limits.md')
+    const content = await readFile(join(ctxDir, 'api/rate-limits.md'), 'utf8')
+    expect(content).to.equal('Original rate limits')
+  })
+
+  // ── CONSOLIDATE/CROSS_REFERENCE undo ──────────────────────────────────────
+
+  it('skips CROSS_REFERENCE (non-destructive)', async () => {
+    dreamLogStore.getById.resolves(completedLog([{
+      action: 'CROSS_REFERENCE',
+      inputFiles: ['auth/jwt.md', 'auth/oauth.md'],
+      needsReview: false,
+      reason: 'Related',
+      type: 'CONSOLIDATE',
+    }]))
+
+    const result = await undoLastDream(deps)
+
+    expect(result.restoredFiles).to.be.empty
+    expect(result.deletedFiles).to.be.empty
+  })
+
+  // ── SYNTHESIZE undo (forward-compatible) ──────────────────────────────────
+
+  it('undoes SYNTHESIZE: deletes created file', async () => {
+    await mkdir(join(ctxDir, 'auth'), {recursive: true})
+    await writeFile(join(ctxDir, 'auth/overview.md'), 'Synthesized content')
+
+    dreamLogStore.getById.resolves(completedLog([{
+      action: 'CREATE',
+      confidence: 0.9,
+      needsReview: false,
+      outputFile: 'auth/overview.md',
+      sources: ['auth/jwt.md', 'auth/oauth.md'],
+      type: 'SYNTHESIZE',
+    }]))
+
+    const result = await undoLastDream(deps)
+
+    expect(result.deletedFiles).to.include('auth/overview.md')
+    let exists = true
+    try {
+      await access(join(ctxDir, 'auth/overview.md'))
+    } catch {
+      exists = false
+    }
+
+    expect(exists).to.be.false
+  })
+
+  // ── PRUNE undo (forward-compatible) ───────────────────────────────────────
+
+  it('undoes PRUNE/ARCHIVE: calls archiveService.restoreEntry', async () => {
+    const archiveService = {restoreEntry: stub().resolves('auth/old-doc.md')}
+
+    dreamLogStore.getById.resolves(completedLog([{
+      action: 'ARCHIVE',
+      file: 'auth/old-doc.md',
+      needsReview: false,
+      reason: 'Stale',
+      type: 'PRUNE',
+    }]))
+
+    const result = await undoLastDream({...deps, archiveService})
+
+    expect(archiveService.restoreEntry.calledOnce).to.be.true
+    expect(result.restoredArchives).to.include('auth/old-doc.md')
+  })
+
+  it('skips PRUNE/KEEP (no-op)', async () => {
+    dreamLogStore.getById.resolves(completedLog([{
+      action: 'KEEP',
+      file: 'auth/important.md',
+      needsReview: false,
+      reason: 'Active',
+      type: 'PRUNE',
+    }]))
+
+    const result = await undoLastDream(deps)
+    expect(result.restoredFiles).to.be.empty
+    expect(result.deletedFiles).to.be.empty
+  })
+
+  it('undoes PRUNE/SUGGEST_MERGE: removes from pendingMerges', async () => {
+    dreamStateService.read.resolves({
+      ...EMPTY_DREAM_STATE,
+      lastDreamLogId: 'drm-1000',
+      pendingMerges: [
+        {mergeTarget: 'auth/target.md', sourceFile: 'auth/source.md'},
+        {mergeTarget: 'api/other.md', sourceFile: 'api/src.md'},
+      ],
+      totalDreams: 1,
+    })
+
+    dreamLogStore.getById.resolves(completedLog([{
+      action: 'SUGGEST_MERGE',
+      file: 'auth/source.md',
+      mergeTarget: 'auth/target.md',
+      needsReview: false,
+      reason: 'Similar',
+      type: 'PRUNE',
+    }]))
+
+    await undoLastDream(deps)
+
+    const writtenState = dreamStateService.write.firstCall.args[0]
+    expect(writtenState.pendingMerges).to.have.lengthOf(1)
+    expect(writtenState.pendingMerges[0].sourceFile).to.equal('api/src.md')
+  })
+
+  // ── Post-undo checks ─────────────────────────────────────────────────────
+
+  it('marks dream log as undone with undoneAt', async () => {
+    const result = await undoLastDream(deps)
+
+    expect(result.dreamId).to.equal('drm-1000')
+
+    const savedLog = dreamLogStore.save.lastCall.args[0]
+    expect(savedLog.status).to.equal('undone')
+    expect(savedLog.undoneAt).to.be.a('number')
+    expect(savedLog.id).to.equal('drm-1000')
+  })
+
+  it('rewinds dream state: nulls lastDreamAt and decrements totalDreams', async () => {
+    dreamStateService.read.resolves({
+      ...EMPTY_DREAM_STATE,
+      lastDreamLogId: 'drm-1000',
+      totalDreams: 3,
+    })
+
+    await undoLastDream(deps)
+
+    const writtenState = dreamStateService.write.firstCall.args[0]
+    expect(writtenState.lastDreamAt).to.be.null
+    expect(writtenState.totalDreams).to.equal(2)
+  })
+
+  it('does not decrement totalDreams below zero', async () => {
+    dreamStateService.read.resolves({
+      ...EMPTY_DREAM_STATE,
+      lastDreamLogId: 'drm-1000',
+      totalDreams: 0,
+    })
+
+    await undoLastDream(deps)
+
+    const writtenState = dreamStateService.write.firstCall.args[0]
+    expect(writtenState.totalDreams).to.equal(0)
+  })
+
+  it('rebuilds manifest after undo', async () => {
+    await undoLastDream(deps)
+    expect(manifestService.buildManifest.calledOnce).to.be.true
+  })
+
+  // ── Mixed operations and partial failure ──────────────────────────────────
+
+  it('reverses operations in reverse order', async () => {
+    await mkdir(join(ctxDir, 'auth'), {recursive: true})
+    await mkdir(join(ctxDir, 'api'), {recursive: true})
+    await writeFile(join(ctxDir, 'auth/login.md'), 'Merged')
+    await writeFile(join(ctxDir, 'api/config.md'), 'Updated')
+
+    dreamLogStore.getById.resolves(completedLog([
+      {
+        action: 'MERGE',
+        inputFiles: ['auth/login.md', 'auth/signup.md'],
+        needsReview: true,
+        outputFile: 'auth/login.md',
+        previousTexts: {'auth/login.md': 'Original login', 'auth/signup.md': 'Original signup'},
+        reason: 'Merge',
+        type: 'CONSOLIDATE',
+      },
+      {
+        action: 'TEMPORAL_UPDATE',
+        inputFiles: ['api/config.md'],
+        needsReview: true,
+        previousTexts: {'api/config.md': 'Original config'},
+        reason: 'Update',
+        type: 'CONSOLIDATE',
+      },
+    ]))
+
+    const result = await undoLastDream(deps)
+
+    expect(result.restoredFiles).to.have.lengthOf(3)
+
+    const login = await readFile(join(ctxDir, 'auth/login.md'), 'utf8')
+    expect(login).to.equal('Original login')
+    const signup = await readFile(join(ctxDir, 'auth/signup.md'), 'utf8')
+    expect(signup).to.equal('Original signup')
+    const config = await readFile(join(ctxDir, 'api/config.md'), 'utf8')
+    expect(config).to.equal('Original config')
+  })
+
+  it('continues on error and collects errors', async () => {
+    await mkdir(join(ctxDir, 'api'), {recursive: true})
+    await writeFile(join(ctxDir, 'api/config.md'), 'Updated')
+
+    dreamLogStore.getById.resolves(completedLog([
+      {
+        action: 'MERGE',
+        inputFiles: ['auth/a.md', 'auth/b.md'],
+        needsReview: true,
+        outputFile: 'auth/a.md',
+        // No previousTexts — will cause error
+        reason: 'Merge',
+        type: 'CONSOLIDATE',
+      },
+      {
+        action: 'TEMPORAL_UPDATE',
+        inputFiles: ['api/config.md'],
+        needsReview: true,
+        previousTexts: {'api/config.md': 'Original'},
+        reason: 'Update',
+        type: 'CONSOLIDATE',
+      },
+    ]))
+
+    const result = await undoLastDream(deps)
+
+    expect(result.errors.length).to.be.greaterThan(0)
+    expect(result.restoredFiles).to.include('api/config.md')
+  })
+
+  it('returns empty result for dream with no operations', async () => {
+    const result = await undoLastDream(deps)
+
+    expect(result.dreamId).to.equal('drm-1000')
+    expect(result.restoredFiles).to.be.empty
+    expect(result.deletedFiles).to.be.empty
+    expect(result.restoredArchives).to.be.empty
+    expect(result.errors).to.be.empty
+  })
+})


### PR DESCRIPTION
## Summary

- Problem: No way to revert dream operations if consolidation produces unwanted results
- Why it matters: Users need a safety net to trust automated consolidation — undo builds that trust
- What changed: Added `brv dream --undo` CLI flag and `dream-undo.ts` reversal logic
- What did NOT change (scope boundary): No daemon task type changes, no schema changes, no agent/LLM involvement

## Type of change

- [x] New feature

## Scope (select all touched areas)

- [x] Server / Daemon
- [x] CLI Commands (oclif)

## Linked issues

- Closes ENG-2070
- Related ENG-2060

## Root cause (bug fixes only, otherwise write `N/A`)

N/A

## Test plan

- Coverage added:
  - [x] Unit test
  - [x] Manual verification only
- Test file(s): `test/unit/infra/dream/dream-undo.test.ts`
- Key scenario(s) covered:
  - Precondition checks: no dream, log not found, already undone, invalid status
  - MERGE undo: restore from previousTexts, delete new output files
  - TEMPORAL_UPDATE undo: restore original content
  - CROSS_REFERENCE: skip (non-destructive)
  - SYNTHESIZE undo: delete created file (forward-compatible)
  - PRUNE/ARCHIVE: archive service restore (forward-compatible)
  - PRUNE/KEEP: no-op, PRUNE/SUGGEST_MERGE: remove from pendingMerges
  - Post-undo: log marked undone, state rewound, manifest rebuilt
  - Mixed operations reversed in order, partial failure resilience
  - Interactive: ran 10+ curate commands, dream with 3 MERGEs + 1 CROSS_REF, undo restored all 9 files (MD5 verified), double undo error, re-dream after undo, JSON output

## User-visible changes

- New `brv dream --undo` flag reverts the last dream
- Text output: `Undone dream drm-XXXX` with file counts
- JSON output: `{ status: "undone", dreamId, restoredFiles, deletedFiles, restoredArchives, errors }`
- Error messages: "No dream to undo", "Dream already undone", "Cannot undo dream with status: X"

## Evidence

Interactive testing verified:
- 3 MERGE operations undone: 6 deleted files recreated, 3 output files restored to original content
- MD5 hash comparison confirmed byte-identical restoration
- State correctly rewound: `lastDreamAt: null`, `totalDreams` decremented
- Re-dream ran immediately after undo (proved `lastDreamAt` reset works)

## Checklist

- [x] Tests added or updated and passing (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow Conventional Commits format
- [x] No breaking changes

## Risks and mitigations

- Risk: Undo runs directly from CLI without daemon — bypasses daemon project resolution
  - Mitigation: Uses `resolveProject()` (same utility daemon uses) for project resolution. Pure file I/O with no agent/LLM needed.
- Risk: CROSS_REFERENCE frontmatter links not reverted on undo
  - Mitigation: By design — non-destructive changes. Documented in plan as accepted limitation.