### PR TITLE
Release/3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable user-facing changes to ByteRover CLI will be documented in this file.
 
+## [3.4.0]
+
+### Added
+- **`brv swarm` — unified memory swarm** — Connect multiple memory providers (ByteRover context tree, Obsidian vaults, local markdown folders, GBrain, OpenClaw Memory Wiki) into a single query and storage layer. `brv swarm onboard` walks through an interactive setup wizard; `brv swarm status` shows provider health, write targets, and enrichment topology. `brv swarm query <question>` runs intelligent routing, parallel provider execution, and Reciprocal Rank Fusion merging — add `--explain` for classification reasoning and provider selection details. `brv swarm curate <content>` stores to the best writable provider based on content classification (`--provider` to override), falling back to ByteRover context-tree curation when no external target is available. Control how providers feed context to each other via `enrichment.edges` in `swarm.config.yaml` — the engine validates cycles, self-edges, and missing providers, and disabled-provider edges produce warnings instead of errors so partial setups degrade gracefully. The agent also gains `swarm_query` and `swarm_store` tools, and sandboxed code can call `tools.swarmQuery()` / `tools.swarmStore()`.
+- **GPT-5.4 Mini support** — Added `gpt-5.4-mini` to the Codex allowed models list.
+
+### Fixed
+- **Context-tree `.gitignore` auto-sync** — The context-tree `.gitignore` now stays up to date automatically. When any `brv vc` command runs, missing patterns are appended to the existing file instead of only being written on first init. This prevents derived artifacts from polluting `brv vc` diffs after CLI updates.
+- **Stale knowledge locations** — Knowledge entries whose source files were deleted are now cleaned up, preventing dead references in search and query results.
+- **Security dependency update** — Pinned axios to 1.15.0 to address a critical vulnerability.
+
 ## [3.3.0]
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,11 +55,11 @@ npm run typecheck                    # TypeScript type checking
 
 ### Source Layout (`src/`)
 
-- `agent/` — LLM agent: `core/` (interfaces/domain), `infra/` (22 modules, including llm, memory, map, tools, document-parser), `resources/` (prompts YAML, tool `.txt` descriptions)
+- `agent/` — LLM agent: `core/` (interfaces/domain), `infra/` (23 modules, including llm, memory, map, swarm, tools, document-parser), `resources/` (prompts YAML, tool `.txt` descriptions)
 - `server/` — Daemon infrastructure: `config/`, `core/` (domain/interfaces), `infra/` (29 modules, including vc, git, hub, mcp, cogit, project, provider-oauth, space), `templates/`, `utils/`
 - `shared/` — Cross-module: constants, types, transport events, utils
 - `tui/` — React/Ink TUI: app (router/pages), components, features (23 modules, including vc, worktree, source, hub, curate), hooks, lib, providers, stores
-- `oclif/` — Commands grouped by topic (`vc/`, `hub/`, `worktree/`, `source/`, `space/`, `review/`, `connectors/`, `curate/`, `model/`, `providers/`) + top-level `.ts` commands; hooks, lib (daemon-client, task-client, json-response)
+- `oclif/` — Commands grouped by topic (`vc/`, `hub/`, `worktree/`, `source/`, `space/`, `review/`, `connectors/`, `curate/`, `model/`, `providers/`, `swarm/`) + top-level `.ts` commands; hooks, lib (daemon-client, task-client, json-response)
 
 **Import boundary** (ESLint-enforced): `tui/` must not import from `server/`, `agent/`, or `oclif/`. Use transport events or `shared/`.
 
@@ -73,7 +73,7 @@ npm run typecheck                    # TypeScript type checking
 
 - Global daemon (`server/infra/daemon/`) hosts Socket.IO transport; clients connect via `@campfirein/brv-transport-client`
 - Agent pool manages forked child processes per project; task routing in `server/infra/process/`
-- MCP server in `server/infra/mcp/` exposes tools via Model Context Protocol
+- MCP server in `server/infra/mcp/` exposes tools via Model Context Protocol; `tools/` subdir has dedicated implementations (`brv-query-tool`, `brv-curate-tool`)
 
 ### VC, Worktrees & Knowledge Sources
 
@@ -88,11 +88,22 @@ npm run typecheck                    # TypeScript type checking
 ### Agent (`src/agent/`)
 
 - Tools: definitions in `resources/tools/*.txt`, implementations in `infra/tools/implementations/`, registry in `infra/tools/tool-registry.ts`
-- Tool categories: file ops (read/write/glob/grep), knowledge (create/expand/search), memory (read/write/edit/delete/list), curate, code exec, map
+- Tool categories: file ops (read/write/edit/glob/grep/list-dir), bash (exec/output), knowledge (create/expand/search), memory (read/write/edit/delete/list), swarm (query/store), todos (read/write), curate, code exec, batch, detect domains, kill process, search history
 - LLM: 18 providers in `infra/llm/providers/`; 6 compression strategies in `infra/llm/context/compression/`
 - System prompts: contributor pattern (XML sections) in `infra/system-prompt/`
 - Map/memory: `infra/map/` (agentic map, context-tree store, LLM map memory, worker pool); `infra/memory/` (memory-manager, deduplicator)
 - Storage: file-based blob (`infra/blob/`) and key storage (`infra/storage/`) — no SQLite
