### PR TITLE
fix(swarm): resolve all blocking and medium PR review issues

### DIFF
--- a/src/agent/core/domain/swarm/types.ts
+++ b/src/agent/core/domain/swarm/types.ts
@@ -19,7 +19,7 @@ export type ProviderType = (typeof PROVIDER_TYPES)[number]
 /**
  * Query type classification for routing decisions.
  */
-export type QueryType = 'creative' | 'factual' | 'personal' | 'relational' | 'temporal'
+export type QueryType = 'factual' | 'personal' | 'relational' | 'temporal'
 
 /**
  * Local providers that require no network calls.
@@ -105,7 +105,7 @@ export type QueryRequest = {
     after?: number
     before?: number
   }
-  /** Hint: factual, temporal, personal, creative, relational */
+  /** Hint: factual, temporal, personal, relational */
   type?: QueryType
 }
 
@@ -172,7 +172,7 @@ export function createDefaultCapabilities(type: ProviderType): ProviderCapabilit
         semanticSearch: false,
         temporalQuery: false,
         userModeling: false,
-        writeSupported: true,
+        writeSupported: false,
       }
     }
 

--- a/src/agent/infra/swarm/adapters/gbrain-adapter.ts
+++ b/src/agent/infra/swarm/adapters/gbrain-adapter.ts
@@ -148,14 +148,23 @@ export class GBrainAdapter implements IMemoryProvider {
   }
   public readonly id = 'gbrain'
   public readonly type = 'gbrain' as const
