### PR TITLE
chore: Bump veversion to 3.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "coding-assistant",
     "knowledge-management"
   ],
-  "version": "3.6.0",
+  "version": "3.6.1",
   "author": "ByteRover",
   "bin": {
     "brv": "./bin/run.js"


### PR DESCRIPTION
## Summary

- Problem: The 3.6.0 release was built before the GitHub Actions `.env` secret was updated, so the published artifact does not contain the intended bundled environment values.
- Why it matters: Users installing 3.6.0 get a distribution wired to the wrong/stale env, which affects runtime configuration of the CLI.
- What changed: Bumped `package.json` version from 3.6.0 → 3.6.1. Paired with an out-of-band update to the GitHub Actions `.env` secret so the release workflow rebuilds and publishes a corrected artifact.
- What did NOT change (scope boundary): No source code, no behavior, no dependencies, no CI workflow files. Only the version field in `package.json`.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [x] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [ ] Agent / Tools
- [ ] LLM Providers
- [ ] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [x] CI/CD / Infra

## Linked issues

- Closes #N/A
- Related #N/A

## Root cause (bug fixes only, otherwise write `N/A`)

N/A

## Test plan

- Coverage added:
  - [ ] Unit test
  - [ ] Integration test
  - [x] Manual verification only
- Test file(s): none
- Key scenario(s) covered:
  - GitHub Actions release workflow runs on the new tag and produces a 3.6.1 artifact.
  - Installing the published 3.6.1 yields a bundle built with the updated `.env` secret.
  - `brv --version` reports `3.6.1`.

## User-visible changes

- Version string reported by `brv --version` changes from `3.6.0` to `3.6.1`. No other user-visible changes.

## Evidence

- [x] Trace/log snippets
  - GitHub Actions release run for tag `v3.6.1` (link to be attached once the workflow completes).
  - Local `npm run build` output showing version `3.6.1`.

## Checklist

- [x] Tests added or updated and passing (`npm test`) — no code change; existing suite unaffected
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow Conventional Commits format (`chore: bump version to 3.6.1`)
- [ ] Documentation updated (if applicable) — N/A
- [x] No breaking changes
- [x] Branch is up to date with `main`

## Risks and mitigations

- Risk: The updated GitHub Actions `.env` secret contains an incorrect value, producing a broken 3.6.1 artifact.
  - Mitigation: Verify the secret values before merging; smoke-test the published 3.6.1 build (install from the release artifact, run `brv --version` and a basic command) before announcing.
- Risk: 3.6.0 remains published alongside 3.6.1 and users pin to the broken version.
  - Mitigation: Deprecate/remove 3.6.0 on the registry or add a release note pointing users to 3.6.1.
