### PR TITLE
feat: [ENG-2061] Synthesize operation — cross-domain pattern detection

### DIFF
--- a/src/agent/core/interfaces/i-cipher-agent.ts
+++ b/src/agent/core/interfaces/i-cipher-agent.ts
@@ -156,7 +156,7 @@ export interface ICipherAgent {
   executeOnSession(
     sessionId: string,
     input: string,
-    options?: {executionContext?: ExecutionContext; taskId?: string},
+    options?: {executionContext?: ExecutionContext; signal?: AbortSignal; taskId?: string},
   ): Promise<string>
 
   /**

--- a/src/agent/infra/agent/cipher-agent.ts
+++ b/src/agent/infra/agent/cipher-agent.ts
@@ -436,13 +436,14 @@ export class CipherAgent extends BaseAgent implements ICipherAgent {
   public async executeOnSession(
     sessionId: string,
     input: string,
-    options?: {executionContext?: ExecutionContext; taskId?: string},
+    options?: {executionContext?: ExecutionContext; signal?: AbortSignal; taskId?: string},
   ): Promise<string> {
     this.ensureStarted()
 
     const response = await this.generate(input, {
       executionContext: options?.executionContext,
       sessionId,
+      signal: options?.signal,
       taskId: options?.taskId,
     })
 

--- a/src/server/infra/dream/dream-undo.ts
+++ b/src/server/infra/dream/dream-undo.ts
@@ -79,7 +79,7 @@ export async function undoLastDream(deps: DreamUndoDeps): Promise<DreamUndoResul
 
   // ── Post-undo: rebuild manifest ─────────────────────────────────────────
   try {
-    await manifestService.buildManifest(contextTreeDir)
+    await manifestService.buildManifest()
   } catch (error) {
     result.errors.push(`Manifest rebuild failed: ${error instanceof Error ? error.message : String(error)}`)
   }

--- a/src/server/infra/dream/operations/consolidate.ts
+++ b/src/server/infra/dream/operations/consolidate.ts
@@ -91,6 +91,7 @@ async function processDomain(domain: string, files: string[], deps: ConsolidateD
     const prompt = buildPrompt(files, [...relatedPaths], Object.keys(filesPayload))
     const response = await agent.executeOnSession(sessionId, prompt, {
       executionContext: {commandType: 'curate', maxIterations: 10},
+      signal: deps.signal,
       taskId,
     })
 

--- a/src/server/infra/dream/operations/synthesize.ts
+++ b/src/server/infra/dream/operations/synthesize.ts
@@ -11,10 +11,10 @@
  * Never throws — returns empty array on errors.
  */
 
-import {load as yamlLoad} from 'js-yaml'
+import {dump as yamlDump, load as yamlLoad} from 'js-yaml'
 import {randomUUID} from 'node:crypto'
 import {access, mkdir, readdir, readFile, rename, writeFile} from 'node:fs/promises'
-import {dirname, join} from 'node:path'
+import {dirname, join, resolve} from 'node:path'
 
 import type {ICipherAgent} from '../../../../agent/core/interfaces/i-cipher-agent.js'
 import type {DreamOperation} from '../dream-log-schema.js'
@@ -73,6 +73,7 @@ export async function synthesize(deps: SynthesizeDeps): Promise<DreamOperation[]
     const prompt = buildPrompt(domains, existingSyntheses)
     const response = await agent.executeOnSession(sessionId, prompt, {
       executionContext: {commandType: 'curate', maxIterations: 10},
+      signal: deps.signal,
       taskId,
     })
 
@@ -90,12 +91,16 @@ export async function synthesize(deps: SynthesizeDeps): Promise<DreamOperation[]
 
     if (novel.length === 0) return []
 
-    // Step 5: Write synthesis files
+    // Step 5: Write synthesis files (per-candidate error handling to preserve partial results)
     const results: DreamOperation[] = []
     for (const candidate of novel) {
-      // eslint-disable-next-line no-await-in-loop
-      const op = await writeSynthesisFile(candidate, contextTreeDir)
-      if (op) results.push(op)
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        const op = await writeSynthesisFile(candidate, contextTreeDir)
+        if (op) results.push(op)
+      } catch {
+        // Skip failed candidate — don't discard already-written results
+      }
     }
 
     return results
