### PR TITLE
fix: [ENG-2126] address 4 dream spec-violation gaps post-merge

### DIFF
--- a/src/server/infra/daemon/agent-process.ts
+++ b/src/server/infra/daemon/agent-process.ts
@@ -506,11 +506,15 @@ async function executeTask(
           const dreamLockService = new DreamLockService({baseDir: brvDir})
           const dreamStateService = new DreamStateService({baseDir: brvDir})
 
-          // Run trigger check (acquires lock if eligible)
+          // Run trigger check (acquires lock if eligible).
+          // Gate 3 (queue) is pre-checked by the daemon (TransportHandlers.preDispatchCheck
+          // for CLI dispatch, onAgentIdle for idle-trigger dispatch), so the agent treats
+          // its own queue view as empty. Gates 1 (time) and 2 (activity) are re-checked here
+          // as defense-in-depth in case state drifted between dispatch and execution.
           const dreamTrigger = new DreamTrigger({
             dreamLockService,
             dreamStateService,
-            getQueueLength: () => 0, // Agent-level: this task is the only active one
+            getQueueLength: () => 0,
           })
           const eligibility = await dreamTrigger.tryStartDream(projectPath, force)
           if (!eligibility.eligible) {

--- a/src/server/infra/daemon/brv-server.ts
+++ b/src/server/infra/daemon/brv-server.ts
@@ -227,6 +227,16 @@ async function main(): Promise<void> {
     const getQueueLength = (projectPath: string): number =>
       agentPool?.getQueueState().find((q) => q.projectPath === projectPath)?.queueLength ?? 0
 
+    // Shared dream pre-check trigger factory.
+    // The lock service explicitly throws if invoked — gate 4 (lock) is the agent's job;
+    // the daemon must only ever evaluate gates 1-3 via checkEligibility().
+    const makeDreamPreCheckTrigger = (projectPath: string): DreamTrigger =>
+      new DreamTrigger({
+        dreamLockService: {tryAcquire() { throw new Error('Lock must not be acquired during daemon eligibility pre-check') }},
+        dreamStateService: new DreamStateService({baseDir: join(projectPath, BRV_DIR)}),
+        getQueueLength,
+      })
+
     // Agent idle timeout policy — kills agents after period of inactivity
     const agentIdleTimeoutPolicy = new AgentIdleTimeoutPolicy({
       checkIntervalMs: AGENT_IDLE_CHECK_INTERVAL_MS,
@@ -249,15 +259,7 @@ async function main(): Promise<void> {
         // Check dream eligibility before killing (gates 1-3 only, no lock).
         // Lock acquisition happens in the agent process when the dream task executes.
         try {
-          const brvDir = join(projectPath, BRV_DIR)
-          const dreamTrigger = new DreamTrigger({
-            // Lock must NOT be acquired during daemon pre-check — guard against accidental gate-4 calls
-            dreamLockService: {tryAcquire() { throw new Error('Lock must not be acquired during daemon eligibility pre-check') }},
-            dreamStateService: new DreamStateService({baseDir: brvDir}),
-            getQueueLength,
-          })
-
-          const result = await dreamTrigger.checkEligibility(projectPath)
+          const result = await makeDreamPreCheckTrigger(projectPath).checkEligibility(projectPath)
           if (result.eligible) {
             log(`Dream eligible, dispatching dream task: ${projectPath}`)
             agentPool?.submitTask({
@@ -334,6 +336,24 @@ async function main(): Promise<void> {
       agentPool,
       clientManager,
       lifecycleHooks: [curateLogHandler],
+      // Daemon-side gate for dream task:create — mirrors the idle-trigger pre-check
+      // in this file so the CLI path (brv dream without --force) actually honors
+      // gate 3 (queue). The agent-side check kept gate 3 hardcoded to skip,
+      // which made the CLI ignore the spec when other tasks were queued.
+      async preDispatchCheck(task, projectPath) {
+        if (task.type !== 'dream' || task.force) return {eligible: true}
+        if (!projectPath) return {eligible: true}
+
+        try {
+          const result = await makeDreamPreCheckTrigger(projectPath).checkEligibility(projectPath)
+          return result.eligible
+            ? {eligible: true}
+            : {eligible: false, skipResult: `Dream skipped: ${result.reason}`}
+        } catch {
+          // Fail-open on pre-check errors: let the agent's own gate check be the fallback.
+          return {eligible: true}
+        }
+      },
       projectRegistry,
       projectRouter,
       transport: transportServer,

--- a/src/server/infra/dream/dream-state-service.ts
+++ b/src/server/infra/dream/dream-state-service.ts
@@ -1,10 +1,30 @@
 import {randomUUID} from 'node:crypto'
 import {mkdir, readFile, rename, writeFile} from 'node:fs/promises'
-import {dirname, join} from 'node:path'
+import {dirname, join, resolve} from 'node:path'
 
+import {AsyncMutex} from '../../../agent/infra/llm/context/async-mutex.js'
 import {type DreamState, DreamStateSchema, EMPTY_DREAM_STATE} from './dream-state-schema.js'
 
 const STATE_FILENAME = 'dream-state.json'
+
+// Module-level mutex registry keyed by absolute state file path.
+// The agent process can hold up to AGENT_MAX_CONCURRENT_TASKS concurrent curate tasks
+// AND a dream task running concurrently, so read-modify-write on dream-state.json must
+// be serialized across all writers — incrementCurationCount, dream-executor's step 7
+// reset, and consolidate's pendingMerges clear all share this mutex via update().
+// Independent DreamStateService instances pointing at the same file share a mutex.
+const stateMutexes = new Map<string, AsyncMutex>()
+
+function getStateMutex(stateFilePath: string): AsyncMutex {
+  const key = resolve(stateFilePath)
+  let mutex = stateMutexes.get(key)
+  if (!mutex) {
+    mutex = new AsyncMutex()
+    stateMutexes.set(key, mutex)
+  }
+
+  return mutex
+}
 
 type DreamStateServiceOptions = {
   baseDir: string
@@ -24,13 +44,11 @@ export class DreamStateService {
   }
 
   /**
-   * Atomic read-modify-write. Safe under the single-writer assumption
-   * (project task queue is sequential, max concurrency = 1 per project).
+   * Read-modify-write under a per-file mutex. Serializes concurrent increments
+   * from parallel curate tasks within the same agent process so no updates are lost.
    */
   async incrementCurationCount(): Promise<void> {
-    const state = await this.read()
-    state.curationsSinceDream++
-    await this.write(state)
+    await this.update((state) => ({...state, curationsSinceDream: state.curationsSinceDream + 1}))
   }
 
   async read(): Promise<DreamState> {
@@ -42,6 +60,23 @@ export class DreamStateService {
     } catch {
       return {...EMPTY_DREAM_STATE, pendingMerges: []}
     }
+  }
+
+  /**
+   * Generic read-modify-write under the same per-file mutex used by
+   * incrementCurationCount. All writers that mutate dream-state.json based on
+   * its current contents (e.g. dream-executor step 7's reset, consolidate's
+   * pendingMerges clear) MUST go through this method, otherwise concurrent
+   * increments can be silently overwritten.
+   */
+  async update(updater: (state: DreamState) => DreamState): Promise<DreamState> {
+    const mutex = getStateMutex(this.stateFilePath)
+    return mutex.withLock(async () => {
+      const state = await this.read()
+      const next = updater(state)
+      await this.write(next)
+      return next
+    })
   }
 
   async write(state: DreamState): Promise<void> {

--- a/src/server/infra/dream/dream-state-service.ts
+++ b/src/server/infra/dream/dream-state-service.ts
@@ -13,6 +13,12 @@ const STATE_FILENAME = 'dream-state.json'
 // be serialized across all writers — incrementCurationCount, dream-executor's step 7
 // reset, and consolidate's pendingMerges clear all share this mutex via update().
 // Independent DreamStateService instances pointing at the same file share a mutex.
+//
+// Note: this Map grows monotonically — one entry per unique absolute state-file
+// path ever instantiated. In practice it is bounded by the number of registered
+// projects in the agent process (typically single digits), so memory growth is
+// negligible. If the daemon ever needs to support project unregister, evict
+// entries here on unregister to keep the registry tight.
 const stateMutexes = new Map<string, AsyncMutex>()
 
 function getStateMutex(stateFilePath: string): AsyncMutex {
@@ -79,6 +85,14 @@ export class DreamStateService {
     })
   }
 
+  /**
+   * Atomic write (tmp file → rename). Does NOT acquire the per-file mutex.
+   *
+   * Direct callers that perform a logical read-modify-write by pairing
+   * {@link read} + write bypass serialization and may lose updates from
+   * concurrent writers. Use {@link update} for any RMW that depends on the
+   * current state.
+   */
   async write(state: DreamState): Promise<void> {
     DreamStateSchema.parse(state)
     const dir = dirname(this.stateFilePath)

--- a/src/server/infra/dream/operations/consolidate.ts
+++ b/src/server/infra/dream/operations/consolidate.ts
@@ -85,6 +85,18 @@ export async function consolidate(
  * Reads pendingMerges from state, mutates `changedFiles` to include any
  * pending sourceFiles that still exist on disk, and clears the list.
  * Returns the list for use as LLM prompt hints (may be empty).
+ *
+ * Two-phase access pattern (intentional):
+ *   1. unguarded `read()` to build hints — hints are non-binding LLM
+ *      suggestions, so a slightly-stale snapshot here is acceptable. Avoids
+ *      holding the per-file mutex across the file-existence checks below.
+ *   2. mutex-guarded `update()` to clear pendingMerges — must be atomic so a
+ *      concurrent `incrementCurationCount` isn't overwritten by writing back
+ *      from a stale snapshot.
+ *
+ * If a concurrent prune appends new entries between the two phases, those new
+ * entries are NOT cleared by this call — they remain for the next dream's
+ * consolidate to consume. That's correct behavior.
  */
 async function loadAndClearPendingMerges(
   deps: ConsolidateDeps,
@@ -96,6 +108,9 @@ async function loadAndClearPendingMerges(
   try {
     state = await deps.dreamStateService.read()
   } catch {
+    // If the state file is unreadable we can't safely build hints; the
+    // matching `update()` below would also fail. Return early — the next
+    // dream will retry once the file is readable again.
     return []
   }
 

--- a/src/server/infra/dream/operations/consolidate.ts
+++ b/src/server/infra/dream/operations/consolidate.ts
@@ -13,12 +13,13 @@
 
 import {dump as yamlDump, load as yamlLoad} from 'js-yaml'
 import {randomUUID} from 'node:crypto'
-import {mkdir, readdir, readFile, rename, unlink, writeFile} from 'node:fs/promises'
+import {access, mkdir, readdir, readFile, rename, unlink, writeFile} from 'node:fs/promises'
 import {dirname, join} from 'node:path'
 
 import type {ICipherAgent} from '../../../../agent/core/interfaces/i-cipher-agent.js'
 import type {DreamOperation} from '../dream-log-schema.js'
 import type {ConsolidationAction} from '../dream-response-schemas.js'
+import type {DreamState, PendingMerge} from '../dream-state-schema.js'
 
 import {parseFrontmatterScoring} from '../../../core/domain/knowledge/markdown-writer.js'
 import {ConsolidateResponseSchema} from '../dream-response-schemas.js'
@@ -27,6 +28,17 @@ import {parseDreamResponse} from '../parse-dream-response.js'
 export type ConsolidateDeps = {
   agent: ICipherAgent
   contextTreeDir: string
+  /**
+   * Optional. When present, pendingMerges from prior dreams (written by prune's
+   * SUGGEST_MERGE) are consumed at the start of consolidate: source files are
+   * added to changedFiles, their target/reason is passed to the LLM as a hint,
+   * and the pendingMerges list is cleared.
+   */
+  dreamStateService?: {
+    read(): Promise<DreamState>
+    update(updater: (state: DreamState) => DreamState): Promise<DreamState>
+    write(state: DreamState): Promise<void>
+  }
   reviewBackupStore?: {
     save(relativePath: string, content: string): Promise<void>
   }
@@ -45,6 +57,13 @@ export async function consolidate(
   changedFiles: string[],
   deps: ConsolidateDeps,
 ): Promise<DreamOperation[]> {
+  // Cross-cycle: fold in pendingMerges written by the previous dream's Prune.
+  // Source files (if still on disk) join the changedFiles set so consolidate
+  // re-evaluates them; mergeTarget + reason surface to the LLM as a hint.
+  // pendingMerges is cleared unconditionally after this pass — consumed
+  // regardless of outcome, per notes/byterover-dream/6-dream-undo-and-cross-cycle.md.
+  const hints = await loadAndClearPendingMerges(deps, changedFiles)
+
   if (changedFiles.length === 0) return []
 
   // Step 1: Group by domain
@@ -55,14 +74,74 @@ export async function consolidate(
   for (const [domain, files] of domainGroups) {
     if (deps.signal?.aborted) break
     // eslint-disable-next-line no-await-in-loop
-    const domainOps = await processDomain(domain, files, deps)
+    const domainOps = await processDomain(domain, files, deps, hints)
     allResults.push(...domainOps)
   }
 
   return allResults
 }
 
-async function processDomain(domain: string, files: string[], deps: ConsolidateDeps): Promise<DreamOperation[]> {
+/**
+ * Reads pendingMerges from state, mutates `changedFiles` to include any
+ * pending sourceFiles that still exist on disk, and clears the list.
+ * Returns the list for use as LLM prompt hints (may be empty).
+ */
+async function loadAndClearPendingMerges(
+  deps: ConsolidateDeps,
+  changedFiles: string[],
+): Promise<PendingMerge[]> {
+  if (!deps.dreamStateService) return []
+
+  let state: DreamState
+  try {
+    state = await deps.dreamStateService.read()
+  } catch {
+    return []
+  }
+
+  const pending = state.pendingMerges ?? []
+  if (pending.length === 0) return []
+
+  // Check all source files in parallel — independent fs stat calls.
+  const presenceChecks = await Promise.all(
+    pending.map((entry) => fileExists(join(deps.contextTreeDir, entry.sourceFile))),
+  )
+
+  const existing = new Set(changedFiles)
+  const hints: PendingMerge[] = []
+  for (const [index, entry] of pending.entries()) {
+    if (!presenceChecks[index]) continue // Stale suggestion — skip silently
+    hints.push(entry)
+    if (!existing.has(entry.sourceFile)) {
+      changedFiles.push(entry.sourceFile)
+      existing.add(entry.sourceFile)
+    }
+  }
+
+  try {
+    // Clear pendingMerges under the per-file mutex so a concurrent
+    // incrementCurationCount can't be lost by overwriting from a stale snapshot.
+    // The updater spreads the latest state, preserving any field a parallel
+    // writer just touched.
+    await deps.dreamStateService.update((latest) => ({...latest, pendingMerges: []}))
+  } catch {
+    // Fail-open: failure to clear pendingMerges is a minor bookkeeping issue,
+    // not a reason to block the dream.
+  }
+
+  return hints
+}
+
+async function fileExists(absolutePath: string): Promise<boolean> {
+  try {
+    await access(absolutePath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function processDomain(domain: string, files: string[], deps: ConsolidateDeps, hints: PendingMerge[] = []): Promise<DreamOperation[]> {
   const {agent, contextTreeDir, searchService, taskId} = deps
   const results: DreamOperation[] = []
   let sessionId: string
@@ -89,7 +168,7 @@ async function processDomain(domain: string, files: string[], deps: ConsolidateD
     // Step 3: LLM classification — cap payload to avoid exceeding model context limits
     const filesPayload = capPayloadSize(Object.fromEntries(fileContents), files)
 
-    const prompt = buildPrompt(files, [...relatedPaths], filesPayload)
+    const prompt = buildPrompt(files, [...relatedPaths], filesPayload, hints)
     const response = await agent.executeOnSession(sessionId, prompt, {
       executionContext: {commandType: 'curate', maxIterations: 10},
       signal: deps.signal,
@@ -299,6 +378,7 @@ function buildPrompt(
   changedFiles: string[],
   relatedFiles: string[],
   filesPayload: Record<string, string>,
+  pendingMergeHints: PendingMerge[] = [],
 ): string {
   const allFiles = Object.keys(filesPayload)
   const marker = '━'.repeat(60)
@@ -306,12 +386,26 @@ function buildPrompt(
     .map((path) => `\n${marker}\nPATH: ${path}\n${marker}\n${filesPayload[path]}`)
     .join('\n')
 
-  return [
+  const lines: string[] = [
     'You are consolidating a knowledge context tree. The full contents of every file are included below — read them directly, then classify relationships. Do NOT use code_exec.',
     '',
     `Changed files (recently curated): ${JSON.stringify(changedFiles)}`,
     `Related files (found via search): ${JSON.stringify(relatedFiles)}`,
     `All available files: ${JSON.stringify(allFiles)}`,
+  ]
+
+  // Surface prior-dream merge suggestions as non-binding hints. LLM may still classify SKIP.
+  const relevantHints = pendingMergeHints.filter((h) => allFiles.includes(h.sourceFile) || allFiles.includes(h.mergeTarget))
+  if (relevantHints.length > 0) {
+    lines.push('', 'Note: A previous analysis suggested these files may be merge candidates:')
+    for (const h of relevantHints) {
+      lines.push(`- ${h.sourceFile} → merge into ${h.mergeTarget} (reason: ${h.reason})`)
+    }
+
+    lines.push('Consider these suggestions but make your own judgment.')
+  }
+
+  lines.push(
     '',
     'File contents:',
     fileBlocks,
@@ -334,7 +428,8 @@ function buildPrompt(
     '- For TEMPORAL_UPDATE, preserve all facts and add temporal context. Include confidence (0-1) indicating certainty that the update is correct.',
     '- For CROSS_REFERENCE, just list the files — the system will add frontmatter links.',
     '- Preserve all diagrams, tables, code examples, and structured data verbatim.',
-  ].join('\n')
+  )
+  return lines.join('\n')
 }
 
 async function executeAction(

--- a/src/server/infra/executor/dream-executor.ts
+++ b/src/server/infra/executor/dream-executor.ts
@@ -106,6 +106,11 @@ export class DreamExecutor {
     // history accurate for partial runs.
     const allOperations: DreamOperation[] = []
     let succeeded = false
+    // Tracks whether the success-path createReviewEntries already ran. The
+    // catch path also calls createReviewEntries for partial runs; without this
+    // flag, a failure that occurs after step 6b succeeds (e.g. step 7
+    // dreamStateService.update throws) would re-write the same review entries.
+    let reviewEntriesWritten = false
 
     try {
       // Step 1: Capture pre-state
@@ -169,6 +174,7 @@ export class DreamExecutor {
       // Step 6b: Create curate log entries for needsReview operations (dual-write for review system).
       // Runs after the completed dream log is durably written so review tasks never outlive their dream log.
       await this.createReviewEntries(allOperations, contextTreeDir, options.taskId)
+      reviewEntriesWritten = true
 
       // Step 7: Update dream state — atomic RMW under the per-file mutex so a
       // concurrent curate's incrementCurationCount can't be overwritten by the
@@ -219,8 +225,10 @@ export class DreamExecutor {
       // Surface review-flagged ops that did complete into `brv review pending` even
       // when the dream failed overall. Skipped when no work accumulated so the
       // "no dream log, no review entries" invariant holds for errors that fire
-      // before any operation ran.
-      if (allOperations.length > 0) {
+      // before any operation ran. Also skipped when the success-path call
+      // already wrote the entries (i.e. step 7 threw after step 6b succeeded)
+      // to prevent duplicate review items.
+      if (allOperations.length > 0 && !reviewEntriesWritten) {
         await this.createReviewEntries(allOperations, contextTreeDir, options.taskId)
       }
 

--- a/src/server/infra/executor/dream-executor.ts
+++ b/src/server/infra/executor/dream-executor.ts
@@ -55,6 +55,7 @@ export type DreamExecutorDeps = {
   }
   dreamStateService: {
     read(): Promise<import('../dream/dream-state-schema.js').DreamState>
+    update(updater: (state: import('../dream/dream-state-schema.js').DreamState) => import('../dream/dream-state-schema.js').DreamState): Promise<import('../dream/dream-state-schema.js').DreamState>
     write(state: import('../dream/dream-state-schema.js').DreamState): Promise<void>
   }
   reviewBackupStore?: {
@@ -100,6 +101,10 @@ export class DreamExecutor {
     }
     await this.deps.dreamLogStore.save(processingEntry)
 
+    // Hoisted so the catch block can surface any work that completed before a
+    // timeout or error — keeps the dream log audit trail and `brv dream --undo`
+    // history accurate for partial runs.
+    const allOperations: DreamOperation[] = []
     let succeeded = false
 
     try {
@@ -117,36 +122,19 @@ export class DreamExecutor {
 
       // Step 3: Find changed files since last dream
       const changedFiles = await this.findChangedFilesSinceLastDream(dreamState.lastDreamAt, contextTreeDir)
-      // Step 4: Run operations
-      const consolidateResults = await consolidate([...changedFiles], {
+
+      // Step 4: Run operations, pushing results incrementally so partial work
+      // is preserved if a later step throws or the budget aborts.
+      await this.runOperations({
         agent,
+        changedFiles,
         contextTreeDir,
-        reviewBackupStore: this.deps.reviewBackupStore,
-        searchService: this.deps.searchService,
-        signal: controller.signal,
-        taskId: options.taskId,
-      })
-      const synthesizeResults = changedFiles.size > 0
-        ? await synthesize({
-            agent,
-            contextTreeDir,
-            searchService: this.deps.searchService,
-            signal: controller.signal,
-            taskId: options.taskId,
-          })
-        : []
-      const pruneResults = await prune({
-        agent,
-        archiveService: this.deps.archiveService,
-        contextTreeDir,
-        dreamLogId: logId,
-        dreamStateService: this.deps.dreamStateService,
+        logId,
+        out: allOperations,
         projectRoot,
-        reviewBackupStore: this.deps.reviewBackupStore,
         signal: controller.signal,
         taskId: options.taskId,
       })
-      const allOperations: DreamOperation[] = [...consolidateResults, ...synthesizeResults, ...pruneResults]
 
       // Step 5: Post-dream propagation (fail-open)
       if (preState) {
@@ -182,29 +170,33 @@ export class DreamExecutor {
       // Runs after the completed dream log is durably written so review tasks never outlive their dream log.
       await this.createReviewEntries(allOperations, contextTreeDir, options.taskId)
 
-      // Step 7: Update dream state — re-read to preserve pendingMerges written by prune
-      const currentState = await this.deps.dreamStateService.read()
-      await this.deps.dreamStateService.write({
-        ...currentState,
+      // Step 7: Update dream state — atomic RMW under the per-file mutex so a
+      // concurrent curate's incrementCurationCount can't be overwritten by the
+      // reset, and so pendingMerges written by prune are preserved by the spread.
+      await this.deps.dreamStateService.update((state) => ({
+        ...state,
         curationsSinceDream: 0,
         lastDreamAt: new Date().toISOString(),
         lastDreamLogId: logId,
-        totalDreams: currentState.totalDreams + 1,
-      })
+        totalDreams: state.totalDreams + 1,
+      }))
 
       succeeded = true
       return {logId, result: this.formatResult(logId, summary)}
     } catch (error) {
-      // Save error/partial log entry (best-effort)
+      // Save error/partial log entry (best-effort). Use allOperations so any work
+      // that completed before the failure is captured — keeps the audit trail and
+      // undo history accurate even for partial runs.
+      const summary = this.computeSummary(allOperations)
       if (controller.signal.aborted) {
         const partialEntry: DreamLogEntry = {
           abortReason: 'Budget exceeded (5 min)',
           completedAt: Date.now(),
           id: logId,
-          operations: [],
+          operations: allOperations,
           startedAt,
           status: 'partial',
-          summary: zeroes,
+          summary,
           taskId: options.taskId,
           trigger,
         }
@@ -214,14 +206,22 @@ export class DreamExecutor {
           completedAt: Date.now(),
           error: error instanceof Error ? error.message : String(error),
           id: logId,
-          operations: [],
+          operations: allOperations,
           startedAt,
           status: 'error',
-          summary: zeroes,
+          summary,
           taskId: options.taskId,
           trigger,
         }
         await this.deps.dreamLogStore.save(errorEntry).catch(() => {})
+      }
+
+      // Surface review-flagged ops that did complete into `brv review pending` even
+      // when the dream failed overall. Skipped when no work accumulated so the
+      // "no dream log, no review entries" invariant holds for errors that fire
+      // before any operation ran.
+      if (allOperations.length > 0) {
+        await this.createReviewEntries(allOperations, contextTreeDir, options.taskId)
       }
 
       throw error
@@ -235,6 +235,62 @@ export class DreamExecutor {
         await this.deps.dreamLockService.rollback(priorMtime).catch(() => {})
       }
     }
+  }
+
+  /**
+   * Runs the three dream operations sequentially, pushing results into `out` after
+   * each step. Extracted so the executor can preserve partial work when a later step
+   * throws — and so tests can inject controlled ops without a full LLM round-trip.
+   */
+  protected async runOperations(args: {
+    agent: ICipherAgent
+    changedFiles: Set<string>
+    contextTreeDir: string
+    logId: string
+    out: DreamOperation[]
+    projectRoot: string
+    signal: AbortSignal
+    taskId: string
+  }): Promise<void> {
+    const {agent, changedFiles, contextTreeDir, logId, out, projectRoot, signal, taskId} = args
+
+    out.push(
+      ...(await consolidate([...changedFiles], {
+        agent,
+        contextTreeDir,
+        dreamStateService: this.deps.dreamStateService,
+        reviewBackupStore: this.deps.reviewBackupStore,
+        searchService: this.deps.searchService,
+        signal,
+        taskId,
+      })),
+    )
+
+    if (changedFiles.size > 0) {
+      out.push(
+        ...(await synthesize({
+          agent,
+          contextTreeDir,
+          searchService: this.deps.searchService,
+          signal,
+          taskId,
+        })),
+      )
+    }
+
+    out.push(
+      ...(await prune({
+        agent,
+        archiveService: this.deps.archiveService,
+        contextTreeDir,
+        dreamLogId: logId,
+        dreamStateService: this.deps.dreamStateService,
+        projectRoot,
+        reviewBackupStore: this.deps.reviewBackupStore,
+        signal,
+        taskId,
+      })),
+    )
   }
 
   /** Errors are tracked at the log level (status='error'), not per-operation — always 0 here. */

--- a/src/server/infra/process/task-router.ts
+++ b/src/server/infra/process/task-router.ts
@@ -66,12 +66,31 @@ type LlmEventPayloadMap = {
  */
 const TASK_CLEANUP_GRACE_PERIOD_MS = 5000
 
+/**
+ * Outcome of the daemon-side pre-dispatch check.
+ *
+ * `skipResult` is the full string sent to the client as the task:completed `result`.
+ * The callback owns the message format so task-router stays task-type-agnostic
+ * (e.g. dream uses "Dream skipped: <reason>"; future task types can use their own).
+ */
+export type PreDispatchCheckResult = {eligible: false; skipResult: string} | {eligible: true}
+
+export type PreDispatchCheck = (task: TaskCreateRequest, projectPath?: string) => Promise<PreDispatchCheckResult>
+
 type TaskRouterOptions = {
   agentPool?: IAgentPool
   /** Function to resolve agent clientId for a given project */
   getAgentForProject: (projectPath?: string) => string | undefined
   /** Lifecycle hooks for task events (e.g. CurateLogHandler). */
   lifecycleHooks?: ITaskLifecycleHook[]
+  /**
+   * Optional daemon-side gate run before dispatching to the agent pool. If it
+   * resolves ineligible, task-router short-circuits with task:completed carrying
+   * the skip reason and never submits the task to an agent.
+   * Used for dream task type to enforce gates 1-3 (time, activity, queue) even
+   * on the CLI dispatch path — mirrors the idle-trigger pre-check pattern.
+   */
+  preDispatchCheck?: PreDispatchCheck
   projectRegistry?: IProjectRegistry
   projectRouter?: IProjectRouter
   /** Resolves the projectPath a client registered with (from client:register). */
@@ -92,6 +111,7 @@ export class TaskRouter {
   private completedTasks: Map<string, {completedAt: number; task: TaskInfo}> = new Map()
   private readonly getAgentForProject: (projectPath?: string) => string | undefined
   private readonly lifecycleHooks: ITaskLifecycleHook[]
+  private readonly preDispatchCheck: TaskRouterOptions['preDispatchCheck']
   private readonly projectRegistry: IProjectRegistry | undefined
   private readonly projectRouter: IProjectRouter | undefined
   private readonly resolveClientProjectPath: ((clientId: string) => string | undefined) | undefined
@@ -104,6 +124,7 @@ export class TaskRouter {
     this.agentPool = options.agentPool
     this.getAgentForProject = options.getAgentForProject
     this.lifecycleHooks = options.lifecycleHooks ?? []
+    this.preDispatchCheck = options.preDispatchCheck
     this.projectRegistry = options.projectRegistry
     this.projectRouter = options.projectRouter
     this.resolveClientProjectPath = options.resolveClientProjectPath
@@ -480,6 +501,28 @@ export class TaskRouter {
       ...(logId ? {logId} : {}),
       taskId,
     })
+
+    // ── Daemon-side pre-dispatch gate (dream uses this for gates 1-3) ────────
+    // Runs after ack so the client has a logId to correlate; short-circuits with
+    // task:completed + skip-reason when ineligible. Mirrors the idle-trigger
+    // pattern in brv-server.ts:260 for the CLI dispatch path.
+
+    if (this.preDispatchCheck) {
+      let check: PreDispatchCheckResult = {eligible: true}
+      try {
+        check = await this.preDispatchCheck(data, projectPath)
+      } catch (error_) {
+        transportLog(
+          `preDispatchCheck threw for task ${taskId}, proceeding with dispatch: ${error_ instanceof Error ? error_.message : String(error_)}`,
+        )
+      }
+
+      if (!check.eligible) {
+        transportLog(`Task ${taskId} (type=${data.type}) skipped by daemon pre-check: ${check.skipResult}`)
+        this.handleTaskCompleted({result: check.skipResult, taskId})
+        return {taskId}
+      }
+    }
 
     // ── Submit to AgentPool (fire-and-forget) ─────────────────────────────────
 

--- a/src/server/infra/process/task-router.ts
+++ b/src/server/infra/process/task-router.ts
@@ -519,7 +519,10 @@ export class TaskRouter {
 
       if (!check.eligible) {
         transportLog(`Task ${taskId} (type=${data.type}) skipped by daemon pre-check: ${check.skipResult}`)
-        this.handleTaskCompleted({result: check.skipResult, taskId})
+        // Use the skip-specific handler so the pool's activeTasks counter and
+        // onTaskCompleted hooks aren't notified for a task that never reached
+        // submitTask. See handleTaskSkippedByPreCheck for rationale.
+        this.handleTaskSkippedByPreCheck(taskId, check.skipResult)
         return {taskId}
       }
     }
@@ -650,6 +653,44 @@ export class TaskRouter {
     if (task) {
       this.notifyHooksError(taskId, error.message, task).catch(() => {})
     }
+  }
+
+  /**
+   * Emit `task:completed` for a task that the daemon's pre-dispatch gate skipped
+   * before it ever reached `AgentPool.submitTask`.
+   *
+   * Distinct from {@link handleTaskCompleted}:
+   *   - does NOT call `agentPool.notifyTaskCompleted` (the pool's `activeTasks`
+   *     counter was never incremented, so decrementing here would undercount real
+   *     load and let `drainQueue` dispatch an extra queued task)
+   *   - does NOT fire `onTaskCompleted` lifecycle hooks (counters/metrics that
+   *     act on completed tasks should not see pre-check skips as completions)
+   *
+   * Still emits the event to the client and the project room so REPL/TUI
+   * receive the skip result, and still calls `moveToCompleted` so the task is
+   * removed from the active set.
+   */
+  private handleTaskSkippedByPreCheck(taskId: string, result: string): void {
+    const task = this.tasks.get(taskId)
+
+    transportLog(`Task skipped by pre-dispatch gate: ${taskId}`)
+
+    if (task) {
+      this.transport.sendTo(task.clientId, TransportTaskEventNames.COMPLETED, {
+        result,
+        taskId,
+      })
+    }
+
+    broadcastToProjectRoom(
+      this.projectRegistry,
+      this.projectRouter,
+      task?.projectPath,
+      TransportTaskEventNames.COMPLETED,
+      {result, taskId},
+      task?.clientId,
+    )
+    this.moveToCompleted(taskId)
   }
 
   private handleTaskStarted(data: TaskStartedEvent): void {

--- a/src/server/infra/process/transport-handlers.ts
+++ b/src/server/infra/process/transport-handlers.ts
@@ -33,10 +33,12 @@ import type {ITaskLifecycleHook} from '../../core/interfaces/process/i-task-life
 import type {IProjectRegistry} from '../../core/interfaces/project/i-project-registry.js'
 import type {IProjectRouter} from '../../core/interfaces/routing/i-project-router.js'
 import type {ITransportServer} from '../../core/interfaces/transport/i-transport-server.js'
+import type {PreDispatchCheck} from './task-router.js'
 
 import {ConnectionCoordinator} from './connection-coordinator.js'
 import {TaskRouter} from './task-router.js'
 
+export type {PreDispatchCheck, PreDispatchCheckResult} from './task-router.js'
 export type {TaskInfo} from './types.js'
 
 type TransportHandlersOptions = {
@@ -44,6 +46,8 @@ type TransportHandlersOptions = {
   clientManager?: IClientManager
   /** Lifecycle hooks for task events (e.g. CurateLogHandler). */
   lifecycleHooks?: ITaskLifecycleHook[]
+  /** Optional daemon-side gate run before dispatching a task to the agent pool. */
+  preDispatchCheck?: PreDispatchCheck
   projectRegistry?: IProjectRegistry
   projectRouter?: IProjectRouter
   transport: ITransportServer
@@ -64,6 +68,7 @@ export class TransportHandlers {
       agentPool: options.agentPool,
       getAgentForProject: (projectPath) => this.connectionCoordinator.getAgentForProject(projectPath),
       lifecycleHooks: options.lifecycleHooks,
+      preDispatchCheck: options.preDispatchCheck,
       projectRegistry: options.projectRegistry,
       projectRouter: options.projectRouter,
       resolveClientProjectPath: (clientId) => options.clientManager?.getClient(clientId)?.projectPath,

--- a/test/unit/infra/dream/dream-state-service.test.ts
+++ b/test/unit/infra/dream/dream-state-service.test.ts
@@ -143,5 +143,78 @@ describe('DreamStateService', () => {
       expect(state.totalDreams).to.equal(5)
       expect(state.lastDreamLogId).to.equal('drm-123')
     })
+
+    it('should count every increment even when 10 run concurrently (no lost updates)', async () => {
+      const N = 10
+      await Promise.all(Array.from({length: N}, () => service.incrementCurationCount()))
+      const state = await service.read()
+      expect(state.curationsSinceDream).to.equal(N)
+    })
+
+    it('should serialize concurrent increments per service instance (FIFO)', async () => {
+      // Two services pointing at the SAME baseDir still share per-file serialization
+      // when the mutex is keyed on the absolute state file path.
+      const serviceB = new DreamStateService({baseDir: tempDir})
+      const N = 20
+      await Promise.all(
+        Array.from({length: N}, (_, i) =>
+          (i % 2 === 0 ? service : serviceB).incrementCurationCount(),
+        ),
+      )
+      const state = await service.read()
+      expect(state.curationsSinceDream).to.equal(N)
+    })
+  })
+
+  // ==========================================================================
+  // update — generic RMW under the same per-file mutex
+  // ==========================================================================
+
+  describe('update', () => {
+    it('returns the updated state', async () => {
+      const next = await service.update((state) => ({...state, totalDreams: 7}))
+      expect(next.totalDreams).to.equal(7)
+
+      const persisted = await service.read()
+      expect(persisted.totalDreams).to.equal(7)
+    })
+
+    it('does not lose increments when interleaved with a step-7-style reset writer', async () => {
+      // Models the dream-executor step 7 race: a dream "resets" curationsSinceDream
+      // to 0 while a curate's incrementCurationCount runs concurrently. Without the
+      // mutex covering both writers, the increment is lost.
+      await service.update((state) => ({...state, curationsSinceDream: 5, totalDreams: 1}))
+
+      // Fire a step-7-style reset and an increment in parallel.
+      await Promise.all([
+        service.update((state) => ({...state, curationsSinceDream: 0, totalDreams: state.totalDreams + 1})),
+        service.incrementCurationCount(),
+      ])
+
+      const final = await service.read()
+
+      // Either ordering is acceptable, but both writes must be visible:
+      //   - reset-then-increment → curationsSinceDream=1 (reset to 0, then ++)
+      //   - increment-then-reset → curationsSinceDream=0 (incremented to 6, then reset to 0)
+      // The test asserts that increments are NEVER lost: if the reset runs FIRST
+      // the increment must show; if the reset runs LAST the increment is consumed
+      // (which is the design intent — the dream consumed it).
+      expect(final.curationsSinceDream).to.be.oneOf([0, 1])
+      expect(final.totalDreams, 'reset-side update must always commit').to.equal(2)
+    })
+
+    it('serializes mixed update + incrementCurationCount calls (no lost writes)', async () => {
+      // 5 increments interleaved with 5 totalDreams bumps — neither side should drop a write.
+      const ops = Array.from({length: 10}, (_, i) =>
+        i % 2 === 0
+          ? service.incrementCurationCount()
+          : service.update((state) => ({...state, totalDreams: state.totalDreams + 1})),
+      )
+      await Promise.all(ops)
+
+      const final = await service.read()
+      expect(final.curationsSinceDream).to.equal(5)
+      expect(final.totalDreams).to.equal(5)
+    })
   })
 })

--- a/test/unit/infra/dream/operations/consolidate.test.ts
+++ b/test/unit/infra/dream/operations/consolidate.test.ts
@@ -447,7 +447,10 @@ describe('consolidate', () => {
       // LLM returns no actions — consolidate still clears pendingMerges
       await consolidate(['auth/login.md'], {...deps, dreamStateService})
 
-      expect(dreamStateService.write.calledOnce).to.be.true
+      // Asserting on `update` (the contract) rather than `write` (the stub's
+      // current implementation) keeps this test honest under future refactors
+      // that route the clear through update() without calling write directly.
+      expect(dreamStateService.update.calledOnce).to.be.true
       const writtenState = dreamStateService.write.firstCall.args[0] as {pendingMerges: unknown[]}
       expect(writtenState.pendingMerges).to.deep.equal([])
     })

--- a/test/unit/infra/dream/operations/consolidate.test.ts
+++ b/test/unit/infra/dream/operations/consolidate.test.ts
@@ -34,6 +34,31 @@ function llmResponse(actions: Array<{confidence?: number; files: string[]; merge
   return '```json\n' + JSON.stringify({actions}) + '\n```'
 }
 
+/** Test helper: build a stubbed DreamStateService exposing read/update/write with seeded pendingMerges. */
+function makePendingMergeStateService(pendingMerges: Array<{mergeTarget: string; reason: string; sourceFile: string; suggestedByDreamId: string}>) {
+  type State = import('../../../../../src/server/infra/dream/dream-state-schema.js').DreamState
+  const service: {read: ReturnType<typeof stub>; update: ReturnType<typeof stub>; write: ReturnType<typeof stub>} = {
+    read: stub().resolves({
+      curationsSinceDream: 0,
+      lastDreamAt: null,
+      lastDreamLogId: null,
+      pendingMerges,
+      totalDreams: 0,
+      version: 1 as const,
+    }),
+    update: stub(),
+    write: stub().resolves(),
+  }
+  // Default update: read → updater → write — keeps tests that assert on write.callCount valid.
+  service.update.callsFake(async (updater: (state: State) => State) => {
+    const current = await service.read()
+    const next = updater(current)
+    await service.write(next)
+    return next
+  })
+  return service
+}
+
 describe('consolidate', () => {
   let ctxDir: string
   let agent: {
@@ -377,5 +402,87 @@ describe('consolidate', () => {
 
     // Only one domain processed — the second was skipped because signal was aborted
     expect(agent.createTaskSession.callCount).to.equal(1)
+  })
+
+  // ==========================================================================
+  // pendingMerges consumption (ENG-2126 fix #3)
+  // ==========================================================================
+
+  describe('pendingMerges consumption', () => {
+    it('adds pendingMerge source files to the changedFiles set when they exist on disk', async () => {
+      await createMdFile(ctxDir, 'auth/login.md', '# Login')
+      await createMdFile(ctxDir, 'auth/session.md', '# Session (suggested merge source)')
+      const dreamStateService = makePendingMergeStateService([
+        {mergeTarget: 'auth/login.md', reason: 'Overlaps login flow', sourceFile: 'auth/session.md', suggestedByDreamId: 'drm-prev'},
+      ])
+
+      // Only pass login.md — session.md should be added via pendingMerges
+      await consolidate(['auth/login.md'], {...deps, dreamStateService})
+
+      // File contents are inlined in the prompt — verify session.md was loaded as a sibling
+      const prompt = agent.executeOnSession.firstCall.args[1] as string
+      expect(prompt).to.include('PATH: auth/session.md')
+    })
+
+    it('skips pendingMerge entries whose sourceFile is missing on disk', async () => {
+      await createMdFile(ctxDir, 'auth/login.md', '# Login')
+      const dreamStateService = makePendingMergeStateService([
+        {mergeTarget: 'auth/login.md', reason: 'Stale suggestion', sourceFile: 'auth/never-existed.md', suggestedByDreamId: 'drm-prev'},
+      ])
+
+      await consolidate(['auth/login.md'], {...deps, dreamStateService})
+
+      // No errors, consolidation proceeds normally with just the original changedFiles
+      const prompt = agent.executeOnSession.firstCall.args[1] as string
+      expect(prompt).to.not.include('PATH: auth/never-existed.md')
+    })
+
+    it('clears pendingMerges after processing (consumed regardless of outcome)', async () => {
+      await createMdFile(ctxDir, 'auth/login.md', '# Login')
+      await createMdFile(ctxDir, 'auth/session.md', '# Session')
+      const dreamStateService = makePendingMergeStateService([
+        {mergeTarget: 'auth/login.md', reason: 'Overlaps login flow', sourceFile: 'auth/session.md', suggestedByDreamId: 'drm-prev'},
+      ])
+
+      // LLM returns no actions — consolidate still clears pendingMerges
+      await consolidate(['auth/login.md'], {...deps, dreamStateService})
+
+      expect(dreamStateService.write.calledOnce).to.be.true
+      const writtenState = dreamStateService.write.firstCall.args[0] as {pendingMerges: unknown[]}
+      expect(writtenState.pendingMerges).to.deep.equal([])
+    })
+
+    it('passes mergeTarget and reason to the LLM prompt as hints', async () => {
+      await createMdFile(ctxDir, 'auth/login.md', '# Login')
+      await createMdFile(ctxDir, 'auth/session.md', '# Session')
+      const dreamStateService = makePendingMergeStateService([
+        {mergeTarget: 'auth/login.md', reason: 'Share session state docs', sourceFile: 'auth/session.md', suggestedByDreamId: 'drm-prev'},
+      ])
+
+      await consolidate(['auth/login.md'], {...deps, dreamStateService})
+
+      const prompt = agent.executeOnSession.firstCall.args[1] as string
+      expect(prompt).to.include('auth/session.md')
+      expect(prompt).to.include('auth/login.md')
+      expect(prompt).to.include('Share session state docs')
+    })
+
+    it('is a no-op when dreamStateService is not provided (backwards compatible)', async () => {
+      await createMdFile(ctxDir, 'auth/login.md', '# Login')
+
+      // No dreamStateService in deps — should not throw, should proceed normally
+      const results = await consolidate(['auth/login.md'], deps)
+      expect(results).to.deep.equal([])
+    })
+
+    it('is a no-op when pendingMerges is empty', async () => {
+      await createMdFile(ctxDir, 'auth/login.md', '# Login')
+      const dreamStateService = makePendingMergeStateService([])
+
+      await consolidate(['auth/login.md'], {...deps, dreamStateService})
+
+      // No write needed when there's nothing to clear
+      expect(dreamStateService.write.called).to.be.false
+    })
   })
 })

--- a/test/unit/infra/executor/dream-executor.test.ts
+++ b/test/unit/infra/executor/dream-executor.test.ts
@@ -9,8 +9,43 @@ import type {ICipherAgent} from '../../../../src/agent/core/interfaces/i-cipher-
 import {EMPTY_DREAM_STATE} from '../../../../src/server/infra/dream/dream-state-schema.js'
 import {DreamExecutor, type DreamExecutorDeps} from '../../../../src/server/infra/executor/dream-executor.js'
 
+/**
+ * Test helper: subclass of DreamExecutor whose runOperations pushes a caller-supplied
+ * list of operations and then throws, so tests can assert that the catch block surfaces
+ * those operations in the partial/error log entry.
+ */
+function makePartialRunExecutor(args: {
+  aborted?: boolean
+  deps: DreamExecutorDeps
+  injected: import('../../../../src/server/infra/dream/dream-log-schema.js').DreamOperation[]
+  throwErr: Error
+}): DreamExecutor {
+  class TestExecutor extends DreamExecutor {
+    protected override async runOperations(opArgs: {
+      agent: ICipherAgent
+      changedFiles: Set<string>
+      contextTreeDir: string
+      logId: string
+      out: import('../../../../src/server/infra/dream/dream-log-schema.js').DreamOperation[]
+      projectRoot: string
+      signal: AbortSignal
+      taskId: string
+    }): Promise<void> {
+      opArgs.out.push(...args.injected)
+      if (args.aborted) {
+        // Simulate the budget timer firing after some ops completed.
+        Object.defineProperty(opArgs.signal, 'aborted', {configurable: true, value: true})
+      }
+
+      throw args.throwErr
+    }
+  }
+
+  return new TestExecutor(args.deps)
+}
+
 describe('DreamExecutor', () => {
-  let dreamStateService: {read: SinonStub; write: SinonStub}
+  let dreamStateService: {read: SinonStub; update: SinonStub; write: SinonStub}
   let dreamLogStore: {getNextId: SinonStub; save: SinonStub}
   let dreamLockService: {release: SinonStub; rollback: SinonStub}
   let curateLogStore: {getNextId: SinonStub; list: SinonStub; save: SinonStub}
@@ -26,6 +61,14 @@ describe('DreamExecutor', () => {
   beforeEach(() => {
     dreamStateService = {
       read: stub().resolves({...EMPTY_DREAM_STATE, pendingMerges: []}),
+      // Default update implementation: read → updater → write, mirroring the real
+      // service so tests that count write.callCount stay valid without changes.
+      update: stub().callsFake(async (updater: (state: import('../../../../src/server/infra/dream/dream-state-schema.js').DreamState) => import('../../../../src/server/infra/dream/dream-state-schema.js').DreamState) => {
+        const current = await dreamStateService.read()
+        const next = updater(current)
+        await dreamStateService.write(next)
+        return next
+      }),
       write: stub().resolves(),
     }
     dreamLogStore = {
@@ -225,22 +268,37 @@ describe('DreamExecutor', () => {
       expect(listArgs.status).to.deep.equal(['completed'])
     })
 
-    it('preserves pending merges and version in updated dream state', async () => {
-      const pendingMerge = {mergeTarget: 'target.md', sourceFile: 'source.md'}
-      dreamStateService.read.resolves({
+    it('clears pendingMerges consumed by consolidate and preserves version in the post-dream state write', async () => {
+      // After ENG-2126 fix #3, consolidate consumes pendingMerges up-front (writes
+      // pendingMerges=[] to state) so they are not re-applied in the next dream.
+      // Step 7's write then inherits the cleared value from the re-read.
+      const pendingMerge = {mergeTarget: 'target.md', reason: 'Overlap', sourceFile: 'source.md', suggestedByDreamId: 'drm-prev'}
+
+      // Dynamic stub — read() returns the latest write so later steps see the
+      // consumed state (mirrors real disk-backed service semantics).
+      let currentState: import('../../../../src/server/infra/dream/dream-state-schema.js').DreamState = {
         ...EMPTY_DREAM_STATE,
         curationsSinceDream: 3,
         pendingMerges: [pendingMerge],
         totalDreams: 1,
         version: 1,
+      }
+      dreamStateService.read.callsFake(async () => currentState)
+      dreamStateService.write.callsFake(async (state: import('../../../../src/server/infra/dream/dream-state-schema.js').DreamState) => {
+        currentState = state
       })
 
       const executor = new DreamExecutor(deps)
       await executor.executeWithAgent(agent, defaultOptions)
 
-      const writtenState = dreamStateService.write.firstCall.args[0]
-      expect(writtenState.version).to.equal(1)
-      expect(writtenState.pendingMerges).to.deep.equal([pendingMerge])
+      // First write comes from consolidate's consumption step.
+      const consumeWrite = dreamStateService.write.firstCall.args[0]
+      expect(consumeWrite.pendingMerges).to.deep.equal([])
+
+      // Final (step 7) write preserves version and carries the cleared pendingMerges forward.
+      const finalWrite = dreamStateService.write.lastCall.args[0]
+      expect(finalWrite.version).to.equal(1)
+      expect(finalWrite.pendingMerges).to.deep.equal([])
     })
 
     it('propagates trigger value from options to log entry', async () => {
@@ -434,6 +492,92 @@ describe('DreamExecutor', () => {
       } finally {
         rmSync(projectRoot, {force: true, recursive: true})
       }
+    })
+
+    // ==========================================================================
+    // Partial / error log preservation (ENG-2126 fix #2)
+    // ==========================================================================
+
+    describe('partial / error log preservation', () => {
+      const reviewableOp: import('../../../../src/server/infra/dream/dream-log-schema.js').DreamOperation = {
+        action: 'MERGE',
+        inputFiles: ['auth/a.md', 'auth/b.md'],
+        needsReview: true,
+        outputFile: 'auth/a.md',
+        previousTexts: {'auth/a.md': '# a before', 'auth/b.md': '# b before'},
+        reason: 'Duplicate concepts',
+        type: 'CONSOLIDATE',
+      }
+
+      it('preserves partial operations in the partial log entry when the budget aborts', async () => {
+        const executor = makePartialRunExecutor({
+          aborted: true,
+          deps,
+          injected: [reviewableOp],
+          throwErr: new Error('timeout'),
+        })
+
+        try {
+          await executor.executeWithAgent(agent, defaultOptions)
+          expect.fail('should have thrown')
+        } catch {
+          // expected
+        }
+
+        // Find the partial save (last dream log save with status=partial)
+        const dreamLogSaves = dreamLogStore.save.getCalls().map((c) => c.args[0])
+        const partial = dreamLogSaves.find((e) => e.status === 'partial')
+        expect(partial, 'expected a partial log entry').to.exist
+        expect(partial!.operations, 'partial operations should be preserved').to.deep.equal([reviewableOp])
+        expect(partial!.summary.consolidated).to.equal(1)
+        expect(partial!.summary.flaggedForReview).to.equal(1)
+        expect(partial!.abortReason).to.include('Budget exceeded')
+      })
+
+      it('preserves partial operations in the error log entry on non-abort errors', async () => {
+        const executor = makePartialRunExecutor({
+          aborted: false,
+          deps,
+          injected: [reviewableOp],
+          throwErr: new Error('disk full'),
+        })
+
+        try {
+          await executor.executeWithAgent(agent, defaultOptions)
+          expect.fail('should have thrown')
+        } catch {
+          // expected
+        }
+
+        const dreamLogSaves = dreamLogStore.save.getCalls().map((c) => c.args[0])
+        const errorEntry = dreamLogSaves.find((e) => e.status === 'error')
+        expect(errorEntry, 'expected an error log entry').to.exist
+        expect(errorEntry!.operations, 'error operations should be preserved').to.deep.equal([reviewableOp])
+        expect(errorEntry!.summary.consolidated).to.equal(1)
+        expect(errorEntry!.summary.flaggedForReview).to.equal(1)
+        expect(errorEntry!.error).to.include('disk full')
+      })
+
+      it('surfaces review-flagged ops from a partial run into the curate review log', async () => {
+        const executor = makePartialRunExecutor({
+          aborted: false,
+          deps,
+          injected: [reviewableOp],
+          throwErr: new Error('disk full'),
+        })
+
+        try {
+          await executor.executeWithAgent(agent, defaultOptions)
+        } catch {
+          // expected
+        }
+
+        // createReviewEntries should have been invoked for the completed review-flagged op
+        expect(curateLogStore.save.called, 'expected review entry to be created for partial run').to.be.true
+        const reviewEntry = curateLogStore.save.firstCall.args[0]
+        expect(reviewEntry.operations).to.have.lengthOf(1)
+        expect(reviewEntry.operations[0].reviewStatus).to.equal('pending')
+      })
     })
   })
 })

--- a/test/unit/infra/executor/dream-executor.test.ts
+++ b/test/unit/infra/executor/dream-executor.test.ts
@@ -578,6 +578,47 @@ describe('DreamExecutor', () => {
         expect(reviewEntry.operations).to.have.lengthOf(1)
         expect(reviewEntry.operations[0].reviewStatus).to.equal('pending')
       })
+
+      it('does NOT duplicate review entries when step 7 (state update) throws after success-path review writes', async () => {
+        // Regression for Codex P2: success-path createReviewEntries (after the
+        // completed log save) writes review entries; if the subsequent
+        // dreamStateService.update throws, control jumps to catch, which would
+        // re-invoke createReviewEntries on the same allOperations, producing
+        // duplicate entries in `brv review pending`.
+        dreamStateService.update.rejects(new Error('state.json EROFS'))
+
+        const executor = new DreamExecutor(deps)
+        const createReviewEntries = stub().resolves()
+        ;(executor as unknown as {createReviewEntries: SinonStub}).createReviewEntries = createReviewEntries
+
+        // Inject a single completed reviewable op via a runOperations override
+        ;(executor as unknown as {
+          runOperations: (args: {
+            agent: ICipherAgent
+            changedFiles: Set<string>
+            contextTreeDir: string
+            logId: string
+            out: import('../../../../src/server/infra/dream/dream-log-schema.js').DreamOperation[]
+            projectRoot: string
+            signal: AbortSignal
+            taskId: string
+          }) => Promise<void>
+        }).runOperations = async (args) => {
+          args.out.push(reviewableOp)
+        }
+
+        try {
+          await executor.executeWithAgent(agent, defaultOptions)
+          expect.fail('should have thrown')
+        } catch {
+          // expected (state.json EROFS)
+        }
+
+        expect(
+          createReviewEntries.callCount,
+          'createReviewEntries must run exactly once when step 7 throws after success-path review write',
+        ).to.equal(1)
+      })
     })
   })
 })

--- a/test/unit/infra/process/task-router.test.ts
+++ b/test/unit/infra/process/task-router.test.ts
@@ -501,6 +501,84 @@ describe('TaskRouter', () => {
 
       expect((agentPool.submitTask as SinonStub).calledOnce).to.be.true
     })
+
+    it('does NOT decrement agentPool.activeTasks counter when pre-check skips (the task was never submitted)', async () => {
+      // Regression for Codex P1: handleTaskCompleted unconditionally calls
+      // agentPool.notifyTaskCompleted, which decrements activeTasks. For a
+      // pre-dispatch skip the task never reached the pool, so notifying would
+      // undercount real load and let drainQueue dispatch an extra queued task.
+      const preDispatchCheck = sandbox.stub().resolves({eligible: false, skipResult: 'Dream skipped: Queue not empty (3 tasks pending)'})
+
+      router = new TaskRouter({
+        agentPool,
+        getAgentForProject,
+        preDispatchCheck,
+        projectRegistry,
+        projectRouter,
+        transport: transportHelper.transport,
+      })
+      router.setup()
+
+      const handler = transportHelper.requestHandlers.get(TransportTaskEventNames.CREATE)
+      const request = makeTaskCreateRequest({type: 'dream'})
+      await handler!(request, 'client-1')
+
+      expect(agentPool.notifyTaskCompleted.called, 'pre-check skip must not notify the agent pool').to.be.false
+    })
+
+    it('does NOT fire onTaskCompleted lifecycle hooks when pre-check skips', async () => {
+      // Regression for RyanNg #5: hooks that act on completed tasks (metrics,
+      // counters) should not see pre-check skips as completions.
+      const hookOnCompleted = sandbox.stub().resolves()
+      const preDispatchCheck = sandbox.stub().resolves({eligible: false, skipResult: 'Dream skipped: Queue not empty (1 task pending)'})
+      const hookHelper = makeStubTransportServer(sandbox)
+
+      const routerWithHooks = new TaskRouter({
+        agentPool,
+        getAgentForProject,
+        lifecycleHooks: [{onTaskCompleted: hookOnCompleted}],
+        preDispatchCheck,
+        projectRegistry,
+        projectRouter,
+        transport: hookHelper.transport,
+      })
+      routerWithHooks.setup()
+
+      const handler = hookHelper.requestHandlers.get(TransportTaskEventNames.CREATE)
+      const request = makeTaskCreateRequest({type: 'dream'})
+      await handler!(request, 'client-1')
+
+      // Allow async hook chain to flush
+      await new Promise((resolve) => {
+        setTimeout(resolve, 10)
+      })
+
+      expect(hookOnCompleted.called, 'onTaskCompleted must not fire for pre-check skips').to.be.false
+    })
+
+    it('still broadcasts task:completed to the project room on pre-check skip (so REPL/TUI see it)', async () => {
+      const preDispatchCheck = sandbox.stub().resolves({eligible: false, skipResult: 'Dream skipped: Queue not empty (1 task pending)'})
+
+      router = new TaskRouter({
+        agentPool,
+        getAgentForProject,
+        preDispatchCheck,
+        projectRegistry,
+        projectRouter,
+        transport: transportHelper.transport,
+      })
+      router.setup()
+
+      const handler = transportHelper.requestHandlers.get(TransportTaskEventNames.CREATE)
+      const request = makeTaskCreateRequest({type: 'dream'})
+      await handler!(request, 'client-1')
+
+      const broadcastCall = projectRouter.broadcastToProject.getCalls().find(
+        (c) => c.args[1] === TransportTaskEventNames.COMPLETED,
+      )
+      expect(broadcastCall, 'project room should still see task:completed for skips').to.exist
+      expect(broadcastCall!.args[2].result).to.equal('Dream skipped: Queue not empty (1 task pending)')
+    })
   })
 
   // ==========================================================================

--- a/test/unit/infra/process/task-router.test.ts
+++ b/test/unit/infra/process/task-router.test.ts
@@ -418,6 +418,92 @@ describe('TaskRouter', () => {
   })
 
   // ==========================================================================
+  // preDispatchCheck (ENG-2126 fix #4)
+  // ==========================================================================
+
+  describe('preDispatchCheck', () => {
+    it('dispatches to agent pool when check resolves eligible', async () => {
+      const preDispatchCheck = sandbox.stub().resolves({eligible: true})
+
+      router = new TaskRouter({
+        agentPool,
+        getAgentForProject,
+        preDispatchCheck,
+        projectRegistry,
+        projectRouter,
+        transport: transportHelper.transport,
+      })
+      router.setup()
+
+      const handler = transportHelper.requestHandlers.get(TransportTaskEventNames.CREATE)
+      const request = makeTaskCreateRequest({type: 'dream'})
+      await handler!(request, 'client-1')
+
+      expect(preDispatchCheck.calledOnce, 'preDispatchCheck should be invoked').to.be.true
+      expect((agentPool.submitTask as SinonStub).calledOnce, 'eligible task should reach the agent pool').to.be.true
+    })
+
+    it('short-circuits to task:completed with skip reason when check resolves ineligible', async () => {
+      const preDispatchCheck = sandbox.stub().resolves({eligible: false, skipResult: 'Dream skipped: Queue not empty (2 tasks pending)'})
+
+      router = new TaskRouter({
+        agentPool,
+        getAgentForProject,
+        preDispatchCheck,
+        projectRegistry,
+        projectRouter,
+        transport: transportHelper.transport,
+      })
+      router.setup()
+
+      const handler = transportHelper.requestHandlers.get(TransportTaskEventNames.CREATE)
+      const request = makeTaskCreateRequest({type: 'dream'})
+      await handler!(request, 'client-1')
+
+      // Agent pool never receives the task
+      expect((agentPool.submitTask as SinonStub).called, 'ineligible task must not reach the agent pool').to.be.false
+
+      // Client receives task:completed with the skip reason
+      const completedCall = (transportHelper.transport.sendTo as SinonStub).getCalls().find(
+        (c) => c.args[0] === 'client-1' && c.args[1] === TransportTaskEventNames.COMPLETED,
+      )
+      expect(completedCall, 'expected task:completed to be sent').to.exist
+      expect(completedCall!.args[2].result).to.equal('Dream skipped: Queue not empty (2 tasks pending)')
+      expect(completedCall!.args[2].taskId).to.equal(request.taskId)
+    })
+
+    it('falls through to dispatch when check throws (fail-open)', async () => {
+      const preDispatchCheck = sandbox.stub().rejects(new Error('state read failed'))
+
+      router = new TaskRouter({
+        agentPool,
+        getAgentForProject,
+        preDispatchCheck,
+        projectRegistry,
+        projectRouter,
+        transport: transportHelper.transport,
+      })
+      router.setup()
+
+      const handler = transportHelper.requestHandlers.get(TransportTaskEventNames.CREATE)
+      const request = makeTaskCreateRequest({type: 'dream'})
+      await handler!(request, 'client-1')
+
+      // Errors in pre-check must not block dispatch — agent's own gate check is the fallback
+      expect((agentPool.submitTask as SinonStub).calledOnce, 'fail-open: task should still reach the agent').to.be.true
+    })
+
+    it('is skipped when no preDispatchCheck is configured', async () => {
+      // default router in beforeEach has no preDispatchCheck
+      const handler = transportHelper.requestHandlers.get(TransportTaskEventNames.CREATE)
+      const request = makeTaskCreateRequest({type: 'dream'})
+      await handler!(request, 'client-1')
+
+      expect((agentPool.submitTask as SinonStub).calledOnce).to.be.true
+    })
+  })
+
+  // ==========================================================================
   // Task Lifecycle
   // ==========================================================================
 


### PR DESCRIPTION
## Summary

- **Problem:** Four implementation gaps in `proj/dreaming` where the shipped code violated the spec at `notes/byterover-dream/`. All filed together because they share the same project surface and are all "spec says X, code does Y" bugs: counter race in the curation gate, `pendingMerges` never consumed by the next consolidate, queue gate (Gate 3) bypassed on the CLI dispatch path, and partial/error dreams losing the operations audit trail (which also broke `brv dream --undo` for partial runs).
- **Why it matters:** Auto-dream at agent-idle could silently fail to trigger; prune's `MERGE_INTO` suggestions silently lingered forever; `brv dream` competed with queued tasks instead of yielding; and a dream that committed real merges before timing out left the context tree modified with no audit trail and no recovery path.
- **What changed:** Generic `update(updater)` on `DreamStateService` backed by a per-file mutex, with all dream-state RMW callers (`incrementCurationCount`, executor's step-7 reset, consolidate's `pendingMerges` clear) routed through it; `loadAndClearPendingMerges()` consumer at the start of consolidate per `notes/byterover-dream/6-dream-undo-and-cross-cycle.md:89-143`; `preDispatchCheck` hook on `TaskRouter` so the daemon pre-checks gate 3 on the CLI path (matching the existing idle-trigger pre-check); `allOperations` accumulator hoisted above the try block so partial/error log entries carry the ops that did complete, with `createReviewEntries` invoked for partial dreams.
- **What did NOT change (scope boundary):** Dream operation semantics (consolidate / synthesize / prune behavior), gate definitions and ordering, dream-log schema, undo schema, CLI surface, oclif command flags. The 4 fixes are surgical — no refactor of surrounding code.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [ ] Agent / Tools
- [ ] LLM Providers
- [x] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes #
- Related # — Linear `ENG-2126` ([link](https://linear.app/byterover/issue/ENG-2126/dream-fix-4-post-merge-spec-violation-gaps-counter-race-pendingmerges)); stacks on `proj/dreaming` after #432 (ENG-2128)

## Root cause (bug fixes only, otherwise write `N/A`)

- **Root cause:**
  - **Issue 1 (counter race):** `incrementCurationCount` did unguarded read-modify-write on `dream-state.json`. Comment at `dream-state-service.ts:27-28` claimed "single-writer assumption" but `AGENT_MAX_CONCURRENT_TASKS=5` (`constants.ts:94`) allows up to 5 parallel curates per project — increments were lost to last-writer-wins. Two adjacent RMW sites (executor step-7 reset, consolidate pendingMerges clear) had the same race shape.
  - **Issue 2 (pendingMerges):** `prune.ts:417-424` wrote `SUGGEST_MERGE` decisions into `dreamState.pendingMerges` for the next dream's Consolidate to pick up — the consumer was specified in `notes/byterover-dream/6-dream-undo-and-cross-cycle.md:89-143` but never wired in `consolidate.ts`. Entries sat in state forever.
  - **Issue 3 (queue gate):** `agent-process.ts:513` constructed `DreamTrigger` with `getQueueLength: () => 0` and a comment "this task is the only active one" — false under `AGENT_MAX_CONCURRENT_TASKS=5`. The idle-trigger path pre-checked gates 1-3 in `brv-server.ts:260` before dispatch, but the CLI path went straight through with the agent-side gate 3 effectively disabled.
  - **Issue 4 (partial-log):** `dream-executor.ts:149` declared `allOperations` *after* the three op awaits; the catch handler had nothing to reference and hardcoded `operations:[]` and `summary:zeroes`. A consolidate that committed real merges followed by a synthesize timeout left files modified with no log record and `brv dream --undo` as a no-op.
- **Why this was not caught earlier:**
  - **Issue 1:** Per-test mocks satisfy a single-writer assumption that the daemon's concurrency model violates; no concurrent-write regression test existed. The 2 sibling RMW sites (executor + consolidate) needed a follow-up because the original Issue 1 fix only serialized `incrementCurationCount` against itself — flagged by PE review on this branch and addressed in the second-pass commit.
  - **Issue 2:** Spec exists at `notes/byterover-dream/6-...md` but the consumer-side work was lost in the parent ticket split: ENG-2064 (parent) was marked Duplicate after splitting into ENG-2069 (Consolidate) and ENG-2070 (Undo); the cross-cycle consumer fell through the cracks.
  - **Issue 3:** The agent-side comment "this task is the only active one" was technically aspirational and the daemon pre-check looked complete on the path it was tested on (idle); the CLI path's missing pre-check wasn't covered.
  - **Issue 4:** Pre-existing tests covered happy-path success; no regression test exercised the timeout/error path's log contents.

## Test plan

- Coverage added:
  - [x] Unit test
  - [ ] Integration test
  - [x] Manual verification only
- Test file(s):
  - `test/unit/infra/dream/dream-state-service.test.ts` — concurrent-increment + `update()` race regressions
  - `test/unit/infra/dream/operations/consolidate.test.ts` — `pendingMerges consumption` describe block (6 tests)
  - `test/unit/infra/executor/dream-executor.test.ts` — partial-log preservation on budget abort + non-abort error + review entries from partial
  - `test/unit/infra/process/task-router.test.ts` — eligible dispatch, ineligible short-circuit with skip reason, pre-check fail-open, no-op when absent
- Key scenario(s) covered:
  - **Counter race:** 10x and 20x interleaved increments via alternating `DreamStateService` instances + interleaved `update()` ↔ `incrementCurationCount` calls — both preserve all writes
  - **pendingMerges:** sourceFile present-on-disk added to `changedFiles`; stale sourceFile silently skipped; pendingMerges cleared after the run regardless of LLM outcome; `mergeTarget`/`reason` surfaced in prompt; no-op when service absent or list empty
  - **Gate 3:** CLI `dream` short-circuits with `Dream skipped: Queue not empty (N tasks pending)`; `--force` bypasses; daemon pre-check errors fail open (agent gates 1+2 still apply)
  - **Partial-log:** budget-abort and non-abort-error log paths both write the accumulated ops + `computeSummary(...)`; review entries created for review-flagged ops that did complete on partial runs

## User-visible changes

None for normal `brv dream` usage — CLI surface, flags, output format, and dream-log schema are unchanged. Behavior changes visible only in edge cases:

- Auto-dream at agent-idle now triggers reliably under concurrent curates (previously could silently miss the activity threshold).
- `brv dream` (no `--force`) prints `Dream skipped: Queue not empty (N tasks pending)` when the agent has queued work, instead of running on top of it.
- `brv dream --undo` now works on partial dreams (previously a no-op when the dream timed out mid-pipeline).
- `dream-log/*.json` for partial/error dreams now contains the operations that did complete (previously `operations: []`).

## Evidence

- **Unit tests:** All 308 dream-related unit tests pass post-rebase (`dream-state-service`, `consolidate`, `synthesize`, `prune`, `dream-executor`, `dream-trigger`, `dream-undo`, `task-router`).
- **Auto-test suite** (`local-auto-test/dreaming/run.sh`): **24/24 scenarios passing** on this branch. Notable:
  - `force-merge`: produces 1 `CONSOLIDATE/MERGE` op as expected
  - `force-synthesize`: produces 1 `SYNTHESIZE/CREATE` op (confidence 1.0, 3 sources from 3 fixture domains)
  - `force-archive`: produces `PRUNE/ARCHIVE` op, file removed and stub created in `_archived/`
- **Interactive verification per issue** (in squash commit message):
  - Issue 1: 5 `brv curate --detach` + `brv dream --force` in parallel → all 5 increments accounted for in `dream-state.json` (4 consumed by the dream, 1 preserved post-step-7-reset)
  - Issue 2: seeded a `pendingMerge` in `dream-state.json`, ran `brv dream --force` — first `CONSOLIDATE` op was the `sourceFile → mergeTarget` pair, `pendingMerges` cleared after the run
  - Issue 3: 8 parallel curates (overflow the 5-slot agent pool so 3 queue), immediately ran `brv dream` → `Dream skipped: Queue not empty (3 tasks pending)`. Once queue drained, the same `brv dream` completed normally
  - Issue 4: 3 regression tests force budget abort + non-abort error, asserting partial log + review-entry creation

## Checklist

- [x] Tests added or updated and passing (`npm test`)
- [x] Lint passes (`npm run lint` — 0 errors; 186 pre-existing warnings unrelated to this PR)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated (N/A — no user-facing CLI/schema change)
- [x] No breaking changes
- [x] Branch is up to date with `main` — branch is rebased on the latest `proj/dreaming` (which is itself ahead of `main` via the dreaming feature work)

## Risks and mitigations

- **Risk:** `preDispatchCheck` hook fail-open posture for gate 3 (Issue 3). If the daemon's gate-3 check throws, the dream proceeds anyway.
  - **Mitigation:** Fail-open is intentional — gate 3 is a UX nicety (yield to busy queues), not a safety gate. Gates 1 (time) and 2 (activity) remain re-checked at the agent as defense-in-depth, so the only consequence of a fail-open is that one dream may run alongside queued tasks. Lock-based safety (Gate 4) is unaffected.
- **Risk:** Per-file `AsyncMutex` adds a small amount of serialization overhead to dream-state writes (Issue 1).
  - **Mitigation:** The lock is held only for the duration of the read-modify-write window (microseconds in practice). All dream-state writes are already infrequent compared to other agent work. Module-level mutex registry is keyed by absolute file path so independent `DreamStateService` instances pointing at the same project share ordering without affecting other projects.
- **Risk:** Partial-dream review entries may surface ops in `brv review pending` that the user didn't expect to see (Issue 4).
  - **Mitigation:** This is the *intended* behavior per spec (`notes/byterover-dream/6...md:181`): "always write log and update state (even on partial/error)" implies review wiring is preserved. Without this, a partial dream's MERGE that wrote real files would never appear in review. Gated on `allOperations` being non-empty so early failures (zero ops completed) still produce no review entries — the "no log → no review entries" invariant is preserved.