### PR TITLE
feat:[ENG-2075] add ByteRover context tree as write fallback

### DIFF
--- a/src/agent/core/interfaces/i-swarm-coordinator.ts
+++ b/src/agent/core/interfaces/i-swarm-coordinator.ts
@@ -103,6 +103,8 @@ export type SwarmStoreRequest = {
 export type SwarmStoreResult = {
   /** Error message if store failed */
   error?: string
+  /** True when content was routed to context tree as fallback (no external providers available) */
+  fallback?: boolean
   /** ID assigned by the target provider */
   id: string
   /** Store latency in milliseconds */

--- a/src/agent/infra/swarm/swarm-coordinator.ts
+++ b/src/agent/infra/swarm/swarm-coordinator.ts
@@ -1,4 +1,5 @@
-import {execFile} from 'node:child_process'
+import {execFile as execFileCb} from 'node:child_process'
+import {promisify} from 'node:util'
 
 import type {QueryRequest} from '../../core/domain/swarm/types.js'
 import type {IMemoryProvider} from '../../core/interfaces/i-memory-provider.js'
@@ -18,26 +19,27 @@ import {mergeResults} from './swarm-merger.js'
 import {classifyQuery, selectProviders} from './swarm-router.js'
 import {classifyWrite, selectWriteTarget} from './swarm-write-router.js'
 
-type BrvCurateResult = {data?: {logId?: string; taskId?: string}; error?: string; success?: boolean}
+export type BrvCurateResult = {data?: {logId?: string; taskId?: string}; error?: string; success?: boolean}
 
-function execBrvCurate(content: string): Promise<BrvCurateResult> {
-  return new Promise((resolve, reject) => {
-    execFile('brv', ['curate', '--detach', '--format', 'json', content], {
+const execFileAsync = promisify(execFileCb)
+
+async function execBrvCurate(content: string): Promise<BrvCurateResult> {
+  let stdout: string
+  try {
+    ({stdout} = await execFileAsync('brv', ['curate', '--detach', '--format', 'json', content], {
       encoding: 'utf8',
       timeout: 30_000,
-    }, (error, stdout, stderr) => {
-      if (error) {
-        reject(new Error(stderr?.trim() || error.message))
-        return
-      }
+    }))
+  } catch (error) {
+    const err = error as {message: string; stderr?: string}
+    throw new Error(err.stderr?.trim() || err.message)
+  }
 
-      try {
-        resolve(JSON.parse(stdout))
-      } catch {
-        reject(new Error(`Failed to parse brv curate output: ${stdout.slice(0, 200)}`))
-      }
-    })
-  })
+  try {
+    return JSON.parse(stdout) as BrvCurateResult
+  } catch {
+    throw new Error(`Failed to parse brv curate output: ${stdout.slice(0, 200)}`)
+  }
 }
 
 /**

--- a/src/agent/infra/swarm/swarm-coordinator.ts
+++ b/src/agent/infra/swarm/swarm-coordinator.ts
@@ -1,4 +1,5 @@
 import type {QueryRequest} from '../../core/domain/swarm/types.js'
+import type {ICurateService} from '../../core/interfaces/i-curate-service.js'
 import type {IMemoryProvider} from '../../core/interfaces/i-memory-provider.js'
 import type {
   ISwarmCoordinator,
@@ -153,14 +154,16 @@ function resolveEndpoint(endpoint: string, providerIds: string[]): string[] {
  */
 export class SwarmCoordinator implements ISwarmCoordinator {
   private readonly config: SwarmConfig
+  private readonly curateService?: ICurateService
   private readonly graph: SwarmGraph
   private healthCache: Map<string, boolean> = new Map()
   private readonly providers: IMemoryProvider[]
   private totalQueries = 0
 
-  constructor(providers: IMemoryProvider[], config: SwarmConfig) {
+  constructor(providers: IMemoryProvider[], config: SwarmConfig, curateService?: ICurateService) {
     this.providers = providers
     this.config = config
+    this.curateService = curateService
     this.graph = new SwarmGraph(providers, {
       timeoutMs: config.performance.maxQueryLatencyMs,
     })
@@ -349,7 +352,13 @@ export class SwarmCoordinator implements ISwarmCoordinator {
     } else {
       // Auto-route: classify content type, then select target
       const writeType = request.contentType ?? classifyWrite(request.content)
-      target = selectWriteTarget(writeType, this.providers, this.healthCache)
+      const selected = selectWriteTarget(writeType, this.providers, this.healthCache)
+
+      if (!selected) {
+        return this.fallbackToByterover(request, start)
+      }
+
+      target = selected
     }
 
     try {
@@ -373,6 +382,52 @@ export class SwarmCoordinator implements ISwarmCoordinator {
         id: '',
         latencyMs: Date.now() - start,
         provider: target.id,
+        success: false,
+      }
+    }
+  }
+
+  private async fallbackToByterover(
+    request: SwarmStoreRequest,
+    start: number,
+  ): Promise<SwarmStoreResult> {
+    if (!this.curateService) {
+      return {
+        error: 'No writable providers available and curate service not configured. Use `brv curate` to write directly to the context tree.',
+        fallback: false,
+        id: '',
+        latencyMs: Date.now() - start,
+        provider: '',
+        success: false,
+      }
+    }
+
+    try {
+      const result = await this.curateService.curate([{
+        confidence: 'high',
+        content: {snippets: [request.content]},
+        impact: 'low',
+        path: 'swarm_fallback/knowledge',
+        reason: 'Swarm write fallback — no external writable providers available',
+        title: request.content.slice(0, 60).replaceAll(/[^\w\s-]/g, '').trim() || 'untitled',
+        type: 'ADD',
+      }])
+
+      const firstApplied = result.applied[0]
+      return {
+        fallback: true,
+        id: firstApplied?.path ?? 'context-tree',
+        latencyMs: Date.now() - start,
+        provider: 'byterover',
+        success: firstApplied?.status === 'success',
+      }
+    } catch (error) {
+      return {
+        error: error instanceof Error ? error.message : String(error),
+        fallback: true,
+        id: '',
+        latencyMs: Date.now() - start,
+        provider: 'byterover',
         success: false,
       }
     }

--- a/src/agent/infra/swarm/swarm-coordinator.ts
+++ b/src/agent/infra/swarm/swarm-coordinator.ts
@@ -1,6 +1,31 @@
 import {execFile} from 'node:child_process'
 
 import type {QueryRequest} from '../../core/domain/swarm/types.js'
+
+/**
+ * Execute `brv curate --detach --format json` and return the parsed JSON output.
+ * Extracted as a module-level function so tests can stub it.
+ */
+export function execBrvCurate(content: string): Promise<{data?: {logId?: string; taskId?: string}; success?: boolean}> {
+  return new Promise((resolve, reject) => {
+    execFile('brv', ['curate', '--detach', '--format', 'json', content], {
+      encoding: 'utf8',
+      timeout: 30_000,
+    }, (error, stdout, stderr) => {
+      if (error) {
+        reject(new Error(stderr?.trim() || error.message))
+        return
+      }
+
+      try {
+        resolve(JSON.parse(stdout))
+      } catch {
+        reject(new Error(`Failed to parse brv curate output: ${stdout.slice(0, 200)}`))
+      }
+    })
+  })
+}
+
 import type {IMemoryProvider} from '../../core/interfaces/i-memory-provider.js'
 import type {
   ISwarmCoordinator,
@@ -153,8 +178,11 @@ function resolveEndpoint(endpoint: string, providerIds: string[]): string[] {
  *
  * Implements ISwarmCoordinator to serve the CLI command and agent tool.
  */
+export type CurateFallbackFn = (content: string) => Promise<{data?: {logId?: string; taskId?: string}; success?: boolean}>
+
 export class SwarmCoordinator implements ISwarmCoordinator {
   private readonly config: SwarmConfig
+  private readonly curateFallback: CurateFallbackFn
   private readonly graph: SwarmGraph
   private readonly healthCache: Map<string, boolean> = new Map()
   private readonly maxCacheSize = 20
@@ -163,9 +191,10 @@ export class SwarmCoordinator implements ISwarmCoordinator {
   private readonly resultCacheTtlMs: number
   private totalQueries = 0
 
-  constructor(providers: IMemoryProvider[], config: SwarmConfig) {
+  constructor(providers: IMemoryProvider[], config: SwarmConfig, curateFallback?: CurateFallbackFn) {
     this.providers = providers
     this.config = config
+    this.curateFallback = curateFallback ?? execBrvCurate
     this.resultCacheTtlMs = config.performance.resultCacheTtlMs ?? 10_000
     this.graph = new SwarmGraph(providers, {
       timeoutMs: config.performance.maxQueryLatencyMs,
@@ -442,25 +471,13 @@ export class SwarmCoordinator implements ISwarmCoordinator {
     start: number,
   ): Promise<SwarmStoreResult> {
     try {
-      const result = await new Promise<{stderr: string; stdout: string}>((resolve, reject) => {
-        execFile('brv', ['curate', '--detach', request.content], {
-          encoding: 'utf8',
-          timeout: 30_000,
-        }, (error, stdout, stderr) => {
-          if (error) {
-            reject(new Error(stderr?.trim() || error.message))
-          } else {
-            resolve({stderr, stdout})
-          }
-        })
-      })
-
+      const parsed = await this.curateFallback(request.content)
       return {
         fallback: true,
-        id: result.stdout.trim(),
+        id: parsed.data?.logId ?? parsed.data?.taskId ?? '',
         latencyMs: Date.now() - start,
         provider: 'byterover',
-        success: true,
+        success: parsed.success === true,
       }
     } catch (error) {
       return {

--- a/src/agent/infra/swarm/swarm-coordinator.ts
+++ b/src/agent/infra/swarm/swarm-coordinator.ts
@@ -1,5 +1,6 @@
+import {execFile} from 'node:child_process'
+
 import type {QueryRequest} from '../../core/domain/swarm/types.js'
-import type {ICurateService} from '../../core/interfaces/i-curate-service.js'
 import type {IMemoryProvider} from '../../core/interfaces/i-memory-provider.js'
 import type {
   ISwarmCoordinator,
@@ -154,7 +155,6 @@ function resolveEndpoint(endpoint: string, providerIds: string[]): string[] {
  */
 export class SwarmCoordinator implements ISwarmCoordinator {
   private readonly config: SwarmConfig
-  private readonly curateService?: ICurateService
   private readonly graph: SwarmGraph
   private readonly healthCache: Map<string, boolean> = new Map()
   private readonly maxCacheSize = 20
@@ -163,10 +163,9 @@ export class SwarmCoordinator implements ISwarmCoordinator {
   private readonly resultCacheTtlMs: number
   private totalQueries = 0
 
-  constructor(providers: IMemoryProvider[], config: SwarmConfig, curateService?: ICurateService) {
+  constructor(providers: IMemoryProvider[], config: SwarmConfig) {
     this.providers = providers
     this.config = config
-    this.curateService = curateService
     this.resultCacheTtlMs = config.performance.resultCacheTtlMs ?? 10_000
     this.graph = new SwarmGraph(providers, {
       timeoutMs: config.performance.maxQueryLatencyMs,
@@ -442,35 +441,26 @@ export class SwarmCoordinator implements ISwarmCoordinator {
     request: SwarmStoreRequest,
     start: number,
   ): Promise<SwarmStoreResult> {
-    if (!this.curateService) {
-      return {
-        error: 'No writable providers available and curate service not configured. Use `brv curate` to write directly to the context tree.',
-        fallback: false,
-        id: '',
-        latencyMs: Date.now() - start,
-        provider: '',
-        success: false,
-      }
-    }
-
     try {
-      const result = await this.curateService.curate([{
-        confidence: 'high',
-        content: {snippets: [request.content]},
-        impact: 'low',
-        path: 'swarm_fallback/knowledge',
-        reason: 'Swarm write fallback — no external writable providers available',
-        title: request.content.slice(0, 60).replaceAll(/[^\w\s-]/g, '').trim() || 'untitled',
-        type: 'ADD',
-      }])
+      const result = await new Promise<{stderr: string; stdout: string}>((resolve, reject) => {
+        execFile('brv', ['curate', '--detach', request.content], {
+          encoding: 'utf8',
+          timeout: 30_000,
+        }, (error, stdout, stderr) => {
+          if (error) {
+            reject(new Error(stderr?.trim() || error.message))
+          } else {
+            resolve({stderr, stdout})
+          }
+        })
+      })
 
-      const firstApplied = result.applied[0]
       return {
         fallback: true,
-        id: firstApplied?.path ?? 'context-tree',
+        id: result.stdout.trim(),
         latencyMs: Date.now() - start,
         provider: 'byterover',
-        success: firstApplied?.status === 'success',
+        success: true,
       }
     } catch (error) {
       return {

--- a/src/agent/infra/swarm/swarm-coordinator.ts
+++ b/src/agent/infra/swarm/swarm-coordinator.ts
@@ -1,12 +1,26 @@
 import {execFile} from 'node:child_process'
 
 import type {QueryRequest} from '../../core/domain/swarm/types.js'
+import type {IMemoryProvider} from '../../core/interfaces/i-memory-provider.js'
+import type {
+  ISwarmCoordinator,
+  ProviderInfo,
+  ProviderQueryMeta,
+  SwarmQueryResult,
+  SwarmStoreRequest,
+  SwarmStoreResult,
+  SwarmSummary,
+} from '../../core/interfaces/i-swarm-coordinator.js'
+import type {SwarmConfig} from './config/swarm-config-schema.js'
 
-/**
- * Execute `brv curate --detach --format json` and return the parsed JSON output.
- * Extracted as a module-level function so tests can stub it.
- */
-export function execBrvCurate(content: string): Promise<{data?: {logId?: string; taskId?: string}; success?: boolean}> {
+import {SwarmGraph} from './swarm-graph.js'
+import {mergeResults} from './swarm-merger.js'
+import {classifyQuery, selectProviders} from './swarm-router.js'
+import {classifyWrite, selectWriteTarget} from './swarm-write-router.js'
+
+type BrvCurateResult = {data?: {logId?: string; taskId?: string}; error?: string; success?: boolean}
+
+function execBrvCurate(content: string): Promise<BrvCurateResult> {
   return new Promise((resolve, reject) => {
     execFile('brv', ['curate', '--detach', '--format', 'json', content], {
       encoding: 'utf8',
@@ -25,23 +39,6 @@ export function execBrvCurate(content: string): Promise<{data?: {logId?: string;
     })
   })
 }
-
-import type {IMemoryProvider} from '../../core/interfaces/i-memory-provider.js'
-import type {
-  ISwarmCoordinator,
-  ProviderInfo,
-  ProviderQueryMeta,
-  SwarmQueryResult,
-  SwarmStoreRequest,
-  SwarmStoreResult,
-  SwarmSummary,
-} from '../../core/interfaces/i-swarm-coordinator.js'
-import type {SwarmConfig} from './config/swarm-config-schema.js'
-
-import {SwarmGraph} from './swarm-graph.js'
-import {mergeResults} from './swarm-merger.js'
-import {classifyQuery, selectProviders} from './swarm-router.js'
-import {classifyWrite, selectWriteTarget} from './swarm-write-router.js'
 
 /**
  * Default provider weights for RRF fusion.
@@ -178,7 +175,7 @@ function resolveEndpoint(endpoint: string, providerIds: string[]): string[] {
  *
  * Implements ISwarmCoordinator to serve the CLI command and agent tool.
  */
-export type CurateFallbackFn = (content: string) => Promise<{data?: {logId?: string; taskId?: string}; success?: boolean}>
+export type CurateFallbackFn = (content: string) => Promise<BrvCurateResult>
 
 export class SwarmCoordinator implements ISwarmCoordinator {
   private readonly config: SwarmConfig
@@ -473,6 +470,7 @@ export class SwarmCoordinator implements ISwarmCoordinator {
     try {
       const parsed = await this.curateFallback(request.content)
       return {
+        error: parsed.success === true ? undefined : (parsed.error ?? 'brv curate returned success: false'),
         fallback: true,
         id: parsed.data?.logId ?? parsed.data?.taskId ?? '',
         latencyMs: Date.now() - start,

--- a/src/agent/infra/swarm/swarm-write-router.ts
+++ b/src/agent/infra/swarm/swarm-write-router.ts
@@ -40,14 +40,14 @@ export function selectWriteTarget(
   writeType: WriteType,
   providers: IMemoryProvider[],
   healthCache: Map<string, boolean>
-): IMemoryProvider {
+): IMemoryProvider | null {
   // Filter to writable + healthy
   const candidates = providers.filter(
     (p) => p.capabilities.writeSupported && healthCache.get(p.id) !== false
   )
 
   if (candidates.length === 0) {
-    throw new Error('No writable providers configured')
+    return null
   }
 
   // Type-specific preference

--- a/src/agent/infra/swarm/swarm-write-router.ts
+++ b/src/agent/infra/swarm/swarm-write-router.ts
@@ -34,7 +34,7 @@ export function classifyWrite(content: string): WriteType {
  * - note → first local-markdown > first writable
  * - general → first writable (config order)
  *
- * @throws Error if no writable+healthy provider is available
+ * @returns null if no writable+healthy provider is available
  */
 export function selectWriteTarget(
   writeType: WriteType,

--- a/src/agent/infra/swarm/swarm-write-router.ts
+++ b/src/agent/infra/swarm/swarm-write-router.ts
@@ -26,8 +26,7 @@ export function classifyWrite(content: string): WriteType {
 /**
  * Select the best writable provider for a given write type.
  *
- * Receives pre-filtered providers (callers should pass only writeSupported=true).
- * Internal writeSupported check is a defensive assert.
+ * Filters providers to writable + healthy candidates internally.
  *
  * Priority:
  * - entity → GBrain > first writable

--- a/src/oclif/commands/swarm/curate.ts
+++ b/src/oclif/commands/swarm/curate.ts
@@ -1,6 +1,7 @@
 import {Args, Command, Flags} from '@oclif/core'
 
 import {FileSystemService} from '../../../agent/infra/file-system/file-system-service.js'
+import {CurateService} from '../../../agent/infra/sandbox/curate-service.js'
 import {loadSwarmConfig} from '../../../agent/infra/swarm/config/swarm-config-loader.js'
 import {buildProvidersFromConfig} from '../../../agent/infra/swarm/provider-factory.js'
 import {SwarmCoordinator} from '../../../agent/infra/swarm/swarm-coordinator.js'
@@ -53,7 +54,8 @@ public static description = 'Store knowledge in a swarm provider (GBrain, local 
       })
 
       const providers = buildProvidersFromConfig(config, {searchService})
-      const coordinator = new SwarmCoordinator(providers, config)
+      const curateService = new CurateService(workingDirectory)
+      const coordinator = new SwarmCoordinator(providers, config, curateService)
       await coordinator.refreshHealth()
 
       const result = await coordinator.store({
@@ -63,6 +65,8 @@ public static description = 'Store knowledge in a swarm provider (GBrain, local 
 
       if (isJson) {
         this.log(JSON.stringify(result, undefined, 2))
+      } else if (result.success && result.fallback) {
+        this.log(`Stored to ${result.provider} (fallback — no external providers available) as ${result.id}`)
       } else if (result.success) {
         this.log(`Stored to ${result.provider} as ${result.id}`)
       } else {

--- a/src/oclif/commands/swarm/curate.ts
+++ b/src/oclif/commands/swarm/curate.ts
@@ -1,7 +1,6 @@
 import {Args, Command, Flags} from '@oclif/core'
 
 import {FileSystemService} from '../../../agent/infra/file-system/file-system-service.js'
-import {CurateService} from '../../../agent/infra/sandbox/curate-service.js'
 import {loadSwarmConfig} from '../../../agent/infra/swarm/config/swarm-config-loader.js'
 import {buildProvidersFromConfig} from '../../../agent/infra/swarm/provider-factory.js'
 import {SwarmCoordinator} from '../../../agent/infra/swarm/swarm-coordinator.js'
@@ -54,8 +53,7 @@ public static description = 'Store knowledge in a swarm provider (GBrain, local 
       })
 
       const providers = buildProvidersFromConfig(config, {searchService})
-      const curateService = new CurateService(workingDirectory)
-      const coordinator = new SwarmCoordinator(providers, config, curateService)
+      const coordinator = new SwarmCoordinator(providers, config)
       await coordinator.refreshHealth()
 
       const result = await coordinator.store({

--- a/src/oclif/commands/swarm/curate.ts
+++ b/src/oclif/commands/swarm/curate.ts
@@ -64,7 +64,8 @@ public static description = 'Store knowledge in a swarm provider (GBrain, local 
       if (isJson) {
         this.log(JSON.stringify(result, undefined, 2))
       } else if (result.success && result.fallback) {
-        this.log(`Stored to ${result.provider} (fallback — no external providers available) as ${result.id}`)
+        const idPart = result.id ? ` as ${result.id}` : ''
+        this.log(`Stored to ${result.provider} (fallback — no external providers available)${idPart}`)
       } else if (result.success) {
         this.log(`Stored to ${result.provider} as ${result.id}`)
       } else {

--- a/test/unit/agent/swarm/swarm-coordinator.test.ts
+++ b/test/unit/agent/swarm/swarm-coordinator.test.ts
@@ -383,18 +383,80 @@ describe('SwarmCoordinator', () => {
       expect(result.error).to.include('is not healthy')
     })
 
-    it('returns error when no writable provider available', async () => {
+    it('returns error when no writable provider and no curateService', async () => {
       const obsidian = createMockProvider('obsidian', 'obsidian', [])
 
       const config = createMinimalConfig()
       const coordinator = new SwarmCoordinator([obsidian], config)
 
-      try {
-        await coordinator.store({content: 'test'})
-        expect.fail('should have thrown')
-      } catch (error) {
-        expect((error as Error).message).to.include('No writable providers')
+      const result = await coordinator.store({content: 'test'})
+      expect(result.success).to.be.false
+      expect(result.error).to.include('curate service not configured')
+    })
+
+    it('falls back to curateService when no writable providers', async () => {
+      const obsidian = createMockProvider('obsidian', 'obsidian', [])
+      const mockCurate = {
+        curate: sinon.stub().resolves({
+          applied: [{path: 'swarm-fallback/test', status: 'success', type: 'ADD'}],
+          summary: {added: 1, deleted: 0, failed: 0, merged: 0, updated: 0},
+        }),
+        detectDomains: sinon.stub(),
       }
+
+      const config = createMinimalConfig()
+      const coordinator = new SwarmCoordinator([obsidian], config, mockCurate)
+
+      const result = await coordinator.store({content: 'test content'})
+      expect(result.success).to.be.true
+      expect(result.fallback).to.be.true
+      expect(result.provider).to.equal('byterover')
+      expect(mockCurate.curate.calledOnce).to.be.true
+    })
+
+    it('fallback returns failure when curateService throws', async () => {
+      const obsidian = createMockProvider('obsidian', 'obsidian', [])
+      const mockCurate = {
+        curate: sinon.stub().rejects(new Error('Curate pipeline failed')),
+        detectDomains: sinon.stub(),
+      }
+
+      const config = createMinimalConfig()
+      const coordinator = new SwarmCoordinator([obsidian], config, mockCurate)
+
+      const result = await coordinator.store({content: 'test'})
+      expect(result.success).to.be.false
+      expect(result.fallback).to.be.true
+      expect(result.error).to.include('Curate pipeline failed')
+    })
+
+    it('does not fallback for explicit --provider target', async () => {
+      const obsidian = createMockProvider('obsidian', 'obsidian', [])
+      const mockCurate = {
+        curate: sinon.stub().resolves({applied: [], summary: {added: 0, deleted: 0, failed: 0, merged: 0, updated: 0}}),
+        detectDomains: sinon.stub(),
+      }
+
+      const config = createMinimalConfig()
+      const coordinator = new SwarmCoordinator([obsidian], config, mockCurate)
+
+      const result = await coordinator.store({content: 'test', provider: 'obsidian'})
+      expect(result.success).to.be.false
+      expect(result.fallback).to.be.undefined
+      expect(mockCurate.curate.called).to.be.false
+    })
+
+    it('normal write does not set fallback flag', async () => {
+      const p1 = createMockProvider('byterover', 'byterover', [])
+      p1.capabilities.writeSupported = true;
+      (p1.store as sinon.SinonStub).resolves({id: 'note-1', provider: 'byterover', success: true})
+
+      const config = createMinimalConfig()
+      const coordinator = new SwarmCoordinator([p1], config)
+
+      const result = await coordinator.store({content: 'test'})
+      expect(result.success).to.be.true
+      expect(result.fallback).to.be.undefined
     })
   })
 

--- a/test/unit/agent/swarm/swarm-coordinator.test.ts
+++ b/test/unit/agent/swarm/swarm-coordinator.test.ts
@@ -385,17 +385,34 @@ describe('SwarmCoordinator', () => {
     })
 
     it('falls back to brv curate when no writable providers', async () => {
+      const mockCurate = sinon.stub().resolves({
+        data: {logId: 'cur-fallback-123', taskId: 'task-abc'},
+        success: true,
+      })
+
       const obsidian = createMockProvider('obsidian', 'obsidian', [])
       const config = createMinimalConfig()
-      const coordinator = new SwarmCoordinator([obsidian], config)
+      const coordinator = new SwarmCoordinator([obsidian], config, mockCurate)
 
-      // The fallback calls `brv curate --detach` via execFile.
-      // We can't easily mock execFile here, so we verify the result shape
-      // when the fallback is triggered (it will fail because brv daemon
-      // may not be running in test, but the fallback flag should be set).
       const result = await coordinator.store({content: 'test content'})
+      expect(result.success).to.be.true
       expect(result.fallback).to.be.true
       expect(result.provider).to.equal('byterover')
+      expect(result.id).to.equal('cur-fallback-123')
+      expect(mockCurate.calledOnce).to.be.true
+    })
+
+    it('fallback returns failure when brv curate fails', async () => {
+      const mockCurate = sinon.stub().rejects(new Error('No provider connected'))
+
+      const obsidian = createMockProvider('obsidian', 'obsidian', [])
+      const config = createMinimalConfig()
+      const coordinator = new SwarmCoordinator([obsidian], config, mockCurate)
+
+      const result = await coordinator.store({content: 'test'})
+      expect(result.success).to.be.false
+      expect(result.fallback).to.be.true
+      expect(result.error).to.equal('No provider connected')
     })
 
     it('does not fallback for explicit --provider target', async () => {

--- a/test/unit/agent/swarm/swarm-coordinator.test.ts
+++ b/test/unit/agent/swarm/swarm-coordinator.test.ts
@@ -384,67 +384,28 @@ describe('SwarmCoordinator', () => {
       expect(result.error).to.include('is not healthy')
     })
 
-    it('returns error when no writable provider and no curateService', async () => {
+    it('falls back to brv curate when no writable providers', async () => {
       const obsidian = createMockProvider('obsidian', 'obsidian', [])
-
       const config = createMinimalConfig()
       const coordinator = new SwarmCoordinator([obsidian], config)
 
-      const result = await coordinator.store({content: 'test'})
-      expect(result.success).to.be.false
-      expect(result.error).to.include('curate service not configured')
-    })
-
-    it('falls back to curateService when no writable providers', async () => {
-      const obsidian = createMockProvider('obsidian', 'obsidian', [])
-      const mockCurate = {
-        curate: sinon.stub().resolves({
-          applied: [{path: 'swarm-fallback/test', status: 'success', type: 'ADD'}],
-          summary: {added: 1, deleted: 0, failed: 0, merged: 0, updated: 0},
-        }),
-        detectDomains: sinon.stub(),
-      }
-
-      const config = createMinimalConfig()
-      const coordinator = new SwarmCoordinator([obsidian], config, mockCurate)
-
+      // The fallback calls `brv curate --detach` via execFile.
+      // We can't easily mock execFile here, so we verify the result shape
+      // when the fallback is triggered (it will fail because brv daemon
+      // may not be running in test, but the fallback flag should be set).
       const result = await coordinator.store({content: 'test content'})
-      expect(result.success).to.be.true
       expect(result.fallback).to.be.true
       expect(result.provider).to.equal('byterover')
-      expect(mockCurate.curate.calledOnce).to.be.true
-    })
-
-    it('fallback returns failure when curateService throws', async () => {
-      const obsidian = createMockProvider('obsidian', 'obsidian', [])
-      const mockCurate = {
-        curate: sinon.stub().rejects(new Error('Curate pipeline failed')),
-        detectDomains: sinon.stub(),
-      }
-
-      const config = createMinimalConfig()
-      const coordinator = new SwarmCoordinator([obsidian], config, mockCurate)
-
-      const result = await coordinator.store({content: 'test'})
-      expect(result.success).to.be.false
-      expect(result.fallback).to.be.true
-      expect(result.error).to.include('Curate pipeline failed')
     })
 
     it('does not fallback for explicit --provider target', async () => {
       const obsidian = createMockProvider('obsidian', 'obsidian', [])
-      const mockCurate = {
-        curate: sinon.stub().resolves({applied: [], summary: {added: 0, deleted: 0, failed: 0, merged: 0, updated: 0}}),
-        detectDomains: sinon.stub(),
-      }
-
       const config = createMinimalConfig()
-      const coordinator = new SwarmCoordinator([obsidian], config, mockCurate)
+      const coordinator = new SwarmCoordinator([obsidian], config)
 
       const result = await coordinator.store({content: 'test', provider: 'obsidian'})
       expect(result.success).to.be.false
       expect(result.fallback).to.be.undefined
-      expect(mockCurate.curate.called).to.be.false
     })
 
     it('normal write does not set fallback flag', async () => {

--- a/test/unit/agent/swarm/swarm-write-router.test.ts
+++ b/test/unit/agent/swarm/swarm-write-router.test.ts
@@ -62,7 +62,7 @@ describe('SwarmWriteRouter', () => {
       const health = new Map([['gbrain', true], ['local-markdown:notes', true]])
 
       const target = selectWriteTarget('entity', [gbrain, localMd], health)
-      expect(target.id).to.equal('gbrain')
+      expect(target!.id).to.equal('gbrain')
     })
 
     it('selects local-markdown for note write type', () => {
@@ -71,7 +71,7 @@ describe('SwarmWriteRouter', () => {
       const health = new Map([['gbrain', true], ['local-markdown:notes', true]])
 
       const target = selectWriteTarget('note', [gbrain, localMd], health)
-      expect(target.id).to.equal('local-markdown:notes')
+      expect(target!.id).to.equal('local-markdown:notes')
     })
 
     it('falls back to first writable provider for general', () => {
@@ -81,7 +81,7 @@ describe('SwarmWriteRouter', () => {
 
       const target = selectWriteTarget('general', [gbrain, localMd], health)
       // GBrain comes first in the provider list
-      expect(target.id).to.equal('gbrain')
+      expect(target!.id).to.equal('gbrain')
     })
 
     it('skips providers with writeSupported=false', () => {
@@ -90,7 +90,7 @@ describe('SwarmWriteRouter', () => {
       const health = new Map([['gbrain', true], ['obsidian', true]])
 
       const target = selectWriteTarget('entity', [obsidian, gbrain], health)
-      expect(target.id).to.equal('gbrain')
+      expect(target!.id).to.equal('gbrain')
     })
 
     it('skips unhealthy providers', () => {
@@ -100,21 +100,21 @@ describe('SwarmWriteRouter', () => {
 
       const target = selectWriteTarget('entity', [gbrain, localMd], health)
       // GBrain is unhealthy, falls back to local-markdown
-      expect(target.id).to.equal('local-markdown:notes')
+      expect(target!.id).to.equal('local-markdown:notes')
     })
 
-    it('throws when no writable provider available', () => {
+    it('returns null when no writable provider available', () => {
       const obsidian = createMockProvider('obsidian', 'obsidian', false)
       const health = new Map([['obsidian', true]])
 
-      expect(() => selectWriteTarget('entity', [obsidian], health)).to.throw('No writable providers configured')
+      expect(selectWriteTarget('entity', [obsidian], health)).to.be.null
     })
 
-    it('throws when all writable providers are unhealthy', () => {
+    it('returns null when all writable providers are unhealthy', () => {
       const gbrain = createMockProvider('gbrain', 'gbrain', true)
       const health = new Map([['gbrain', false]])
 
-      expect(() => selectWriteTarget('entity', [gbrain], health)).to.throw('No writable providers configured')
+      expect(selectWriteTarget('entity', [gbrain], health)).to.be.null
     })
 
     it('selects first local-markdown by config order with multiple folders', () => {
@@ -123,7 +123,7 @@ describe('SwarmWriteRouter', () => {
       const health = new Map([['local-markdown:docs', true], ['local-markdown:notes', true]])
 
       const target = selectWriteTarget('note', [md1, md2], health)
-      expect(target.id).to.equal('local-markdown:notes')
+      expect(target!.id).to.equal('local-markdown:notes')
     })
 
     it('falls back to local-markdown when GBrain is unavailable for entity', () => {
@@ -131,7 +131,7 @@ describe('SwarmWriteRouter', () => {
       const health = new Map([['local-markdown:notes', true]])
 
       const target = selectWriteTarget('entity', [localMd], health)
-      expect(target.id).to.equal('local-markdown:notes')
+      expect(target!.id).to.equal('local-markdown:notes')
     })
   })
 })


### PR DESCRIPTION
- Change selectWriteTarget() to return null instead of throwing when no writable providers are available
- Add optional ICurateService to SwarmCoordinator constructor
- Add fallbackToByterover() that routes content to the curation pipeline (snippets) when no external provider can accept the write
- Add fallback?: boolean to SwarmStoreResult type
- Update CLI curate output to show fallback message
- 5 new tests: fallback with/without curateService, fallback on curate failure, no fallback for explicit --provider, normal write without fallback flag

## Summary

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [ ] Agent / Tools
- [ ] LLM Providers
- [ ] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes #
- Related #

## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause:
- Why this was not caught earlier:

## Test plan

- Coverage added:
  - [ ] Unit test
  - [ ] Integration test
  - [ ] Manual verification only
- Test file(s):
- Key scenario(s) covered:

## User-visible changes

List user-visible changes (including defaults, config, or CLI output).
If none, write `None`.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording

## Checklist

- [ ] Tests added or updated and passing (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Type check passes (`npm run typecheck`)
- [ ] Build succeeds (`npm run build`)
- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or clearly documented above)
- [ ] Branch is up to date with `main`

## Risks and mitigations

List real risks for this PR. If none, write `None`.

- Risk:
  - Mitigation:
