### PR TITLE
proj/isolate-bundle-node

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -13,6 +13,7 @@ BRV_INSTALL_DIR="${BRV_INSTALL_DIR:-$HOME/.brv-cli}"
 GCS_BASE="https://storage.googleapis.com/brv-releases"
 CHANNEL="stable"
 BIN_DIR="$BRV_INSTALL_DIR/bin"
+LIB_DIR="$BRV_INSTALL_DIR/lib"
 
 # ─── Colors (only when connected to a terminal) ──────────────────────────────
 
@@ -180,16 +181,21 @@ install_brv() {
     rm -rf "$BRV_INSTALL_DIR"
   fi
 
-  # Create install directory and extract
-  mkdir -p "$BRV_INSTALL_DIR"
+  # Extract into lib/ — keeps bundled node out of the PATH-visible bin/
+  mkdir -p "$LIB_DIR"
   info "Extracting..."
-  tar xzf "$tarball_path" -C "$BRV_INSTALL_DIR" --strip-components=1
+  tar xzf "$tarball_path" -C "$LIB_DIR" --strip-components=1
 
-  # Verify installation
-  if [ ! -x "$BIN_DIR/brv" ]; then
-    error "Installation failed: $BIN_DIR/brv not found or not executable after extraction."
+  # Verify tarball contents
+  if [ ! -x "$LIB_DIR/bin/brv" ]; then
+    error "Installation failed: $LIB_DIR/bin/brv not found or not executable after extraction."
   fi
 
+  # Create bin/ with symlink to wrapper in lib/
+  mkdir -p "$BIN_DIR"
+  ln -sf ../lib/bin/brv "$BIN_DIR/brv" || error "Failed to create symlink $BIN_DIR/brv"
+
+  # Version check through symlink — proves the full chain works
   installed_version="$("$BIN_DIR/brv" --version 2>/dev/null || echo "unknown")"
   printf "  Version:   %s\n" "$installed_version"
   printf "\n"


### PR DESCRIPTION
## Summary

- **Problem:** The previous `install.sh` extracted the release tarball directly into `~/.brv-cli/`, placing the bundled Node.js (`v24.13.1`) at `~/.brv-cli/bin/node` — same dir as `brv`. Once users added `~/.brv-cli/bin` to `PATH` (which install.sh does automatically), the bundled node shadowed their system node, breaking `nvm`, project-pinned node versions, and any tool that resolved `node` via `PATH`.
- **Why it matters:** Silent node-version shadowing is a footgun. Users reported `node --version` flipping to v24 after installing brv, breaking unrelated projects. ENG-1990 / project "[CLI] Isolate Bundled Node.js from User PATH".
- **What changed:** `install.sh` now extracts the tarball into `$BRV_INSTALL_DIR/lib/` and creates `$BRV_INSTALL_DIR/bin/brv` as a relative symlink to `../lib/bin/brv`. Only the `brv` symlink lives in the PATH-visible `bin/`; the bundled `node` stays in `lib/bin/` and is invisible to user PATH lookups.
- **What did NOT change (scope boundary):**
  - The release tarball contents/structure on GCS.
  - `BRV_INSTALL_DIR` default (`~/.brv-cli`) or override behavior.
  - PATH-injection logic for bashrc/zshrc/profile/fish.
  - The auto-update mechanism (`@oclif/plugin-update` writes to `~/Library/Application Support/brv/client/` — outside the install dir, unaffected).
  - `uninstall.sh` semantics (already removed `$BRV_INSTALL_DIR` recursively).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [ ] Agent / Tools
- [ ] LLM Providers
- [ ] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [x] CI/CD / Infra (install/uninstall scripts + cross-platform test harness)
 
## Root cause

- **Root cause:** Bundled Node.js binary was extracted into the same directory that install.sh adds to user `PATH`. `bin/` served two purposes (entry point + runtime dependency), so isolating one without breaking the other was impossible without splitting the layout.
- **Why this was not caught earlier:** Most users either don't have a system node, or have it at a stable path managed by nvm/asdf — the shadowing only surfaces when a user pinned `node` to a specific version that differs from the bundled one. No CI test asserted "system `which node` is unchanged after install."

## Test plan

- Coverage added:
  - [ ] Unit test
  - [x] Integration test
  - [ ] Manual verification only
- **Key scenario(s) covered:**
  - Test 1 — Fresh install: layout = `bin/ + lib/` only; `bin/brv` is a symlink to `../lib/bin/brv`; `lib/bin/node` runs v24.13.1; `brv --version` works through the symlink; `DEBUG=*` trace confirms brv runs the bundled node; **no `node` file in `bin/`**; PATH with `bin/` prepended does NOT expose bundled node; system node version is unchanged when brv `bin/` is on PATH (proves no shadowing); `readlink -f` resolves correctly on Linux.
  - Test 2 — Upgrade: install OLD flat layout (3.3.0 from production install.sh, pinned tarball) → install NEW → verify new layout, no stale `package.json`/`dist`/`node_modules`/`oclif.manifest.json`/`bin/node`; real version transition `3.3.0 → 3.4.0`.
  - Test 3 — Uninstall: `uninstall.sh --yes` removes install dir completely.
  - Test 4 — Custom `BRV_INSTALL_DIR`: relative symlink still resolves at non-default path.
  - Test 5 — `brv update`: exit 0, no error patterns; client dir lives outside install dir; nothing leaks into install dir (ENG-1994).
  - Test 6 — `brv restart`: starts via the symlinked wrapper (ENG-1994).
- **Platforms verified:** macOS ARM64 (host: PASS), Linux x64 + ARM64 via `buildpack-deps:bookworm-curl` containers (PASS each).

## User-visible changes

- New install layout under `~/.brv-cli/`:
  - `bin/brv` — symlink → `../lib/bin/brv` (only entry on user PATH)
  - `lib/bin/{brv,node,run.js,...}` — bundled wrapper, bundled Node.js v24.13.1, oclif manifest, dist
- `node`, `npm`, `npx` are no longer shadowed by the brv install. Users on `nvm` / `asdf` / system node will see their existing `node --version` preserved after installing brv.
- Existing installs upgrade transparently: running the new `install.sh` over an old flat install removes the previous directory and re-extracts into the new layout. No user action required.

## Evidence

- [x] Failing test/log before + passing after

Test runs (all green):
- macOS ARM64: `PASS`.
- Linux amd64 (Ubuntu 22.04 in Docker): `PASS`.
- Linux arm64 (Ubuntu 22.04 in Docker): `PASS`.

Key proof of isolation (macOS): `bundled node NOT on PATH (which node = /Users/.../v22.21.1/bin/node)` and `system node (v22.21.1) differs from bundled (v24.13.1) — isolation is meaningful`.

## Checklist

- [x] Tests added or updated and passing (cross-platform integration script; not part of `npm test` because it spawns Docker)
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow Conventional Commits format
- [ ] Documentation updated — N/A (no public docs reference the install layout)
- [x] No breaking changes — old installs upgrade transparently; `BRV_INSTALL_DIR` and PATH semantics unchanged
- [x] Branch is up to date with `main`

## Risks and mitigations

- **Risk:** Users with custom shell aliases or scripts that hardcoded `~/.brv-cli/bin/node` (e.g., to invoke the bundled node directly) will break.
  - **Mitigation:** Internal-only path; not documented as public. If reported, the new path `~/.brv-cli/lib/bin/node` is a one-line fix on the user side. Low likelihood — bundled node was never advertised as a user-facing tool.
- **Risk:** Symlink resolution differs across filesystems (e.g., a future container/sandbox that disables symlinks).
  - **Mitigation:** Relative symlink (`../lib/bin/brv`) is portable across all POSIX filesystems we support; `readlink -f` test asserted on Linux. macOS, Linux x64, Linux ARM64 all verified.
- **Risk:** Auto-update writes a fresh tarball that re-introduces a flat layout (since the tarball still ships as `bin/{brv,node}`).
  - **Mitigation:** Auto-update goes through `@oclif/plugin-update` into `~/Library/Application Support/brv/client/`, not into `~/.brv-cli/`. The wrapper at `~/.brv-cli/lib/bin/brv` re-execs into the cached version. The PATH-visible `~/.brv-cli/bin/brv` symlink is untouched by updates. Verified by Test 5 + the architectural analysis in ENG-1994.
- **Risk:** Pre-existing `brv restart` self-kill behavior (`buildCliPatterns()` in `src/oclif/commands/restart.ts` matches `bin/brv` substring) could be misattributed to this PR.
  - **Mitigation:** Documented in [scripts/test-install-layout.sh](scripts/test-install-layout.sh#L397-L410) as pre-existing; the test treats "Stopping clients" as sufficient evidence the symlink resolves. Full completion was observed on all three platforms in this run.
