### PR TITLE
[ENG-2063] add idle dream trigger and human review wiring

### DIFF
--- a/src/oclif/commands/dream.ts
+++ b/src/oclif/commands/dream.ts
@@ -12,6 +12,9 @@ import {DreamLogStore} from '../../server/infra/dream/dream-log-store.js'
 import {DreamStateService} from '../../server/infra/dream/dream-state-service.js'
 import {undoLastDream} from '../../server/infra/dream/dream-undo.js'
 import {resolveProject} from '../../server/infra/project/resolve-project.js'
+import {FileCurateLogStore} from '../../server/infra/storage/file-curate-log-store.js'
+import {FileReviewBackupStore} from '../../server/infra/storage/file-review-backup-store.js'
+import {getProjectDataDir} from '../../server/utils/path-utils.js'
 import {TaskEvents} from '../../shared/transport/events/index.js'
 import {
   type DaemonClientOptions,
@@ -137,15 +140,18 @@ export default class Dream extends Command {
     const projectRoot = resolveProject()?.projectRoot ?? process.cwd()
     const brvDir = join(projectRoot, BRV_DIR)
     const contextTreeDir = join(brvDir, CONTEXT_TREE_DIR)
+    const projectDataDir = getProjectDataDir(projectRoot)
 
     try {
       const result = await undoLastDream({
         archiveService: new FileContextTreeArchiveService(),
         contextTreeDir,
+        curateLogStore: new FileCurateLogStore({baseDir: projectDataDir}),
         dreamLogStore: new DreamLogStore({baseDir: brvDir}),
         dreamStateService: new DreamStateService({baseDir: brvDir}),
         manifestService: new FileContextTreeManifestService({baseDirectory: projectRoot}),
         projectRoot,
+        reviewBackupStore: new FileReviewBackupStore(brvDir),
       })
 
       if (format === 'json') {

--- a/src/server/core/domain/transport/schemas.ts
+++ b/src/server/core/domain/transport/schemas.ts
@@ -550,6 +550,8 @@ export const TaskCompletedEventSchema = z.object({
   clientId: z.string().optional(),
   /** Log entry ID from CurateLogHandler, if applicable */
   logId: z.string().optional(),
+  /** Project path — used by TaskRouter to notify pool for daemon-submitted tasks */
+  projectPath: z.string().optional(),
   result: z.string(),
   taskId: z.string(),
 })
@@ -573,6 +575,8 @@ export const TaskErrorEventSchema = z.object({
   error: TaskErrorDataSchema,
   /** Log entry ID from CurateLogHandler, if applicable */
   logId: z.string().optional(),
+  /** Project path — used by TaskRouter to notify pool for daemon-submitted tasks */
+  projectPath: z.string().optional(),
   taskId: z.string(),
 })
 

--- a/src/server/core/domain/transport/schemas.ts
+++ b/src/server/core/domain/transport/schemas.ts
@@ -390,6 +390,8 @@ export const TaskExecuteSchema = z.object({
   projectPath: z.string().optional(),
   /** Unique task identifier */
   taskId: z.string(),
+  /** Dream trigger source — how this dream was initiated */
+  trigger: z.enum(['agent-idle', 'cli', 'manual']).optional(),
   /** Task type */
   type: z.enum(['curate', 'curate-folder', 'dream', 'query', 'search']),
   /** Workspace root for scoped query/curate */

--- a/src/server/infra/daemon/agent-process.ts
+++ b/src/server/infra/daemon/agent-process.ts
@@ -554,7 +554,7 @@ async function executeTask(
       // Emit task:completed
       agentLog(`task:completed taskId=${taskId}`)
       try {
-        transport.request(TransportTaskEventNames.COMPLETED, {clientId, result, taskId})
+        transport.request(TransportTaskEventNames.COMPLETED, {clientId, projectPath, result, taskId})
       } catch (error) {
         agentLog(
           `task:completed send failed taskId=${taskId}: ${error instanceof Error ? error.message : String(error)}`,
@@ -565,7 +565,7 @@ async function executeTask(
       const errorData = serializeTaskError(error)
       agentLog(`task:error taskId=${taskId} error=${errorData.message}`)
       try {
-        transport.request(TransportTaskEventNames.ERROR, {clientId, error: errorData, taskId})
+        transport.request(TransportTaskEventNames.ERROR, {clientId, error: errorData, projectPath, taskId})
       } catch (error_) {
         agentLog(
           `task:error send failed taskId=${taskId}: ${error_ instanceof Error ? error_.message : String(error_)}`,

--- a/src/server/infra/daemon/agent-process.ts
+++ b/src/server/infra/daemon/agent-process.ts
@@ -57,6 +57,7 @@ import {FolderPackExecutor} from '../executor/folder-pack-executor.js'
 import {QueryExecutor} from '../executor/query-executor.js'
 import {SearchExecutor} from '../executor/search-executor.js'
 import {FileCurateLogStore} from '../storage/file-curate-log-store.js'
+import {FileReviewBackupStore} from '../storage/file-review-backup-store.js'
 import {AgentInstanceDiscovery} from '../transport/agent-instance-discovery.js'
 import {createAgentLogger} from './agent-logger.js'
 import {resolveSessionId} from './session-resolver.js'
@@ -401,7 +402,7 @@ async function executeTask(
   searchKnowledgeService: ISearchKnowledgeService,
   storagePath: string,
 ): Promise<void> {
-  const {clientCwd, clientId, content, files, folderPath, force, taskId, type, worktreeRoot} = task
+  const {clientCwd, clientId, content, files, folderPath, force, taskId, trigger, type, worktreeRoot} = task
   if (!transport || !agent) return
 
   // Search tasks are pure BM25 retrieval — no LLM, no provider needed.
@@ -522,13 +523,14 @@ async function executeTask(
             dreamLockService,
             dreamLogStore: new DreamLogStore({baseDir: brvDir}),
             dreamStateService,
+            reviewBackupStore: new FileReviewBackupStore(brvDir),
             searchService: searchKnowledgeService,
           })
           result = await dreamExecutor.executeWithAgent(agent, {
             priorMtime: eligibility.priorMtime,
             projectRoot: projectPath,
             taskId,
-            trigger: 'cli',
+            trigger: trigger ?? 'cli',
           })
 
           break

--- a/src/server/infra/daemon/brv-server.ts
+++ b/src/server/infra/daemon/brv-server.ts
@@ -24,6 +24,7 @@
 import {GlobalInstanceManager} from '@campfirein/brv-transport-client'
 import express from 'express'
 import {fork, type StdioOptions} from 'node:child_process'
+import {randomUUID} from 'node:crypto'
 import {mkdirSync, readdirSync, readFileSync, unlinkSync} from 'node:fs'
 import {dirname, join} from 'node:path'
 import {fileURLToPath} from 'node:url'
@@ -44,6 +45,8 @@ import {getProjectDataDir} from '../../utils/path-utils.js'
 import {crashLog, processLog} from '../../utils/process-logger.js'
 import {ClientManager} from '../client/client-manager.js'
 import {ProjectConfigStore} from '../config/file-config-store.js'
+import {DreamStateService} from '../dream/dream-state-service.js'
+import {DreamTrigger} from '../dream/dream-trigger.js'
 import {createReviewApiRouter} from '../http/review-api-handler.js'
 import {broadcastToProjectRoom} from '../process/broadcast-utils.js'
 import {CurateLogHandler} from '../process/curate-log-handler.js'
@@ -220,13 +223,16 @@ async function main(): Promise<void> {
       projectRegistry,
     })
 
+    // Shared queue-length resolver — used by both idle timeout policy and dream trigger
+    const getQueueLength = (projectPath: string): number =>
+      agentPool?.getQueueState().find((q) => q.projectPath === projectPath)?.queueLength ?? 0
+
     // Agent idle timeout policy — kills agents after period of inactivity
     const agentIdleTimeoutPolicy = new AgentIdleTimeoutPolicy({
       checkIntervalMs: AGENT_IDLE_CHECK_INTERVAL_MS,
-      getQueueLength: (projectPath: string) =>
-        agentPool?.getQueueState().find((q) => q.projectPath === projectPath)?.queueLength ?? 0,
+      getQueueLength,
       log,
-      onAgentIdle(projectPath: string, queueLength: number) {
+      async onAgentIdle(projectPath: string, queueLength: number) {
         // Don't kill agents that have queued tasks waiting
         if (queueLength > 0) {
           log(`Skipping idle cleanup: ${projectPath} has ${queueLength} queued tasks`)
@@ -240,7 +246,37 @@ async function main(): Promise<void> {
           return
         }
 
-        log(`Killing idle agent: ${projectPath}`)
+        // Check dream eligibility before killing (gates 1-3 only, no lock).
+        // Lock acquisition happens in the agent process when the dream task executes.
+        try {
+          const brvDir = join(projectPath, BRV_DIR)
+          const dreamTrigger = new DreamTrigger({
+            // Lock service unused by checkEligibility — provide no-op to satisfy type
+            dreamLockService: {tryAcquire: async () => ({acquired: true, priorMtime: 0})},
+            dreamStateService: new DreamStateService({baseDir: brvDir}),
+            getQueueLength,
+          })
+
+          const result = await dreamTrigger.checkEligibility(projectPath)
+          if (result.eligible) {
+            log(`Dream eligible, dispatching dream task: ${projectPath}`)
+            agentPool?.submitTask({
+              clientId: 'daemon',
+              content: '',
+              force: false,
+              projectPath,
+              taskId: randomUUID(),
+              trigger: 'agent-idle',
+              type: 'dream',
+            })
+            return
+          }
+
+          log(`Dream not eligible (${result.reason}), killing idle agent: ${projectPath}`)
+        } catch {
+          log(`Dream eligibility check failed, killing idle agent: ${projectPath}`)
+        }
+
         agentPool?.handleAgentDisconnected(projectPath)
       },
       timeoutMs: AGENT_IDLE_TIMEOUT_MS,

--- a/src/server/infra/daemon/brv-server.ts
+++ b/src/server/infra/daemon/brv-server.ts
@@ -251,8 +251,8 @@ async function main(): Promise<void> {
         try {
           const brvDir = join(projectPath, BRV_DIR)
           const dreamTrigger = new DreamTrigger({
-            // Lock service unused by checkEligibility — provide no-op to satisfy type
-            dreamLockService: {tryAcquire: async () => ({acquired: true, priorMtime: 0})},
+            // Lock must NOT be acquired during daemon pre-check — guard against accidental gate-4 calls
+            dreamLockService: {tryAcquire() { throw new Error('Lock must not be acquired during daemon eligibility pre-check') }},
             dreamStateService: new DreamStateService({baseDir: brvDir}),
             getQueueLength,
           })

--- a/src/server/infra/dream/dream-log-schema.ts
+++ b/src/server/infra/dream/dream-log-schema.ts
@@ -58,6 +58,7 @@ const DreamLogEntryBaseSchema = z.object({
   operations: z.array(DreamOperationSchema),
   startedAt: z.number(),
   summary: DreamLogSummarySchema,
+  taskId: z.string().optional(),
   trigger: z.enum(['agent-idle', 'manual', 'cli']),
 })
 

--- a/src/server/infra/dream/dream-trigger.ts
+++ b/src/server/infra/dream/dream-trigger.ts
@@ -16,6 +16,10 @@ export type DreamEligibility =
   | {eligible: false; reason: string}
   | {eligible: true; priorMtime: number}
 
+type PreCheckResult =
+  | {eligible: false; reason: string}
+  | {eligible: true}
+
 const DEFAULT_MIN_HOURS = 12
 const DEFAULT_MIN_CURATIONS = 3
 
@@ -34,35 +38,21 @@ export class DreamTrigger {
     this.options = options
   }
 
+  /**
+   * Lightweight eligibility pre-check (gates 1-3 only, no lock).
+   *
+   * Used by the daemon to decide whether to dispatch a dream task
+   * without acquiring the PID-based lock (which must be acquired
+   * by the agent process that actually runs the dream).
+   */
+  async checkEligibility(projectPath: string): Promise<PreCheckResult> {
+    return this.checkGates1to3(projectPath)
+  }
+
   async tryStartDream(projectPath: string, force = false): Promise<DreamEligibility> {
-    const minHours = this.options.minHours ?? DEFAULT_MIN_HOURS
-    const minCurations = this.options.minCurations ?? DEFAULT_MIN_CURATIONS
-
     if (!force) {
-      // Gates 1+2: time and activity (share one file read)
-      const state = await this.deps.dreamStateService.read()
-
-      // Gate 1: Time
-      if (state.lastDreamAt !== null) {
-        const hoursSince = (Date.now() - new Date(state.lastDreamAt).getTime()) / (1000 * 60 * 60)
-        if (hoursSince < minHours) {
-          return {eligible: false, reason: `Too recent (${hoursSince.toFixed(1)}h < ${minHours}h)`}
-        }
-      }
-
-      // Gate 2: Activity
-      if (state.curationsSinceDream < minCurations) {
-        return {
-          eligible: false,
-          reason: `Not enough activity (${state.curationsSinceDream} < ${minCurations} curations)`,
-        }
-      }
-
-      // Gate 3: Queue
-      const queueLength = this.deps.getQueueLength(projectPath)
-      if (queueLength > 0) {
-        return {eligible: false, reason: `Queue not empty (${queueLength} tasks pending)`}
-      }
+      const preCheck = await this.checkGates1to3(projectPath)
+      if (!preCheck.eligible) return preCheck
     }
 
     // Gate 4: Lock (NEVER skipped, even with force)
@@ -72,5 +62,37 @@ export class DreamTrigger {
     }
 
     return {eligible: true, priorMtime: lockResult.priorMtime}
+  }
+
+  private async checkGates1to3(projectPath: string): Promise<PreCheckResult> {
+    const minHours = this.options.minHours ?? DEFAULT_MIN_HOURS
+    const minCurations = this.options.minCurations ?? DEFAULT_MIN_CURATIONS
+
+    // Gates 1+2: time and activity (share one file read)
+    const state = await this.deps.dreamStateService.read()
+
+    // Gate 1: Time
+    if (state.lastDreamAt !== null) {
+      const hoursSince = (Date.now() - new Date(state.lastDreamAt).getTime()) / (1000 * 60 * 60)
+      if (hoursSince < minHours) {
+        return {eligible: false, reason: `Too recent (${hoursSince.toFixed(1)}h < ${minHours}h)`}
+      }
+    }
+
+    // Gate 2: Activity
+    if (state.curationsSinceDream < minCurations) {
+      return {
+        eligible: false,
+        reason: `Not enough activity (${state.curationsSinceDream} < ${minCurations} curations)`,
+      }
+    }
+
+    // Gate 3: Queue
+    const queueLength = this.deps.getQueueLength(projectPath)
+    if (queueLength > 0) {
+      return {eligible: false, reason: `Queue not empty (${queueLength} tasks pending)`}
+    }
+
+    return {eligible: true}
   }
 }

--- a/src/server/infra/dream/dream-undo.ts
+++ b/src/server/infra/dream/dream-undo.ts
@@ -321,19 +321,12 @@ function matchLegacyDreamReviewEntry(
 }
 
 async function cleanupReviewEntries(log: DreamLogEntry, deps: DreamUndoDeps): Promise<void> {
-  const reviewFilePaths = new Set<string>()
-  for (const op of log.operations) {
-    if (!op.needsReview) continue
-    if (op.type === 'PRUNE') reviewFilePaths.add(op.file)
-    if (op.type === 'CONSOLIDATE' && op.previousTexts) {
-      for (const file of Object.keys(op.previousTexts)) reviewFilePaths.add(file)
-    }
+  const hasReviewOps = log.operations.some((op) => op.needsReview)
 
-    if (op.type === 'SYNTHESIZE') reviewFilePaths.add(op.outputFile)
-  }
-
-  // Mark curate log entries from dream as rejected
-  if (deps.curateLogStore && reviewFilePaths.size > 0) {
+  // Mark curate log entries from dream as rejected.
+  // Runs whenever the dream had any needsReview ops — even if previousTexts is absent
+  // (e.g. legacy CROSS_REFERENCE entries), so the pending review task is always cleaned up.
+  if (deps.curateLogStore && hasReviewOps) {
     try {
       const entries = await deps.curateLogStore.list({status: ['completed']})
       const dreamEntries = entries.filter((entry) => entry.input.context === 'dream')
@@ -352,11 +345,25 @@ async function cleanupReviewEntries(log: DreamLogEntry, deps: DreamUndoDeps): Pr
     }
   }
 
-  // Delete review backups for affected files
-  if (deps.reviewBackupStore && reviewFilePaths.size > 0) {
-    await Promise.all(
-      [...reviewFilePaths].map((file) => deps.reviewBackupStore!.delete(file).catch(() => {})),
-    )
+  // Delete review backups for affected files (collected from previousTexts keys,
+  // which mirror what the backup store received during the dream).
+  if (deps.reviewBackupStore) {
+    const reviewFilePaths = new Set<string>()
+    for (const op of log.operations) {
+      if (!op.needsReview) continue
+      if (op.type === 'PRUNE') reviewFilePaths.add(op.file)
+      if (op.type === 'CONSOLIDATE' && op.previousTexts) {
+        for (const file of Object.keys(op.previousTexts)) reviewFilePaths.add(file)
+      }
+
+      if (op.type === 'SYNTHESIZE') reviewFilePaths.add(op.outputFile)
+    }
+
+    if (reviewFilePaths.size > 0) {
+      await Promise.all(
+        [...reviewFilePaths].map((file) => deps.reviewBackupStore!.delete(file).catch(() => {})),
+      )
+    }
   }
 }
 

--- a/src/server/infra/dream/dream-undo.ts
+++ b/src/server/infra/dream/dream-undo.ts
@@ -8,12 +8,18 @@
 import {mkdir, unlink, writeFile} from 'node:fs/promises'
 import {dirname, resolve} from 'node:path'
 
+import type {CurateLogEntry, CurateLogOperation} from '../../core/domain/entities/curate-log-entry.js'
+import type {ICurateLogStore} from '../../core/interfaces/storage/i-curate-log-store.js'
+import type {IReviewBackupStore} from '../../core/interfaces/storage/i-review-backup-store.js'
 import type {DreamLogEntry, DreamOperation} from './dream-log-schema.js'
 import type {DreamState} from './dream-state-schema.js'
+
+import {isDescendantOf} from '../../utils/path-utils.js'
 
 export type DreamUndoDeps = {
   archiveService?: {restoreEntry(stubPath: string, directory?: string): Promise<string>}
   contextTreeDir: string
+  curateLogStore?: Pick<ICurateLogStore, 'batchUpdateOperationReviewStatus' | 'list'>
   dreamLogStore: {
     getById(id: string): Promise<DreamLogEntry | null>
     save(entry: DreamLogEntry): Promise<void>
@@ -24,6 +30,7 @@ export type DreamUndoDeps = {
   }
   manifestService: {buildManifest(dir?: string): Promise<unknown>}
   projectRoot?: string
+  reviewBackupStore?: Pick<IReviewBackupStore, 'delete'>
 }
 
 export interface DreamUndoResult {
@@ -78,6 +85,9 @@ export async function undoLastDream(deps: DreamUndoDeps): Promise<DreamUndoResul
     }
   }
 
+  // ── Post-undo: clean up review entries and backups ──────────────────────
+  await cleanupReviewEntries(log, deps)
+
   // ── Post-undo: rebuild manifest ─────────────────────────────────────────
   try {
     await manifestService.buildManifest()
@@ -93,6 +103,7 @@ export async function undoLastDream(deps: DreamUndoDeps): Promise<DreamUndoResul
     startedAt: log.startedAt,
     status: 'undone',
     summary: log.summary,
+    taskId: log.taskId,
     trigger: log.trigger,
     undoneAt: Date.now(),
   }
@@ -128,7 +139,7 @@ async function unlinkSafe(filePath: string): Promise<void> {
 /** Resolve a relative path within contextTreeDir, rejecting traversal outside the tree. */
 function safePath(contextTreeDir: string, relativePath: string): string {
   const full = resolve(contextTreeDir, relativePath)
-  if (!full.startsWith(contextTreeDir + '/') && full !== contextTreeDir) {
+  if (!isDescendantOf(full, contextTreeDir)) {
     throw new Error(`Path traversal blocked: ${relativePath}`)
   }
 
@@ -170,7 +181,17 @@ async function undoConsolidate(
 ): Promise<void> {
   switch (op.action) {
     case 'CROSS_REFERENCE': {
-      // Non-destructive — skip
+      if (!op.previousTexts || Object.keys(op.previousTexts).length === 0) break
+
+      for (const [filePath, content] of Object.entries(op.previousTexts)) {
+        const fullPath = safePath(contextTreeDir, filePath)
+        // eslint-disable-next-line no-await-in-loop
+        await mkdir(dirname(fullPath), {recursive: true})
+        // eslint-disable-next-line no-await-in-loop
+        await writeFile(fullPath, content, 'utf8')
+        result.restoredFiles.push(filePath)
+      }
+
       break
     }
 
@@ -230,6 +251,113 @@ async function undoSynthesize(
   // CREATE — delete the synthesized file
   await unlinkSafe(safePath(contextTreeDir, op.outputFile))
   result.deletedFiles.push(op.outputFile)
+}
+
+/**
+ * Clean up review system artifacts created by the dream's dual-write.
+ * - Mark curate log operations from dream entries as 'rejected'
+ * - Delete review backups for files involved in needsReview operations
+ */
+type ReviewTarget = {
+  path: string
+  type: CurateLogOperation['type']
+}
+
+function reviewTargetKey(target: ReviewTarget): string {
+  return `${target.type}:${target.path}`
+}
+
+function collectReviewTargets(operations: DreamOperation[]): ReviewTarget[] {
+  const targets: ReviewTarget[] = []
+  for (const op of operations) {
+    if (!op.needsReview) continue
+
+    if (op.type === 'PRUNE' && op.action === 'ARCHIVE') {
+      targets.push({path: op.file, type: 'DELETE'})
+      continue
+    }
+
+    if (op.type === 'CONSOLIDATE' && op.action === 'MERGE') {
+      targets.push({path: op.outputFile ?? op.inputFiles[0], type: 'MERGE'})
+      continue
+    }
+
+    if (op.type === 'CONSOLIDATE') {
+      targets.push({path: op.inputFiles[0], type: 'UPDATE'})
+      continue
+    }
+
+    if (op.type === 'SYNTHESIZE') {
+      targets.push({path: op.outputFile, type: op.action === 'CREATE' ? 'ADD' : 'UPDATE'})
+    }
+  }
+
+  return targets
+}
+
+function buildReviewStatusUpdates(entry: CurateLogEntry): Array<{operationIndex: number; reviewStatus: 'rejected'}> {
+  return entry.operations
+    .map((op, operationIndex) =>
+      op.reviewStatus && op.reviewStatus !== 'rejected'
+        ? {operationIndex, reviewStatus: 'rejected' as const}
+        : null,
+    )
+    .filter((update): update is {operationIndex: number; reviewStatus: 'rejected'} => update !== null)
+}
+
+function matchLegacyDreamReviewEntry(
+  entries: CurateLogEntry[],
+  operations: DreamOperation[],
+): CurateLogEntry[] {
+  const expected = collectReviewTargets(operations).map((target) => reviewTargetKey(target)).sort()
+  if (expected.length === 0) return []
+
+  const matches = entries.filter((entry) => {
+    const actual = entry.operations.map((op) => reviewTargetKey({path: op.path, type: op.type})).sort()
+    return actual.length === expected.length && actual.every((value, index) => value === expected[index])
+  })
+
+  return matches.length === 1 ? matches : []
+}
+
+async function cleanupReviewEntries(log: DreamLogEntry, deps: DreamUndoDeps): Promise<void> {
+  const reviewFilePaths = new Set<string>()
+  for (const op of log.operations) {
+    if (!op.needsReview) continue
+    if (op.type === 'PRUNE') reviewFilePaths.add(op.file)
+    if (op.type === 'CONSOLIDATE' && op.previousTexts) {
+      for (const file of Object.keys(op.previousTexts)) reviewFilePaths.add(file)
+    }
+
+    if (op.type === 'SYNTHESIZE') reviewFilePaths.add(op.outputFile)
+  }
+
+  // Mark curate log entries from dream as rejected
+  if (deps.curateLogStore && reviewFilePaths.size > 0) {
+    try {
+      const entries = await deps.curateLogStore.list({status: ['completed']})
+      const dreamEntries = entries.filter((entry) => entry.input.context === 'dream')
+      const matchedEntries = log.taskId
+        ? dreamEntries.filter((entry) => entry.taskId === log.taskId)
+        : matchLegacyDreamReviewEntry(dreamEntries, log.operations)
+
+      for (const entry of matchedEntries) {
+        const updates = buildReviewStatusUpdates(entry)
+        if (updates.length === 0) continue
+        // eslint-disable-next-line no-await-in-loop
+        await deps.curateLogStore.batchUpdateOperationReviewStatus(entry.id, updates)
+      }
+    } catch {
+      // Fail-open: review cleanup must not block undo
+    }
+  }
+
+  // Delete review backups for affected files
+  if (deps.reviewBackupStore && reviewFilePaths.size > 0) {
+    await Promise.all(
+      [...reviewFilePaths].map((file) => deps.reviewBackupStore!.delete(file).catch(() => {})),
+    )
+  }
 }
 
 async function undoPrune(

--- a/src/server/infra/dream/operations/consolidate.ts
+++ b/src/server/infra/dream/operations/consolidate.ts
@@ -431,8 +431,10 @@ async function executeTemporalUpdate(
     previousTexts[targetFile] = original
   }
 
-  // Create review backup before destructive write
-  if (reviewBackupStore && original !== undefined) {
+  const needsReview = determineNeedsReview('TEMPORAL_UPDATE', action.files, fileContents, action.confidence)
+
+  // Create review backup only when the operation needs human review
+  if (reviewBackupStore && original !== undefined && needsReview) {
     try {
       await reviewBackupStore.save(targetFile, original)
     } catch {
@@ -444,8 +446,6 @@ async function executeTemporalUpdate(
   // eslint-disable-next-line camelcase
   const contentWithFm = addFrontmatterFields(updatedContent, {consolidated_at: new Date().toISOString()})
   await atomicWrite(join(contextTreeDir, targetFile), contentWithFm)
-
-  const needsReview = determineNeedsReview('TEMPORAL_UPDATE', action.files, fileContents, action.confidence)
 
   return {
     action: 'TEMPORAL_UPDATE',

--- a/src/server/infra/dream/operations/consolidate.ts
+++ b/src/server/infra/dream/operations/consolidate.ts
@@ -27,6 +27,9 @@ import {parseDreamResponse} from '../parse-dream-response.js'
 export type ConsolidateDeps = {
   agent: ICipherAgent
   contextTreeDir: string
+  reviewBackupStore?: {
+    save(relativePath: string, content: string): Promise<void>
+  }
   searchService: {
     search(query: string, options?: {limit?: number; scope?: string}): Promise<{results: Array<{path: string; score: number; title: string}>}>
   }
@@ -102,7 +105,7 @@ async function processDomain(domain: string, files: string[], deps: ConsolidateD
     for (const action of parsed.actions) {
       try {
         // eslint-disable-next-line no-await-in-loop
-        const op = await executeAction(action, contextTreeDir, fileContents)
+        const op = await executeAction(action, contextTreeDir, fileContents, deps.reviewBackupStore)
         if (op) results.push(op)
       } catch {
         // Skip failed action, continue with others
@@ -327,14 +330,15 @@ async function executeAction(
   action: ConsolidationAction,
   contextTreeDir: string,
   fileContents: Map<string, string>,
+  reviewBackupStore?: ConsolidateDeps['reviewBackupStore'],
 ): Promise<DreamOperation | undefined> {
   switch (action.type) {
     case 'CROSS_REFERENCE': {
-      return executeCrossReference(action, contextTreeDir, fileContents)
+      return executeCrossReference(action, contextTreeDir, fileContents, reviewBackupStore)
     }
 
     case 'MERGE': {
-      return executeMerge(action, contextTreeDir, fileContents)
+      return executeMerge(action, contextTreeDir, fileContents, reviewBackupStore)
     }
 
     case 'SKIP': {
@@ -342,7 +346,7 @@ async function executeAction(
     }
 
     case 'TEMPORAL_UPDATE': {
-      return executeTemporalUpdate(action, contextTreeDir, fileContents)
+      return executeTemporalUpdate(action, contextTreeDir, fileContents, reviewBackupStore)
     }
   }
 }
@@ -351,6 +355,7 @@ async function executeMerge(
   action: ConsolidationAction,
   contextTreeDir: string,
   fileContents: Map<string, string>,
+  reviewBackupStore?: ConsolidateDeps['reviewBackupStore'],
 ): Promise<DreamOperation> {
   const outputFile = action.outputFile ?? action.files[0]
   if (!action.mergedContent) {
@@ -366,6 +371,15 @@ async function executeMerge(
     if (content !== undefined) {
       previousTexts[file] = content
     }
+  }
+
+  // Create review backups before destructive writes (MERGE always needs review)
+  if (reviewBackupStore) {
+    await Promise.all(
+      Object.entries(previousTexts).map(([file, content]) =>
+        reviewBackupStore.save(file, content).catch(() => {}),
+      ),
+    )
   }
 
   // Add consolidation metadata frontmatter, then write atomically
@@ -401,6 +415,7 @@ async function executeTemporalUpdate(
   action: ConsolidationAction,
   contextTreeDir: string,
   fileContents: Map<string, string>,
+  reviewBackupStore?: ConsolidateDeps['reviewBackupStore'],
 ): Promise<DreamOperation> {
   const targetFile = action.files[0]
   if (!action.updatedContent) {
@@ -414,6 +429,15 @@ async function executeTemporalUpdate(
   const original = fileContents.get(targetFile)
   if (original !== undefined) {
     previousTexts[targetFile] = original
+  }
+
+  // Create review backup before destructive write
+  if (reviewBackupStore && original !== undefined) {
+    try {
+      await reviewBackupStore.save(targetFile, original)
+    } catch {
+      // Best-effort: backup failure must not block update
+    }
   }
 
   // Add consolidation timestamp, then write atomically
@@ -437,7 +461,25 @@ async function executeCrossReference(
   action: ConsolidationAction,
   contextTreeDir: string,
   fileContents: Map<string, string>,
+  reviewBackupStore?: ConsolidateDeps['reviewBackupStore'],
 ): Promise<DreamOperation> {
+  const previousTexts: Record<string, string> = {}
+  for (const file of action.files) {
+    const content = fileContents.get(file)
+    if (content !== undefined) {
+      previousTexts[file] = content
+    }
+  }
+
+  const needsReview = determineNeedsReview('CROSS_REFERENCE', action.files, fileContents)
+  if (needsReview && reviewBackupStore) {
+    await Promise.all(
+      Object.entries(previousTexts).map(([file, content]) =>
+        reviewBackupStore.save(file, content).catch(() => {}),
+      ),
+    )
+  }
+
   // For each file, add the other files to its related frontmatter
   await Promise.all(
     action.files.map((file) => {
@@ -446,12 +488,11 @@ async function executeCrossReference(
     }),
   )
 
-  const needsReview = determineNeedsReview('CROSS_REFERENCE', action.files, fileContents)
-
   return {
     action: 'CROSS_REFERENCE',
     inputFiles: action.files,
     needsReview,
+    previousTexts,
     reason: action.reason,
     type: 'CONSOLIDATE',
   }

--- a/src/server/infra/dream/operations/prune.ts
+++ b/src/server/infra/dream/operations/prune.ts
@@ -38,6 +38,9 @@ export type PruneDeps = {
     write(state: DreamState): Promise<void>
   }
   projectRoot: string
+  reviewBackupStore?: {
+    save(relativePath: string, content: string): Promise<void>
+  }
   signal?: AbortSignal
   taskId: string
 }
@@ -344,6 +347,16 @@ async function executeDecisions(
 async function executeDecision(decision: PruneDecision, deps: PruneDeps): Promise<DreamOperation | undefined> {
   switch (decision.decision) {
     case 'ARCHIVE': {
+      // Create review backup before destructive archive (read content → save to review-backups/)
+      if (deps.reviewBackupStore) {
+        try {
+          const content = await readFile(join(deps.contextTreeDir, decision.file), 'utf8')
+          await deps.reviewBackupStore.save(decision.file, content)
+        } catch {
+          // Best-effort: backup failure must not block archive
+        }
+      }
+
       const archiveResult = await deps.archiveService.archiveEntry(decision.file, deps.agent, deps.projectRoot)
       return {
         action: 'ARCHIVE',

--- a/src/server/infra/executor/dream-executor.ts
+++ b/src/server/infra/executor/dream-executor.ts
@@ -41,7 +41,9 @@ export type DreamExecutorDeps = {
     findArchiveCandidates(directory?: string): Promise<string[]>
   }
   curateLogStore: {
+    getNextId(): Promise<string>
     list(filters?: {after?: number; before?: number; limit?: number; status?: CurateLogStatus[]}): Promise<CurateLogEntry[]>
+    save(entry: CurateLogEntry): Promise<void>
   }
   dreamLockService: {
     release(): Promise<void>
@@ -54,6 +56,9 @@ export type DreamExecutorDeps = {
   dreamStateService: {
     read(): Promise<import('../dream/dream-state-schema.js').DreamState>
     write(state: import('../dream/dream-state-schema.js').DreamState): Promise<void>
+  }
+  reviewBackupStore?: {
+    save(relativePath: string, content: string): Promise<void>
   }
   searchService: ConsolidateDeps['searchService']
 }
@@ -90,6 +95,7 @@ export class DreamExecutor {
       startedAt,
       status: 'processing',
       summary: zeroes,
+      taskId: options.taskId,
       trigger,
     }
     await this.deps.dreamLogStore.save(processingEntry)
@@ -115,6 +121,7 @@ export class DreamExecutor {
       const consolidateResults = await consolidate([...changedFiles], {
         agent,
         contextTreeDir,
+        reviewBackupStore: this.deps.reviewBackupStore,
         searchService: this.deps.searchService,
         signal: controller.signal,
         taskId: options.taskId,
@@ -135,6 +142,7 @@ export class DreamExecutor {
         dreamLogId: logId,
         dreamStateService: this.deps.dreamStateService,
         projectRoot,
+        reviewBackupStore: this.deps.reviewBackupStore,
         signal: controller.signal,
         taskId: options.taskId,
       })
@@ -156,6 +164,9 @@ export class DreamExecutor {
         }
       }
 
+      // Step 5b: Create curate log entries for needsReview operations (dual-write for review system)
+      await this.createReviewEntries(allOperations, contextTreeDir, options.taskId)
+
       // Step 6: Write dream log
       const summary = this.computeSummary(allOperations)
       const completedEntry: DreamLogEntry = {
@@ -165,6 +176,7 @@ export class DreamExecutor {
         startedAt,
         status: 'completed',
         summary,
+        taskId: options.taskId,
         trigger,
       }
       await this.deps.dreamLogStore.save(completedEntry)
@@ -192,6 +204,7 @@ export class DreamExecutor {
           startedAt,
           status: 'partial',
           summary: zeroes,
+          taskId: options.taskId,
           trigger,
         }
         await this.deps.dreamLogStore.save(partialEntry).catch(() => {})
@@ -204,6 +217,7 @@ export class DreamExecutor {
           startedAt,
           status: 'error',
           summary: zeroes,
+          taskId: options.taskId,
           trigger,
         }
         await this.deps.dreamLogStore.save(errorEntry).catch(() => {})
@@ -233,6 +247,40 @@ export class DreamExecutor {
     }
 
     return summary
+  }
+
+  /**
+   * Dual-write: create curate log entries for dream operations that need human review.
+   * This surfaces them in `brv review pending` without modifying the review system.
+   */
+  private async createReviewEntries(
+    operations: DreamOperation[],
+    contextTreeDir: string,
+    taskId: string,
+  ): Promise<void> {
+    const reviewOps = operations.filter((op) => op.needsReview)
+    if (reviewOps.length === 0) return
+
+    const curateOps: CurateLogEntry['operations'] = reviewOps.map((op) =>
+      mapDreamOpToCurateOp(op, contextTreeDir),
+    )
+
+    try {
+      const logId = await this.deps.curateLogStore.getNextId()
+      const entry: CurateLogEntry = {
+        completedAt: Date.now(),
+        id: logId,
+        input: {context: 'dream'},
+        operations: curateOps,
+        startedAt: Date.now(),
+        status: 'completed',
+        summary: {added: 0, deleted: 0, failed: 0, merged: 0, updated: 0},
+        taskId,
+      }
+      await this.deps.curateLogStore.save(entry)
+    } catch {
+      // Fail-open: review entry creation must not block dream
+    }
   }
 
   private async findChangedFilesSinceLastDream(
@@ -276,6 +324,91 @@ export class DreamExecutor {
     })
     const results = await Promise.all(checks)
     return new Set(results.filter((f): f is string => f !== null))
+  }
+}
+
+/** Map a dream operation to a curate log operation for the review system. */
+function mapDreamOpToCurateOp(
+  op: DreamOperation,
+  contextTreeDir: string,
+): CurateLogEntry['operations'][number] {
+  if (op.type === 'PRUNE' && op.action === 'ARCHIVE') {
+    return {
+      filePath: join(contextTreeDir, op.file),
+      needsReview: true,
+      path: op.file,
+      reason: `[dream/prune] ${op.reason}`,
+      reviewStatus: 'pending',
+      status: 'success',
+      type: 'DELETE',
+    }
+  }
+
+  if (op.type === 'CONSOLIDATE' && op.action === 'MERGE') {
+    return {
+      additionalFilePaths: op.inputFiles.filter((f) => f !== op.outputFile).map((f) => join(contextTreeDir, f)),
+      filePath: op.outputFile ? join(contextTreeDir, op.outputFile) : undefined,
+      needsReview: true,
+      path: op.outputFile ?? op.inputFiles[0],
+      reason: `[dream/consolidate] ${op.reason}`,
+      reviewStatus: 'pending',
+      status: 'success',
+      type: 'MERGE',
+    }
+  }
+
+  if (op.type === 'CONSOLIDATE' && op.action === 'TEMPORAL_UPDATE') {
+    const targetFile = op.inputFiles[0]
+    return {
+      filePath: join(contextTreeDir, targetFile),
+      needsReview: true,
+      path: targetFile,
+      reason: `[dream/consolidate] ${op.reason}`,
+      reviewStatus: 'pending',
+      status: 'success',
+      type: 'UPDATE',
+    }
+  }
+
+  if (op.type === 'CONSOLIDATE' && op.action === 'CROSS_REFERENCE') {
+    const [targetFile, ...relatedFiles] = op.inputFiles
+    return {
+      additionalFilePaths: relatedFiles.map((file) => join(contextTreeDir, file)),
+      filePath: join(contextTreeDir, targetFile),
+      needsReview: true,
+      path: targetFile,
+      reason: `[dream/consolidate] ${op.reason}`,
+      reviewStatus: 'pending',
+      status: 'success',
+      type: 'UPDATE',
+    }
+  }
+
+  if (op.type === 'SYNTHESIZE' && op.action === 'CREATE') {
+    return {
+      filePath: join(contextTreeDir, op.outputFile),
+      needsReview: true,
+      path: op.outputFile,
+      reason: '[dream/synthesize] Generated synthesis draft',
+      reviewStatus: 'pending',
+      status: 'success',
+      type: 'ADD',
+    }
+  }
+
+  const filePath = 'file' in op
+    ? op.file
+    : 'inputFiles' in op
+      ? op.outputFile ?? op.inputFiles[0]
+      : op.outputFile
+  return {
+    filePath: join(contextTreeDir, filePath),
+    needsReview: true,
+    path: filePath,
+    reason: `[dream/${op.type.toLowerCase()}] ${'reason' in op ? op.reason : ''}`,
+    reviewStatus: 'pending',
+    status: 'success',
+    type: 'UPDATE',
   }
 }
 

--- a/src/server/infra/executor/dream-executor.ts
+++ b/src/server/infra/executor/dream-executor.ts
@@ -164,9 +164,6 @@ export class DreamExecutor {
         }
       }
 
-      // Step 5b: Create curate log entries for needsReview operations (dual-write for review system)
-      await this.createReviewEntries(allOperations, contextTreeDir, options.taskId)
-
       // Step 6: Write dream log
       const summary = this.computeSummary(allOperations)
       const completedEntry: DreamLogEntry = {
@@ -180,6 +177,10 @@ export class DreamExecutor {
         trigger,
       }
       await this.deps.dreamLogStore.save(completedEntry)
+
+      // Step 6b: Create curate log entries for needsReview operations (dual-write for review system).
+      // Runs after the completed dream log is durably written so review tasks never outlive their dream log.
+      await this.createReviewEntries(allOperations, contextTreeDir, options.taskId)
 
       // Step 7: Update dream state — re-read to preserve pendingMerges written by prune
       const currentState = await this.deps.dreamStateService.read()
@@ -274,7 +275,13 @@ export class DreamExecutor {
         operations: curateOps,
         startedAt: Date.now(),
         status: 'completed',
-        summary: {added: 0, deleted: 0, failed: 0, merged: 0, updated: 0},
+        summary: {
+          added: curateOps.filter((op) => op.type === 'ADD').length,
+          deleted: curateOps.filter((op) => op.type === 'DELETE').length,
+          failed: 0,
+          merged: curateOps.filter((op) => op.type === 'MERGE').length,
+          updated: curateOps.filter((op) => op.type === 'UPDATE' || op.type === 'UPSERT').length,
+        },
         taskId,
       }
       await this.deps.curateLogStore.save(entry)
@@ -297,6 +304,8 @@ export class DreamExecutor {
 
     const changedFiles = new Set<string>()
     for (const log of recentLogs) {
+      if (log.input.context === 'dream') continue
+
       for (const op of log.operations ?? []) {
         // op.filePath is absolute; convert to relative for context tree operations
         if (op.filePath) {

--- a/src/server/infra/process/task-router.ts
+++ b/src/server/infra/process/task-router.ts
@@ -320,9 +320,12 @@ export class TaskRouter {
     )
     this.moveToCompleted(taskId)
 
-    // Notify pool so it can clear busy flag and drain queued tasks
-    if (task?.projectPath) {
-      this.agentPool?.notifyTaskCompleted(task.projectPath)
+    // Notify pool so it can clear busy flag and drain queued tasks.
+    // Fallback to data.projectPath for daemon-submitted tasks (e.g. idle dream)
+    // that bypass handleTaskCreate and are not registered in this.tasks.
+    const projectPath = task?.projectPath ?? data.projectPath
+    if (projectPath) {
+      this.agentPool?.notifyTaskCompleted(projectPath)
     }
 
     // Notify hooks (fire-and-forget)
@@ -590,9 +593,11 @@ export class TaskRouter {
     )
     this.moveToCompleted(taskId)
 
-    // Notify pool so it can clear busy flag and drain queued tasks
-    if (task?.projectPath) {
-      this.agentPool?.notifyTaskCompleted(task.projectPath)
+    // Notify pool so it can clear busy flag and drain queued tasks.
+    // Fallback to data.projectPath for daemon-submitted tasks (e.g. idle dream).
+    const errorProjectPath = task?.projectPath ?? data.projectPath
+    if (errorProjectPath) {
+      this.agentPool?.notifyTaskCompleted(errorProjectPath)
     }
 
     // Notify hooks (fire-and-forget)

--- a/test/unit/infra/dream/dream-log-schema.test.ts
+++ b/test/unit/infra/dream/dream-log-schema.test.ts
@@ -189,9 +189,11 @@ describe('DreamLogEntrySchema', () => {
       ...makeBase(),
       completedAt: 1_712_736_060_000,
       status: 'completed',
+      taskId: 'task-123',
     }
     const result = DreamLogEntrySchema.parse(input)
     expect(result.status).to.equal('completed')
+    expect(result.taskId).to.equal('task-123')
   })
 
   it('should parse a partial entry with abortReason', () => {

--- a/test/unit/infra/dream/dream-trigger.test.ts
+++ b/test/unit/infra/dream/dream-trigger.test.ts
@@ -220,4 +220,69 @@ describe('DreamTrigger', () => {
       expect(result.eligible).to.be.true
     })
   })
+
+  describe('checkEligibility', () => {
+    it('should return eligible when gates 1-3 pass', async () => {
+      const deps = makeDeps()
+      const trigger = new DreamTrigger(deps)
+
+      const result = await trigger.checkEligibility('/project')
+      expect(result.eligible).to.be.true
+    })
+
+    it('should NOT call lock service (gate 4)', async () => {
+      const deps = makeDeps()
+      const trigger = new DreamTrigger(deps)
+
+      await trigger.checkEligibility('/project')
+      expect(deps.dreamLockService.tryAcquire.called).to.be.false
+    })
+
+    it('should fail when time gate fails', async () => {
+      const deps = makeDeps({
+        state: makeState({lastDreamAt: new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString()}),
+      })
+      const trigger = new DreamTrigger(deps)
+
+      const result = await trigger.checkEligibility('/project')
+      expect(result.eligible).to.be.false
+      if (!result.eligible) {
+        expect(result.reason).to.include('recent')
+      }
+    })
+
+    it('should fail when activity gate fails', async () => {
+      const deps = makeDeps({
+        state: makeState({curationsSinceDream: 1}),
+      })
+      const trigger = new DreamTrigger(deps)
+
+      const result = await trigger.checkEligibility('/project')
+      expect(result.eligible).to.be.false
+      if (!result.eligible) {
+        expect(result.reason).to.include('activity')
+      }
+    })
+
+    it('should fail when queue is not empty', async () => {
+      const deps = makeDeps({queueLength: 3})
+      const trigger = new DreamTrigger(deps)
+
+      const result = await trigger.checkEligibility('/project')
+      expect(result.eligible).to.be.false
+      if (!result.eligible) {
+        expect(result.reason).to.include('Queue')
+      }
+    })
+
+    it('should respect custom thresholds', async () => {
+      const deps = makeDeps({
+        state: makeState({curationsSinceDream: 1, lastDreamAt: new Date(Date.now() - 5 * 60 * 60 * 1000).toISOString()}),
+      })
+      const trigger = new DreamTrigger(deps, {minCurations: 1, minHours: 4})
+
+      const result = await trigger.checkEligibility('/project')
+      expect(result.eligible).to.be.true
+    })
+  })
 })

--- a/test/unit/infra/dream/dream-undo.test.ts
+++ b/test/unit/infra/dream/dream-undo.test.ts
@@ -18,6 +18,7 @@ function completedLog(operations: DreamLogEntry['operations'] = []): DreamLogEnt
     startedAt: Date.now() - 1000,
     status: 'completed',
     summary: {consolidated: 0, errors: 0, flaggedForReview: 0, pruned: 0, synthesized: 0},
+    taskId: 'task-1',
     trigger: 'cli',
   }
 }
@@ -222,7 +223,7 @@ describe('undoLastDream', () => {
 
   // ── CONSOLIDATE/CROSS_REFERENCE undo ──────────────────────────────────────
 
-  it('skips CROSS_REFERENCE (non-destructive)', async () => {
+  it('skips legacy CROSS_REFERENCE entries without previousTexts', async () => {
     dreamLogStore.getById.resolves(completedLog([{
       action: 'CROSS_REFERENCE',
       inputFiles: ['auth/jwt.md', 'auth/oauth.md'],
@@ -235,6 +236,31 @@ describe('undoLastDream', () => {
 
     expect(result.restoredFiles).to.be.empty
     expect(result.deletedFiles).to.be.empty
+  })
+
+  it('restores files for CROSS_REFERENCE when previousTexts were captured', async () => {
+    await mkdir(join(ctxDir, 'auth'), {recursive: true})
+    await writeFile(join(ctxDir, 'auth/jwt.md'), 'Updated jwt')
+    await writeFile(join(ctxDir, 'auth/oauth.md'), 'Updated oauth')
+
+    dreamLogStore.getById.resolves(completedLog([{
+      action: 'CROSS_REFERENCE',
+      inputFiles: ['auth/jwt.md', 'auth/oauth.md'],
+      needsReview: true,
+      previousTexts: {
+        'auth/jwt.md': 'Original jwt',
+        'auth/oauth.md': 'Original oauth',
+      },
+      reason: 'Related',
+      type: 'CONSOLIDATE',
+    }]))
+
+    const result = await undoLastDream(deps)
+
+    expect(result.restoredFiles).to.include('auth/jwt.md')
+    expect(result.restoredFiles).to.include('auth/oauth.md')
+    expect(await readFile(join(ctxDir, 'auth/jwt.md'), 'utf8')).to.equal('Original jwt')
+    expect(await readFile(join(ctxDir, 'auth/oauth.md'), 'utf8')).to.equal('Original oauth')
   })
 
   // ── SYNTHESIZE undo (forward-compatible) ──────────────────────────────────
@@ -474,5 +500,161 @@ describe('undoLastDream', () => {
     expect(result.deletedFiles).to.be.empty
     expect(result.restoredArchives).to.be.empty
     expect(result.errors).to.be.empty
+  })
+
+  // ── Review cleanup on undo ──────────────────────────────────────────────
+
+  it('marks curate log operations as rejected when undo reverses needsReview ops', async () => {
+    const curateLogStore = {
+      batchUpdateOperationReviewStatus: stub().resolves(true),
+      list: stub().resolves([
+        {
+          completedAt: Date.now(),
+          id: 'cur-5000',
+          input: {context: 'dream'},
+          operations: [{
+            filePath: join(ctxDir, 'auth/stale.md'),
+            needsReview: true,
+            path: 'auth/stale.md',
+            reviewStatus: 'pending',
+            status: 'success',
+            type: 'DELETE',
+          }],
+          startedAt: Date.now(),
+          status: 'completed',
+          summary: {added: 0, deleted: 0, failed: 0, merged: 0, updated: 0},
+          taskId: 'task-1',
+        },
+        {
+          completedAt: Date.now(),
+          id: 'cur-6000',
+          input: {context: 'dream'},
+          operations: [{
+            filePath: join(ctxDir, 'auth/keep.md'),
+            needsReview: true,
+            path: 'auth/keep.md',
+            reviewStatus: 'pending',
+            status: 'success',
+            type: 'DELETE',
+          }],
+          startedAt: Date.now(),
+          status: 'completed',
+          summary: {added: 0, deleted: 0, failed: 0, merged: 0, updated: 0},
+          taskId: 'task-2',
+        },
+      ]),
+    }
+
+    const reviewBackupStore = {delete: stub().resolves()}
+
+    const archiveService = {restoreEntry: stub().resolves('auth/stale.md')}
+
+    dreamLogStore.getById.resolves(completedLog([{
+      action: 'ARCHIVE',
+      file: 'auth/stale.md',
+      needsReview: true,
+      reason: 'Stale',
+      stubPath: '_archived/auth/stale.stub.md',
+      type: 'PRUNE',
+    }]))
+
+    await undoLastDream({...deps, archiveService, curateLogStore, reviewBackupStore})
+
+    expect(curateLogStore.list.calledOnce).to.be.true
+    expect(curateLogStore.batchUpdateOperationReviewStatus.calledOnce).to.be.true
+    const [logId, updates] = curateLogStore.batchUpdateOperationReviewStatus.firstCall.args
+    expect(logId).to.equal('cur-5000')
+    expect(updates).to.deep.equal([{operationIndex: 0, reviewStatus: 'rejected'}])
+  })
+
+  it('falls back to matching the exact dream review entry when legacy dream logs have no taskId', async () => {
+    const curateLogStore = {
+      batchUpdateOperationReviewStatus: stub().resolves(true),
+      list: stub().resolves([
+        {
+          completedAt: Date.now(),
+          id: 'cur-legacy',
+          input: {context: 'dream'},
+          operations: [{
+            filePath: join(ctxDir, 'auth/login.md'),
+            needsReview: true,
+            path: 'auth/login.md',
+            reviewStatus: 'pending',
+            status: 'success',
+            type: 'UPDATE',
+          }],
+          startedAt: Date.now(),
+          status: 'completed',
+          summary: {added: 0, deleted: 0, failed: 0, merged: 0, updated: 1},
+          taskId: 'task-old',
+        },
+      ]),
+    }
+    const reviewBackupStore = {delete: stub().resolves()}
+
+    const legacyLog = completedLog([{
+      action: 'TEMPORAL_UPDATE',
+      inputFiles: ['auth/login.md'],
+      needsReview: true,
+      previousTexts: {'auth/login.md': 'Original login'},
+      reason: 'Normalize chronology',
+      type: 'CONSOLIDATE',
+    }])
+    delete legacyLog.taskId
+    dreamLogStore.getById.resolves(legacyLog)
+
+    await undoLastDream({...deps, curateLogStore, reviewBackupStore})
+
+    expect(curateLogStore.batchUpdateOperationReviewStatus.calledOnce).to.be.true
+    const [logId, updates] = curateLogStore.batchUpdateOperationReviewStatus.firstCall.args
+    expect(logId).to.equal('cur-legacy')
+    expect(updates).to.deep.equal([{operationIndex: 0, reviewStatus: 'rejected'}])
+  })
+
+  it('deletes review backups for undone needsReview operations', async () => {
+    const curateLogStore = {
+      batchUpdateOperationReviewStatus: stub().resolves(true),
+      list: stub().resolves([]),
+    }
+
+    const reviewBackupStore = {delete: stub().resolves()}
+
+    await mkdir(join(ctxDir, 'auth'), {recursive: true})
+    await writeFile(join(ctxDir, 'auth/login.md'), 'Merged')
+
+    dreamLogStore.getById.resolves(completedLog([{
+      action: 'MERGE',
+      inputFiles: ['auth/login.md', 'auth/signup.md'],
+      needsReview: true,
+      outputFile: 'auth/login.md',
+      previousTexts: {'auth/login.md': 'Original login', 'auth/signup.md': 'Original signup'},
+      reason: 'Merge',
+      type: 'CONSOLIDATE',
+    }]))
+
+    await undoLastDream({...deps, curateLogStore, reviewBackupStore})
+
+    // Should delete backups for all files involved in needsReview ops
+    expect(reviewBackupStore.delete.called).to.be.true
+    const deletedPaths = reviewBackupStore.delete.getCalls().map((c: {args: string[]}) => c.args[0])
+    expect(deletedPaths).to.include('auth/login.md')
+    expect(deletedPaths).to.include('auth/signup.md')
+  })
+
+  it('skips review cleanup when curateLogStore is not provided', async () => {
+    dreamLogStore.getById.resolves(completedLog([{
+      action: 'ARCHIVE',
+      file: 'auth/stale.md',
+      needsReview: true,
+      reason: 'Stale',
+      stubPath: '_archived/auth/stale.stub.md',
+      type: 'PRUNE',
+    }]))
+
+    const archiveService = {restoreEntry: stub().resolves('auth/stale.md')}
+
+    // No curateLogStore or reviewBackupStore — should not crash
+    const result = await undoLastDream({...deps, archiveService})
+    expect(result.restoredArchives).to.include('auth/stale.md')
   })
 })

--- a/test/unit/infra/dream/operations/consolidate.test.ts
+++ b/test/unit/infra/dream/operations/consolidate.test.ts
@@ -276,6 +276,7 @@ describe('consolidate', () => {
       keywords: [], maturity: 'core', related: [], tags: [], title: 'Core Auth',
     })
     await createMdFile(ctxDir, 'auth/helper.md', '# Helper')
+    const reviewBackupStore = {save: stub().resolves()}
 
     agent.executeOnSession.resolves(llmResponse([{
       files: ['auth/core-auth.md', 'auth/helper.md'],
@@ -283,10 +284,15 @@ describe('consolidate', () => {
       type: 'CROSS_REFERENCE',
     }]))
 
-    const results = await consolidate(['auth/core-auth.md', 'auth/helper.md'], deps)
+    const results = await consolidate(['auth/core-auth.md', 'auth/helper.md'], {...deps, reviewBackupStore})
 
     // CROSS_REFERENCE is normally needsReview=false, but core maturity overrides
     expect(results[0].needsReview).to.be.true
+    expect(asConsolidate(results[0]).previousTexts).to.deep.equal({
+      'auth/core-auth.md': '---\nkeywords: []\nmaturity: core\nrelated: []\ntags: []\ntitle: Core Auth\n---\n# Core Auth',
+      'auth/helper.md': '# Helper',
+    })
+    expect(reviewBackupStore.save.calledTwice).to.be.true
   })
 
   it('continues processing when LLM fails for one domain', async () => {

--- a/test/unit/infra/dream/operations/prune.test.ts
+++ b/test/unit/infra/dream/operations/prune.test.ts
@@ -442,6 +442,48 @@ describe('prune', () => {
     expect(results).to.deep.equal([])
   })
 
+  // ── Review backup ──────────────────────────────────────────────────────────
+
+  it('calls reviewBackupStore.save before archiveEntry for ARCHIVE decisions', async () => {
+    await createMdFile(ctxDir, 'auth/stale.md', '# Stale doc', {maturity: 'draft'})
+    await setMtimeDaysAgo(ctxDir, 'auth/stale.md', 90)
+
+    const callOrder: string[] = []
+    const reviewBackupStore = {
+      save: stub().callsFake(async () => { callOrder.push('backup') }),
+    }
+    archiveService.archiveEntry.callsFake(async () => {
+      callOrder.push('archive')
+      return {fullPath: '', originalPath: '', stubPath: '_archived/auth/stale.stub.md'}
+    })
+
+    agent.executeOnSession.resolves(llmResponse([
+      {decision: 'ARCHIVE', file: 'auth/stale.md', reason: 'Stale'},
+    ]))
+
+    await prune({...deps, reviewBackupStore})
+
+    expect(reviewBackupStore.save.calledOnce).to.be.true
+    expect(reviewBackupStore.save.firstCall.args[0]).to.equal('auth/stale.md')
+    // Backup must happen BEFORE archive
+    expect(callOrder).to.deep.equal(['backup', 'archive'])
+  })
+
+  it('does not call reviewBackupStore.save for KEEP decisions', async () => {
+    await createMdFile(ctxDir, 'auth/old.md', '# Old but useful', {maturity: 'draft'})
+    await setMtimeDaysAgo(ctxDir, 'auth/old.md', 90)
+
+    const reviewBackupStore = {save: stub().resolves()}
+
+    agent.executeOnSession.resolves(llmResponse([
+      {decision: 'KEEP', file: 'auth/old.md', reason: 'Still relevant'},
+    ]))
+
+    await prune({...deps, reviewBackupStore})
+
+    expect(reviewBackupStore.save.called).to.be.false
+  })
+
   // ── Signal propagation ────────────────────────────────────────────────────
 
   it('passes abort signal to executeOnSession', async () => {

--- a/test/unit/infra/executor/dream-executor.test.ts
+++ b/test/unit/infra/executor/dream-executor.test.ts
@@ -1,4 +1,7 @@
 import {expect} from 'chai'
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
 import {restore, type SinonStub, stub} from 'sinon'
 
 import type {ICipherAgent} from '../../../../src/agent/core/interfaces/i-cipher-agent.js'
@@ -229,6 +232,26 @@ describe('DreamExecutor', () => {
       expect(dreamLockService.rollback.calledOnce).to.be.true
     })
 
+    it('does not create review entries when completed dream log save fails', async () => {
+      dreamLogStore.save.onFirstCall().resolves()
+      dreamLogStore.save.onSecondCall().rejects(new Error('log save failed'))
+
+      const executor = new DreamExecutor(deps)
+      const createReviewEntries = stub().resolves()
+      ;(executor as unknown as {createReviewEntries: SinonStub}).createReviewEntries = createReviewEntries
+
+      let caught: Error | undefined
+      try {
+        await executor.executeWithAgent(agent, defaultOptions)
+      } catch (error) {
+        caught = error as Error
+      }
+
+      expect(caught).to.be.instanceOf(Error)
+      expect(caught!.message).to.equal('log save failed')
+      expect(createReviewEntries.called).to.be.false
+    })
+
     it('does not create curate log entries when no operations have needsReview', async () => {
       const executor = new DreamExecutor(deps)
       await executor.executeWithAgent(agent, defaultOptions)
@@ -317,6 +340,58 @@ describe('DreamExecutor', () => {
         type: 'UPDATE',
       })
       expect(savedEntry.operations[0].additionalFilePaths).to.deep.equal(['/tmp/ctx/auth/helper.md'])
+    })
+
+    it('skips dream-generated curate entries when collecting changed files', async () => {
+      const projectRoot = mkdtempSync(join(tmpdir(), 'brv-dream-executor-'))
+      const contextTreeDir = join(projectRoot, '.brv', 'context-tree')
+      mkdirSync(join(contextTreeDir, 'auth'), {recursive: true})
+      writeFileSync(join(contextTreeDir, 'auth', 'curated.md'), '# curated')
+      writeFileSync(join(contextTreeDir, 'auth', 'dream.md'), '# dream')
+
+      curateLogStore.list.resolves([
+        {
+          completedAt: 2,
+          id: 'cur-dream',
+          input: {context: 'dream'},
+          operations: [{
+            filePath: join(contextTreeDir, 'auth', 'dream.md'),
+            path: 'auth/dream.md',
+            status: 'success',
+            type: 'UPDATE',
+          }],
+          startedAt: 1,
+          status: 'completed',
+          summary: {added: 0, deleted: 0, failed: 0, merged: 0, updated: 1},
+          taskId: 'dream-task',
+        },
+        {
+          completedAt: 4,
+          id: 'cur-user',
+          input: {context: 'cli'},
+          operations: [{
+            filePath: join(contextTreeDir, 'auth', 'curated.md'),
+            path: 'auth/curated.md',
+            status: 'success',
+            type: 'UPDATE',
+          }],
+          startedAt: 3,
+          status: 'completed',
+          summary: {added: 0, deleted: 0, failed: 0, merged: 0, updated: 1},
+          taskId: 'user-task',
+        },
+      ])
+
+      try {
+        const executor = new DreamExecutor(deps)
+        const changedFiles = await (executor as unknown as {
+          findChangedFilesSinceLastDream(lastDreamAt: null | string, contextTreeDir: string): Promise<Set<string>>
+        }).findChangedFilesSinceLastDream(null, contextTreeDir)
+
+        expect([...changedFiles]).to.deep.equal(['auth/curated.md'])
+      } finally {
+        rmSync(projectRoot, {force: true, recursive: true})
+      }
     })
   })
 })

--- a/test/unit/infra/executor/dream-executor.test.ts
+++ b/test/unit/infra/executor/dream-executor.test.ts
@@ -10,7 +10,7 @@ describe('DreamExecutor', () => {
   let dreamStateService: {read: SinonStub; write: SinonStub}
   let dreamLogStore: {getNextId: SinonStub; save: SinonStub}
   let dreamLockService: {release: SinonStub; rollback: SinonStub}
-  let curateLogStore: {list: SinonStub}
+  let curateLogStore: {getNextId: SinonStub; list: SinonStub; save: SinonStub}
   let agent: ICipherAgent
   let deps: DreamExecutorDeps
   const defaultOptions = {
@@ -34,7 +34,9 @@ describe('DreamExecutor', () => {
       rollback: stub().resolves(),
     }
     curateLogStore = {
+      getNextId: stub().resolves('cur-1000'),
       list: stub().resolves([]),
+      save: stub().resolves(),
     }
     agent = {
       createTaskSession: stub().resolves('session-1'),
@@ -72,6 +74,7 @@ describe('DreamExecutor', () => {
       const processingEntry = dreamLogStore.save.firstCall.args[0]
       expect(processingEntry.status).to.equal('processing')
       expect(processingEntry.id).to.equal('drm-1000')
+      expect(processingEntry.taskId).to.equal('test-task-1')
       expect(processingEntry.trigger).to.equal('cli')
       expect(processingEntry.operations).to.deep.equal([])
     })
@@ -83,6 +86,7 @@ describe('DreamExecutor', () => {
       const completedEntry = dreamLogStore.save.lastCall.args[0]
       expect(completedEntry.status).to.equal('completed')
       expect(completedEntry.completedAt).to.be.a('number')
+      expect(completedEntry.taskId).to.equal('test-task-1')
       expect(completedEntry.summary).to.deep.equal({
         consolidated: 0,
         errors: 0,
@@ -223,6 +227,96 @@ describe('DreamExecutor', () => {
 
       // Lock should be rolled back (not released) since the error occurred
       expect(dreamLockService.rollback.calledOnce).to.be.true
+    })
+
+    it('does not create curate log entries when no operations have needsReview', async () => {
+      const executor = new DreamExecutor(deps)
+      await executor.executeWithAgent(agent, defaultOptions)
+
+      // curateLogStore.save should only be called for review entries, not for the dream itself
+      // No operations → no review entries
+      expect(curateLogStore.save.called).to.be.false
+    })
+
+    it('creates curate log entry with reviewStatus=pending for needsReview operations', async () => {
+      const executor = new DreamExecutor(deps)
+      const operations: import('../../../../src/server/infra/dream/dream-log-schema.js').DreamOperation[] = [
+        {action: 'ARCHIVE', file: 'auth/stale.md', needsReview: true, reason: 'Stale doc', stubPath: '_archived/auth/stale.stub.md', type: 'PRUNE'},
+        {action: 'KEEP', file: 'api/useful.md', needsReview: false, reason: 'Still relevant', type: 'PRUNE'},
+      ]
+
+      // Call private method directly to test dual-write logic
+      await (executor as unknown as {createReviewEntries: (ops: typeof operations, dir: string, taskId: string) => Promise<void>})
+        .createReviewEntries(operations, '/tmp/ctx', 'test-task')
+
+      expect(curateLogStore.getNextId.calledOnce).to.be.true
+      expect(curateLogStore.save.calledOnce).to.be.true
+
+      const savedEntry = curateLogStore.save.firstCall.args[0]
+      expect(savedEntry.status).to.equal('completed')
+      expect(savedEntry.input.context).to.equal('dream')
+      expect(savedEntry.operations).to.have.lengthOf(1) // Only the needsReview op
+
+      const op = savedEntry.operations[0]
+      expect(op.type).to.equal('DELETE') // ARCHIVE maps to DELETE
+      expect(op.path).to.equal('auth/stale.md')
+      expect(op.reviewStatus).to.equal('pending')
+      expect(op.needsReview).to.be.true
+      expect(op.reason).to.include('dream/prune')
+    })
+
+    it('maps TEMPORAL_UPDATE review entries to the updated file path', async () => {
+      const executor = new DreamExecutor(deps)
+      const operations: import('../../../../src/server/infra/dream/dream-log-schema.js').DreamOperation[] = [
+        {
+          action: 'TEMPORAL_UPDATE',
+          inputFiles: ['api/changelog.md'],
+          needsReview: true,
+          previousTexts: {'api/changelog.md': 'Before'},
+          reason: 'Normalize chronology',
+          type: 'CONSOLIDATE',
+        },
+      ]
+
+      await (executor as unknown as {createReviewEntries: (ops: typeof operations, dir: string, taskId: string) => Promise<void>})
+        .createReviewEntries(operations, '/tmp/ctx', 'test-task')
+
+      const savedEntry = curateLogStore.save.firstCall.args[0]
+      expect(savedEntry.taskId).to.equal('test-task')
+      expect(savedEntry.operations[0]).to.include({
+        path: 'api/changelog.md',
+        reviewStatus: 'pending',
+        type: 'UPDATE',
+      })
+      expect(savedEntry.operations[0].filePath).to.equal('/tmp/ctx/api/changelog.md')
+    })
+
+    it('maps CROSS_REFERENCE review entries with additional file paths for restoration', async () => {
+      const executor = new DreamExecutor(deps)
+      const operations: import('../../../../src/server/infra/dream/dream-log-schema.js').DreamOperation[] = [
+        {
+          action: 'CROSS_REFERENCE',
+          inputFiles: ['auth/core.md', 'auth/helper.md'],
+          needsReview: true,
+          previousTexts: {
+            'auth/core.md': 'Before core',
+            'auth/helper.md': 'Before helper',
+          },
+          reason: 'Related',
+          type: 'CONSOLIDATE',
+        },
+      ]
+
+      await (executor as unknown as {createReviewEntries: (ops: typeof operations, dir: string, taskId: string) => Promise<void>})
+        .createReviewEntries(operations, '/tmp/ctx', 'test-task')
+
+      const savedEntry = curateLogStore.save.firstCall.args[0]
+      expect(savedEntry.operations[0]).to.include({
+        path: 'auth/core.md',
+        reviewStatus: 'pending',
+        type: 'UPDATE',
+      })
+      expect(savedEntry.operations[0].additionalFilePaths).to.deep.equal(['/tmp/ctx/auth/helper.md'])
     })
   })
 })

--- a/test/unit/infra/process/task-router.test.ts
+++ b/test/unit/infra/process/task-router.test.ts
@@ -495,6 +495,22 @@ describe('TaskRouter', () => {
       expect(agentPool.notifyTaskCompleted.calledWith('/app')).to.be.true
     })
 
+    it('should notify agentPool on task:completed for daemon-submitted tasks', () => {
+      const handler = transportHelper.requestHandlers.get(TransportTaskEventNames.COMPLETED)
+
+      handler!({projectPath: '/daemon-app', result: 'done', taskId: 'daemon-task'}, 'agent-1')
+
+      expect(agentPool.notifyTaskCompleted.calledWith('/daemon-app')).to.be.true
+    })
+
+    it('should notify agentPool on task:error for daemon-submitted tasks', () => {
+      const handler = transportHelper.requestHandlers.get(TransportTaskEventNames.ERROR)
+
+      handler!({error: {message: 'fail', name: 'Error'}, projectPath: '/daemon-app', taskId: 'daemon-task'}, 'agent-1')
+
+      expect(agentPool.notifyTaskCompleted.calledWith('/daemon-app')).to.be.true
+    })
+
     it('should route task:cancelled to client and broadcast', () => {
       const handler = transportHelper.requestHandlers.get(TransportTaskEventNames.CANCELLED)
 


### PR DESCRIPTION
## Summary

- Problem: dreaming was not wired into the daemon idle lifecycle, and reviewable dream operations were not fully integrated with the existing HITL review system. In particular, `brv dream --undo` reverted files but left the dual-written review task pending and left review backups behind.
- Why it matters: users could end up with stale pending review tasks for already-reverted dream changes, and future review/reject flows could operate against the wrong baseline.
- What changed: added daemon-side idle eligibility checks and dream task dispatch, passed dream trigger metadata through transport/execution, dual-wrote reviewable dream operations into the curate log with persisted `taskId`s, created review backups for destructive dream operations, and taught `brv dream --undo` to reject the matching dream review entry, clear backups, and restore reviewable cross-reference changes.
- What did NOT change (scope boundary): this PR does not change the core `brv review` approval/rejection UX, does not add a new review system for dreams, and does not change synthesize behavior beyond existing review mapping support.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [x] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [x] Agent / Tools
- [x] LLM Providers
- [x] Server / Daemon
- [x] Shared (constants, types, transport events)
- [x] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra


## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause: dream undo only restored file contents and marked the dream log undone; it did not clean up the matching curate review entry or review backups. Separately, reviewable cross-reference operations did not persist enough prior state to fully restore every touched file on undo/reject.
- Why this was not caught earlier: the initial validation focused on forward dream execution and review surfacing, but not on the full undo semantics across the review queue, backup store, and multi-file reviewable updates.

## Test plan

- Coverage added:
  - [x] Unit test
  - [ ] Integration test
  - [x] Manual verification only
- Test file(s):
  - `test/unit/infra/dream/dream-trigger.test.ts`
  - `test/unit/infra/executor/dream-executor.test.ts`
  - `test/unit/infra/dream/operations/prune.test.ts`
  - `test/unit/infra/dream/operations/consolidate.test.ts`
  - `test/unit/infra/dream/dream-undo.test.ts`
  - `test/unit/infra/dream/dream-log-schema.test.ts`
- Key scenario(s) covered:
  - daemon idle path dispatches dream work when eligibility gates pass
  - reviewable dream operations dual-write into curate review tasks with `taskId`
  - `MERGE`, `UPDATE`, and `DELETE` dream review ops appear in `brv review pending`
  - `brv dream --undo` rejects only the matching dream review task, removes backups, restores archived files, and restores multi-file cross-reference edits
  - legacy dream logs without `taskId` still match the correct review entry via exact operation signatures

## User-visible changes

- Idle daemon agents can now dispatch dream work instead of being killed immediately when dream eligibility gates pass.
- Reviewable dream operations show up in the existing `brv review pending` flow.
- `brv dream --undo` now has the same semantic effect as rejecting the dream-generated review task: it clears the pending review, removes review backups for the undone files, and restores the affected files to their pre-dream state.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording

- Manual CLI evidence:
  - `drm-1776231536340` produced live `DELETE`, `MERGE`, and `UPDATE` review ops for task `7ae4892d-43ae-4fec-9124-1208d9bbd1f0`.
  - `brv review pending` showed 9 pending ops including `[DELETE] quality_assurance/delete-review-fixture.md`.
  - `brv dream --undo` reported `Restored: 22 files`, `Deleted: 4 files`, `Restored archives: 1 files`.
  - after undo, `brv review pending` returned `No pending reviews.` and curate log `cur-1776231732807` had only `reviewStatus: rejected` entries.
- Validation commands:
  - `npm run typecheck`
  - `npm run lint -- --quiet`
  - `npm test` (`6153 passing, 16 pending`)
  - `npm run build`

## Checklist

- [x] Tests added or updated and passing (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented above)
- [ ] Branch is up to date with `main`

## Risks and mitigations

List real risks for this PR. If none, write `None`.

- Risk:
  - legacy dream logs without `taskId` rely on exact operation-signature matching, so ambiguous historical entries intentionally fail open rather than rejecting the wrong review task.
  - Mitigation: new dream logs now persist `taskId`, and undo prefers exact `taskId` matching for all new runs.
- Risk:
  - daemon idle eligibility is checked before task dispatch and lock acquisition happens later in the agent process, which leaves a small race window between eligibility and execution.
  - Mitigation: the dream lock is still authoritative in the agent process, so concurrent execution is prevented even if idle dispatch races.
