### PR TITLE
feat: add gpt-5.4-mini to Codex allowed models

### DIFF
--- a/src/server/infra/http/provider-model-fetchers.ts
+++ b/src/server/infra/http/provider-model-fetchers.ts
@@ -168,6 +168,7 @@ export const CODEX_ALLOWED_MODELS = new Set([
   'gpt-5.2-codex',
   'gpt-5.3-codex',
   'gpt-5.4',
+  'gpt-5.4-mini',
 ])
 
 /**


### PR DESCRIPTION
## Summary

- Adds `gpt-5.4-mini` to the `CODEX_ALLOWED_MODELS` allowlist in `src/server/infra/http/provider-model-fetchers.ts`
- This enables users to select and use the GPT-5.4-mini model via the Codex endpoint

Closes #391