### PR TITLE
feat:[ENG-2080] Integrate Memory Wiki with Swarm memory

### DIFF
--- a/src/agent/core/domain/swarm/types.ts
+++ b/src/agent/core/domain/swarm/types.ts
@@ -8,6 +8,7 @@ export const PROVIDER_TYPES = [
   'obsidian',
   'local-markdown',
   'gbrain',
+  'memory-wiki',
 ] as const
 
 /**
@@ -242,6 +243,20 @@ export function createDefaultCapabilities(type: ProviderType): ProviderCapabilit
         temporalQuery: true,
         userModeling: false,
         writeSupported: true,
+      }
+    }
+
+    case 'memory-wiki': {
+      return {
+        avgLatencyMs: 150,
+        graphTraversal: false,
+        keywordSearch: true,
+        localOnly: true,
+        maxTokensPerQuery: 8000,
+        semanticSearch: true,
+        temporalQuery: false,
+        userModeling: false,
+        writeSupported: false,
       }
     }
   }

--- a/src/agent/core/domain/swarm/types.ts
+++ b/src/agent/core/domain/swarm/types.ts
@@ -24,7 +24,7 @@ export type QueryType = 'creative' | 'factual' | 'personal' | 'relational' | 'te
 /**
  * Local providers that require no network calls.
  */
-const LOCAL_PROVIDERS: ReadonlySet<ProviderType> = new Set(['byterover', 'local-markdown', 'obsidian'])
+const LOCAL_PROVIDERS: ReadonlySet<ProviderType> = new Set(['byterover', 'local-markdown', 'memory-wiki', 'obsidian'])
 
 /**
  * Check if a provider type is local (no network required).
@@ -248,15 +248,15 @@ export function createDefaultCapabilities(type: ProviderType): ProviderCapabilit
 
     case 'memory-wiki': {
       return {
-        avgLatencyMs: 150,
+        avgLatencyMs: 60,
         graphTraversal: false,
         keywordSearch: true,
         localOnly: true,
         maxTokensPerQuery: 8000,
-        semanticSearch: true,
+        semanticSearch: false,
         temporalQuery: false,
         userModeling: false,
-        writeSupported: false,
+        writeSupported: true,
       }
     }
   }

--- a/src/agent/infra/swarm/adapters/memory-wiki-adapter.ts
+++ b/src/agent/infra/swarm/adapters/memory-wiki-adapter.ts
@@ -1,5 +1,5 @@
 import MiniSearch from 'minisearch'
-import {existsSync, readdirSync, readFileSync, statSync, writeFileSync} from 'node:fs'
+import {existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync} from 'node:fs'
 import {join} from 'node:path'
 
 import type {
@@ -80,13 +80,19 @@ function buildIndexSignature(vaultPath: string): string {
 }
 
 function extractContentSection(fullContent: string): string {
-  // Extract just the ## Content section from wiki page template
-  const contentMatch = fullContent.match(/```text\n([\s\S]*?)```/)
-  if (contentMatch) {
-    return contentMatch[1].trim()
+  // Extract content from openclaw:wiki:content markers (written by store())
+  const wikiMarkerMatch = fullContent.match(/<!-- openclaw:wiki:content:start -->\n([\s\S]*?)<!-- openclaw:wiki:content:end -->/)
+  if (wikiMarkerMatch) {
+    return wikiMarkerMatch[1].trim()
   }
 
-  // If no code block, strip frontmatter and return everything
+  // Extract from ```text code block (wiki source page format)
+  const codeBlockMatch = fullContent.match(/```text\n([\s\S]*?)```/)
+  if (codeBlockMatch) {
+    return codeBlockMatch[1].trim()
+  }
+
+  // Fallback: strip frontmatter and return everything
   const withoutFrontmatter = fullContent.replace(/^---[\s\S]*?---\n*/, '')
   return withoutFrontmatter.trim()
 }
@@ -193,6 +199,7 @@ private readonly boostFresh: boolean
     const pageType = this.writePageType
     const dir = pageType === 'entity' ? 'entities' : 'concepts'
     const dirPath = join(this.vaultPath, dir)
+    mkdirSync(dirPath, {recursive: true})
     const now = new Date().toISOString()
 
     // Resolve unique filename

--- a/src/agent/infra/swarm/adapters/memory-wiki-adapter.ts
+++ b/src/agent/infra/swarm/adapters/memory-wiki-adapter.ts
@@ -1,5 +1,6 @@
 import MiniSearch from 'minisearch'
