### PR TITLE
feat: [ENG-2136]  add section 11 for query and curate history

### DIFF
--- a/src/server/templates/skill/SKILL.md
+++ b/src/server/templates/skill/SKILL.md
@@ -452,7 +452,7 @@ Swarm is operational (5/5 providers configured).
 ```
 
 ### 11. Query and Curate History
-**Overview:** Inspect past query and curate operations. Use `brv query-log view` to review query history and `brv curate view` to review curate history. Supports filtering by time, status, and detailed per-operation output.
+**Overview:** Inspect past query and curate operations. Use `brv query-log view` to review query history, `brv curate view` to review curate history, and `brv query-log summary` to see aggregated recall metrics. Supports filtering by time, status, tier, and detailed per-operation output.
 
 **Use this skill when:**
 - You want to review what was queried or curated previously
@@ -460,13 +460,14 @@ Swarm is operational (5/5 providers configured).
 - You want to filter history by time window or completion status
 - You want to collect data for analysis or debugging
 - You want to know what knowledge was added, updated, or deleted over time
+- You want aggregated metrics on query recall, cache hit rate, or knowledge gaps
 
 **Do NOT use this skill when:**
 - You want to run a new query — use `brv query` instead
 - You want to curate new knowledge — use `brv curate` instead
 
 **View curate history:** to check past curations
-- Show recent entries (last 1000)
+- Show recent entries (last 10)
 ```bash
 brv curate view
 ```
@@ -476,7 +477,7 @@ brv curate view cur-1739700001000
 ```
 - List entries with file operations visible (no logId needed)
 ```bash
-brv curate view detail
+brv curate view --detail
 ```
 - Filter by time and status
 ```bash
@@ -487,26 +488,46 @@ brv curate view --since 1h --status completed --limit 1000
 brv curate view --help
 ```
 
-**View query history:** to check past curations
+**View query history:** to check past queries
 - Show recent entries (last 10)
 ```bash
 brv query-log view
 ```
-- Full detail for a specific entry: all files and operations performed (logId is printed by `brv query-log` on completion, e.g. `qry-1739700001000`)
+- Full detail for a specific entry: matched docs and search metadata (logId is printed by `brv query` on completion, e.g. `qry-1739700001000`)
 ```bash
 brv query-log view qry-1739700001000
 ```
-- List entries with file operations visible (no logId needed)
+- List entries with matched docs visible (no logId needed)
 ```bash
-brv query-log view detail
+brv query-log view --detail
 ```
-- Filter by time and status
+- Filter by time, status, or resolution tier (0=exact cache, 1=fuzzy cache, 2=direct search, 3=optimized LLM, 4=full agentic)
 ```bash
 brv query-log view --since 1h --status completed --limit 1000
+brv query-log view --tier 0 --tier 1
 ```
 - For all filter options
 ```bash
 brv query-log view --help
+```
+
+**View query recall metrics:** to see aggregated stats across recent queries
+- Summary for the last 24 hours (default)
+```bash
+brv query-log summary
+```
+- Summary for a specific time window
+```bash
+brv query-log summary --last 7d
+brv query-log summary --since 2026-04-01 --before 2026-04-03
+```
+- Narrative format (human-readable prose report)
+```bash
+brv query-log summary --format narrative
+```
+- For all options
+```bash
+brv query-log summary --help
 ```
 
 ## Data Handling