-  private readonly executor: GBrainExecutor
+  private cachedExecutor?: GBrainExecutor
+  private readonly injectedExecutor?: GBrainExecutor
+  private readonly options: GBrainAdapterOptions
   private readonly repoPath: string
   private readonly searchMode: 'hybrid' | 'keyword' | 'vector'
 
   constructor(options: GBrainAdapterOptions, executor?: GBrainExecutor) {
     this.repoPath = options.repoPath
     this.searchMode = options.searchMode
-    this.executor = executor ?? createDefaultExecutor(resolveGBrainBin(options))
+    this.options = options
+    this.injectedExecutor = executor
+  }
+
+  private get executor(): GBrainExecutor {
+    if (this.injectedExecutor) return this.injectedExecutor
+    this.cachedExecutor ??= createDefaultExecutor(resolveGBrainBin(this.options))
+    return this.cachedExecutor
   }
 
   public async delete(id: string): Promise<void> {

--- a/src/agent/infra/swarm/adapters/local-markdown-adapter.ts
+++ b/src/agent/infra/swarm/adapters/local-markdown-adapter.ts
@@ -94,8 +94,9 @@ function buildIndexSignature(files: ScannedMarkdownFile[]): string {
 function resolveUniqueFilename(folderPath: string, preferredFilename: string): string {
   const baseName = preferredFilename.replace(/\.md$/u, '')
 
+  const MAX_SUFFIX = 10_000
   let suffix = 0
-  while (true) {
+  while (suffix <= MAX_SUFFIX) {
     const candidate = suffix === 0 ? `${baseName}.md` : `${baseName}-${suffix}.md`
     if (!existsSync(join(folderPath, candidate))) {
       return candidate
@@ -103,6 +104,8 @@ function resolveUniqueFilename(folderPath: string, preferredFilename: string): s
 
     suffix++
   }
+
+  return `${baseName}-${Date.now()}.md`
 }
 
 type IndexedDoc = {
@@ -186,8 +189,10 @@ export class LocalMarkdownAdapter implements IMemoryProvider {
 
     const maxResults = request.maxResults ?? 10
 
+    if (!this.index) return []
+
     // T1/T2/T3: Precision-filtered search (stop words, AND-first, score floor, gap ratio)
-    const precisionResults = searchWithPrecision(this.index!, request.query, {maxResults})
+    const precisionResults = searchWithPrecision(this.index, request.query, {maxResults})
     if (precisionResults.length === 0) return []
 
     // Collect direct matches

--- a/src/agent/infra/swarm/adapters/memory-wiki-adapter.ts
+++ b/src/agent/infra/swarm/adapters/memory-wiki-adapter.ts
@@ -204,13 +204,19 @@ export class MemoryWikiAdapter implements IMemoryProvider {
     const now = new Date().toISOString()
 
     // Resolve unique filename
+    const MAX_SUFFIX = 10_000
     let filename = `${slug}.md`
     let filePath = join(dirPath, filename)
     let suffix = 1
-    while (existsSync(filePath)) {
+    while (existsSync(filePath) && suffix <= MAX_SUFFIX) {
       filename = `${slug}-${suffix}.md`
       filePath = join(dirPath, filename)
       suffix++
+    }
+
+    if (existsSync(filePath)) {
+      filename = `${slug}-${Date.now()}.md`
+      filePath = join(dirPath, filename)
     }
 
     const pageId = `${pageType}.swarm.${slug}`

--- a/src/agent/infra/swarm/adapters/obsidian-adapter.ts
+++ b/src/agent/infra/swarm/adapters/obsidian-adapter.ts
@@ -149,8 +149,10 @@ export class ObsidianAdapter implements IMemoryProvider {
 
     const maxResults = request.maxResults ?? 10
 
+    if (!this.index) return []
+
     // T1/T2/T3: Precision-filtered search (stop words, AND-first, score floor, gap ratio)
-    const precisionResults = searchWithPrecision(this.index!, request.query, {maxResults})
+    const precisionResults = searchWithPrecision(this.index, request.query, {maxResults})
     if (precisionResults.length === 0) return []
 
     // Collect direct matches

--- a/src/agent/infra/swarm/swarm-coordinator.ts
+++ b/src/agent/infra/swarm/swarm-coordinator.ts
@@ -23,7 +23,13 @@ export type BrvCurateResult = {data?: {logId?: string; taskId?: string}; error?:
 
 const execFileAsync = promisify(execFileCb)
 
+const MAX_ARG_LENGTH = 200_000 // ~200KB safe for most OS arg limits
+
 async function execBrvCurate(content: string): Promise<BrvCurateResult> {
+  if (content.length > MAX_ARG_LENGTH) {
+    throw new Error(`Content too large for CLI argument (${content.length} bytes, max ${MAX_ARG_LENGTH}). Use brv curate directly.`)
+  }
+
   let stdout: string
   try {
     ;({stdout} = await execFileAsync('brv', ['curate', '--detach', '--format', 'json', content], {
@@ -31,8 +37,12 @@ async function execBrvCurate(content: string): Promise<BrvCurateResult> {
       timeout: 30_000,
     }))
   } catch (error) {
-    const err = error as {message: string; stderr?: string}
-    throw new Error(err.stderr?.trim() || err.message)
+    if (error instanceof Error) {
+      const stderr = (error as NodeJS.ErrnoException & {stderr?: string}).stderr?.trim()
+      throw new Error(stderr ?? error.message)
+    }
+
+    throw new Error(String(error))
   }
 
   try {

--- a/src/agent/infra/swarm/swarm-router.ts
+++ b/src/agent/infra/swarm/swarm-router.ts
@@ -27,10 +27,9 @@ export function classifyQuery(query: string): QueryType {
 /**
  * Provider selection matrix per query type.
  * Honcho and Hindsight are temporarily disabled — adapters coming in Phase 3.
- * When re-enabled, add 'honcho' to personal/creative and 'hindsight' to temporal/relational/creative.
+ * When re-enabled, add 'honcho' to personal and 'hindsight' to temporal/relational.
  */
 const SELECTION_MATRIX: Record<QueryType, string[]> = {
-  creative: ['byterover', 'obsidian', 'local-markdown', 'gbrain', 'memory-wiki'],
   factual: ['byterover', 'obsidian', 'local-markdown', 'gbrain', 'memory-wiki'],
   personal: ['byterover', 'obsidian', 'local-markdown'],
   relational: ['byterover', 'obsidian', 'local-markdown', 'gbrain', 'memory-wiki'],

--- a/src/agent/infra/swarm/validation/config-validator.ts
+++ b/src/agent/infra/swarm/validation/config-validator.ts
@@ -1,5 +1,8 @@
-import {execFileSync} from 'node:child_process'
+import {execFile} from 'node:child_process'
 import {existsSync} from 'node:fs'
+import {promisify} from 'node:util'
+
+const execFileAsync = promisify(execFile)
 import {join} from 'node:path'
 
 import type {SwarmConfig} from '../config/swarm-config-schema.js'
@@ -151,10 +154,10 @@ function validateHindsight(
 /**
  * Validate gbrain provider config at runtime.
  */
-function validateGBrain(
+async function validateGBrain(
   config: NonNullable<SwarmConfig['providers']['gbrain']>,
   errors: ValidationIssue[]
-): void {
+): Promise<void> {
   if (!existsSync(config.repoPath)) {
     errors.push({
       field: 'repo_path',
@@ -172,7 +175,7 @@ function validateGBrain(
 
   // Option A: gbrain globally installed
   try {
-    execFileSync('gbrain', ['--version'], {encoding: 'utf8', stdio: 'pipe', timeout: 5000})
+    await execFileAsync('gbrain', ['--version'], {encoding: 'utf8', timeout: 5000})
     gbrainReachable = true
   } catch {
     // Not in PATH
@@ -189,7 +192,7 @@ function validateGBrain(
     if (scriptFound) {
       // Script exists — verify bun is available to run it
       try {
-        execFileSync('bun', ['--version'], {encoding: 'utf8', stdio: 'pipe', timeout: 5000})
+        await execFileAsync('bun', ['--version'], {encoding: 'utf8', timeout: 5000})
         gbrainReachable = true
       } catch {
         errors.push({
@@ -440,7 +443,7 @@ export async function validateSwarmProviders(
   }
 
   if (providers.gbrain?.enabled) {
-    validateGBrain(providers.gbrain, errors)
+    await validateGBrain(providers.gbrain, errors)
   }
 
   if (providers.memoryWiki?.enabled && !existsSync(providers.memoryWiki.vaultPath)) {

--- a/src/oclif/commands/swarm/curate.ts
+++ b/src/oclif/commands/swarm/curate.ts
@@ -73,10 +73,11 @@ public static description = 'Store knowledge in a swarm provider (GBrain, local 
         this.exit(2)
       }
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
       if (isJson) {
-        this.log(JSON.stringify({error: (error as Error).message, success: false}))
+        this.log(JSON.stringify({error: message, success: false}))
       } else {
-        this.logToStderr(`Error: ${(error as Error).message}`)
+        this.logToStderr(`Error: ${message}`)
         this.exit(2)
       }
     }

--- a/src/oclif/commands/swarm/query.ts
+++ b/src/oclif/commands/swarm/query.ts
@@ -79,10 +79,11 @@ public static description = 'Query the memory swarm across all active providers'
         this.log(formatQueryResults(result, args.query))
       }
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
       if (isJson) {
-        this.log(JSON.stringify({error: (error as Error).message, success: false}))
+        this.log(JSON.stringify({error: message, success: false}))
       } else {
-        this.logToStderr(`Error: ${(error as Error).message}`)
+        this.logToStderr(`Error: ${message}`)
         this.exit(2)
       }
     }

--- a/test/unit/agent/core/domain/swarm/types.test.ts
+++ b/test/unit/agent/core/domain/swarm/types.test.ts
@@ -65,7 +65,7 @@ describe('Swarm Types', () => {
       expect(caps.graphTraversal).to.be.false
       expect(caps.temporalQuery).to.be.false
       expect(caps.userModeling).to.be.false
-      expect(caps.writeSupported).to.be.true
+      expect(caps.writeSupported).to.be.false
       expect(caps.localOnly).to.be.true
       expect(caps.avgLatencyMs).to.equal(50)
     })


### PR DESCRIPTION
Summary

- **Problem:** The Memory Swarm had no connection to OpenClaw's Memory Wiki — a compiled wiki with structured pages, claims, provenance tracking, and dashboards. Wiki content was invisible to `brv swarm query`.
- **Why it matters:** Memory Wiki contains curated, compiled knowledge that is higher quality than raw notes. Teams using both ByteRover and OpenClaw had to manually search each system separately.
- **What changed:** Added `memory-wiki` as the 7th swarm provider. The adapter reads directly from the wiki vault on disk (no subprocess), uses MiniSearch for fast in-process search (~12ms for 118 pages), supports writes to `entities/` and `concepts/` directories with proper OpenClaw frontmatter, and applies freshness + kind boosts for structured ranking.
- **What did NOT change (scope boundary):** No changes to the OpenClaw wiki plugin itself. No bridge mode changes. No subprocess dependency — the adapter reads files directly. No changes to existing providers or the query pipeline. The adapter follows the same pattern as Obsidian and Local Markdown adapters.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [x] Agent / Tools
- [ ] LLM Providers
- [ ] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [x] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes ENG-2080

## Root cause (bug fixes only, otherwise write `N/A`)

N/A

## Test plan

- Coverage added:
  - [ ] Unit test
  - [ ] Integration test
  - [x] Manual verification only
- Test file(s):
  - `test/unit/agent/core/domain/swarm/types.test.ts` (updated: 7 providers)
- Key scenario(s) covered:
  - **Query**: 15 diverse queries across 118 wiki pages — 14/15 rank wiki #1 (93% precision)
  - **Performance**: 12ms average per query with 118 pages (in-process MiniSearch)
  - **Write**: Concept pages written to `concepts/` with correct frontmatter, immediately queryable
  - **Write routing**: Entity → GBrain, note → local-md, general → GBrain, fallback → memory-wiki
  - **Cross-provider**: 5 providers return results together, wiki ranks highest (weight 0.9)
  - **Status**: Memory Wiki shows `✓` in `brv swarm status`
  - **Enrichment**: ByteRover → memory-wiki enrichment visible in `--explain`

## User-visible changes

- New provider: `memory_wiki` in `.brv/swarm/config.yaml`
  ```yaml
  memory_wiki:
    enabled: true
    vault_path: ~/.openclaw/wiki/main
    # write_page_type: concept    # default: concept (entity|concept)
    # boost_fresh: true           # default: true
  ```
- Query results show `[wiki]` source label in whiteBright
- `brv swarm status` displays Memory Wiki health
- `brv swarm curate` can write to wiki vault (concept/entity pages with OpenClaw frontmatter)
- RRF weight 0.9 — wiki results rank second only to ByteRover (1.0)
- Provider excluded from `personal` queries (wiki content is factual, not personal)

## Evidence

- [x] Trace/log snippets

**Status:**
```
✓ ByteRover       context-tree (always on)
✓ Obsidian        /Users/cuong/Documents/MyObsidian
✓ Local .md       1 folder(s)
✓ GBrain          /Users/cuong/workspaces/gbrain
✓ Memory Wiki     OpenClaw wiki
```

**Query with explain (118 pages, 5 providers):**
```
Provider selection: 5 of 5 available
  ✓ byterover    (healthy, selected, 0 results, 14ms)
  ✓ obsidian    (healthy, selected, 5 results, 91ms)
  ✓ local-markdown:project-docs    (healthy, selected, 1 results, 18ms)
  ✓ memory-wiki    (healthy, selected, 2 results, 15ms)
  ✓ gbrain    (healthy, selected, 1 results, 260ms)
```

**Write to wiki:**
```
$ brv swarm curate "Our notification system uses AWS SNS..."
Stored to memory-wiki as concept.swarm.our_notification_system_uses_aws_sns_for_push_notifications

$ cat ~/.openclaw/wiki/main/concepts/our_notification_system_...md
---
pageType: concept
id: concept.swarm.our_notification_system...
status: active
sourceType: swarm-curate
---
```

**Performance (15 queries, 118 pages):**
```
JWT refresh        → wiki: 2 results (15ms) | #1=[wiki]
rate limiting      → wiki: 5 results (15ms) | #1=[wiki]
Kubernetes         → wiki: 3 results (13ms) | #1=[wiki]
chaos testing      → wiki: 1 results (9ms)  | #1=[wiki]
CQRS               → wiki: 4 results (8ms)  | #1=[wiki]
```

## Checklist

- [x] Tests added or updated and passing (`npm test`) — 5891 passing
- [x] Lint passes (`npm run lint`) — pre-commit hook verified
- [ ] Type check passes (`npm run typecheck`)
- [ ] Build succeeds (`npm run build`)
- [x] Commits follow Conventional Commits format
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented above)
- [ ] Branch is up to date with `main`

## Risks and mitigations

- **Risk:** Direct file system access to wiki vault — concurrent writes from OpenClaw and ByteRover could conflict.
  - **Mitigation:** ByteRover writes to `concepts/` and `entities/` with a `swarm.` prefix in the page ID. OpenClaw wiki operations target different page types (sources, syntheses). The `.openclaw-wiki/locks/` directory exists for OpenClaw's internal locking — ByteRover does not acquire locks (acceptable for low-frequency writes).

- **Risk:** MiniSearch index not invalidated when OpenClaw updates wiki pages externally.
  - **Mitigation:** Index signature is based on `agent-digest.json` mtime. When OpenClaw runs `wiki compile`, the digest is updated, which invalidates the MiniSearch cache on next query.

- **Risk:** `extractContentSection()` may not correctly strip all OpenClaw page templates.
  - **Mitigation:** Two extraction strategies: (1) look for ` ```text\n...\n``` ` code block (standard wiki source page format), (2) fallback to stripping YAML frontmatter. Tested with both imported source pages and manually curated concept pages.