+
+### Swarm (`src/agent/infra/swarm/`, `src/oclif/commands/swarm/`)
+
+- Multi-provider memory/knowledge federation: routes queries and writes across pluggable adapters (byterover, gbrain, local-markdown, memory-wiki, obsidian)
+- `brv swarm query` — RRF-fused search across providers; flags: `--explain`, `--format`, `-n`
+- `brv swarm curate` — auto-routes content to best provider; flags: `--provider`, `--format`
+- `brv swarm onboard` — interactive wizard (`@inquirer/prompts`) to scaffold swarm config; uses snake_case YAML keys (`eslint-disable camelcase`)
+- `brv swarm status` — pre-flight health check for configured providers
+- Agent tools: `swarm_query.txt`, `swarm_store.txt` in `resources/tools/`
+- Config: `swarm/config/` (loader + schema), `swarm/validation/` (config validator)
+- CLI-only (oclif) — no TUI feature dir; swarm queries flow through existing `tui/features/query/`
 
 ## Testing Gotchas
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "coding-assistant",
     "knowledge-management"
   ],
-  "version": "3.3.0",
+  "version": "3.4.0",
   "author": "ByteRover",
   "bin": {
     "brv": "./bin/run.js"


### PR DESCRIPTION
## Summary

- Problem: 3.4.0's scope (unified memory swarm + several hardening/security/docs fixes) has landed incrementally on `main`, but there is no tagged release yet — `package.json` still reports `3.3.0`, `CHANGELOG.md` has no `[3.4.0]` entry, and `CLAUDE.md` architecture docs do not mention the new `swarm` module.
- Why it matters: this merge + subsequent tag is what publishes 3.4.0 to users. Without it, `brv --version` drifts from shipped behavior, release tooling cannot cut the tag, and contributor onboarding docs miss the new `swarm` subsystem entirely.
- What changed: consolidates everything shipped since `v3.3.0` — `brv swarm` (onboard/status/query/curate) with adapters for ByteRover, Obsidian, local-markdown, GBrain, and OpenClaw Memory Wiki; agent `swarm_query` / `swarm_store` tools with sandbox SDK integration; swarm system-prompt contributor; user-configurable enrichment topology with cycle/self-edge validation; 5-tier search precision pipeline; RRF merging; short-lived result cache; transparent `--explain` output; ByteRover write fallback; auto-sync of context-tree `.gitignore` on `brv vc`; stale-location cleanup; axios pinned to 1.15.0 (security); `gpt-5.4-mini` added to Codex allowed models; tightened PR auto-review author associations; CODEOWNERS; dead-code removal; SKILL.md swarm docs; plus the 3.4.0 release-prep commits (version bump, CHANGELOG, CLAUDE.md).
- What did NOT change (scope boundary): no database/storage format changes; no transport/daemon protocol break; no TUI feature directory added (swarm is CLI-only through oclif); no existing provider behavior altered outside the documented fixes (stale locations, `.gitignore` sync, axios pin); no changes to authentication, billing, or cloud-sync surfaces.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [x] Documentation
- [x] Test
- [x] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [x] Agent / Tools
- [x] LLM Providers
- [x] Server / Daemon
- [x] Shared (constants, types, transport events)
- [x] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [x] CI/CD / Infra

## Linked issues

- Closes #
- Related: ENG-1610, ENG-1611, ENG-1933, ENG-1938, ENG-2038, ENG-2039, ENG-2048, ENG-2050, ENG-2072, ENG-2073, ENG-2075, ENG-2077, ENG-2078, ENG-2080
- Related PRs: #364, #372, #373, #374, #376, #377, #383, #384, #388, #390, #393, #396, #398, #399, #405, #408, #409

## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause:
  - ENG-2050 (`.gitignore` auto-sync): initial context-tree `.gitignore` was only written at init time, so patterns added in later CLI versions never reached existing projects; derived artifacts then polluted `brv vc` diffs.
  - ENG-1610 (stale locations): knowledge entries whose source files were deleted were never cleaned up, leaving dead references in search/query.
  - ENG-2038 (axios): axios < 1.15.0 contained a critical security vulnerability; the unpinned minor let upgrades regress.
  - ENG-2078 (review defaults): `confidence`/`impact` were required on review outputs; missing fields crashed the reviewer with no safe fallback.
- Why this was not caught earlier:
  - `.gitignore` behavior is only visible on long-lived projects created before the pattern changes — no prior test asserted re-sync on upgrade.
  - Stale-location cleanup was assumed to happen during re-index, but the code path deleted source files never re-ran expansion.
  - axios pinning was an explicit security-advisory response, not a test gap.
  - Reviewer-output tests asserted happy-path shapes only, not missing-field tolerance.

## Test plan

- Coverage added:
  - [x] Unit test
  - [x] Integration test
  - [ ] Manual verification only
- Test file(s):
  - `test/unit/agent/swarm/**` (swarm-coordinator, swarm-graph, swarm-merger, swarm-router, swarm-write-router, search-precision, provider-factory, config loader/schema, validation, wizard, CLI renderer, system-prompt contributor)
  - `test/unit/agent/swarm/adapters/**` (byterover, gbrain, local-markdown, obsidian, memory-wiki)
  - `test/unit/agent/swarm/tools/{swarm-query-tool,swarm-store-tool}.test.ts`
  - `test/unit/agent/sandbox/tools-sdk-swarm.test.ts`
  - `test/unit/agent/core/domain/swarm/types.test.ts`
  - `test/unit/agent/tools/curate-tool.test.ts`
  - `test/unit/utils/gitignore.test.ts` (ENG-2050 auto-sync)
  - `test/unit/server/infra/transport/handlers/{locations-handler,vc-handler}.test.ts` (ENG-1610)
  - `test/unit/infra/project/project-registry.test.ts`
  - `test/commands/swarm/{onboard,status,query,curate}.test.ts`
- Key scenario(s) covered:
  - Swarm: query routing, RRF merging, enrichment DAG validation (cycles, self-edges, disabled-provider warnings), write-router fallback to ByteRover, adapter health checks, wizard scaffolding, `--explain` output, result cache TTL.
  - gitignore auto-sync: missing patterns appended on subsequent `brv vc` runs without clobbering user entries.
  - Stale locations: entries referencing deleted files are pruned on next scan.
  - Security: axios resolves to 1.15.0 in `package-lock.json`.
  - `gpt-5.4-mini`: appears in Codex allowed-models list.

## User-visible changes

- New command group `brv swarm` (`onboard`, `status`, `query`, `curate`) — see CHANGELOG `[3.4.0]` for the full behavior surface.
- `brv swarm query` and `brv swarm curate` now usable from the agent as `swarm_query` / `swarm_store` tools and from sandboxed code as `tools.swarmQuery()` / `tools.swarmStore()`.
- `brv --version` will report `3.4.0` after tag/publish.
- Codex provider accepts `gpt-5.4-mini`.
- Context-tree `.gitignore` now auto-heals on any `brv vc` command; previously-init'd projects pick up new patterns on upgrade.
- Search/query no longer surface dead references to deleted source files.
- Defaults only — no breaking flag or output-format changes.

## Evidence

- [x] Failing test/log before + passing after (new suites under `test/unit/agent/swarm/**` all green)
- [x] Trace/log snippets (swarm `--explain` reasoning visible in `query-renderer` tests)
- [ ] Screenshot/recording

`git diff --stat v3.3.0..release/3.4.0` summary: **94 files changed, +12,031 / −217 lines**, including ~20 new `src/agent/infra/swarm/**` modules, 4 oclif commands under `src/oclif/commands/swarm/`, 2 agent tool implementations + `.txt` definitions, and matching test suites.

`git log --oneline main..release/3.4.0` (release-prep only, on top of the feature work already on `main`):

```
4093b92b chore: update CHANGELOG.md
4aa42287 chore: update CLAUDE.md
2800f889 chore: Bump version to 3.4.0
```

## Checklist

- [x] Tests added or updated and passing (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Documentation updated (`CHANGELOG.md`, `CLAUDE.md`, `src/server/templates/skill/SKILL.md`)
- [x] No breaking changes (or clearly documented above)
- [x] Branch is up to date with `main` (3 release-prep commits ahead, 0 behind)

## Risks and mitigations

- Risk: Swarm adapters (Obsidian / local-markdown / Memory Wiki) touch user filesystem paths outside the context tree; a misconfigured `swarm.config.yaml` could read/write the wrong directory.
  - Mitigation: `brv swarm onboard` wizard validates each provider's root path before writing config; `brv swarm status` performs pre-flight health checks; config validator rejects cycles/self-edges and warns on disabled providers.
- Risk: Memory Wiki YAML content from untrusted sources could attempt YAML injection.
  - Mitigation: memory-wiki adapter hardened against YAML injection in `ce4a23b4` with dedicated regression tests.
- Risk: axios pin to `1.15.0` could conflict with transitive dependents expecting a newer minor.
  - Mitigation: `package-lock.json` regenerated and full test suite green; transitive axios users in the tree are compatible with 1.15.x.
- Risk: `.gitignore` auto-sync could append patterns a user intentionally removed.
  - Mitigation: sync only *appends missing* patterns — it never rewrites or removes existing lines; covered by `test/unit/utils/gitignore.test.ts`.
- Risk: Tagging from the merge commit while `main` is still advancing could race with late merges.
  - Mitigation: cut `v3.4.0` immediately after this PR merges, before accepting further non-critical PRs; freeze window is short.