-import {existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync} from 'node:fs'
+import {existsSync, mkdirSync, readdirSync, readFileSync, statSync} from 'node:fs'
+import {writeFile} from 'node:fs/promises'
 import {join} from 'node:path'
 
 import type {
@@ -232,7 +233,7 @@ private readonly boostFresh: boolean
       '',
     ].join('\n')
 
-    writeFileSync(filePath, pageContent)
+    await writeFile(filePath, pageContent)
 
     // Invalidate index so next query picks up the new page
     this.index = null

--- a/src/agent/infra/swarm/adapters/memory-wiki-adapter.ts
+++ b/src/agent/infra/swarm/adapters/memory-wiki-adapter.ts
@@ -112,7 +112,7 @@ export class MemoryWikiAdapter implements IMemoryProvider {
   }
   public readonly id = 'memory-wiki'
   public readonly type = 'memory-wiki' as const
-private readonly boostFresh: boolean
+  private readonly boostFresh: boolean
   private digest: AgentDigest | null = null
   private documents: IndexedDoc[] = []
   private index: MiniSearch<IndexedDoc> | null = null

--- a/src/agent/infra/swarm/adapters/memory-wiki-adapter.ts
+++ b/src/agent/infra/swarm/adapters/memory-wiki-adapter.ts
@@ -1,0 +1,309 @@
+import MiniSearch from 'minisearch'
+import {existsSync, readdirSync, readFileSync, statSync, writeFileSync} from 'node:fs'
+import {join} from 'node:path'
+
+import type {
+  CostEstimate,
+  HealthStatus,
+  MemoryEntry,
+  ProviderCapabilities,
+  QueryRequest,
+  QueryResult,
+  StoreResult,
+} from '../../../core/domain/swarm/types.js'
+import type {IMemoryProvider} from '../../../core/interfaces/i-memory-provider.js'
+
+import {searchWithPrecision} from '../search-precision.js'
+
+/** Directories to scan for wiki pages */
+const PAGE_DIRS = ['entities', 'concepts', 'syntheses', 'sources']
+
+/** Score boost for fresh pages */
+const FRESH_BOOST = 1.2
+
+/** Score boost for entities/concepts over sources */
+const KIND_BOOST: Record<string, number> = {
+  concept: 1.3,
+  entity: 1.4,
+  source: 1,
+  synthesis: 1.2,
+}
+
+interface DigestPage {
+  claimCount: number
+  freshnessLevel: string
+  id: string
+  kind: string
+  lastTouchedAt: string
+  path: string
+  title: string
+  topClaims: Array<{text: string}>
+}
+
+interface AgentDigest {
+  pageCounts: Record<string, number>
+  pages: DigestPage[]
+}
+
+interface IndexedDoc {
+  content: string
+  freshnessLevel: string
+  id: number
+  kind: string
+  pageId: string
+  path: string
+  title: string
+}
+
+export interface MemoryWikiAdapterOptions {
+  boostFresh?: boolean
+  vaultPath: string
+  writePageType?: 'concept' | 'entity'
+}
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replaceAll(/[^\w\s-]/g, '')
+    .trim()
+    .replaceAll(/\s+/g, '_')
+}
+
+function buildIndexSignature(vaultPath: string): string {
+  const digestPath = join(vaultPath, '.openclaw-wiki', 'cache', 'agent-digest.json')
+  try {
+    const stat = statSync(digestPath)
+    return `${stat.mtimeMs}:${stat.size}`
+  } catch {
+    return ''
+  }
+}
+
+function extractContentSection(fullContent: string): string {
+  // Extract just the ## Content section from wiki page template
+  const contentMatch = fullContent.match(/```text\n([\s\S]*?)```/)
+  if (contentMatch) {
+    return contentMatch[1].trim()
+  }
+
+  // If no code block, strip frontmatter and return everything
+  const withoutFrontmatter = fullContent.replace(/^---[\s\S]*?---\n*/, '')
+  return withoutFrontmatter.trim()
+}
+
+export class MemoryWikiAdapter implements IMemoryProvider {
+  public readonly capabilities: ProviderCapabilities = {
+    avgLatencyMs: 60,
+    graphTraversal: false,
+    keywordSearch: true,
+    localOnly: true,
+    maxTokensPerQuery: 8000,
+    semanticSearch: false,
+    temporalQuery: false,
+    userModeling: false,
+    writeSupported: true,
+  }
+  public readonly id = 'memory-wiki'
+  public readonly type = 'memory-wiki' as const
+private readonly boostFresh: boolean
+  private digest: AgentDigest | null = null
+  private documents: IndexedDoc[] = []
+  private index: MiniSearch<IndexedDoc> | null = null
+  private indexSignature = ''
+  private readonly vaultPath: string
+  private readonly writePageType: 'concept' | 'entity'
+
+  constructor(options: MemoryWikiAdapterOptions) {
+    this.vaultPath = options.vaultPath
+    this.boostFresh = options.boostFresh ?? true
+    this.writePageType = options.writePageType ?? 'concept'
+  }
+
+  public async delete(_id: string): Promise<void> {
+    throw new Error('Memory Wiki pages should be managed via wiki_apply.')
+  }
+
+  public estimateCost(_request: QueryRequest): CostEstimate {
+    return {estimatedCostCents: 0, estimatedLatencyMs: 60, estimatedTokens: 0}
+  }
+
+  public async healthCheck(): Promise<HealthStatus> {
+    try {
+      if (!existsSync(this.vaultPath)) {
+        return {available: false, error: `Wiki vault not found at ${this.vaultPath}`}
+      }
+
+      return {available: true}
+    } catch (error) {
+      return {available: false, error: error instanceof Error ? error.message : String(error)}
+    }
+  }
+
+  public async query(request: QueryRequest): Promise<QueryResult[]> {
+    this.ensureIndex()
+
+    if (!this.index) {
+      return []
+    }
+
+    const maxResults = request.maxResults ?? 10
+    const precisionResults = searchWithPrecision(this.index, request.query, {maxResults})
+
+    if (precisionResults.length === 0) {
+      return []
+    }
+
+    const mapped: QueryResult[] = []
+    for (const pr of precisionResults) {
+      const doc = this.documents[pr.id as number]
+      if (!doc) continue
+
+      let score = pr.normalizedScore
+
+      // Freshness boost
+      if (this.boostFresh && doc.freshnessLevel === 'fresh') {
+        score *= FRESH_BOOST
+      }
+
+      // Kind boost
+      score *= KIND_BOOST[doc.kind] ?? 1
+
+      mapped.push({
+        content: extractContentSection(doc.content).slice(0, 5000),
+        id: doc.pageId,
+        metadata: {
+          matchType: 'keyword' as const,
+          path: doc.path,
+          source: doc.path,
+        },
+        provider: 'memory-wiki',
+        providerType: 'memory-wiki' as const,
+        score,
+      })
+    }
+
+    return mapped.sort((a, b) => b.score - a.score).slice(0, maxResults)
+  }
+
+  public async store(entry: MemoryEntry): Promise<StoreResult> {
+    const {content} = entry
+    const titleMatch = content.match(/^#\s+(.+)$/m)
+    const title = titleMatch?.[1] ?? content.slice(0, 60).trim()
+    const slug = slugify(title)
+    const pageType = this.writePageType
+    const dir = pageType === 'entity' ? 'entities' : 'concepts'
+    const dirPath = join(this.vaultPath, dir)
+    const now = new Date().toISOString()
+
+    // Resolve unique filename
+    let filename = `${slug}.md`
+    let filePath = join(dirPath, filename)
+    let suffix = 1
+    while (existsSync(filePath)) {
+      filename = `${slug}-${suffix}.md`
+      filePath = join(dirPath, filename)
+      suffix++
+    }
+
+    const pageId = `${pageType}.swarm.${slug}`
+    const pageContent = [
+      '---',
+      `pageType: ${pageType}`,
+      `id: ${pageId}`,
+      `title: "${title}"`,
+      'status: active',
+      `updatedAt: "${now}"`,
+      'sourceType: swarm-curate',
+      '---',
+      '',
+      '<!-- openclaw:wiki:content:start -->',
+      content,
+      '<!-- openclaw:wiki:content:end -->',
+      '',
+      '<!-- openclaw:human:start -->',
+      '<!-- openclaw:human:end -->',
+      '',
+    ].join('\n')
+
+    writeFileSync(filePath, pageContent)
+
+    // Invalidate index so next query picks up the new page
+    this.index = null
+    this.indexSignature = ''
+
+    return {id: pageId, provider: 'memory-wiki', success: true}
+  }
+
+  public async update(_id: string, _entry: Partial<MemoryEntry>): Promise<void> {
+    throw new Error('Memory Wiki pages should be managed via wiki_apply.')
+  }
+
+  private ensureIndex(): void {
+    const nextSignature = buildIndexSignature(this.vaultPath)
+    if (this.index && this.indexSignature === nextSignature) {
+      return
+    }
+
+    this.digest = this.loadDigest()
+    this.documents = this.scanPages()
+
+    this.index = new MiniSearch<IndexedDoc>({
+      fields: ['title', 'content'],
+      idField: 'id',
+      storeFields: ['title', 'path'],
+    })
+    this.index.addAll(this.documents)
+    this.indexSignature = nextSignature
+  }
+
+  private loadDigest(): AgentDigest | null {
+    const digestPath = join(this.vaultPath, '.openclaw-wiki', 'cache', 'agent-digest.json')
+    try {
+      return JSON.parse(readFileSync(digestPath, 'utf8')) as AgentDigest
+    } catch {
+      return null
+    }
+  }
+
+  private scanPages(): IndexedDoc[] {
+    const digestMap = new Map<string, DigestPage>()
+    if (this.digest) {
+      for (const page of this.digest.pages) {
+        digestMap.set(page.path, page)
+      }
+    }
+
+    const docs: IndexedDoc[] = []
+    let docId = 0
+
+    for (const dir of PAGE_DIRS) {
+      const dirPath = join(this.vaultPath, dir)
+      if (!existsSync(dirPath)) continue
+
+      for (const entry of readdirSync(dirPath)) {
+        if (!entry.endsWith('.md') || entry === 'index.md') continue
+
+        try {
+          const content = readFileSync(join(dirPath, entry), 'utf8')
+          const relPath = `${dir}/${entry}`
+          const digestPage = digestMap.get(relPath)
+          const titleMatch = content.match(/^title:\s*"?(.+?)"?\s*$/m) ?? content.match(/^#\s+(.+)$/m)
+
+          docs.push({
+            content,
+            freshnessLevel: digestPage?.freshnessLevel ?? 'unknown',
+            id: docId++,
+            kind: digestPage?.kind ?? dir.replace(/s$/, ''),
+            pageId: digestPage?.id ?? `${dir}.${entry.replace(/\.md$/, '')}`,
+            path: relPath,
+            title: titleMatch?.[1] ?? entry.replace(/\.md$/, ''),
+          })
+        } catch {
+          // Skip unreadable files
+        }
+      }
+    }
+
+    return docs
+  }
+}

--- a/src/agent/infra/swarm/cli/query-renderer.ts
+++ b/src/agent/infra/swarm/cli/query-renderer.ts
@@ -24,6 +24,9 @@ export function providerTypeToLabel(type: ProviderType, id: string): string {
       return `notes:${name}`
     }
 
+    case 'memory-wiki': { return 'wiki'
+    }
+
     case 'obsidian': { return 'obsidian'
     }
   }
@@ -35,6 +38,7 @@ const LABEL_COLORS: Record<ProviderType, (s: string) => string> = {
   hindsight: chalk.blueBright,
   honcho: chalk.blue,
   'local-markdown': chalk.green,
+  'memory-wiki': chalk.whiteBright,
   obsidian: chalk.magenta,
 }
 

--- a/src/agent/infra/swarm/config/swarm-config-schema.ts
+++ b/src/agent/infra/swarm/config/swarm-config-schema.ts
@@ -158,6 +158,24 @@ const GBrainProviderSchema = z.preprocess(
   })
 )
 
