### PR TITLE
feat: [ENG-2122] add --detach flag to brv dream for async execution

### DIFF
--- a/src/oclif/commands/dream.ts
+++ b/src/oclif/commands/dream.ts
@@ -114,7 +114,7 @@ export default class Dream extends Command {
             force: rawFlags.force,
             format,
             projectRoot,
-            timeoutMs: (rawFlags.timeout ?? DEFAULT_TIMEOUT_SECONDS) * 1000,
+            timeout: rawFlags.timeout ?? DEFAULT_TIMEOUT_SECONDS,
             worktreeRoot,
           })
         },
@@ -191,14 +191,14 @@ export default class Dream extends Command {
 
   private async submitTask(props: {
     client: ITransportClient
-    detach?: boolean
+    detach: boolean
     force: boolean
     format: 'json' | 'text'
     projectRoot?: string
-    timeoutMs?: number
+    timeout: number
     worktreeRoot?: string
   }): Promise<void> {
-    const {client, detach, force, format, projectRoot, timeoutMs, worktreeRoot} = props
+    const {client, detach, force, format, projectRoot, timeout, worktreeRoot} = props
     const taskId = randomUUID()
     const taskPayload = {
       content: '',
@@ -210,7 +210,7 @@ export default class Dream extends Command {
     }
 
     if (detach) {
-      if (timeoutMs !== DEFAULT_TIMEOUT_SECONDS * 1000 && format !== 'json') {
+      if (timeout !== DEFAULT_TIMEOUT_SECONDS && format !== 'json') {
         this.log('Note: --timeout has no effect with --detach')
       }
 
@@ -225,7 +225,7 @@ export default class Dream extends Command {
         })
       } else {
         const logSuffix = logId ? ` (Log: ${logId})` : ''
-        this.log(`Dream queued for processing.${logSuffix}`)
+        this.log(`✓ Dream queued for processing.${logSuffix}`)
       }
     } else {
       const completionPromise = waitForTaskCompletion(
@@ -261,7 +261,7 @@ export default class Dream extends Command {
             }
           },
           taskId,
-          timeoutMs,
+          timeoutMs: timeout * 1000,
         },
         (msg) => this.log(msg),
       )

--- a/src/oclif/commands/dream.ts
+++ b/src/oclif/commands/dream.ts
@@ -39,10 +39,20 @@ export default class Dream extends Command {
     '# Revert the last dream',
     '<%= config.bin %> <%= command.id %> --undo',
     '',
+    '# Queue dream and exit immediately',
+    '<%= config.bin %> <%= command.id %> --detach',
+    '',
+    '# Force dream and exit immediately',
+    '<%= config.bin %> <%= command.id %> --force --detach',
+    '',
     '# JSON output',
     '<%= config.bin %> <%= command.id %> --format json',
   ]
   public static flags = {
+    detach: Flags.boolean({
+      default: false,
+      description: 'Queue task and exit without waiting for completion',
+    }),
     force: Flags.boolean({
       char: 'f',
       default: false,
@@ -100,6 +110,7 @@ export default class Dream extends Command {
 
           await this.submitTask({
             client,
+            detach: rawFlags.detach,
             force: rawFlags.force,
             format,
             projectRoot,
@@ -180,13 +191,14 @@ export default class Dream extends Command {
 
   private async submitTask(props: {
     client: ITransportClient
+    detach?: boolean
     force: boolean
     format: 'json' | 'text'
     projectRoot?: string
     timeoutMs?: number
     worktreeRoot?: string
   }): Promise<void> {
-    const {client, force, format, projectRoot, timeoutMs, worktreeRoot} = props
+    const {client, detach, force, format, projectRoot, timeoutMs, worktreeRoot} = props
     const taskId = randomUUID()
     const taskPayload = {
       content: '',
@@ -197,44 +209,64 @@ export default class Dream extends Command {
       ...(worktreeRoot ? {worktreeRoot} : {}),
     }
 
-    const completionPromise = waitForTaskCompletion(
-      {
-        client,
-        command: 'dream',
-        format,
-        onCompleted: ({result, taskId: tid}) => {
-          const skipped = result?.startsWith('Dream skipped:')
-          if (format === 'json') {
-            writeJsonResponse({
-              command: 'dream',
-              data: skipped
-                ? {reason: result, status: 'skipped', taskId: tid}
-                : {logId: result, status: 'completed', taskId: tid},
-              success: true,
-            })
-          } else if (skipped) {
-            this.log(result ?? '')
-          } else {
-            this.log(`Dream completed. (Log: ${result})`)
-          }
+    if (detach) {
+      if (timeoutMs !== DEFAULT_TIMEOUT_SECONDS * 1000 && format !== 'json') {
+        this.log('Note: --timeout has no effect with --detach')
+      }
+
+      const ack = await client.requestWithAck<TaskAck>(TaskEvents.CREATE, taskPayload)
+      const {logId} = ack
+
+      if (format === 'json') {
+        writeJsonResponse({
+          command: 'dream',
+          data: {logId, message: 'Dream queued for processing', status: 'queued', taskId},
+          success: true,
+        })
+      } else {
+        const logSuffix = logId ? ` (Log: ${logId})` : ''
+        this.log(`Dream queued for processing.${logSuffix}`)
+      }
+    } else {
+      const completionPromise = waitForTaskCompletion(
+        {
+          client,
+          command: 'dream',
+          format,
+          onCompleted: ({result, taskId: tid}) => {
+            const skipped = result?.startsWith('Dream skipped:')
+            if (format === 'json') {
+              writeJsonResponse({
+                command: 'dream',
+                data: skipped
+                  ? {reason: result, status: 'skipped', taskId: tid}
+                  : {logId: result, status: 'completed', taskId: tid},
+                success: true,
+              })
+            } else if (skipped) {
+              this.log(result ?? '')
+            } else {
+              this.log(`Dream completed. (Log: ${result})`)
+            }
+          },
+          onError: ({error}) => {
+            if (format === 'json') {
+              writeJsonResponse({
+                command: 'dream',
+                data: {event: 'error', message: error.message, status: 'error'},
+                success: false,
+              })
+            } else {
+              this.log(`Dream failed: ${error.message}`)
+            }
+          },
+          taskId,
+          timeoutMs,
         },
-        onError: ({error}) => {
-          if (format === 'json') {
-            writeJsonResponse({
-              command: 'dream',
-              data: {event: 'error', message: error.message, status: 'error'},
-              success: false,
-            })
-          } else {
-            this.log(`Dream failed: ${error.message}`)
-          }
-        },
-        taskId,
-        timeoutMs,
-      },
-      (msg) => this.log(msg),
-    )
-    await client.requestWithAck<TaskAck>(TaskEvents.CREATE, taskPayload)
-    await completionPromise
+        (msg) => this.log(msg),
+      )
+      await client.requestWithAck<TaskAck>(TaskEvents.CREATE, taskPayload)
+      await completionPromise
+    }
   }
 }

--- a/test/commands/dream.test.ts
+++ b/test/commands/dream.test.ts
@@ -1,0 +1,157 @@
+import type {ConnectionResult, ITransportClient} from '@campfirein/brv-transport-client'
+import type {Config} from '@oclif/core'
+
+import {Config as OclifConfig} from '@oclif/core'
+import {expect} from 'chai'
+import sinon, {restore, stub} from 'sinon'
+
+import Dream from '../../src/oclif/commands/dream.js'
+
+// ==================== TestableDreamCommand ====================
+
+class TestableDreamCommand extends Dream {
+  private readonly mockConnector: () => Promise<ConnectionResult>
+
+  constructor(argv: string[], mockConnector: () => Promise<ConnectionResult>, config: Config) {
+    super(argv, config)
+    this.mockConnector = mockConnector
+  }
+
+  protected override getDaemonClientOptions() {
+    return {
+      maxRetries: 1,
+      retryDelayMs: 0,
+      transportConnector: this.mockConnector,
+    }
+  }
+}
+
+// ==================== Tests ====================
+
+describe('Dream Command', () => {
+  let config: Config
+  let loggedMessages: string[]
+  let stdoutOutput: string[]
+  let mockClient: sinon.SinonStubbedInstance<ITransportClient>
+  let mockConnector: sinon.SinonStub<[], Promise<ConnectionResult>>
+
+  before(async () => {
+    config = await OclifConfig.load(import.meta.url)
+  })
+
+  beforeEach(() => {
+    loggedMessages = []
+    stdoutOutput = []
+
+    mockClient = {
+      connect: stub().resolves(),
+      disconnect: stub().resolves(),
+      getClientId: stub().returns('test-client-id'),
+      getState: stub().returns('connected'),
+      isConnected: stub().resolves(true),
+      joinRoom: stub().resolves(),
+      leaveRoom: stub().resolves(),
+      on: stub().returns(() => {}),
+      once: stub(),
+      onStateChange: stub().returns(() => {}),
+      request: stub() as unknown as ITransportClient['request'],
+      requestWithAck: stub().resolves({activeProvider: 'anthropic'}),
+    } as unknown as sinon.SinonStubbedInstance<ITransportClient>
+
+    mockConnector = stub<[], Promise<ConnectionResult>>().resolves({
+      client: mockClient as unknown as ITransportClient,
+      projectRoot: '/test/project',
+    })
+  })
+
+  afterEach(() => {
+    restore()
+  })
+
+  function createCommand(...argv: string[]): TestableDreamCommand {
+    const command = new TestableDreamCommand(argv, mockConnector, config)
+    stub(command, 'log').callsFake((msg?: string) => {
+      if (msg) loggedMessages.push(msg)
+    })
+    return command
+  }
+
+  function createJsonCommand(...argv: string[]): TestableDreamCommand {
+    const command = new TestableDreamCommand([...argv, '--format', 'json'], mockConnector, config)
+    stub(command, 'log').callsFake((msg?: string) => {
+      if (msg) loggedMessages.push(msg)
+    })
+    stub(process.stdout, 'write').callsFake((chunk: string | Uint8Array) => {
+      stdoutOutput.push(String(chunk))
+      return true
+    })
+    return command
+  }
+
+  function parseJsonOutput(): {command: string; data: Record<string, unknown>; success: boolean} {
+    const output = stdoutOutput.join('')
+    return JSON.parse(output.trim())
+  }
+
+  // ==================== Detach Mode ====================
+
+  describe('detach mode', () => {
+    it('should submit task and exit immediately with confirmation', async () => {
+      await createCommand('--detach').run()
+
+      const requestStub = mockClient.requestWithAck as sinon.SinonStub
+      expect(requestStub.calledTwice).to.be.true
+      expect(requestStub.firstCall.args[0]).to.equal('state:getProviderConfig')
+      const [event, payload] = requestStub.secondCall.args
+      expect(event).to.equal('task:create')
+      expect(payload).to.have.property('type', 'dream')
+      expect(payload).to.have.property('taskId').that.is.a('string')
+      expect(loggedMessages.some((m) => m.includes('Dream queued for processing'))).to.be.true
+    })
+
+    it('should include force in task payload when combined with --force', async () => {
+      await createCommand('--detach', '--force').run()
+
+      const requestStub = mockClient.requestWithAck as sinon.SinonStub
+      const [, payload] = requestStub.secondCall.args
+      expect(payload).to.have.property('force', true)
+    })
+
+    it('should warn when --timeout is used with --detach', async () => {
+      await createCommand('--detach', '--timeout', '600').run()
+
+      expect(loggedMessages).to.include('Note: --timeout has no effect with --detach')
+    })
+
+    it('should not warn about --timeout with --detach when using default', async () => {
+      await createCommand('--detach').run()
+
+      expect(loggedMessages).to.not.include('Note: --timeout has no effect with --detach')
+    })
+
+    it('should output JSON on detach', async () => {
+      await createJsonCommand('--detach').run()
+
+      const json = parseJsonOutput()
+      expect(json.command).to.equal('dream')
+      expect(json.success).to.be.true
+      expect(json.data).to.have.property('status', 'queued')
+      expect(json.data).to.have.property('taskId').that.is.a('string')
+      expect(json.data).to.have.property('message', 'Dream queued for processing')
+    })
+
+    it('should output JSON on detach with --force', async () => {
+      await createJsonCommand('--detach', '--force').run()
+
+      const json = parseJsonOutput()
+      expect(json.success).to.be.true
+      expect(json.data).to.have.property('status', 'queued')
+    })
+
+    it('should disconnect client after detach', async () => {
+      await createCommand('--detach').run()
+
+      expect(mockClient.disconnect.calledOnce).to.be.true
+    })
+  })
+})

--- a/test/commands/dream.test.ts
+++ b/test/commands/dream.test.ts
@@ -100,7 +100,7 @@ describe('Dream Command', () => {
       await createCommand('--detach').run()
 
       const requestStub = mockClient.requestWithAck as sinon.SinonStub
-      expect(requestStub.calledTwice).to.be.true
+      expect(requestStub.callCount).to.equal(2)
       expect(requestStub.firstCall.args[0]).to.equal('state:getProviderConfig')
       const [event, payload] = requestStub.secondCall.args
       expect(event).to.equal('task:create')
@@ -125,6 +125,12 @@ describe('Dream Command', () => {
 
     it('should not warn about --timeout with --detach when using default', async () => {
       await createCommand('--detach').run()
+
+      expect(loggedMessages).to.not.include('Note: --timeout has no effect with --detach')
+    })
+
+    it('should not warn about --timeout in JSON mode even when non-default', async () => {
+      await createJsonCommand('--detach', '--timeout', '600').run()
 
       expect(loggedMessages).to.not.include('Note: --timeout has no effect with --detach')
     })


### PR DESCRIPTION
## Summary
- Add `--detach` flag to `brv dream` matching the existing `brv curate --detach` pattern
- When detached, submits dream task to daemon and exits immediately with confirmation
- Composes with `--force` and `--format json`
- Warns when `--timeout` is used with `--detach` (no effect)

## Test plan
- [x] `brv dream --detach` exits immediately with "Dream queued for processing"
- [x] `brv dream --detach --force` queues forced dream
- [x] `brv dream --detach --format json` returns proper JSON with `status: "queued"`
- [x] `brv dream --detach --timeout 600` shows timeout warning
- [x] 7 new command-level tests (test/commands/dream.test.ts)
- [x] Full test suite passing (6164 tests)
- [x] Code quality audit passed