### PR TITLE
feat: [ENG-2121] improve dream task TUI display with meaningful content

### DIFF
--- a/src/oclif/commands/dream.ts
+++ b/src/oclif/commands/dream.ts
@@ -202,14 +202,14 @@ export default class Dream extends Command {
         client,
         command: 'dream',
         format,
-        onCompleted: ({result, taskId: tid}) => {
+        onCompleted: ({logId, result, taskId: tid}) => {
           const skipped = result?.startsWith('Dream skipped:')
           if (format === 'json') {
             writeJsonResponse({
               command: 'dream',
               data: skipped
                 ? {reason: result, status: 'skipped', taskId: tid}
-                : {result, status: 'completed', taskId: tid},
+                : {logId, result, status: 'completed', taskId: tid},
               success: true,
             })
           } else {

--- a/src/oclif/commands/dream.ts
+++ b/src/oclif/commands/dream.ts
@@ -189,7 +189,7 @@ export default class Dream extends Command {
     const {client, force, format, projectRoot, timeoutMs, worktreeRoot} = props
     const taskId = randomUUID()
     const taskPayload = {
-      content: '',
+      content: force ? 'Memory consolidation (force)' : 'Memory consolidation',
       ...(force ? {force: true} : {}),
       ...(projectRoot ? {projectPath: projectRoot} : {}),
       taskId,
@@ -209,13 +209,11 @@ export default class Dream extends Command {
               command: 'dream',
               data: skipped
                 ? {reason: result, status: 'skipped', taskId: tid}
-                : {logId: result, status: 'completed', taskId: tid},
+                : {result, status: 'completed', taskId: tid},
               success: true,
             })
-          } else if (skipped) {
-            this.log(result ?? '')
           } else {
-            this.log(`Dream completed. (Log: ${result})`)
+            this.log(result ?? '')
           }
         },
         onError: ({error}) => {

--- a/src/oclif/commands/dream.ts
+++ b/src/oclif/commands/dream.ts
@@ -202,17 +202,14 @@ export default class Dream extends Command {
         client,
         command: 'dream',
         format,
-        onCompleted: ({result, taskId: tid}) => {
+        onCompleted: ({logId, result, taskId: tid}) => {
           const skipped = result?.startsWith('Dream skipped:')
-          // Transport logId is undefined for dream tasks (only curate lifecycle hooks populate it).
-          // Extract from the formatted result string instead.
-          const dreamLogId = result?.match(/^Dream completed \(([^)]+)\)/)?.[1]
           if (format === 'json') {
             writeJsonResponse({
               command: 'dream',
               data: skipped
                 ? {reason: result, status: 'skipped', taskId: tid}
-                : {logId: dreamLogId, result, status: 'completed', taskId: tid},
+                : {logId, result, status: 'completed', taskId: tid},
               success: true,
             })
           } else {

--- a/src/oclif/commands/dream.ts
+++ b/src/oclif/commands/dream.ts
@@ -202,14 +202,17 @@ export default class Dream extends Command {
         client,
         command: 'dream',
         format,
-        onCompleted: ({logId, result, taskId: tid}) => {
+        onCompleted: ({result, taskId: tid}) => {
           const skipped = result?.startsWith('Dream skipped:')
+          // Transport logId is undefined for dream tasks (only curate lifecycle hooks populate it).
+          // Extract from the formatted result string instead.
+          const dreamLogId = result?.match(/^Dream completed \(([^)]+)\)/)?.[1]
           if (format === 'json') {
             writeJsonResponse({
               command: 'dream',
               data: skipped
                 ? {reason: result, status: 'skipped', taskId: tid}
-                : {logId, result, status: 'completed', taskId: tid},
+                : {logId: dreamLogId, result, status: 'completed', taskId: tid},
               success: true,
             })
           } else {

--- a/src/server/infra/daemon/agent-process.ts
+++ b/src/server/infra/daemon/agent-process.ts
@@ -480,6 +480,7 @@ async function executeTask(
 
     try {
       let result: string
+      let logId: string | undefined
       switch (type) {
         case 'curate': {
           result = await curateExecutor.executeWithAgent(agent, {clientCwd, content, files, projectRoot: projectPath, taskId, worktreeRoot})
@@ -526,12 +527,14 @@ async function executeTask(
             reviewBackupStore: new FileReviewBackupStore(brvDir),
             searchService: searchKnowledgeService,
           })
-          result = await dreamExecutor.executeWithAgent(agent, {
+          const dreamResult = await dreamExecutor.executeWithAgent(agent, {
             priorMtime: eligibility.priorMtime,
             projectRoot: projectPath,
             taskId,
             trigger: trigger ?? 'cli',
           })
+          result = dreamResult.result
+          logId = dreamResult.logId
 
           break
         }
@@ -554,7 +557,7 @@ async function executeTask(
       // Emit task:completed
       agentLog(`task:completed taskId=${taskId}`)
       try {
-        transport.request(TransportTaskEventNames.COMPLETED, {clientId, projectPath, result, taskId})
+        transport.request(TransportTaskEventNames.COMPLETED, {clientId, ...(logId ? {logId} : {}), projectPath, result, taskId})
       } catch (error) {
         agentLog(
           `task:completed send failed taskId=${taskId}: ${error instanceof Error ? error.message : String(error)}`,

--- a/src/server/infra/daemon/brv-server.ts
+++ b/src/server/infra/daemon/brv-server.ts
@@ -262,7 +262,7 @@ async function main(): Promise<void> {
             log(`Dream eligible, dispatching dream task: ${projectPath}`)
             agentPool?.submitTask({
               clientId: 'daemon',
-              content: '',
+              content: 'Memory consolidation (idle trigger)',
               force: false,
               projectPath,
               taskId: randomUUID(),

--- a/src/server/infra/executor/dream-executor.ts
+++ b/src/server/infra/executor/dream-executor.ts
@@ -76,7 +76,7 @@ export class DreamExecutor {
   async executeWithAgent(
     agent: ICipherAgent,
     options: DreamExecuteOptions,
-  ): Promise<string> {
+  ): Promise<{logId: string; result: string}> {
     const {priorMtime, projectRoot, trigger} = options
     const contextTreeDir = join(projectRoot, BRV_DIR, CONTEXT_TREE_DIR)
 
@@ -193,7 +193,7 @@ export class DreamExecutor {
       })
 
       succeeded = true
-      return this.formatResult(logId, summary)
+      return {logId, result: this.formatResult(logId, summary)}
     } catch (error) {
       // Save error/partial log entry (best-effort)
       if (controller.signal.aborted) {

--- a/src/server/infra/executor/dream-executor.ts
+++ b/src/server/infra/executor/dream-executor.ts
@@ -344,8 +344,12 @@ export class DreamExecutor {
     ].filter(Boolean)
     if (counts.length > 0) {
       parts.push(counts.join(' | '))
-    } else {
+    } else if (summary.errors === 0) {
       parts.push('No changes needed — context tree is up to date')
+    }
+
+    if (summary.errors > 0) {
+      parts.push(`${summary.errors} operations failed`)
     }
 
     if (summary.flaggedForReview > 0) {

--- a/src/server/infra/executor/dream-executor.ts
+++ b/src/server/infra/executor/dream-executor.ts
@@ -193,7 +193,7 @@ export class DreamExecutor {
       })
 
       succeeded = true
-      return logId
+      return this.formatResult(logId, summary)
     } catch (error) {
       // Save error/partial log entry (best-effort)
       if (controller.signal.aborted) {
@@ -333,6 +333,26 @@ export class DreamExecutor {
     })
     const results = await Promise.all(checks)
     return new Set(results.filter((f): f is string => f !== null))
+  }
+
+  private formatResult(logId: string, summary: DreamLogSummary): string {
+    const parts = [`Dream completed (${logId})`]
+    const counts = [
+      summary.consolidated > 0 ? `${summary.consolidated} consolidated` : '',
+      summary.synthesized > 0 ? `${summary.synthesized} synthesized` : '',
+      summary.pruned > 0 ? `${summary.pruned} pruned` : '',
+    ].filter(Boolean)
+    if (counts.length > 0) {
+      parts.push(counts.join(' | '))
+    } else {
+      parts.push('No changes needed — context tree is up to date')
+    }
+
+    if (summary.flaggedForReview > 0) {
+      parts.push(`${summary.flaggedForReview} operations flagged for review`)
+    }
+
+    return parts.join('\n')
   }
 }
 

--- a/src/server/infra/executor/dream-executor.ts
+++ b/src/server/infra/executor/dream-executor.ts
@@ -344,7 +344,7 @@ export class DreamExecutor {
     ].filter(Boolean)
     if (counts.length > 0) {
       parts.push(counts.join(' | '))
-    } else if (summary.errors === 0) {
+    } else if (summary.errors === 0 && summary.flaggedForReview === 0) {
       parts.push('No changes needed — context tree is up to date')
     }
 

--- a/src/server/infra/process/task-router.ts
+++ b/src/server/infra/process/task-router.ts
@@ -277,7 +277,7 @@ export class TaskRouter {
   }
 
   private handleTaskCompleted(data: TaskCompletedEvent): void {
-    const {result, taskId} = data
+    const {logId: eventLogId, result, taskId} = data
     const task = this.tasks.get(taskId)
 
     transportLog(`Task completed: ${taskId}`)
@@ -296,9 +296,12 @@ export class TaskRouter {
       }
     }
 
+    // Prefer logId from lifecycle hooks (curate), fall back to executor-provided logId (dream)
+    const resolvedLogId = task?.logId ?? eventLogId
+
     if (task) {
       this.transport.sendTo(task.clientId, TransportTaskEventNames.COMPLETED, {
-        ...(task.logId ? {logId: task.logId} : {}),
+        ...(resolvedLogId ? {logId: resolvedLogId} : {}),
         ...hookData,
         result,
         taskId,
@@ -311,7 +314,7 @@ export class TaskRouter {
       task?.projectPath,
       TransportTaskEventNames.COMPLETED,
       {
-        ...(task?.logId ? {logId: task.logId} : {}),
+        ...(resolvedLogId ? {logId: resolvedLogId} : {}),
         ...hookData,
         result,
         taskId,

--- a/test/unit/infra/executor/dream-executor.test.ts
+++ b/test/unit/infra/executor/dream-executor.test.ts
@@ -69,6 +69,37 @@ describe('DreamExecutor', () => {
       expect(result).to.include('No changes needed')
     })
 
+    it('formats result with operation counts when present', () => {
+      const executor = new DreamExecutor(deps)
+      const formatResult = (executor as unknown as {formatResult(logId: string, summary: import('../../../../src/server/infra/dream/dream-log-schema.js').DreamLogSummary): string}).formatResult.bind(executor)
+
+      const result = formatResult('drm-2000', {consolidated: 3, errors: 0, flaggedForReview: 0, pruned: 1, synthesized: 2})
+      expect(result).to.include('Dream completed (drm-2000)')
+      expect(result).to.include('3 consolidated')
+      expect(result).to.include('2 synthesized')
+      expect(result).to.include('1 pruned')
+      expect(result).to.not.include('No changes needed')
+    })
+
+    it('formats result with flagged-for-review count', () => {
+      const executor = new DreamExecutor(deps)
+      const formatResult = (executor as unknown as {formatResult(logId: string, summary: import('../../../../src/server/infra/dream/dream-log-schema.js').DreamLogSummary): string}).formatResult.bind(executor)
+
+      const result = formatResult('drm-3000', {consolidated: 1, errors: 0, flaggedForReview: 2, pruned: 0, synthesized: 0})
+      expect(result).to.include('1 consolidated')
+      expect(result).to.include('2 operations flagged for review')
+    })
+
+    it('formats result with error count and omits no-changes message', () => {
+      const executor = new DreamExecutor(deps)
+      const formatResult = (executor as unknown as {formatResult(logId: string, summary: import('../../../../src/server/infra/dream/dream-log-schema.js').DreamLogSummary): string}).formatResult.bind(executor)
+
+      const result = formatResult('drm-4000', {consolidated: 0, errors: 2, flaggedForReview: 0, pruned: 0, synthesized: 0})
+      expect(result).to.include('Dream completed (drm-4000)')
+      expect(result).to.include('2 operations failed')
+      expect(result).to.not.include('No changes needed')
+    })
+
     it('saves a processing log entry before executing', async () => {
       const executor = new DreamExecutor(deps)
       await executor.executeWithAgent(agent, defaultOptions)

--- a/test/unit/infra/executor/dream-executor.test.ts
+++ b/test/unit/infra/executor/dream-executor.test.ts
@@ -90,6 +90,15 @@ describe('DreamExecutor', () => {
       expect(result).to.include('2 operations flagged for review')
     })
 
+    it('omits no-changes message when only flaggedForReview is non-zero', () => {
+      const executor = new DreamExecutor(deps)
+      const formatResult = (executor as unknown as {formatResult(logId: string, summary: import('../../../../src/server/infra/dream/dream-log-schema.js').DreamLogSummary): string}).formatResult.bind(executor)
+
+      const result = formatResult('drm-3500', {consolidated: 0, errors: 0, flaggedForReview: 1, pruned: 0, synthesized: 0})
+      expect(result).to.include('1 operations flagged for review')
+      expect(result).to.not.include('No changes needed')
+    })
+
     it('formats result with error count and omits no-changes message', () => {
       const executor = new DreamExecutor(deps)
       const formatResult = (executor as unknown as {formatResult(logId: string, summary: import('../../../../src/server/infra/dream/dream-log-schema.js').DreamLogSummary): string}).formatResult.bind(executor)

--- a/test/unit/infra/executor/dream-executor.test.ts
+++ b/test/unit/infra/executor/dream-executor.test.ts
@@ -62,10 +62,11 @@ describe('DreamExecutor', () => {
   })
 
   describe('executeWithAgent', () => {
-    it('returns the dream log ID', async () => {
+    it('returns a formatted result summary', async () => {
       const executor = new DreamExecutor(deps)
       const result = await executor.executeWithAgent(agent, defaultOptions)
-      expect(result).to.equal('drm-1000')
+      expect(result).to.include('Dream completed (drm-1000)')
+      expect(result).to.include('No changes needed')
     })
 
     it('saves a processing log entry before executing', async () => {

--- a/test/unit/infra/executor/dream-executor.test.ts
+++ b/test/unit/infra/executor/dream-executor.test.ts
@@ -62,9 +62,10 @@ describe('DreamExecutor', () => {
   })
 
   describe('executeWithAgent', () => {
-    it('returns a formatted result summary', async () => {
+    it('returns a structured result with logId and formatted summary', async () => {
       const executor = new DreamExecutor(deps)
-      const result = await executor.executeWithAgent(agent, defaultOptions)
+      const {logId, result} = await executor.executeWithAgent(agent, defaultOptions)
+      expect(logId).to.equal('drm-1000')
       expect(result).to.include('Dream completed (drm-1000)')
       expect(result).to.include('No changes needed')
     })


### PR DESCRIPTION
## Summary
- Dream executor now returns a formatted summary (counts of consolidated/synthesized/pruned operations) instead of a raw log ID
- CLI dream command sets meaningful `content` field ("Memory consolidation") so TUI input area isn't blank
- Daemon idle-trigger dream tasks also get meaningful content

## Test plan
- [x] `brv dream --force` shows formatted result in TUI expanded view
- [x] TUI input area displays "Memory consolidation (force)" instead of blank
- [x] Zero-ops dream shows "No changes needed" message
- [x] Existing dream-executor unit tests updated and passing
- [x] Full test suite passing (6164 tests)
- [x] Code quality audit passed