### PR TITLE
Release/3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable user-facing changes to ByteRover CLI will be documented in this file.
 
+## [3.7.0]
+
+### Added
+- **Intel Mac (darwin-x64) install support** — `curl -fsSL https://byterover.dev/install.sh | sh` now installs on Intel Macs. Previously the installer rejected `darwin-x64` with an Apple-Silicon-only error. CI also publishes a `darwin-x64` tarball alongside the existing `darwin-arm64`, `linux-x64`, and `linux-arm64` builds.
+
+### Fixed
+- **Security dependency update** — Updated `basic-ftp` and `hono` to patch a high-severity npm advisory.
+
 ## [3.6.0]
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "coding-assistant",
     "knowledge-management"
   ],
-  "version": "3.6.1",
+  "version": "3.7.0",
   "author": "ByteRover",
   "bin": {
     "brv": "./bin/run.js"


### PR DESCRIPTION
## Summary

- Problem: Intel Mac users couldn't use the `install.sh` one-liner (it errored out with an Apple-Silicon-only message), and `npm audit` was flagging a high-severity advisory in transitive deps `basic-ftp` and `hono`.
- Why it matters: Intel Macs are still in active use among users and CI runners; blocking them forces an npm install fallback. The security advisory shows up on every fresh install and in downstream security scans.
- What changed: (1) `scripts/install.sh` and the release workflow now accept and publish a `darwin-x64` tarball, and the README lists Intel Mac as supported. (2) `package-lock.json` bumps `basic-ftp` 5.2.2 → 5.3.0 and `hono` 4.12.12 → 4.12.14. (3) Version bumped to 3.7.0 and CHANGELOG updated.
- What did NOT change (scope boundary): No source code in `src/` changed. No CLI command behavior, transport schemas, agent tools, or daemon logic was touched. No direct dependency upgrades — only transitive lockfile bumps.

## Type of change

- [ ] Bug fix
- [x] New feature  *(Intel Mac install target)*
- [ ] Refactor (no behavior change)
- [x] Documentation  *(README + CHANGELOG)*
- [ ] Test
- [x] Chore (build, dependencies, CI)  *(release workflow + lockfile patch + version bump)*

## Scope (select all touched areas)

- [ ] TUI / REPL
- [ ] Agent / Tools
- [ ] LLM Providers
- [ ] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [x] CI/CD / Infra

## Linked issues

- Closes ENG-1674, ENG-2149
- Related #440, #443

## Root cause (bug fixes only, otherwise write `N/A`)

N/A

## Test plan

- Coverage added:
  - [ ] Unit test
  - [ ] Integration test
  - [x] Manual verification only
- Test file(s): N/A — no source changes.
- Key scenario(s) covered:
  - Run `scripts/install.sh` on an Intel Mac (`uname -m` = `x86_64`) and confirm it downloads the `darwin-x64` tarball and `brv --version` prints `3.7.0`.
  - Confirm the `pack-and-release.yml` workflow produces a `darwin-x64` artifact alongside the existing three.
  - `npm ci && npm audit --omit=dev` shows the previously flagged high-severity advisory cleared.
  - Smoke: `npm run build`, `npm run lint`, `npm run typecheck`, `npm test`.

## User-visible changes

- macOS Intel (`darwin-x64`) is now a supported install target via `curl -fsSL https://byterover.dev/install.sh | sh`.
- README "Supported platforms" line now includes "macOS x64 (Intel)".
- No CLI flag, command, output, or config default changed.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording

*Suggested attachments:*
- Terminal capture of `install.sh` succeeding on an Intel Mac (or CI log showing the `darwin-x64` job pass).
- Before/after `npm audit` output showing the high-severity advisory cleared.

## Checklist

- [ ] Tests added or updated and passing (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Type check passes (`npm run typecheck`)
- [ ] Build succeeds (`npm run build`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Documentation updated (if applicable)  *(README + CHANGELOG)*
- [x] No breaking changes (or clearly documented above)
- [ ] Branch is up to date with `main`

## Risks and mitigations

- Risk: `darwin-x64` tarball builds on a different runner image than `darwin-arm64`; the bundled Node + native modules could behave differently on real Intel hardware than in CI.
  - Mitigation: Manually run the published Intel tarball on a real Intel Mac (or a `macos-13` GitHub runner, which is x64) before tagging the release; keep the `darwin-arm64` install path unchanged so existing users aren't affected.
- Risk: `hono` minor bump (4.12.12 → 4.12.14) could shift behavior of any HTTP server code that touches it.
  - Mitigation: Patch-level diff only; smoke-test daemon startup and an MCP tool call locally before merging.
