### PR TITLE
Release/3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable user-facing changes to ByteRover CLI will be documented in this file.
 
+## [3.5.0]
+
+### Added
+- **Claude Desktop support** — Connect ByteRover to the Claude Desktop app with `brv connectors install "Claude Desktop"` (or pick it in `/connectors`). Works on macOS, Windows (including Store installs), and Linux. After installing, fully quit Claude Desktop from the tray or menu bar and reopen it to apply.
+
+### Changed
+- **Cleaner install layout** — The `install.sh` installer now keeps its bundled Node.js tucked away so it won't conflict with the `node` already on your system. Just reinstall to pick up the new layout.
+
+### Fixed
+- **Security dependency update** — Updated `basic-ftp` to patch a high-severity vulnerability.
+
 ## [3.4.0]
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ npm run typecheck                    # TypeScript type checking
 - `brv worktree` (add/list/remove) — git-style worktree pointer model: `.brv/` is either a real project directory OR a pointer file to a parent project; parent stores registry in `.brv/worktrees/<name>/link.json`
 - `brv source` (add/list/remove) — link another project's context tree as a read-only knowledge source with write isolation
 - `brv search <query>` — pure BM25 retrieval over the context tree (minisearch, no LLM, no token cost); structured results with paths/scores. Pairs with `brv query` (LLM-synthesized answer). Engine: `server/infra/executor/search-executor.ts`
+- `brv locations` — lists all registered projects with context-tree status (text or `--format json`); reads from `LocationsEvents` over the daemon transport
 - Canonical project resolver: `resolveProject()` in `server/infra/project/` — priority `flag > direct > linked > walked-up > null`. `projectRoot` and `worktreeRoot` are threaded through transport schemas, task routing, and all executors
 - All commands are daemon-routed: `oclif/` and `tui/` never import from `server/`
 - Oclif: `src/oclif/commands/{vc,worktree,source}/`; TUI: `src/tui/features/{vc,worktree,source}/`; slash commands (`vc-*`, `worktree`, `source`) in `src/tui/features/commands/definitions/`

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "coding-assistant",
     "knowledge-management"
   ],
-  "version": "3.4.0",
+  "version": "3.5.0",
   "author": "ByteRover",
   "bin": {
     "brv": "./bin/run.js"


### PR DESCRIPTION
## Summary

- Problem: Ship the 3.5.0 release — Claude Desktop connector support, install.sh layout fix, and a high-severity npm dependency patch — by promoting `release/3.5.0` into `main`.
- Why it matters: Unblocks Claude Desktop users, removes a `node` shadowing issue from the installer, and closes a known security advisory in a transitive dependency.
- What changed (since v3.4.0):
  - feat [ENG-2079] (#417) — patch npm high-severity vulnerability via `basic-ftp` bump.
  - feat [ENG-1990] (#404 / #413) — `install.sh` keeps bundled Node.js isolated from system `node`.
  - feat #406 — Claude Desktop integration: new connector option in `brv connectors install` and `/connectors`, with macOS, Windows (incl. Store installs), and Linux config-path resolution in `server/infra/connectors/mcp/claude-desktop-config-path.ts`.
  - fix [ENG-2085] (#411) — strip ANSI codes in query-renderer test assertions.
  - chore — version bump to `3.5.0`, `CHANGELOG.md` entry, `CLAUDE.md` refresh (test/e2e/, connectors note, `brv locations`).
- What did NOT change (scope boundary): No swarm, agent core, LLM provider, daemon transport, or VC/worktree behavior changes in this release.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [x] Documentation
- [ ] Test
- [x] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [ ] Agent / Tools
- [ ] LLM Providers
- [x] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [x] CLI Commands (oclif)
- [x] Hub / Connectors
- [ ] Cloud Sync
- [x] CI/CD / Infra

## Linked issues

- Closes # ENG-2079, ENG-1990, ENG-2085
- Related # #406 (Claude Desktop integration)

## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause:
  - ENG-2085: query-renderer tests asserted on raw output that included ANSI color escape codes, making assertions brittle.
  - ENG-2079: transitive `basic-ftp` version had a high-severity advisory open against it.
  - ENG-1990: `install.sh` placed bundled Node.js on `PATH` ahead of the user's system `node`, causing version conflicts.
- Why this was not caught earlier:
  - ENG-2085: ANSI was only emitted in TTY-attached environments; CI passed because output was plain.
  - ENG-2079: surfaced by a fresh `npm audit` run after upstream advisory publication.
  - ENG-1990: only manifested for users with a pre-existing Node.js install of a different major version.

## Test plan

- Coverage added:
  - [x] Unit test
  - [x] Integration test
  - [x] Manual verification only
- Test file(s):
  - `test/integration/connectors/mcp/claude-desktop-mcp-connector.test.ts`
  - `test/unit/connectors/mcp/claude-desktop-config-path.test.ts`
  - `test/integration/connectors/mcp/mcp-connector.test.ts` (extended)
  - `test/commands/connectors/install.test.ts` (extended)
- Key scenario(s) covered:
  - `brv connectors install "Claude Desktop"` writes the correct config path on macOS, Windows (incl. Store install), and Linux.
  - `brv connectors install "Claude Code"` continues to work unchanged.
  - `npm audit` reports no high-severity findings on the production dependency tree.
  - `install.sh` on a host with system `node` does not shadow or get shadowed by it.
  - `brv --version` reports `3.5.0`.

## User-visible changes

- New connector: "Claude Desktop" selectable from `brv connectors install` and `/connectors`. Users must fully quit Claude Desktop (tray/menu bar) and reopen to apply.
- `install.sh` no longer conflicts with an existing system `node`. Existing users should reinstall to pick up the new layout.
- `basic-ftp` upgraded to a patched version (resolves npm audit high-severity finding).
- `brv --version` reports `3.5.0`.

## Evidence

- [x] Failing test/log before + passing after (`test/integration/connectors/mcp/claude-desktop-mcp-connector.test.ts`, `test/unit/connectors/mcp/claude-desktop-config-path.test.ts`)
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- `npm audit --omit=dev` clean after #417.

## Checklist

- [x] Tests added or updated and passing (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow Conventional Commits format
- [x] Documentation updated (CLAUDE.md, CHANGELOG.md)
- [x] No breaking changes
- [x] Branch is up to date with `main`

## Risks and mitigations

- Risk: Claude Desktop config path detection misfires on uncommon Windows install layouts (e.g. Store vs. MSI).
  - Mitigation: Dedicated unit tests in `claude-desktop-config-path.test.ts` cover Store and standard installs; users can re-run `brv connectors install` to overwrite.
- Risk: `install.sh` layout change could leave stale bundled Node.js from prior installs on `PATH`.
  - Mitigation: CHANGELOG explicitly instructs users to reinstall to pick up the new layout.
- Risk: Auto-update clients pull `3.5.0` before the GCS release artifact (`brv-releases`) is published.
  - Mitigation: Confirm the `oclif` release pipeline uploads the 3.5.0 tarball to `https://storage.googleapis.com/brv-releases` before merging the announce.