+const MemoryWikiProviderSchema = z.preprocess(
+  (data) => {
+    if (typeof data !== 'object' || data === null) return data
+
+    return mapKeys(data as Record<string, unknown>, {
+      boost_fresh: 'boostFresh',
+      vault_path: 'vaultPath',
+      write_page_type: 'writePageType',
+    })
+  },
+  z.object({
+    boostFresh: z.boolean().optional().default(true),
+    enabled: z.boolean(),
+    vaultPath: z.string(),
+    writePageType: z.enum(['concept', 'entity']).optional().default('concept'),
+  })
+)
+
 // ============================================================
 // Top-level sections
 // ============================================================
@@ -168,6 +186,7 @@ const ProvidersSchema = z.preprocess(
 
     return mapKeys(data as Record<string, unknown>, {
       local_markdown: 'localMarkdown',
+      memory_wiki: 'memoryWiki',
     })
   },
   z.object({
@@ -176,6 +195,7 @@ const ProvidersSchema = z.preprocess(
     hindsight: HindsightProviderSchema.optional(),
     honcho: HonchoProviderSchema.optional(),
     localMarkdown: LocalMarkdownProviderSchema.optional(),
+    memoryWiki: MemoryWikiProviderSchema.optional(),
     obsidian: ObsidianProviderSchema.optional(),
   })
 )

