### PR TITLE
fix:[ENG-2078] make confidence and impact optional with safe defaults

### DIFF
--- a/src/agent/infra/tools/implementations/curate-tool.ts
+++ b/src/agent/infra/tools/implementations/curate-tool.ts
@@ -213,6 +213,7 @@ const SubtopicContextSchema = z.object({
 const OperationSchema = z.object({
   confidence: z
     .enum(['high', 'low'])
+    .default('low')
     .describe(
       'Your confidence in the accuracy and completeness of this operation. Use "high" when you have direct evidence from the source material; use "low" when the information is inferred, uncertain, or incomplete.',
     ),
@@ -222,6 +223,7 @@ const OperationSchema = z.object({
   ),
   impact: z
     .enum(['high', 'low'])
+    .default('high')
     .describe(
       'Estimated scope of impact of this knowledge change. "high": Changes that alter core decisions, strategies, tools, or established approaches. Any change that contradicts or reverses previously curated knowledge. Updates to existing knowledge that change its core substance. Deletions are always high impact. "low": New additions to previously undocumented topics, minor corrections, supplementary details like examples and clarifications, or updates that extend existing knowledge without changing its core substance.',
     ),

--- a/test/unit/agent/tools/curate-tool.test.ts
+++ b/test/unit/agent/tools/curate-tool.test.ts
@@ -1320,4 +1320,88 @@ describe('Curate Tool', () => {
       expect(result.applied[0].previousSummary).to.be.undefined
     })
   })
+
+  describe('confidence and impact defaults', () => {
+    it('should accept operation without confidence (defaults to low)', async () => {
+      const tool = createCurateTool()
+      const result = (await tool.execute({
+        basePath,
+        operations: [
+          {
+            content: {keywords: [], snippets: ['test snippet'], tags: []},
+            impact: 'low',
+            path: 'test_domain/test_topic',
+            reason: 'testing confidence default',
+            title: 'Test',
+            type: 'ADD',
+          },
+        ],
+      })) as CurateOutput
+
+      expect(result.applied[0].status).to.equal('success')
+      expect(result.applied[0].confidence).to.equal('low')
+    })
+
+    it('should accept operation without impact (defaults to high)', async () => {
+      const tool = createCurateTool()
+      const result = (await tool.execute({
+        basePath,
+        operations: [
+          {
+            confidence: 'high',
+            content: {keywords: [], snippets: ['test snippet'], tags: []},
+            path: 'test_domain/test_topic',
+            reason: 'testing impact default',
+            title: 'Test',
+            type: 'ADD',
+          },
+        ],
+      })) as CurateOutput
+
+      expect(result.applied[0].status).to.equal('success')
+      expect(result.applied[0].impact).to.equal('high')
+    })
+
+    it('should accept operation with both omitted', async () => {
+      const tool = createCurateTool()
+      const result = (await tool.execute({
+        basePath,
+        operations: [
+          {
+            content: {keywords: [], snippets: ['test snippet'], tags: []},
+            path: 'test_domain/test_topic',
+            reason: 'testing both defaults',
+            title: 'Test',
+            type: 'ADD',
+          },
+        ],
+      })) as CurateOutput
+
+      expect(result.applied[0].status).to.equal('success')
+      expect(result.applied[0].confidence).to.equal('low')
+      expect(result.applied[0].impact).to.equal('high')
+    })
+
+    it('should accept operation with both explicitly provided', async () => {
+      const tool = createCurateTool()
+      const result = (await tool.execute({
+        basePath,
+        operations: [
+          {
+            confidence: 'high',
+            content: {keywords: [], snippets: ['test snippet'], tags: []},
+            impact: 'low',
+            path: 'test_domain/test_topic',
+            reason: 'testing explicit values',
+            title: 'Test',
+            type: 'ADD',
+          },
+        ],
+      })) as CurateOutput
+
+      expect(result.applied[0].status).to.equal('success')
+      expect(result.applied[0].confidence).to.equal('high')
+      expect(result.applied[0].impact).to.equal('low')
+    })
+  })
 })

--- a/test/unit/agent/tools/curate-tool.test.ts
+++ b/test/unit/agent/tools/curate-tool.test.ts
@@ -1360,6 +1360,7 @@ describe('Curate Tool', () => {
 
       expect(result.applied[0].status).to.equal('success')
       expect(result.applied[0].impact).to.equal('high')
+      expect(result.applied[0].needsReview).to.be.true
     })
 
     it('should accept operation with both omitted', async () => {
@@ -1380,6 +1381,7 @@ describe('Curate Tool', () => {
       expect(result.applied[0].status).to.equal('success')
       expect(result.applied[0].confidence).to.equal('low')
       expect(result.applied[0].impact).to.equal('high')
+      expect(result.applied[0].needsReview).to.be.true
     })
 
     it('should accept operation with both explicitly provided', async () => {


### PR DESCRIPTION
Summary

- **Problem:** `OperationSchema` in `curate-tool.ts` defines `confidence` and `impact` as required fields, but every other schema in the codebase marks them optional. When the LLM agent omits either field (reasonable for many operations), Zod validation fails, the curate operation is lost, and the agent sees an unhelpful schema error.
- **Why it matters:** Every curate tool call that omits `confidence` or `impact` silently fails. The agent may retry with hallucinated values. For DELETE operations, these fields are meaningless but still required.
- **What changed:** Added `.default('low')` to `confidence` and `.default('high')` to `impact` in `OperationSchema`. Zod fills in safe values when the LLM omits the fields. No changes to `deriveReviewMetadata()` — Zod applies defaults before the parsed value reaches the function.
- **What did NOT change (scope boundary):** No changes to `ICurateService`, `CurateOperation` interface, other schemas, review logic, or the LLM prompt. Only the Zod validation schema is affected.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [x] Agent / Tools
- [ ] LLM Providers
- [ ] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes ENG-2078

## Root cause (bug fixes only)

- **Root cause:** `OperationSchema` at `curate-tool.ts:214-227` defines `confidence` and `impact` with `z.enum(['high', 'low'])` — no `.optional()` or `.default()`. All other schemas (`CurateLogOperation`, `CurateLogOperationFileSchema`, `CurateOperationSchema`) mark these fields optional. The mismatch means the LLM-facing schema is stricter than the internal types.
- **Why this was not caught earlier:** Existing tests always provide both fields explicitly. The failure only surfaces when the LLM agent decides not to include them — which happens frequently in practice but wasn't covered by test fixtures.

## Test plan

- Coverage added:
  - [x] Unit test
  - [ ] Integration test
  - [ ] Manual verification only
- Test file(s):
  - `test/unit/agent/tools/curate-tool.test.ts` (+4 tests)
- Key scenario(s) covered:
  - Operation without `confidence` → parses successfully, defaults to `'low'`
  - Operation without `impact` → parses successfully, defaults to `'high'`
  - Operation with both omitted → parses successfully, both defaults applied
  - Operation with both explicitly provided → explicit values preserved (no regression)

## User-visible changes

- Curate tool no longer fails with "Required" validation errors when the LLM omits `confidence` or `impact`
- Operations with omitted `impact` now default to `'high'`, which triggers `needsReview: true` — conservative safety default
- Operations with omitted `confidence` default to `'low'`

## Evidence

- [x] Failing test/log before + passing after

**Before (from real curate log):**
```
✗ [ADD] — Invalid input: [
  {"expected": "'high' | 'low'", "received": "undefined", "path": ["operations", 0, "confidence"], "message": "Required"},
  {"expected": "'high' | 'low'", "received": "undefined", "path": ["operations", 0, "impact"], "message": "Required"}
]
```

**After:**
```
✔ should accept operation with both omitted
  confidence: 'low' (default)
  impact: 'high' (default)
```

## Checklist

- [x] Tests added or updated and passing (`npm test`) — 5540 passing
- [x] Lint passes (`npm run lint`) — pre-commit hook verified
- [ ] Type check passes (`npm run typecheck`)
- [ ] Build succeeds (`npm run build`)
- [x] Commits follow Conventional Commits format
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented above)
- [ ] Branch is up to date with `main`

## Risks and mitigations

- **Risk:** Changing `confidence` from required to defaulted could hide cases where the LLM *should* express confidence but doesn't.
  - **Mitigation:** Default is `'low'` — the conservative value. The `.describe()` text still guides the LLM to provide explicit values. The field remains in the schema definition, just no longer fails on omission.

- **Risk:** Changing `impact` from required to defaulted means omitted impact always triggers human review (`needsReview = impact === 'high'`).
  - **Mitigation:** This is intentionally conservative. Better to over-trigger review than silently skip it. The LLM can still set `impact: 'low'` to skip review when it's confident.