--- a/src/server/templates/skill/SKILL.md
+++ b/src/server/templates/skill/SKILL.md
@@ -77,28 +77,6 @@ brv curate "Auth uses JWT with 24h expiry. Tokens stored in httpOnly cookies via
 brv curate "Authentication middleware details" -f src/middleware/auth.ts
 ```
 
-**View curate history:** to check past curations
-- Show recent entries (last 10)
-```bash
-brv curate view
-```
-- Full detail for a specific entry: all files and operations performed (logId is printed by `brv curate` on completion, e.g. `cur-1739700001000`)
-```bash
-brv curate view cur-1739700001000
-```
-- List entries with file operations visible (no logId needed)
-```bash
-brv curate view detail
-```
-- Filter by time and status
-```bash
-brv curate view --since 1h --status completed
-```
-- For all filter options
-```bash
-brv curate view --help
-```
-
 ### 4. Review Pending Changes
 **Overview:** After a curate operation, some changes may require human review before being applied. Use `brv review` to list, approve, or reject pending operations.
 
@@ -471,6 +449,64 @@ Write Targets:
   local-markdown:project-docs (note, general)
 
 Swarm is operational (5/5 providers configured).
+```
+
+### 11. Query and Curate History
+**Overview:** Inspect past query and curate operations. Use `brv query-log view` to review query history and `brv curate view` to review curate history. Supports filtering by time, status, and detailed per-operation output.
+
+**Use this skill when:**
+- You want to review what was queried or curated previously
+- You need to inspect a specific operation by logId
+- You want to filter history by time window or completion status
+- You want to collect data for analysis or debugging
+- You want to know what knowledge was added, updated, or deleted over time
+
+**Do NOT use this skill when:**
+- You want to run a new query — use `brv query` instead
+- You want to curate new knowledge — use `brv curate` instead
+
+**View curate history:** to check past curations
+- Show recent entries (last 1000)
+```bash
+brv curate view
+```
+- Full detail for a specific entry: all files and operations performed (logId is printed by `brv curate` on completion, e.g. `cur-1739700001000`)
+```bash
+brv curate view cur-1739700001000
+```
+- List entries with file operations visible (no logId needed)
+```bash
+brv curate view detail
+```
+- Filter by time and status
+```bash
+brv curate view --since 1h --status completed --limit 1000
+```
+- For all filter options
+```bash
+brv curate view --help
+```
+
+**View query history:** to check past curations
+- Show recent entries (last 10)
+```bash
+brv query-log view
+```
+- Full detail for a specific entry: all files and operations performed (logId is printed by `brv query-log` on completion, e.g. `qry-1739700001000`)
+```bash
+brv query-log view qry-1739700001000
+```
+- List entries with file operations visible (no logId needed)
+```bash
+brv query-log view detail
+```
+- Filter by time and status
+```bash
+brv query-log view --since 1h --status completed --limit 1000
+```
+- For all filter options
+```bash
+brv query-log view --help
 ```
 
 ## Data Handling


### PR DESCRIPTION
Moves curate history content from section 3 into a dedicated section 11 (Query and Curate History) alongside query-log history. Adds standard Overview, Use/Do-NOT-use blocks to match the rest of SKILL.md's format.

## Summary

- Problem: Curate history commands were buried inside section 3 (Curate Context) with no dedicated home, and query-log history had no section at all.
- Why it matters: Agents following SKILL.md couldn't easily discover or reason about history inspection commands; the inconsistent structure made the skill harder to parse reliably.
- What changed: Added section 11 "Query and Curate History" with Overview, Use/Do-NOT-use blocks, and both `brv curate view` and `brv query-log view` command references. Removed the curate history block from section 3.
- What did NOT change (scope boundary): No CLI behavior, no code, no tests — documentation only.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [x] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [x] Agent / Tools
- [ ] LLM Providers
- [ ] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes #N/A
- Related #N/A

## Root cause (bug fixes only, otherwise write `N/A`)

N/A

## Test plan

- Coverage added:
  - [ ] Unit test
  - [ ] Integration test
  - [x] Manual verification only
- Test file(s): N/A
- Key scenario(s) covered: Verified section 11 renders correctly and matches the heading/block structure of sections 8–10.

## User-visible changes

Agents using the `byterover` skill will now find history inspection commands under a dedicated section 11 instead of embedded in section 3.

## Evidence

- [x] Trace/log snippets — diff reviewed; section structure confirmed consistent with surrounding sections.

## Checklist

- [x] Tests added or updated and passing (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented above)
- [x] Branch is up to date with `main`

## Risks and mitigations

None — documentation-only change with no runtime impact.