### PR TITLE
fix: [ENG-2085] strip ANSI codes in query-renderer assertions

### DIFF
--- a/test/unit/agent/swarm/cli/query-renderer.test.ts
+++ b/test/unit/agent/swarm/cli/query-renderer.test.ts
@@ -2,11 +2,16 @@ import {expect} from 'chai'
 
 import type {SwarmQueryResult} from '../../../../../src/agent/core/interfaces/i-swarm-coordinator.js'
 
-import {formatQueryResults, formatQueryResultsExplain, formatQueryResultsJson, providerTypeToLabel} from '../../../../../src/agent/infra/swarm/cli/query-renderer.js'
+import {
+  formatQueryResults,
+  formatQueryResultsExplain,
+  formatQueryResultsJson,
+  providerTypeToLabel,
+} from '../../../../../src/agent/infra/swarm/cli/query-renderer.js'
 
 /** Strip ANSI escape codes so assertions match visible text. */
 // eslint-disable-next-line no-control-regex
-const stripAnsi = (s: string): string => s.replaceAll(/\u001B\[\d+m/g, '')
+const stripAnsi = (s: string): string => s.replaceAll(/\u001B\[[0-9;]*m/g, '')
 
 function makeSwarmResult(overrides?: Partial<SwarmQueryResult>): SwarmQueryResult {
   return {
@@ -85,10 +90,38 @@ describe('QueryRenderer', () => {
     it('shows source labels per result', () => {
       const result = makeSwarmResult({
         results: [
-          {content: 'Auth content', id: 'brv-0', metadata: {matchType: 'keyword', source: 'auth.md'}, provider: 'byterover', providerType: 'byterover', score: 0.8},
-          {content: 'Notes content', id: 'obs-0', metadata: {matchType: 'graph', source: 'notes.md'}, provider: 'obsidian', providerType: 'obsidian', score: 0.6},
-          {content: 'Concept content', id: 'gb-0', metadata: {matchType: 'semantic', path: 'concept', source: 'concept'}, provider: 'gbrain', providerType: 'gbrain', score: 0.4},
-          {content: 'Doc content', id: 'lm-0', metadata: {matchType: 'keyword', source: 'doc.md'}, provider: 'local-markdown:project-docs', providerType: 'local-markdown', score: 0.3},
+          {
+            content: 'Auth content',
+            id: 'brv-0',
+            metadata: {matchType: 'keyword', source: 'auth.md'},
+            provider: 'byterover',
+            providerType: 'byterover',
+            score: 0.8,
+          },
+          {
+            content: 'Notes content',
+            id: 'obs-0',
+            metadata: {matchType: 'graph', source: 'notes.md'},
+            provider: 'obsidian',
+            providerType: 'obsidian',
+            score: 0.6,
+          },
+          {
+            content: 'Concept content',
+            id: 'gb-0',
+            metadata: {matchType: 'semantic', path: 'concept', source: 'concept'},
+            provider: 'gbrain',
+            providerType: 'gbrain',
+            score: 0.4,
+          },
+          {
+            content: 'Doc content',
+            id: 'lm-0',
+            metadata: {matchType: 'keyword', source: 'doc.md'},
+            provider: 'local-markdown:project-docs',
+            providerType: 'local-markdown',
+            score: 0.3,
+          },
         ],
       })
       const output = formatQueryResults(result, 'test')
@@ -154,7 +187,12 @@ describe('QueryRenderer', () => {
           costCents: 0,
           providers: {
             byterover: {latencyMs: 10, resultCount: 1, selected: true},
-            gbrain: {excludeReason: 'not in selection matrix for personal', latencyMs: 0, resultCount: 0, selected: false},
+            gbrain: {
+              excludeReason: 'not in selection matrix for personal',
+              latencyMs: 0,
+              resultCount: 0,
+              selected: false,
+            },
           },
           queryType: 'personal',
           totalLatencyMs: 100,
@@ -174,7 +212,13 @@ describe('QueryRenderer', () => {
           costCents: 0,
           providers: {
             byterover: {latencyMs: 10, resultCount: 1, selected: true},
-            obsidian: {enrichedBy: 'byterover', enrichmentExcerpts: ['JWT', 'token', 'refresh'], latencyMs: 80, resultCount: 2, selected: true},
+            obsidian: {
+              enrichedBy: 'byterover',
+              enrichmentExcerpts: ['JWT', 'token', 'refresh'],
+              latencyMs: 80,
+              resultCount: 2,
+              selected: true,
+            },
           },
           queryType: 'factual',
           totalLatencyMs: 100,

--- a/test/unit/agent/swarm/cli/query-renderer.test.ts
+++ b/test/unit/agent/swarm/cli/query-renderer.test.ts
@@ -4,6 +4,10 @@ import type {SwarmQueryResult} from '../../../../../src/agent/core/interfaces/i-
 
 import {formatQueryResults, formatQueryResultsExplain, formatQueryResultsJson, providerTypeToLabel} from '../../../../../src/agent/infra/swarm/cli/query-renderer.js'
 
+/** Strip ANSI escape codes so assertions match visible text. */
+// eslint-disable-next-line no-control-regex
+const stripAnsi = (s: string): string => s.replaceAll(/\u001B\[\d+m/g, '')
+
 function makeSwarmResult(overrides?: Partial<SwarmQueryResult>): SwarmQueryResult {
   return {
     meta: {
@@ -108,7 +112,7 @@ describe('QueryRenderer', () => {
           totalLatencyMs: 300,
         },
       })
-      const output = formatQueryResults(result, 'test')
+      const output = stripAnsi(formatQueryResults(result, 'test'))
 
       expect(output).to.include('Providers: 3 queried')
     })
@@ -139,7 +143,7 @@ describe('QueryRenderer', () => {
   describe('formatQueryResultsExplain()', () => {
     it('shows classification reasoning', () => {
       const result = makeSwarmResult()
-      const output = formatQueryResultsExplain(result, 'auth tokens')
+      const output = stripAnsi(formatQueryResultsExplain(result, 'auth tokens'))
 
       expect(output).to.include('Classification: factual')
     })


### PR DESCRIPTION
## Summary

- **Problem:** Two `QueryRenderer` tests (`shows simplified provider count in header` and `shows classification reasoning`) were failing because `string.include()` can't match text split by chalk ANSI escape codes.
- **Why it matters:** CI failures block merges; these tests validate swarm query output formatting.
- **What changed:** Added a `stripAnsi()` helper in the test file and applied it to the two failing assertions before comparing.
- **What did NOT change:** No production code changes. Only test file updated.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [x] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [ ] Agent / Tools
- [ ] LLM Providers
- [ ] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes ENG-2085

## Root cause (bug fixes only, otherwise write `N/A`)

- **Root cause:** `chalk.yellow('3 queried')` and `chalk.cyan('factual')` wrap text in ANSI escape codes (`\u001b[33m...\u001b[39m`), breaking `expect(output).to.include('Providers: 3 queried')` because the plain string doesn't exist contiguously in the colored output.
- **Why this was not caught earlier:** Tests may have passed in environments where `chalk` was disabled (no TTY / `FORCE_COLOR=0`), or the colored output formatting was added after the tests were written.

## Test plan

- Coverage added:
  - [ ] Unit test
  - [ ] Integration test
  - [x] Manual verification only
- Test file(s): `test/unit/agent/swarm/cli/query-renderer.test.ts`
- Key scenario(s) covered:
  - All 18 QueryRenderer tests passing (was 16/18)

## User-visible changes

None — test-only fix.

## Evidence

- [x] Failing test/log before + passing after

Before: 2 failing (`AssertionError: expected ... to include 'Providers: 3 queried'`)
After: 18 passing (0 failing)

## Checklist

- [x] Tests added or updated and passing (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented above)
- [x] Branch is up to date with `main`

## Risks and mitigations

None — test-only change with no production impact.