@@ -186,9 +191,9 @@ function parseFrontmatterType(content: string): string | undefined {
 
   try {
     const yamlBlock = content.slice(4, actualEnd)
-    const parsed = yamlLoad(yamlBlock) as null | Record<string, unknown>
-    if (parsed && typeof parsed === 'object' && typeof parsed.type === 'string') {
-      return parsed.type
+    const raw = yamlLoad(yamlBlock)
+    if (raw !== null && typeof raw === 'object' && !Array.isArray(raw) && 'type' in raw && typeof raw.type === 'string') {
+      return raw.type
     }
   } catch {
     // Invalid YAML
@@ -223,7 +228,12 @@ async function writeSynthesisFile(
 ): Promise<DreamOperation | undefined> {
   const slug = slugify(candidate.title)
   const relativePath = `${candidate.placement}/${slug}.md`
-  const absPath = join(contextTreeDir, relativePath)
+  const absPath = resolve(contextTreeDir, relativePath)
+
+  // Guard against LLM-supplied path traversal (e.g. placement = "../../etc")
+  if (!absPath.startsWith(contextTreeDir + '/')) {
+    return undefined
+  }
 
   // Name collision check
   try {
@@ -234,16 +244,17 @@ async function writeSynthesisFile(
   }
 
   const sources = candidate.evidence.map((e) => `${e.domain}/_index.md`)
-  const content = [
-    '---',
-    'type: synthesis',
-    'maturity: draft',
-    `confidence: ${candidate.confidence}`,
-    'sources:',
-    ...sources.map((s) => `  - ${s}`),
-    `synthesized_at: '${new Date().toISOString()}'`,
-    '---',
-    '',
+  /* eslint-disable camelcase */
+  const frontmatter = {
+    confidence: candidate.confidence,
+    maturity: 'draft',
+    sources,
+    synthesized_at: new Date().toISOString(),
+    type: 'synthesis',
+  }
+  /* eslint-enable camelcase */
+  const yaml = yamlDump(frontmatter, {lineWidth: -1, sortKeys: true}).trimEnd()
+  const body = [
     `# ${candidate.title}`,
     '',
     candidate.claim,
@@ -253,6 +264,7 @@ async function writeSynthesisFile(
     ...candidate.evidence.map((e) => `- **${e.domain}**: ${e.fact}`),
     '',
   ].join('\n')
+  const content = `---\n${yaml}\n---\n\n${body}`
 
   await atomicWrite(absPath, content)
 

--- a/src/server/infra/dream/operations/synthesize.ts
+++ b/src/server/infra/dream/operations/synthesize.ts
@@ -79,11 +79,12 @@ export async function synthesize(deps: SynthesizeDeps): Promise<DreamOperation[]
     const parsed = parseDreamResponse(response, SynthesizeResponseSchema)
     if (!parsed || parsed.syntheses.length === 0) return []
 
-    // Step 4: Deduplicate against existing files
+    // Step 4: Deduplicate against existing synthesis files only — the whole tree
+    // will naturally score high since synthesis derives from domain summaries
     const novel: SynthesisCandidate[] = []
     for (const candidate of parsed.syntheses) {
       // eslint-disable-next-line no-await-in-loop
-      const isDuplicate = await isDuplicateCandidate(candidate, searchService)
+      const isDuplicate = await isDuplicateCandidate(candidate, existingSyntheses, searchService)
       if (!isDuplicate) novel.push(candidate)
     }
 
@@ -198,12 +199,18 @@ function parseFrontmatterType(content: string): string | undefined {
 
 async function isDuplicateCandidate(
   candidate: SynthesisCandidate,
+  existingSyntheses: string[],
   searchService: SynthesizeDeps['searchService'],
 ): Promise<boolean> {
+  if (existingSyntheses.length === 0) return false
+
   try {
     const query = `${candidate.title} ${candidate.claim}`
-    const results = await searchService.search(query, {limit: 3})
-    const topScore = results.results[0]?.score ?? 0
+    const results = await searchService.search(query, {limit: 5})
+    // Only consider matches against existing synthesis files — the whole tree
+    // will naturally score high since synthesis derives from domain summaries
+    const synthesisMatch = results.results.find((r) => existingSyntheses.includes(r.path))
+    const topScore = synthesisMatch?.score ?? 0
     return topScore >= DEDUP_THRESHOLD
   } catch {
     return false // Search failure → assume novel

--- a/src/server/infra/dream/operations/synthesize.ts
+++ b/src/server/infra/dream/operations/synthesize.ts
@@ -1,0 +1,304 @@
+/**
+ * Synthesize operation — detects cross-domain patterns from domain summaries.
+ *
+ * Flow:
+ * 1. Collect domain summaries from _index.md files
+ * 2. Collect existing synthesis files (to avoid duplicates)
+ * 3. Single LLM call for cross-domain analysis
+ * 4. Deduplicate candidates against existing files via BM25
+ * 5. Write new synthesis files as regular draft context entries
+ *
+ * Never throws — returns empty array on errors.
+ */
+
+import {load as yamlLoad} from 'js-yaml'
+import {randomUUID} from 'node:crypto'
+import {access, mkdir, readdir, readFile, rename, writeFile} from 'node:fs/promises'
+import {dirname, join} from 'node:path'
+
+import type {ICipherAgent} from '../../../../agent/core/interfaces/i-cipher-agent.js'
+import type {DreamOperation} from '../dream-log-schema.js'
+import type {SynthesisCandidate} from '../dream-response-schemas.js'
+
+import {SynthesizeResponseSchema} from '../dream-response-schemas.js'
+import {parseDreamResponse} from '../parse-dream-response.js'
+
+export type SynthesizeDeps = {
+  agent: ICipherAgent
+  contextTreeDir: string
+  searchService: {
+    search(query: string, options?: {limit?: number; scope?: string}): Promise<{results: Array<{path: string; score: number; title: string}>}>
+  }
+  signal?: AbortSignal
+  taskId: string
+}
+
+type DomainSummary = {
+  content: string
+  name: string
+}
+
+const DEDUP_THRESHOLD = 0.5
+
+/**
+ * Run synthesis on the context tree.
+ * Returns DreamOperation results (never throws).
+ */
+export async function synthesize(deps: SynthesizeDeps): Promise<DreamOperation[]> {
+  const {agent, contextTreeDir, searchService, taskId} = deps
+
+  if (deps.signal?.aborted) return []
+
+  // Step 1: Collect domain summaries
+  const domains = await collectDomainSummaries(contextTreeDir)
+  if (domains.length < 2) return []
+
+  // Step 2: Collect existing synthesis files
+  const existingSyntheses = await collectExistingSyntheses(contextTreeDir, domains)
+
+  // Step 3: LLM cross-domain analysis
+  let sessionId: string
+  try {
+    sessionId = await agent.createTaskSession(taskId, 'dream-synthesize')
+  } catch {
+    return []
+  }
+
+  try {
+    const domainPayload: Record<string, string> = {}
+    for (const d of domains) domainPayload[d.name] = d.content
+
+    agent.setSandboxVariableOnSession(sessionId, '__dream_synthesize_domains', domainPayload)
+
+    const prompt = buildPrompt(domains, existingSyntheses)
+    const response = await agent.executeOnSession(sessionId, prompt, {
+      executionContext: {commandType: 'curate', maxIterations: 10},
+      taskId,
+    })
+
+    const parsed = parseDreamResponse(response, SynthesizeResponseSchema)
+    if (!parsed || parsed.syntheses.length === 0) return []
+
+    // Step 4: Deduplicate against existing files
+    const novel: SynthesisCandidate[] = []
+    for (const candidate of parsed.syntheses) {
+      // eslint-disable-next-line no-await-in-loop
+      const isDuplicate = await isDuplicateCandidate(candidate, searchService)
+      if (!isDuplicate) novel.push(candidate)
+    }
+
+    if (novel.length === 0) return []
+
+    // Step 5: Write synthesis files
+    const results: DreamOperation[] = []
+    for (const candidate of novel) {
+      // eslint-disable-next-line no-await-in-loop
+      const op = await writeSynthesisFile(candidate, contextTreeDir)
+      if (op) results.push(op)
+    }
+
+    return results
+  } catch {
+    return []
+  } finally {
+    await agent.deleteTaskSession(sessionId).catch(() => {})
+  }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+async function collectDomainSummaries(contextTreeDir: string): Promise<DomainSummary[]> {
+  let dirNames: string[]
+  try {
+    const entries = await readdir(contextTreeDir, {withFileTypes: true})
+    dirNames = entries
+      .filter((e) => e.isDirectory())
+      .map((e) => String(e.name))
+      .filter((n) => !n.startsWith('_') && !n.startsWith('.'))
+  } catch {
+    return []
+  }
+
+  const loaded = await Promise.all(
+    dirNames.map(async (name) => {
+      try {
+        const content = await readFile(join(contextTreeDir, name, '_index.md'), 'utf8')
+        return {content, name}
+      } catch {
+        return null
+      }
+    }),
+  )
+
+  return loaded.filter((item): item is DomainSummary => item !== null)
+}
+
+async function collectExistingSyntheses(contextTreeDir: string, domains: DomainSummary[]): Promise<string[]> {
+  const syntheses: string[] = []
+
+  const domainResults = await Promise.all(
+    domains.map(async (domain) => {
+      const domainDir = join(contextTreeDir, domain.name)
+      let files: string[]
+      try {
+        const entries = await readdir(domainDir)
+        files = entries.filter((f) => f.endsWith('.md') && !f.startsWith('_'))
+      } catch {
+        return []
+      }
+
+      const found: string[] = []
+      const checks = files.map(async (file) => {
+        try {
+          const content = await readFile(join(domainDir, file), 'utf8')
+          const fm = parseFrontmatterType(content)
+          if (fm === 'synthesis') {
+            return `${domain.name}/${file}`
+          }
+        } catch {
+          // skip
+        }
+
+        return null
+      })
+      const results = await Promise.all(checks)
+      for (const r of results) {
+        if (r) found.push(r)
+      }
+
+      return found
+    }),
+  )
+
+  for (const paths of domainResults) syntheses.push(...paths)
+  return syntheses
+}
+
+/** Extract the `type` field from YAML frontmatter, or undefined. */
+function parseFrontmatterType(content: string): string | undefined {
+  if (!content.startsWith('---\n') && !content.startsWith('---\r\n')) return undefined
+
+  const endIndex = content.indexOf('\n---\n', 4)
+  const endIndexCrlf = content.indexOf('\r\n---\r\n', 5)
+  const actualEnd = endIndex === -1 ? endIndexCrlf : endIndex
+  if (actualEnd < 0) return undefined
+
+  try {
+    const yamlBlock = content.slice(4, actualEnd)
+    const parsed = yamlLoad(yamlBlock) as null | Record<string, unknown>
+    if (parsed && typeof parsed === 'object' && typeof parsed.type === 'string') {
+      return parsed.type
+    }
+  } catch {
+    // Invalid YAML
+  }
+
+  return undefined
+}
+
+async function isDuplicateCandidate(
+  candidate: SynthesisCandidate,
+  searchService: SynthesizeDeps['searchService'],
+): Promise<boolean> {
+  try {
+    const query = `${candidate.title} ${candidate.claim}`
+    const results = await searchService.search(query, {limit: 3})
+    const topScore = results.results[0]?.score ?? 0
+    return topScore >= DEDUP_THRESHOLD
+  } catch {
+    return false // Search failure → assume novel
+  }
+}
+
+async function writeSynthesisFile(
+  candidate: SynthesisCandidate,
+  contextTreeDir: string,
+): Promise<DreamOperation | undefined> {
+  const slug = slugify(candidate.title)
+  const relativePath = `${candidate.placement}/${slug}.md`
+  const absPath = join(contextTreeDir, relativePath)
+
+  // Name collision check
+  try {
+    await access(absPath)
+    return undefined // File exists — skip
+  } catch {
+    // ENOENT — good, proceed
+  }
+
+  const sources = candidate.evidence.map((e) => `${e.domain}/_index.md`)
+  const content = [
+    '---',
+    'type: synthesis',
+    'maturity: draft',
+    `confidence: ${candidate.confidence}`,
+    'sources:',
+    ...sources.map((s) => `  - ${s}`),
+    `synthesized_at: '${new Date().toISOString()}'`,
+    '---',
+    '',
+    `# ${candidate.title}`,
+    '',
+    candidate.claim,
+    '',
+    '## Evidence',
+    '',
+    ...candidate.evidence.map((e) => `- **${e.domain}**: ${e.fact}`),
+    '',
+  ].join('\n')
+
+  await atomicWrite(absPath, content)
+
+  return {
+    action: 'CREATE',
+    confidence: candidate.confidence,
+    needsReview: candidate.confidence < 0.7,
+    outputFile: relativePath,
+    sources,
+    type: 'SYNTHESIZE',
+  }
+}
+
+function slugify(title: string): string {
+  return title
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/g, '-')
+    .replaceAll(/^-|-$/g, '')
+    .slice(0, 80)
+}
+
+async function atomicWrite(filePath: string, content: string): Promise<void> {
+  await mkdir(dirname(filePath), {recursive: true})
+  const tmpPath = `${filePath}.${randomUUID()}.tmp`
+  await writeFile(tmpPath, content, 'utf8')
+  await rename(tmpPath, filePath)
+}
+
+function buildPrompt(domains: DomainSummary[], existingSyntheses: string[]): string {
+  const existingList = existingSyntheses.length > 0
+    ? `Existing synthesis files (do NOT recreate these):\n${existingSyntheses.map((s) => `- ${s}`).join('\n')}`
+    : 'No existing synthesis files.'
+
+  return [
+    'You are analyzing a knowledge base organized into domains. Each domain has a summary of its contents loaded into __dream_synthesize_domains (a JSON object mapping domain name → _index.md content).',
+    '',
+    `Domains: ${domains.map((d) => d.name).join(', ')}`,
+    '',
+    existingList,
+    '',
+    'Your job is to find cross-cutting patterns — concepts, concerns, or conflicts that span multiple domains.',
+    '',
+    'Rules:',
+    '- Only report genuinely useful insights that a developer would benefit from knowing.',
+    '- Do NOT report trivial or obvious connections.',
+    '- Each synthesis must reference at least 2 domains with specific evidence.',
+    '- For "placement", choose the domain where this insight is MOST actionable.',
+    '- If nothing meaningful is found, return an empty array. That is fine.',
+    '- Read domain summaries from __dream_synthesize_domains via code_exec before making decisions.',
+    '',
+    'Respond with JSON:',
+    '```',
+    '{ "syntheses": [{ "title": "...", "claim": "...", "evidence": [{"domain": "...", "fact": "..."}], "confidence": 0.0-1.0, "placement": "..." }] }',
+    '```',
+  ].join('\n')
+}

--- a/src/server/infra/executor/dream-executor.ts
+++ b/src/server/infra/executor/dream-executor.ts
@@ -114,13 +114,15 @@ export class DreamExecutor {
         signal: controller.signal,
         taskId: options.taskId,
       })
-      const synthesizeResults = await synthesize({
-        agent,
-        contextTreeDir,
-        searchService: this.deps.searchService,
-        signal: controller.signal,
-        taskId: options.taskId,
-      })
+      const synthesizeResults = changedFiles.size > 0
+        ? await synthesize({
+            agent,
+            contextTreeDir,
+            searchService: this.deps.searchService,
+            signal: controller.signal,
+            taskId: options.taskId,
+          })
+        : []
       const allOperations: DreamOperation[] = [...consolidateResults, ...synthesizeResults]
 
       // Step 5: Post-dream propagation (fail-open)

--- a/src/server/infra/executor/dream-executor.ts
+++ b/src/server/infra/executor/dream-executor.ts
@@ -5,7 +5,7 @@
  * 1. Capture pre-state snapshot
  * 2. Load dream state
  * 3. Find changed files since last dream (via curate log scanning)
- * 4. Run operations (NO-OP stubs in Phase 1 — consolidate/synthesize/prune added later)
+ * 4. Run operations (consolidate, synthesize; prune in ENG-2062)
  * 5. Post-dream propagation (staleness + manifest rebuild)
  * 6. Write dream log
  * 7. Update dream state
@@ -30,6 +30,7 @@ import {FileContextTreeSnapshotService} from '../context-tree/file-context-tree-
 import {FileContextTreeSummaryService} from '../context-tree/file-context-tree-summary-service.js'
 import {diffStates} from '../context-tree/snapshot-diff.js'
 import {consolidate, type ConsolidateDeps} from '../dream/operations/consolidate.js'
+import {synthesize} from '../dream/operations/synthesize.js'
 
 const DREAM_TIMEOUT_MS = 5 * 60 * 1000 // 5 minutes
 
@@ -105,7 +106,7 @@ export class DreamExecutor {
 
       // Step 3: Find changed files since last dream
       const changedFiles = await this.findChangedFilesSinceLastDream(dreamState.lastDreamAt, contextTreeDir)
-      // Step 4: Run operations (consolidate now, synthesize + prune in ENG-2061/2062)
+      // Step 4: Run operations
       const consolidateResults = await consolidate([...changedFiles], {
         agent,
         contextTreeDir,
@@ -113,7 +114,14 @@ export class DreamExecutor {
         signal: controller.signal,
         taskId: options.taskId,
       })
-      const allOperations: DreamOperation[] = [...consolidateResults]
+      const synthesizeResults = await synthesize({
+        agent,
+        contextTreeDir,
+        searchService: this.deps.searchService,
+        signal: controller.signal,
+        taskId: options.taskId,
+      })
+      const allOperations: DreamOperation[] = [...consolidateResults, ...synthesizeResults]
 
       // Step 5: Post-dream propagation (fail-open)
       if (preState) {

--- a/test/unit/infra/dream/operations/synthesize.test.ts
+++ b/test/unit/infra/dream/operations/synthesize.test.ts
@@ -207,12 +207,14 @@ describe('synthesize', () => {
 
   // ── Deduplication ─────────────────────────────────────────────────────────
 
-  it('skips candidate when BM25 score > 0.8 (already captured)', async () => {
+  it('skips candidate when existing synthesis scores > 0.5', async () => {
     await createMdFile(ctxDir, 'auth/_index.md', '# Auth', {type: 'summary'})
     await createMdFile(ctxDir, 'api/_index.md', '# API', {type: 'summary'})
+    // Existing synthesis file — dedup only matches against these
+    await createMdFile(ctxDir, 'auth/existing-synthesis.md', '# Existing', {type: 'synthesis'})
 
     searchService.search.resolves({
-      results: [{path: 'auth/existing.md', score: 0.9, title: 'Existing'}],
+      results: [{path: 'auth/existing-synthesis.md', score: 0.9, title: 'Existing'}],
       totalFound: 1,
     })
 
@@ -228,33 +230,36 @@ describe('synthesize', () => {
     expect(results).to.deep.equal([])
   })
 
-  it('skips candidate when BM25 score 0.5-0.8 (partial match)', async () => {
+  it('creates file when no existing synthesis files exist (dedup skipped)', async () => {
     await createMdFile(ctxDir, 'auth/_index.md', '# Auth', {type: 'summary'})
     await createMdFile(ctxDir, 'api/_index.md', '# API', {type: 'summary'})
 
+    // High score but against non-synthesis files — should NOT dedup
     searchService.search.resolves({
-      results: [{path: 'auth/similar.md', score: 0.6, title: 'Similar'}],
+      results: [{path: 'auth/regular-doc.md', score: 0.9, title: 'Regular Doc'}],
       totalFound: 1,
     })
 
     agent.executeOnSession.resolves(llmResponse([{
-      claim: 'Partially known.',
-      confidence: 0.8,
+      claim: 'Novel insight.',
+      confidence: 0.9,
       evidence: [{domain: 'auth', fact: 'A'}, {domain: 'api', fact: 'B'}],
       placement: 'auth',
-      title: 'Partial Pattern',
+      title: 'New Pattern',
     }]))
 
     const results = await synthesize(deps)
-    expect(results).to.deep.equal([])
+    expect(results).to.have.lengthOf(1)
   })
 
-  it('creates file when BM25 score < 0.5 (novel insight)', async () => {
+  it('creates file when search hits non-synthesis files only', async () => {
     await createMdFile(ctxDir, 'auth/_index.md', '# Auth', {type: 'summary'})
     await createMdFile(ctxDir, 'api/_index.md', '# API', {type: 'summary'})
+    await createMdFile(ctxDir, 'auth/existing-synthesis.md', '# Existing', {type: 'synthesis'})
 
+    // High score but path doesn't match any synthesis file
     searchService.search.resolves({
-      results: [{path: 'auth/unrelated.md', score: 0.2, title: 'Unrelated'}],
+      results: [{path: 'auth/unrelated.md', score: 0.95, title: 'Unrelated'}],
       totalFound: 1,
     })
 

--- a/test/unit/infra/dream/operations/synthesize.test.ts
+++ b/test/unit/infra/dream/operations/synthesize.test.ts
@@ -399,6 +399,53 @@ describe('synthesize', () => {
     expect(results[0].needsReview).to.be.false
   })
 
+  // ── Path traversal ────────────────────────────────────────────────────────
+
+  it('rejects candidate with path-traversal placement', async () => {
+    await createMdFile(ctxDir, 'auth/_index.md', '# Auth', {type: 'summary'})
+    await createMdFile(ctxDir, 'api/_index.md', '# API', {type: 'summary'})
+
+    agent.executeOnSession.resolves(llmResponse([{
+      claim: 'Malicious placement.',
+      confidence: 0.9,
+      evidence: [{domain: 'auth', fact: 'A'}, {domain: 'api', fact: 'B'}],
+      placement: '../../etc',
+      title: 'Escape Attempt',
+    }]))
+
+    const results = await synthesize(deps)
+    expect(results).to.deep.equal([])
+  })
+
+  // ── Partial write failure ────────────────────────────────────────────────
+
+  it('preserves successful results when a later candidate fails to write', async () => {
+    await createMdFile(ctxDir, 'auth/_index.md', '# Auth', {type: 'summary'})
+    await createMdFile(ctxDir, 'api/_index.md', '# API', {type: 'summary'})
+
+    // First candidate writes to 'auth' (valid), second to path-traversal (rejected)
+    agent.executeOnSession.resolves(llmResponse([
+      {
+        claim: 'Good insight.',
+        confidence: 0.9,
+        evidence: [{domain: 'auth', fact: 'A'}, {domain: 'api', fact: 'B'}],
+        placement: 'auth',
+        title: 'Valid Pattern',
+      },
+      {
+        claim: 'Bad placement.',
+        confidence: 0.9,
+        evidence: [{domain: 'auth', fact: 'A'}, {domain: 'api', fact: 'B'}],
+        placement: '../../tmp',
+        title: 'Invalid Pattern',
+      },
+    ]))
+
+    const results = await synthesize(deps)
+    expect(results).to.have.lengthOf(1)
+    expect(asSynthesize(results[0]).outputFile).to.equal('auth/valid-pattern.md')
+  })
+
   // ── Signal abort ──────────────────────────────────────────────────────────
 
   it('respects abort signal', async () => {
@@ -411,5 +458,19 @@ describe('synthesize', () => {
     const results = await synthesize({...deps, signal: controller.signal})
     expect(results).to.deep.equal([])
     expect(agent.createTaskSession.called).to.be.false
+  })
+
+  it('passes abort signal to executeOnSession', async () => {
+    await createMdFile(ctxDir, 'auth/_index.md', '# Auth', {type: 'summary'})
+    await createMdFile(ctxDir, 'api/_index.md', '# API', {type: 'summary'})
+
+    const controller = new AbortController()
+    agent.executeOnSession.resolves(llmResponse([]))
+
+    await synthesize({...deps, signal: controller.signal})
+
+    expect(agent.executeOnSession.calledOnce).to.be.true
+    const options = agent.executeOnSession.firstCall.args[2]
+    expect(options).to.have.property('signal', controller.signal)
   })
 })

--- a/test/unit/infra/dream/operations/synthesize.test.ts
+++ b/test/unit/infra/dream/operations/synthesize.test.ts
@@ -1,0 +1,410 @@
+import {expect} from 'chai'
+import {mkdir, readFile, writeFile} from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+import {restore, type SinonStub, stub} from 'sinon'
+
+import type {ICipherAgent} from '../../../../../src/agent/core/interfaces/i-cipher-agent.js'
+import type {DreamOperation} from '../../../../../src/server/infra/dream/dream-log-schema.js'
+
+import {synthesize, type SynthesizeDeps} from '../../../../../src/server/infra/dream/operations/synthesize.js'
+
+/** Helper: create a markdown file with optional frontmatter */
+async function createMdFile(dir: string, relativePath: string, body: string, frontmatter?: Record<string, unknown>): Promise<void> {
+  const fullPath = join(dir, relativePath)
+  await mkdir(join(fullPath, '..'), {recursive: true})
+  let content = body
+  if (frontmatter) {
+    const {dump} = await import('js-yaml')
+    const yaml = dump(frontmatter, {flowLevel: 1, lineWidth: -1, sortKeys: true}).trimEnd()
+    content = `---\n${yaml}\n---\n${body}`
+  }
+
+  await writeFile(fullPath, content, 'utf8')
+}
+
+/** Build a canned LLM response */
+function llmResponse(syntheses: Array<{claim: string; confidence?: number; evidence: Array<{domain: string; fact: string}>; placement: string; title: string}>): string {
+  return '```json\n' + JSON.stringify({syntheses}) + '\n```'
+}
+
+/** Narrow DreamOperation to SYNTHESIZE variant */
+function asSynthesize(op: DreamOperation) {
+  expect(op.type).to.equal('SYNTHESIZE')
+  return op as Extract<DreamOperation, {type: 'SYNTHESIZE'}>
+}
+
+describe('synthesize', () => {
+  let ctxDir: string
+  let agent: {
+    createTaskSession: SinonStub
+    deleteTaskSession: SinonStub
+    executeOnSession: SinonStub
+    setSandboxVariableOnSession: SinonStub
+  }
+  let searchService: {search: SinonStub}
+  let deps: SynthesizeDeps
+
+  beforeEach(async () => {
+    ctxDir = join(tmpdir(), `brv-synthesize-test-${Date.now()}`)
+    await mkdir(ctxDir, {recursive: true})
+
+    agent = {
+      createTaskSession: stub().resolves('session-1'),
+      deleteTaskSession: stub().resolves(),
+      executeOnSession: stub().resolves('```json\n{"syntheses":[]}\n```'),
+      setSandboxVariableOnSession: stub(),
+    }
+
+    searchService = {
+      search: stub().resolves({results: [], totalFound: 0}),
+    }
+
+    deps = {agent: agent as unknown as ICipherAgent, contextTreeDir: ctxDir, searchService, taskId: 'test-task'}
+  })
+
+  afterEach(() => {
+    restore()
+  })
+
+  // ── Preconditions ─────────────────────────────────────────────────────────
+
+  it('returns empty array when < 2 domains have _index.md', async () => {
+    await createMdFile(ctxDir, 'auth/_index.md', '# Auth Summary', {type: 'summary'})
+
+    const results = await synthesize(deps)
+    expect(results).to.deep.equal([])
+    expect(agent.createTaskSession.called).to.be.false
+  })
+
+  it('returns empty array for empty context tree', async () => {
+    const results = await synthesize(deps)
+    expect(results).to.deep.equal([])
+  })
+
+  it('skips directories starting with _ or .', async () => {
+    await createMdFile(ctxDir, '_archived/_index.md', '# Archived', {type: 'summary'})
+    await createMdFile(ctxDir, '.hidden/_index.md', '# Hidden', {type: 'summary'})
+    await createMdFile(ctxDir, 'auth/_index.md', '# Auth', {type: 'summary'})
+
+    const results = await synthesize(deps)
+    expect(results).to.deep.equal([])
+    expect(agent.createTaskSession.called).to.be.false
+  })
+
+  // ── LLM interaction ───────────────────────────────────────────────────────
+
+  it('creates session and passes domain summaries to LLM', async () => {
+    await createMdFile(ctxDir, 'auth/_index.md', '# Auth Summary', {type: 'summary'})
+    await createMdFile(ctxDir, 'api/_index.md', '# API Summary', {type: 'summary'})
+
+    agent.executeOnSession.resolves(llmResponse([]))
+
+    await synthesize(deps)
+
+    expect(agent.createTaskSession.calledOnce).to.be.true
+    expect(agent.setSandboxVariableOnSession.called).to.be.true
+    expect(agent.deleteTaskSession.calledOnce).to.be.true
+  })
+
+  it('returns empty array when LLM finds nothing', async () => {
+    await createMdFile(ctxDir, 'auth/_index.md', '# Auth', {type: 'summary'})
+    await createMdFile(ctxDir, 'api/_index.md', '# API', {type: 'summary'})
+
+    agent.executeOnSession.resolves(llmResponse([]))
+
+    const results = await synthesize(deps)
+    expect(results).to.deep.equal([])
+  })
+
+  it('returns empty array on LLM failure', async () => {
+    await createMdFile(ctxDir, 'auth/_index.md', '# Auth', {type: 'summary'})
+    await createMdFile(ctxDir, 'api/_index.md', '# API', {type: 'summary'})
+
+    agent.executeOnSession.rejects(new Error('LLM timeout'))
+
+    const results = await synthesize(deps)
+    expect(results).to.deep.equal([])
+    expect(agent.deleteTaskSession.calledOnce).to.be.true
+  })
+
+  // ── Synthesis file creation ───────────────────────────────────────────────
+
+  it('creates synthesis file in placement domain', async () => {
+    await createMdFile(ctxDir, 'auth/_index.md', '# Auth Summary', {type: 'summary'})
+    await createMdFile(ctxDir, 'api/_index.md', '# API Summary', {type: 'summary'})
+
+    agent.executeOnSession.resolves(llmResponse([{
+      claim: 'Both auth and API share token validation logic.',
+      confidence: 0.85,
+      evidence: [{domain: 'auth', fact: 'JWT validation'}, {domain: 'api', fact: 'Token middleware'}],
+      placement: 'auth',
+      title: 'Shared Token Validation',
+    }]))
+
+    const results = await synthesize(deps)
+
+    expect(results).to.have.lengthOf(1)
+    const op = asSynthesize(results[0])
+    expect(op.action).to.equal('CREATE')
+    expect(op.outputFile).to.equal('auth/shared-token-validation.md')
+    expect(op.confidence).to.equal(0.85)
+    expect(op.sources).to.include('auth/_index.md')
+    expect(op.sources).to.include('api/_index.md')
+
+    const content = await readFile(join(ctxDir, 'auth/shared-token-validation.md'), 'utf8')
+    expect(content).to.include('type: synthesis')
+    expect(content).to.include('maturity: draft')
+    expect(content).to.include('Shared Token Validation')
+    expect(content).to.include('Both auth and API share token validation logic.')
+  })
+
+  it('writes correct frontmatter fields', async () => {
+    await createMdFile(ctxDir, 'auth/_index.md', '# Auth', {type: 'summary'})
+    await createMdFile(ctxDir, 'api/_index.md', '# API', {type: 'summary'})
+
+    agent.executeOnSession.resolves(llmResponse([{
+      claim: 'Test claim.',
+      confidence: 0.7,
+      evidence: [{domain: 'auth', fact: 'Fact A'}, {domain: 'api', fact: 'Fact B'}],
+      placement: 'api',
+      title: 'Test Synthesis',
+    }]))
+
+    const results = await synthesize(deps)
+    expect(results).to.have.lengthOf(1)
+
+    const content = await readFile(join(ctxDir, 'api/test-synthesis.md'), 'utf8')
+    expect(content).to.include('confidence:')
+    expect(content).to.include('sources:')
+    expect(content).to.include('synthesized_at:')
+    expect(content).to.include('auth/_index.md')
+    expect(content).to.include('api/_index.md')
+  })
+
+  it('writes evidence section in body', async () => {
+    await createMdFile(ctxDir, 'auth/_index.md', '# Auth', {type: 'summary'})
+    await createMdFile(ctxDir, 'infra/_index.md', '# Infra', {type: 'summary'})
+
+    agent.executeOnSession.resolves(llmResponse([{
+      claim: 'Cross-cutting concern.',
+      confidence: 0.9,
+      evidence: [{domain: 'auth', fact: 'Uses Redis sessions'}, {domain: 'infra', fact: 'Redis cluster config'}],
+      placement: 'infra',
+      title: 'Redis Dependency',
+    }]))
+
+    const results = await synthesize(deps)
+    expect(results).to.have.lengthOf(1)
+
+    const content = await readFile(join(ctxDir, 'infra/redis-dependency.md'), 'utf8')
+    expect(content).to.include('## Evidence')
+    expect(content).to.include('**auth**')
+    expect(content).to.include('Uses Redis sessions')
+    expect(content).to.include('**infra**')
+    expect(content).to.include('Redis cluster config')
+  })
+
+  // ── Deduplication ─────────────────────────────────────────────────────────
+
+  it('skips candidate when BM25 score > 0.8 (already captured)', async () => {
+    await createMdFile(ctxDir, 'auth/_index.md', '# Auth', {type: 'summary'})
+    await createMdFile(ctxDir, 'api/_index.md', '# API', {type: 'summary'})
+
+    searchService.search.resolves({
+      results: [{path: 'auth/existing.md', score: 0.9, title: 'Existing'}],
+      totalFound: 1,
+    })
+
+    agent.executeOnSession.resolves(llmResponse([{
+      claim: 'Already documented.',
+      confidence: 0.8,
+      evidence: [{domain: 'auth', fact: 'A'}, {domain: 'api', fact: 'B'}],
+      placement: 'auth',
+      title: 'Existing Pattern',
+    }]))
+
+    const results = await synthesize(deps)
+    expect(results).to.deep.equal([])
+  })
+
+  it('skips candidate when BM25 score 0.5-0.8 (partial match)', async () => {
+    await createMdFile(ctxDir, 'auth/_index.md', '# Auth', {type: 'summary'})
+    await createMdFile(ctxDir, 'api/_index.md', '# API', {type: 'summary'})
+
+    searchService.search.resolves({
+      results: [{path: 'auth/similar.md', score: 0.6, title: 'Similar'}],
+      totalFound: 1,
+    })
+
+    agent.executeOnSession.resolves(llmResponse([{
+      claim: 'Partially known.',
+      confidence: 0.8,
+      evidence: [{domain: 'auth', fact: 'A'}, {domain: 'api', fact: 'B'}],
+      placement: 'auth',
+      title: 'Partial Pattern',
+    }]))
+
+    const results = await synthesize(deps)
+    expect(results).to.deep.equal([])
+  })
+
+  it('creates file when BM25 score < 0.5 (novel insight)', async () => {
+    await createMdFile(ctxDir, 'auth/_index.md', '# Auth', {type: 'summary'})
+    await createMdFile(ctxDir, 'api/_index.md', '# API', {type: 'summary'})
+
+    searchService.search.resolves({
+      results: [{path: 'auth/unrelated.md', score: 0.2, title: 'Unrelated'}],
+      totalFound: 1,
+    })
+
+    agent.executeOnSession.resolves(llmResponse([{
+      claim: 'Novel insight.',
+      confidence: 0.9,
+      evidence: [{domain: 'auth', fact: 'A'}, {domain: 'api', fact: 'B'}],
+      placement: 'auth',
+      title: 'New Pattern',
+    }]))
+
+    const results = await synthesize(deps)
+    expect(results).to.have.lengthOf(1)
+  })
+
+  // ── Existing synthesis & collision ────────────────────────────────────────
+
+  it('lists existing synthesis files in LLM prompt', async () => {
+    await createMdFile(ctxDir, 'auth/_index.md', '# Auth', {type: 'summary'})
+    await createMdFile(ctxDir, 'api/_index.md', '# API', {type: 'summary'})
+    await createMdFile(ctxDir, 'auth/existing-synthesis.md', '# Existing', {type: 'synthesis'})
+
+    agent.executeOnSession.resolves(llmResponse([]))
+
+    await synthesize(deps)
+
+    const prompt = agent.executeOnSession.firstCall.args[1]
+    expect(prompt).to.include('auth/existing-synthesis.md')
+  })
+
+  it('skips file creation on name collision', async () => {
+    await createMdFile(ctxDir, 'auth/_index.md', '# Auth', {type: 'summary'})
+    await createMdFile(ctxDir, 'api/_index.md', '# API', {type: 'summary'})
+    // Pre-create a file that would collide
+    await createMdFile(ctxDir, 'auth/shared-pattern.md', '# Pre-existing content')
+
+    agent.executeOnSession.resolves(llmResponse([{
+      claim: 'This would collide.',
+      confidence: 0.9,
+      evidence: [{domain: 'auth', fact: 'A'}, {domain: 'api', fact: 'B'}],
+      placement: 'auth',
+      title: 'Shared Pattern',
+    }]))
+
+    const results = await synthesize(deps)
+    expect(results).to.deep.equal([])
+
+    // Original file unchanged
+    const content = await readFile(join(ctxDir, 'auth/shared-pattern.md'), 'utf8')
+    expect(content).to.include('Pre-existing content')
+  })
+
+  // ── Multiple candidates ───────────────────────────────────────────────────
+
+  it('creates multiple synthesis files from one LLM call', async () => {
+    await createMdFile(ctxDir, 'auth/_index.md', '# Auth', {type: 'summary'})
+    await createMdFile(ctxDir, 'api/_index.md', '# API', {type: 'summary'})
+    await createMdFile(ctxDir, 'infra/_index.md', '# Infra', {type: 'summary'})
+
+    agent.executeOnSession.resolves(llmResponse([
+      {
+        claim: 'First insight.',
+        confidence: 0.85,
+        evidence: [{domain: 'auth', fact: 'A'}, {domain: 'api', fact: 'B'}],
+        placement: 'auth',
+        title: 'Pattern One',
+      },
+      {
+        claim: 'Second insight.',
+        confidence: 0.7,
+        evidence: [{domain: 'api', fact: 'C'}, {domain: 'infra', fact: 'D'}],
+        placement: 'infra',
+        title: 'Pattern Two',
+      },
+    ]))
+
+    const results = await synthesize(deps)
+    expect(results).to.have.lengthOf(2)
+    expect(results.map((r) => asSynthesize(r).outputFile)).to.include('auth/pattern-one.md')
+    expect(results.map((r) => asSynthesize(r).outputFile)).to.include('infra/pattern-two.md')
+  })
+
+  // ── Slugify ───────────────────────────────────────────────────────────────
+
+  it('slugifies title for filename (special chars, max 80 chars)', async () => {
+    await createMdFile(ctxDir, 'auth/_index.md', '# Auth', {type: 'summary'})
+    await createMdFile(ctxDir, 'api/_index.md', '# API', {type: 'summary'})
+
+    agent.executeOnSession.resolves(llmResponse([{
+      claim: 'Test.',
+      confidence: 0.9,
+      evidence: [{domain: 'auth', fact: 'A'}, {domain: 'api', fact: 'B'}],
+      placement: 'auth',
+      title: 'Complex Title: With Special (Characters) & More!',
+    }]))
+
+    const results = await synthesize(deps)
+    expect(results).to.have.lengthOf(1)
+    const op = asSynthesize(results[0])
+    expect(op.outputFile).to.match(/^auth\/[a-z0-9-]+\.md$/)
+    expect(op.outputFile.length).to.be.lessThanOrEqual(80 + 'auth/'.length + '.md'.length)
+  })
+
+  // ── needsReview ───────────────────────────────────────────────────────────
+
+  it('sets needsReview=true when confidence < 0.7', async () => {
+    await createMdFile(ctxDir, 'auth/_index.md', '# Auth', {type: 'summary'})
+    await createMdFile(ctxDir, 'api/_index.md', '# API', {type: 'summary'})
+
+    agent.executeOnSession.resolves(llmResponse([{
+      claim: 'Low confidence.',
+      confidence: 0.5,
+      evidence: [{domain: 'auth', fact: 'A'}, {domain: 'api', fact: 'B'}],
+      placement: 'auth',
+      title: 'Uncertain Pattern',
+    }]))
+
+    const results = await synthesize(deps)
+    expect(results).to.have.lengthOf(1)
+    expect(results[0].needsReview).to.be.true
+  })
+
+  it('sets needsReview=false when confidence >= 0.7', async () => {
+    await createMdFile(ctxDir, 'auth/_index.md', '# Auth', {type: 'summary'})
+    await createMdFile(ctxDir, 'api/_index.md', '# API', {type: 'summary'})
+
+    agent.executeOnSession.resolves(llmResponse([{
+      claim: 'High confidence.',
+      confidence: 0.85,
+      evidence: [{domain: 'auth', fact: 'A'}, {domain: 'api', fact: 'B'}],
+      placement: 'auth',
+      title: 'Confident Pattern',
+    }]))
+
+    const results = await synthesize(deps)
+    expect(results).to.have.lengthOf(1)
+    expect(results[0].needsReview).to.be.false
+  })
+
+  // ── Signal abort ──────────────────────────────────────────────────────────
+
+  it('respects abort signal', async () => {
+    await createMdFile(ctxDir, 'auth/_index.md', '# Auth', {type: 'summary'})
+    await createMdFile(ctxDir, 'api/_index.md', '# API', {type: 'summary'})
+
+    const controller = new AbortController()
+    controller.abort()
+
+    const results = await synthesize({...deps, signal: controller.signal})
+    expect(results).to.deep.equal([])
+    expect(agent.createTaskSession.called).to.be.false
+  })
+})


### PR DESCRIPTION
## Summary

- Problem: No mechanism to detect and persist cross-domain patterns in the context tree
- Why it matters: Recurring cross-cutting insights become searchable without LLM calls, cheaper retrieval
- What changed: Added `synthesize.ts` pipeline (domain summary collection, LLM analysis, BM25 dedup, file creation), wired into executor after consolidate
- What did NOT change (scope boundary): No new task types, no schema changes, no CLI changes

## Type of change

- [x] New feature

## Scope (select all touched areas)

- [x] Server / Daemon

## Linked issues

- Closes ENG-2061
- Related ENG-2060

## Root cause (bug fixes only, otherwise write `N/A`)

N/A (includes minor fix: manifest rebuild path in dream-undo was doubled)

## Test plan

- Coverage added:
  - [x] Unit test
  - [x] Manual verification only
- Test file(s): `test/unit/infra/dream/operations/synthesize.test.ts`
- Key scenario(s) covered:
  - Preconditions: < 2 domains, empty tree, skip _ and . dirs
  - LLM interaction: session lifecycle, domain summaries passed, empty response, LLM failure
  - File creation: correct placement, frontmatter (type/maturity/confidence/sources/synthesized_at), evidence section
  - Dedup: BM25 > 0.8 skip, 0.5-0.8 skip, < 0.5 create
  - Existing synthesis listed in prompt, name collision skip
  - Multiple candidates, slugify with special chars, needsReview gating
  - Abort signal respected
  - Interactive: 15+ curate commands, dream with consolidate+synthesize, JSON output confirms both sandbox variables read by LLM

## User-visible changes

- `brv dream` now runs synthesize after consolidate (transparent to user)
- New synthesis files appear as regular draft `.md` files with `type: synthesis` frontmatter
- `brv search` returns synthesis files for relevant queries (no additional wiring needed)

## Evidence

Interactive testing confirmed:
- JSON output shows `__dream_synthesize_domains` sandbox variable read via code_exec
- Both consolidate and synthesize execute in sequence within a single dream
- LLM correctly returns empty syntheses when no meaningful patterns found (quality gate working)
- Dream undo works after combined consolidate+synthesize dream

## Checklist

- [x] Tests added or updated and passing (`npm test` — 5725 passing)
- [x] Lint passes (`npm run lint` — 0 errors)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow Conventional Commits format
- [x] No breaking changes

## Risks and mitigations

- Risk: Synthesize adds LLM cost to every dream even with 0 candidates
  - Mitigation: Single LLM call; < 2 domains short-circuits before any LLM interaction. Plan notes "can be disabled by returning [] early" if low-value.