--- a/src/agent/infra/swarm/provider-factory.ts
+++ b/src/agent/infra/swarm/provider-factory.ts
@@ -81,7 +81,7 @@ export function buildProvidersFromConfig(
     }))
   }
 
-  if (config.providers.memoryWiki?.enabled && config.providers.memoryWiki.vaultPath) {
+  if (config.providers.memoryWiki?.enabled) {
     providers.push(new MemoryWikiAdapter({
       boostFresh: config.providers.memoryWiki.boostFresh,
       vaultPath: config.providers.memoryWiki.vaultPath,

--- a/src/agent/infra/swarm/provider-factory.ts
+++ b/src/agent/infra/swarm/provider-factory.ts
@@ -4,6 +4,7 @@ import type {SwarmConfig} from './config/swarm-config-schema.js'
 import {ByteRoverAdapter, type SearchService} from './adapters/byterover-adapter.js'
 import {GBrainAdapter} from './adapters/gbrain-adapter.js'
 import {LocalMarkdownAdapter} from './adapters/local-markdown-adapter.js'
+import {MemoryWikiAdapter} from './adapters/memory-wiki-adapter.js'
 import {ObsidianAdapter} from './adapters/obsidian-adapter.js'
 
 /**
@@ -77,6 +78,14 @@ export function buildProvidersFromConfig(
     providers.push(new GBrainAdapter({
       repoPath: config.providers.gbrain.repoPath,
       searchMode: config.providers.gbrain.searchMode,
+    }))
+  }
+
+  if (config.providers.memoryWiki?.enabled && config.providers.memoryWiki.vaultPath) {
+    providers.push(new MemoryWikiAdapter({
+      boostFresh: config.providers.memoryWiki.boostFresh,
+      vaultPath: config.providers.memoryWiki.vaultPath,
+      writePageType: config.providers.memoryWiki.writePageType,
     }))
   }
 

--- a/src/agent/infra/swarm/swarm-coordinator.ts
+++ b/src/agent/infra/swarm/swarm-coordinator.ts
@@ -26,6 +26,7 @@ const DEFAULT_WEIGHTS: Record<string, number> = {
   hindsight: 0.8,
   honcho: 0.75,
   'local-markdown': 0.8,
+  'memory-wiki': 0.9,
   obsidian: 0.85,
 }
 

--- a/src/agent/infra/swarm/swarm-coordinator.ts
+++ b/src/agent/infra/swarm/swarm-coordinator.ts
@@ -52,7 +52,7 @@ const DEFAULT_WEIGHTS: Record<string, number> = {
   hindsight: 0.8,
   honcho: 0.75,
   'local-markdown': 0.8,
-  'memory-wiki': 0.8,
+  'memory-wiki': 0.9,
   obsidian: 0.85,
 }
 

--- a/src/agent/infra/swarm/swarm-router.ts
+++ b/src/agent/infra/swarm/swarm-router.ts
@@ -30,11 +30,11 @@ export function classifyQuery(query: string): QueryType {
  * When re-enabled, add 'honcho' to personal/creative and 'hindsight' to temporal/relational/creative.
  */
 const SELECTION_MATRIX: Record<QueryType, string[]> = {
-  creative: ['byterover', 'obsidian', 'local-markdown', 'gbrain'],
-  factual: ['byterover', 'obsidian', 'local-markdown', 'gbrain'],
+  creative: ['byterover', 'obsidian', 'local-markdown', 'gbrain', 'memory-wiki'],
+  factual: ['byterover', 'obsidian', 'local-markdown', 'gbrain', 'memory-wiki'],
   personal: ['byterover', 'obsidian', 'local-markdown'],
-  relational: ['byterover', 'obsidian', 'local-markdown', 'gbrain'],
-  temporal: ['byterover', 'obsidian', 'local-markdown', 'gbrain'],
+  relational: ['byterover', 'obsidian', 'local-markdown', 'gbrain', 'memory-wiki'],
+  temporal: ['byterover', 'obsidian', 'local-markdown', 'gbrain', 'memory-wiki'],
 }
 
 /**

--- a/src/agent/infra/swarm/validation/config-validator.ts
+++ b/src/agent/infra/swarm/validation/config-validator.ts
@@ -443,6 +443,14 @@ export async function validateSwarmProviders(
     validateGBrain(providers.gbrain, errors)
   }
 
+  if (providers.memoryWiki?.enabled && !existsSync(providers.memoryWiki.vaultPath)) {
+      errors.push({
+        field: 'providers.memory_wiki.vault_path',
+        message: `Memory Wiki vault not found at ${providers.memoryWiki.vaultPath}`,
+        provider: 'memory-wiki',
+      })
+    }
+
   // Validate enrichment edges
   validateEnrichmentEdges(config, errors, warnings)
 

--- a/src/agent/infra/swarm/validation/config-validator.ts
+++ b/src/agent/infra/swarm/validation/config-validator.ts
@@ -232,6 +232,7 @@ function getEnabledProviderIds(providers: SwarmConfig['providers']): Set<string>
   if (providers.honcho?.enabled) ids.add('honcho')
   if (providers.hindsight?.enabled) ids.add('hindsight')
   if (providers.gbrain?.enabled) ids.add('gbrain')
+  if (providers.memoryWiki?.enabled) ids.add('memory-wiki')
 
   return ids
 }
@@ -258,6 +259,7 @@ function isConfiguredProvider(edgeEndpoint: string, providers: SwarmConfig['prov
   if (edgeEndpoint === 'honcho') return providers.honcho !== undefined
   if (edgeEndpoint === 'hindsight') return providers.hindsight !== undefined
   if (edgeEndpoint === 'gbrain') return providers.gbrain !== undefined
+  if (edgeEndpoint === 'memory-wiki') return providers.memoryWiki !== undefined
 
   // Generic "local-markdown" — valid if the section exists
   if (edgeEndpoint === 'local-markdown') return providers.localMarkdown !== undefined

--- a/src/agent/infra/swarm/validation/config-validator.ts
+++ b/src/agent/infra/swarm/validation/config-validator.ts
@@ -444,12 +444,12 @@ export async function validateSwarmProviders(
   }
 
   if (providers.memoryWiki?.enabled && !existsSync(providers.memoryWiki.vaultPath)) {
-      errors.push({
-        field: 'providers.memory_wiki.vault_path',
-        message: `Memory Wiki vault not found at ${providers.memoryWiki.vaultPath}`,
-        provider: 'memory-wiki',
-      })
-    }
+    errors.push({
+      field: 'providers.memory_wiki.vault_path',
+      message: `Memory Wiki vault not found at ${providers.memoryWiki.vaultPath}`,
+      provider: 'memory-wiki',
+    })
+  }
 
   // Validate enrichment edges
   validateEnrichmentEdges(config, errors, warnings)

--- a/src/oclif/commands/swarm/status.ts
+++ b/src/oclif/commands/swarm/status.ts
@@ -239,6 +239,13 @@ export default class SwarmStatus extends Command {
     } else {
       this.renderProviderLine('GBrain', false, 'not configured', 'disabled')
     }
+
+    if (providers.memoryWiki) {
+      const hasError = validation.errors.some((e) => e.provider === 'memory-wiki')
+      this.renderProviderLine('Memory Wiki', providers.memoryWiki.enabled && !hasError, 'OpenClaw wiki')
+    } else {
+      this.renderProviderLine('Memory Wiki', false, 'not configured', 'disabled')
+    }
   }
 
   private renderSuggestionLines(suggestions: string[]): void {

--- a/src/oclif/commands/swarm/status.ts
+++ b/src/oclif/commands/swarm/status.ts
@@ -242,7 +242,7 @@ export default class SwarmStatus extends Command {
 
     if (providers.memoryWiki) {
       const hasError = validation.errors.some((e) => e.provider === 'memory-wiki')
-      this.renderProviderLine('Memory Wiki', providers.memoryWiki.enabled && !hasError, 'OpenClaw wiki')
+      this.renderProviderLine('Memory Wiki', providers.memoryWiki.enabled && !hasError, providers.memoryWiki.vaultPath)
     } else {
       this.renderProviderLine('Memory Wiki', false, 'not configured', 'disabled')
     }
@@ -268,6 +268,15 @@ export default class SwarmStatus extends Command {
       providers.localMarkdown?.enabled,
       // Honcho and Hindsight temporarily disabled
       providers.gbrain?.enabled,
+      providers.memoryWiki?.enabled,
+    ].filter(Boolean).length
+
+    const totalProviders = [
+      true, // byterover always counts
+      providers.obsidian !== undefined,
+      providers.localMarkdown !== undefined,
+      providers.gbrain !== undefined,
+      providers.memoryWiki !== undefined,
     ].filter(Boolean).length
 
     const errorCount = validation.errors.length
@@ -275,7 +284,7 @@ export default class SwarmStatus extends Command {
       ? chalk.green('operational')
       : chalk.yellow('degraded')
 
-    this.log(`\nSwarm is ${status} (${enabledCount}/4 providers configured).`)
+    this.log(`\nSwarm is ${status} (${enabledCount}/${totalProviders} providers configured).`)
   }
 
   private renderTextOutput(
@@ -337,6 +346,10 @@ export default class SwarmStatus extends Command {
           targets.push(`local-markdown:${folder.name} (note, general)`)
         }
       }
+    }
+
+    if (providers.memoryWiki?.enabled) {
+      targets.push(`memory-wiki (${providers.memoryWiki.writePageType ?? 'concept'}, entity)`)
     }
 
     if (targets.length === 0) return

--- a/test/unit/agent/core/domain/swarm/types.test.ts
+++ b/test/unit/agent/core/domain/swarm/types.test.ts
@@ -32,6 +32,7 @@ describe('Swarm Types', () => {
       expect(isLocalProvider('byterover')).to.be.true
       expect(isLocalProvider('obsidian')).to.be.true
       expect(isLocalProvider('local-markdown')).to.be.true
+      expect(isLocalProvider('memory-wiki')).to.be.true
     })
 
     it('returns false for cloud providers', () => {
@@ -52,6 +53,7 @@ describe('Swarm Types', () => {
       expect(isCloudProvider('byterover')).to.be.false
       expect(isCloudProvider('obsidian')).to.be.false
       expect(isCloudProvider('local-markdown')).to.be.false
+      expect(isCloudProvider('memory-wiki')).to.be.false
     })
   })
 
@@ -123,16 +125,6 @@ describe('Swarm Types', () => {
       expect(caps.writeSupported).to.be.true
       expect(caps.localOnly).to.be.true
       expect(caps.avgLatencyMs).to.equal(60)
-    })
-  })
-
-  describe('isLocalProvider - memory-wiki', () => {
-    it('returns true for memory-wiki', () => {
-      expect(isLocalProvider('memory-wiki')).to.be.true
-    })
-
-    it('isCloudProvider returns false for memory-wiki', () => {
-      expect(isCloudProvider('memory-wiki')).to.be.false
     })
   })
 })

--- a/test/unit/agent/core/domain/swarm/types.test.ts
+++ b/test/unit/agent/core/domain/swarm/types.test.ts
@@ -114,5 +114,25 @@ describe('Swarm Types', () => {
       expect(caps.localOnly).to.be.true
       expect(caps.avgLatencyMs).to.equal(80)
     })
+
+    it('returns correct defaults for memory-wiki', () => {
+      const caps = createDefaultCapabilities('memory-wiki')
+      expect(caps.keywordSearch).to.be.true
+      expect(caps.semanticSearch).to.be.false
+      expect(caps.graphTraversal).to.be.false
+      expect(caps.writeSupported).to.be.true
+      expect(caps.localOnly).to.be.true
+      expect(caps.avgLatencyMs).to.equal(60)
+    })
+  })
+
+  describe('isLocalProvider - memory-wiki', () => {
+    it('returns true for memory-wiki', () => {
+      expect(isLocalProvider('memory-wiki')).to.be.true
+    })
+
+    it('isCloudProvider returns false for memory-wiki', () => {
+      expect(isCloudProvider('memory-wiki')).to.be.false
+    })
   })
 })

--- a/test/unit/agent/core/domain/swarm/types.test.ts
+++ b/test/unit/agent/core/domain/swarm/types.test.ts
@@ -9,14 +9,15 @@ import {
 
 describe('Swarm Types', () => {
   describe('PROVIDER_TYPES', () => {
-    it('contains all six provider types', () => {
-      expect(PROVIDER_TYPES).to.have.length(6)
+    it('contains all seven provider types', () => {
+      expect(PROVIDER_TYPES).to.have.length(7)
       expect(PROVIDER_TYPES).to.include('byterover')
       expect(PROVIDER_TYPES).to.include('honcho')
       expect(PROVIDER_TYPES).to.include('hindsight')
       expect(PROVIDER_TYPES).to.include('obsidian')
       expect(PROVIDER_TYPES).to.include('local-markdown')
       expect(PROVIDER_TYPES).to.include('gbrain')
+      expect(PROVIDER_TYPES).to.include('memory-wiki')
     })
 
     it('is readonly', () => {


### PR DESCRIPTION
Summary

- **Problem:** The Memory Swarm had no connection to OpenClaw's Memory Wiki — a compiled wiki with structured pages, claims, provenance tracking, and dashboards. Wiki content was invisible to `brv swarm query`.
- **Why it matters:** Memory Wiki contains curated, compiled knowledge that is higher quality than raw notes. Teams using both ByteRover and OpenClaw had to manually search each system separately.
- **What changed:** Added `memory-wiki` as the 7th swarm provider. The adapter reads directly from the wiki vault on disk (no subprocess), uses MiniSearch for fast in-process search (~12ms for 118 pages), supports writes to `entities/` and `concepts/` directories with proper OpenClaw frontmatter, and applies freshness + kind boosts for structured ranking.
- **What did NOT change (scope boundary):** No changes to the OpenClaw wiki plugin itself. No bridge mode changes. No subprocess dependency — the adapter reads files directly. No changes to existing providers or the query pipeline. The adapter follows the same pattern as Obsidian and Local Markdown adapters.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [x] Agent / Tools
- [ ] LLM Providers
- [ ] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [x] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes ENG-2080

## Root cause (bug fixes only, otherwise write `N/A`)

N/A

## Test plan

- Coverage added:
  - [ ] Unit test
  - [ ] Integration test
  - [x] Manual verification only
- Test file(s):
  - `test/unit/agent/core/domain/swarm/types.test.ts` (updated: 7 providers)
- Key scenario(s) covered:
  - **Query**: 15 diverse queries across 118 wiki pages — 14/15 rank wiki #1 (93% precision)
  - **Performance**: 12ms average per query with 118 pages (in-process MiniSearch)
  - **Write**: Concept pages written to `concepts/` with correct frontmatter, immediately queryable
  - **Write routing**: Entity → GBrain, note → local-md, general → GBrain, fallback → memory-wiki
  - **Cross-provider**: 5 providers return results together, wiki ranks highest (weight 0.9)
  - **Status**: Memory Wiki shows `✓` in `brv swarm status`
  - **Enrichment**: ByteRover → memory-wiki enrichment visible in `--explain`

## User-visible changes

- New provider: `memory_wiki` in `.brv/swarm/config.yaml`
  ```yaml
  memory_wiki:
    enabled: true
    vault_path: ~/.openclaw/wiki/main
    # write_page_type: concept    # default: concept (entity|concept)
    # boost_fresh: true           # default: true
  ```
- Query results show `[wiki]` source label in whiteBright
- `brv swarm status` displays Memory Wiki health
- `brv swarm curate` can write to wiki vault (concept/entity pages with OpenClaw frontmatter)
- RRF weight 0.9 — wiki results rank second only to ByteRover (1.0)
- Provider excluded from `personal` queries (wiki content is factual, not personal)

## Evidence

- [x] Trace/log snippets

**Status:**
```
✓ ByteRover       context-tree (always on)
✓ Obsidian        /Users/cuong/Documents/MyObsidian
✓ Local .md       1 folder(s)
✓ GBrain          /Users/cuong/workspaces/gbrain
✓ Memory Wiki     OpenClaw wiki
```

**Query with explain (118 pages, 5 providers):**
```
Provider selection: 5 of 5 available
  ✓ byterover    (healthy, selected, 0 results, 14ms)
  ✓ obsidian    (healthy, selected, 5 results, 91ms)
  ✓ local-markdown:project-docs    (healthy, selected, 1 results, 18ms)
  ✓ memory-wiki    (healthy, selected, 2 results, 15ms)
  ✓ gbrain    (healthy, selected, 1 results, 260ms)
```

**Write to wiki:**
```
$ brv swarm curate "Our notification system uses AWS SNS..."
Stored to memory-wiki as concept.swarm.our_notification_system_uses_aws_sns_for_push_notifications

$ cat ~/.openclaw/wiki/main/concepts/our_notification_system_...md
---
pageType: concept
id: concept.swarm.our_notification_system...
status: active
sourceType: swarm-curate
---
```

**Performance (15 queries, 118 pages):**
```
JWT refresh        → wiki: 2 results (15ms) | #1=[wiki]
rate limiting      → wiki: 5 results (15ms) | #1=[wiki]
Kubernetes         → wiki: 3 results (13ms) | #1=[wiki]
chaos testing      → wiki: 1 results (9ms)  | #1=[wiki]
CQRS               → wiki: 4 results (8ms)  | #1=[wiki]
```

## Checklist

- [x] Tests added or updated and passing (`npm test`) — 5891 passing
- [x] Lint passes (`npm run lint`) — pre-commit hook verified
- [ ] Type check passes (`npm run typecheck`)
- [ ] Build succeeds (`npm run build`)
- [x] Commits follow Conventional Commits format
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented above)
- [ ] Branch is up to date with `main`

## Risks and mitigations

- **Risk:** Direct file system access to wiki vault — concurrent writes from OpenClaw and ByteRover could conflict.
  - **Mitigation:** ByteRover writes to `concepts/` and `entities/` with a `swarm.` prefix in the page ID. OpenClaw wiki operations target different page types (sources, syntheses). The `.openclaw-wiki/locks/` directory exists for OpenClaw's internal locking — ByteRover does not acquire locks (acceptable for low-frequency writes).

- **Risk:** MiniSearch index not invalidated when OpenClaw updates wiki pages externally.
  - **Mitigation:** Index signature is based on `agent-digest.json` mtime. When OpenClaw runs `wiki compile`, the digest is updated, which invalidates the MiniSearch cache on next query.

- **Risk:** `extractContentSection()` may not correctly strip all OpenClaw page templates.
  - **Mitigation:** Two extraction strategies: (1) look for ` ```text\n...\n``` ` code block (standard wiki source page format), (2) fallback to stripping YAML frontmatter. Tested with both imported source pages and manually curated concept pages.