### PR TITLE
feat: [ENG-2145] align E2E env config with runtime contract

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,10 +3,11 @@
     "allow": [
       "WebSearch",
       "Bash(find:*)",
-      "Bash(npm run test:*)",
       "Bash(grep:*)",
+      "Bash(npm run test:*)",
       "Bash(npm run build:*)",
       "Bash(npx mocha:*)",
+      "Bash(npm test:*)",
       "Bash(git log:*)",
       "Bash(git show:*)",
       "mcp__linear__list_issues",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,7 @@ npm run typecheck                    # TypeScript type checking
 
 - **HTTP (nock)**: Must verify `.matchHeader('authorization', ...)` + `.matchHeader('x-byterover-session-id', ...)`
 - **ES Modules**: Cannot stub ES exports with sinon; test utils with real filesystem (`tmpdir()`)
+- **Sinon import**: Use `import * as sinon from 'sinon'` (namespace import) to avoid default-export lint warnings
 
 ## Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ npm run typecheck                    # TypeScript type checking
 
 - **HTTP (nock)**: Must verify `.matchHeader('authorization', ...)` + `.matchHeader('x-byterover-session-id', ...)`
 - **ES Modules**: Cannot stub ES exports with sinon; test utils with real filesystem (`tmpdir()`)
+- **Sinon import**: Use `import * as sinon from 'sinon'` (namespace import) to avoid default-export lint warnings
 
 ## Conventions
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -6,7 +6,22 @@ End-to-end tests that run against real backend services. These tests verify full
 
 - Node.js (same version as the rest of the project)
 - A running backend service (or access to a staging environment)
-- Required environment variables configured.
+- Required environment variables configured (see below)
+
+## Environment Variables
+
+E2E tests use the same variable names as the runtime (see `.env.example`). All are required — there are no hardcoded defaults.
+
+| Variable | Required | Notes |
+|---|---|---|
+| `BRV_E2E_API_KEY` | Yes | Auth gate — tests skip if unset |
+| `BRV_IAM_BASE_URL` | Yes | Root domain only (no path) |
+| `BRV_COGIT_BASE_URL` | Yes | Root domain only (no path) |
+| `BRV_LLM_BASE_URL` | Yes | Root domain only |
+| `BRV_GIT_REMOTE_BASE_URL` | Yes | May include path |
+| `BRV_WEB_APP_URL` | Yes | May include path |
+
+Copy `.env.example` to `.env.development` and fill in your environment's values. The E2E mocha config loads dotenv automatically.
 
 ## Running Tests
 

--- a/test/e2e/helpers/env-guard.test.ts
+++ b/test/e2e/helpers/env-guard.test.ts
@@ -1,0 +1,223 @@
+import {expect} from 'chai'
+import * as sinon from 'sinon'
+
+import type {E2eConfig} from './env-guard.js'
+
+import {getE2eConfig, requireE2eEnv} from './env-guard.js'
+
+describe('E2E env-guard', () => {
+  const URL_VARS = {
+    BRV_COGIT_BASE_URL: 'https://cogit.test',
+    BRV_GIT_REMOTE_BASE_URL: 'https://git.test',
+    BRV_IAM_BASE_URL: 'https://iam.test',
+    BRV_LLM_BASE_URL: 'https://llm.test',
+    BRV_WEB_APP_URL: 'https://app.test',
+  }
+
+  const ALL_KEYS = ['BRV_E2E_API_KEY', ...Object.keys(URL_VARS)]
+  const savedEnvVars: Record<string, string | undefined> = {}
+
+  // Snapshot env vars before the suite so we can restore them after.
+  // This prevents our cleanup from clobbering values that were already
+  // present in the runner's environment (e.g. BRV_E2E_API_KEY in CI).
+  before(() => {
+    for (const key of ALL_KEYS) {
+      savedEnvVars[key] = process.env[key]
+    }
+  })
+
+  // Restore the original env vars so other test files see the same
+  // environment they would have seen without this suite running.
+  after(() => {
+    for (const key of ALL_KEYS) {
+      if (savedEnvVars[key] === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = savedEnvVars[key]
+      }
+    }
+  })
+
+  beforeEach(() => {
+    for (const key of ALL_KEYS) {
+      delete process.env[key]
+    }
+
+    process.env.BRV_E2E_API_KEY = 'test-api-key'
+    for (const [key, value] of Object.entries(URL_VARS)) {
+      process.env[key] = value
+    }
+  })
+
+  afterEach(() => {
+    for (const key of ALL_KEYS) {
+      delete process.env[key]
+    }
+  })
+
+  describe('requireE2eEnv', () => {
+    let consoleStub: sinon.SinonStub
+
+    beforeEach(() => {
+      consoleStub = sinon.stub(console, 'log')
+    })
+
+    afterEach(() => {
+      consoleStub.restore()
+    })
+
+    it('should call this.skip() when BRV_E2E_API_KEY is not set', () => {
+      delete process.env.BRV_E2E_API_KEY
+      const skip = sinon.stub<[], never>()
+
+      requireE2eEnv.call({skip})
+
+      expect(skip.calledOnce).to.be.true
+    })
+
+    it('should not call this.skip() when BRV_E2E_API_KEY is set', () => {
+      const skip = sinon.stub<[], never>()
+
+      requireE2eEnv.call({skip})
+
+      expect(skip.called).to.be.false
+    })
+  })
+
+  describe('getE2eConfig', () => {
+    describe('happy path', () => {
+      it('should return all fields from env vars', () => {
+        const config: E2eConfig = getE2eConfig()
+
+        expect(config.apiKey).to.equal('test-api-key')
+        expect(config.iamBaseUrl).to.equal('https://iam.test')
+        expect(config.cogitBaseUrl).to.equal('https://cogit.test')
+        expect(config.llmBaseUrl).to.equal('https://llm.test')
+        expect(config.gitRemoteBaseUrl).to.equal('https://git.test')
+        expect(config.webAppUrl).to.equal('https://app.test')
+      })
+
+      it('should return all fields as non-empty strings', () => {
+        const config: E2eConfig = getE2eConfig()
+
+        for (const [key, value] of Object.entries(config)) {
+          expect(value, `${key} should be a non-empty string`).to.be.a('string').and.not.empty
+        }
+      })
+    })
+
+    describe('missing required variables', () => {
+      it('should throw when BRV_E2E_API_KEY is missing', () => {
+        delete process.env.BRV_E2E_API_KEY
+
+        expect(() => getE2eConfig()).to.throw('BRV_E2E_API_KEY is required')
+      })
+
+      for (const envVar of Object.keys(URL_VARS)) {
+        it(`should throw when ${envVar} is missing`, () => {
+          delete process.env[envVar]
+
+          expect(() => getE2eConfig()).to.throw(`Missing required environment variable: ${envVar}`)
+        })
+      }
+    })
+
+    describe('root-domain validation', () => {
+      it('should throw when BRV_IAM_BASE_URL contains a path component', () => {
+        process.env.BRV_IAM_BASE_URL = 'https://iam.test/api/v1'
+
+        expect(() => getE2eConfig()).to.throw('BRV_IAM_BASE_URL must not include a path component')
+      })
+
+      it('should throw when BRV_COGIT_BASE_URL contains a path component', () => {
+        process.env.BRV_COGIT_BASE_URL = 'https://cogit.test/api/v1'
+
+        expect(() => getE2eConfig()).to.throw('BRV_COGIT_BASE_URL must not include a path component')
+      })
+
+      it('should allow paths on BRV_GIT_REMOTE_BASE_URL', () => {
+        process.env.BRV_GIT_REMOTE_BASE_URL = 'https://git.test/some/path'
+
+        const config: E2eConfig = getE2eConfig()
+
+        expect(config.gitRemoteBaseUrl).to.equal('https://git.test/some/path')
+      })
+
+      it('should allow paths on BRV_WEB_APP_URL', () => {
+        process.env.BRV_WEB_APP_URL = 'https://app.test/some/path'
+
+        const config: E2eConfig = getE2eConfig()
+
+        expect(config.webAppUrl).to.equal('https://app.test/some/path')
+      })
+    })
+
+    describe('normalization', () => {
+      it('should strip trailing slashes from all URL fields', () => {
+        process.env.BRV_IAM_BASE_URL = 'https://iam.test/'
+        process.env.BRV_COGIT_BASE_URL = 'https://cogit.test/'
+        process.env.BRV_LLM_BASE_URL = 'https://llm.test/'
+        process.env.BRV_GIT_REMOTE_BASE_URL = 'https://git.test/'
+        process.env.BRV_WEB_APP_URL = 'https://app.test/'
+
+        const config: E2eConfig = getE2eConfig()
+
+        expect(config.iamBaseUrl).to.equal('https://iam.test')
+        expect(config.cogitBaseUrl).to.equal('https://cogit.test')
+        expect(config.llmBaseUrl).to.equal('https://llm.test')
+        expect(config.gitRemoteBaseUrl).to.equal('https://git.test')
+        expect(config.webAppUrl).to.equal('https://app.test')
+      })
+
+      it('should strip multiple consecutive trailing slashes', () => {
+        process.env.BRV_IAM_BASE_URL = 'https://iam.test///'
+
+        const config: E2eConfig = getE2eConfig()
+
+        expect(config.iamBaseUrl).to.equal('https://iam.test')
+      })
+
+      it('should trim whitespace from env var values', () => {
+        process.env.BRV_IAM_BASE_URL = '  https://iam.test  '
+        process.env.BRV_COGIT_BASE_URL = '  https://cogit.test  '
+
+        const config: E2eConfig = getE2eConfig()
+
+        expect(config.iamBaseUrl).to.equal('https://iam.test')
+        expect(config.cogitBaseUrl).to.equal('https://cogit.test')
+      })
+    })
+
+    describe('variable name alignment', () => {
+      it('should read from BRV_IAM_BASE_URL, not BRV_API_BASE_URL', () => {
+        process.env.BRV_IAM_BASE_URL = 'https://iam.correct'
+        process.env.BRV_API_BASE_URL = 'https://iam.wrong'
+
+        const config: E2eConfig = getE2eConfig()
+
+        expect(config.iamBaseUrl).to.equal('https://iam.correct')
+        delete process.env.BRV_API_BASE_URL
+      })
+
+      it('should read from BRV_COGIT_BASE_URL, not BRV_COGIT_API_BASE_URL', () => {
+        process.env.BRV_COGIT_BASE_URL = 'https://cogit.correct'
+        process.env.BRV_COGIT_API_BASE_URL = 'https://cogit.wrong'
+
+        const config: E2eConfig = getE2eConfig()
+
+        expect(config.cogitBaseUrl).to.equal('https://cogit.correct')
+        delete process.env.BRV_COGIT_API_BASE_URL
+      })
+
+      it('should read from BRV_LLM_BASE_URL, not BRV_LLM_API_BASE_URL', () => {
+        process.env.BRV_LLM_BASE_URL = 'https://llm.correct'
+        process.env.BRV_LLM_API_BASE_URL = 'https://llm.wrong'
+
+        const config: E2eConfig = getE2eConfig()
+
+        expect(config.llmBaseUrl).to.equal('https://llm.correct')
+        delete process.env.BRV_LLM_API_BASE_URL
+      })
+    })
+  })
+})

--- a/test/e2e/helpers/env-guard.test.ts
+++ b/test/e2e/helpers/env-guard.test.ts
@@ -190,33 +190,42 @@ describe('E2E env-guard', () => {
 
     describe('variable name alignment', () => {
       it('should read from BRV_IAM_BASE_URL, not BRV_API_BASE_URL', () => {
-        process.env.BRV_IAM_BASE_URL = 'https://iam.correct'
-        process.env.BRV_API_BASE_URL = 'https://iam.wrong'
+        try {
+          process.env.BRV_IAM_BASE_URL = 'https://iam.correct'
+          process.env.BRV_API_BASE_URL = 'https://iam.wrong'
 
-        const config: E2eConfig = getE2eConfig()
+          const config: E2eConfig = getE2eConfig()
 
-        expect(config.iamBaseUrl).to.equal('https://iam.correct')
-        delete process.env.BRV_API_BASE_URL
+          expect(config.iamBaseUrl).to.equal('https://iam.correct')
+        } finally {
+          delete process.env.BRV_API_BASE_URL
+        }
       })
 
       it('should read from BRV_COGIT_BASE_URL, not BRV_COGIT_API_BASE_URL', () => {
-        process.env.BRV_COGIT_BASE_URL = 'https://cogit.correct'
-        process.env.BRV_COGIT_API_BASE_URL = 'https://cogit.wrong'
+        try {
+          process.env.BRV_COGIT_BASE_URL = 'https://cogit.correct'
+          process.env.BRV_COGIT_API_BASE_URL = 'https://cogit.wrong'
 
-        const config: E2eConfig = getE2eConfig()
+          const config: E2eConfig = getE2eConfig()
 
-        expect(config.cogitBaseUrl).to.equal('https://cogit.correct')
-        delete process.env.BRV_COGIT_API_BASE_URL
+          expect(config.cogitBaseUrl).to.equal('https://cogit.correct')
+        } finally {
+          delete process.env.BRV_COGIT_API_BASE_URL
+        }
       })
 
       it('should read from BRV_LLM_BASE_URL, not BRV_LLM_API_BASE_URL', () => {
-        process.env.BRV_LLM_BASE_URL = 'https://llm.correct'
-        process.env.BRV_LLM_API_BASE_URL = 'https://llm.wrong'
+        try {
+          process.env.BRV_LLM_BASE_URL = 'https://llm.correct'
+          process.env.BRV_LLM_API_BASE_URL = 'https://llm.wrong'
 
-        const config: E2eConfig = getE2eConfig()
+          const config: E2eConfig = getE2eConfig()
 
-        expect(config.llmBaseUrl).to.equal('https://llm.correct')
-        delete process.env.BRV_LLM_API_BASE_URL
+          expect(config.llmBaseUrl).to.equal('https://llm.correct')
+        } finally {
+          delete process.env.BRV_LLM_API_BASE_URL
+        }
       })
     })
   })

--- a/test/e2e/helpers/env-guard.ts
+++ b/test/e2e/helpers/env-guard.ts
@@ -12,7 +12,14 @@ const normalizeUrl = (url: string): string => url.trim().replace(/\/+$/, '')
 
 /** Throws if the URL contains a path component (anything beyond '/'). */
 const assertRootDomain = (name: string, url: string): void => {
-  if (new URL(url).pathname !== '/') {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    throw new Error(`${name} is not a valid URL: "${url}". Provide a full URL including scheme (e.g., https://example.com).`)
+  }
+
+  if (parsed.pathname !== '/') {
     throw new Error(
       `${name} must not include a path component. Provide the root domain only (e.g., https://example.com).`,
     )

--- a/test/e2e/helpers/env-guard.ts
+++ b/test/e2e/helpers/env-guard.ts
@@ -1,10 +1,38 @@
 export type E2eConfig = {
-  apiBaseUrl: string
   apiKey: string
-  cogitApiBaseUrl: string
+  cogitBaseUrl: string
   gitRemoteBaseUrl: string
-  llmApiBaseUrl: string
+  iamBaseUrl: string
+  llmBaseUrl: string
   webAppUrl: string
+}
+
+/** Strips trailing slashes and leading/trailing whitespace from a URL. */
+const normalizeUrl = (url: string): string => url.trim().replace(/\/+$/, '')
+
+/** Throws if the URL contains a path component (anything beyond '/'). */
+const assertRootDomain = (name: string, url: string): void => {
+  if (new URL(url).pathname !== '/') {
+    throw new Error(
+      `${name} must not include a path component. Provide the root domain only (e.g., https://example.com).`,
+    )
+  }
+}
+
+/**
+ * Reads a required environment variable, trims whitespace, and normalizes
+ * trailing slashes. Throws if the variable is missing or empty.
+ */
+const readRequiredEnv = (name: string): string => {
+  const value = process.env[name]?.trim()
+  if (!value) {
+    throw new Error(
+      `Missing required environment variable: ${name}. ` +
+      'Ensure .env.development is loaded via dotenv. See test/e2e/README.md',
+    )
+  }
+
+  return normalizeUrl(value)
 }
 
 /**
@@ -25,20 +53,29 @@ export function requireE2eEnv(this: {skip(): never}): void {
 
 /**
  * Returns typed E2E configuration from environment variables.
- * BRV_E2E_API_KEY is required; all other variables default to dev-beta URLs.
+ *
+ * All variables are required — no hardcoded defaults. Variable names and
+ * validation match the runtime contract in src/server/config/environment.ts.
+ * BRV_IAM_BASE_URL and BRV_COGIT_BASE_URL must be root domains (no path).
  */
-export const getE2eConfig =  (): E2eConfig => {
+export const getE2eConfig = (): E2eConfig => {
   const apiKey = process.env.BRV_E2E_API_KEY
   if (!apiKey) {
     throw new Error('BRV_E2E_API_KEY is required. See test/e2e/README.md')
   }
 
+  const iamBaseUrl = readRequiredEnv('BRV_IAM_BASE_URL')
+  assertRootDomain('BRV_IAM_BASE_URL', iamBaseUrl)
+
+  const cogitBaseUrl = readRequiredEnv('BRV_COGIT_BASE_URL')
+  assertRootDomain('BRV_COGIT_BASE_URL', cogitBaseUrl)
+
   return {
-    apiBaseUrl: process.env.BRV_API_BASE_URL ?? 'https://dev-beta-iam.byterover.dev/api/v1',
     apiKey,
-    cogitApiBaseUrl: process.env.BRV_COGIT_API_BASE_URL ?? 'https://dev-beta-cgit.byterover.dev/api/v1',
-    gitRemoteBaseUrl: process.env.BRV_GIT_REMOTE_BASE_URL ?? 'https://dev-beta.byterover.dev',
-    llmApiBaseUrl: process.env.BRV_LLM_API_BASE_URL ?? 'https://dev-beta-llm.byterover.dev',
-    webAppUrl: process.env.BRV_WEB_APP_URL ?? 'https://dev-beta-app.byterover.dev',
+    cogitBaseUrl,
+    gitRemoteBaseUrl: readRequiredEnv('BRV_GIT_REMOTE_BASE_URL'),
+    iamBaseUrl,
+    llmBaseUrl: readRequiredEnv('BRV_LLM_BASE_URL'),
+    webAppUrl: readRequiredEnv('BRV_WEB_APP_URL'),
   }
 }

--- a/test/e2e/smoke.test.ts
+++ b/test/e2e/smoke.test.ts
@@ -9,9 +9,9 @@ describe('E2E Smoke Test', () => {
     const config = getE2eConfig()
 
     expect(config).to.have.property('apiKey').that.is.a('string').and.is.not.empty
-    expect(config).to.have.property('apiBaseUrl').that.is.a('string').and.is.not.empty
-    expect(config).to.have.property('cogitApiBaseUrl').that.is.a('string').and.is.not.empty
-    expect(config).to.have.property('llmApiBaseUrl').that.is.a('string').and.is.not.empty
+    expect(config).to.have.property('iamBaseUrl').that.is.a('string').and.is.not.empty
+    expect(config).to.have.property('cogitBaseUrl').that.is.a('string').and.is.not.empty
+    expect(config).to.have.property('llmBaseUrl').that.is.a('string').and.is.not.empty
     expect(config).to.have.property('gitRemoteBaseUrl').that.is.a('string').and.is.not.empty
     expect(config).to.have.property('webAppUrl').that.is.a('string').and.is.not.empty
   })


### PR DESCRIPTION
## Summary

- Rename E2E env vars to match runtime contract (`BRV_IAM_BASE_URL`, `BRV_COGIT_BASE_URL`, `BRV_LLM_BASE_URL` instead of the old parallel `BRV_API_BASE_URL`, `BRV_COGIT_API_BASE_URL`, `BRV_LLM_API_BASE_URL`)
- Remove hardcoded dev-beta URL defaults — all URL vars are now required, preventing infrastructure topology leaks in the open-source repo
- Add `normalizeUrl`, `assertRootDomain`, and `readRequiredEnv` to match runtime validation (trailing slash strip, whitespace trim, root-domain enforcement on IAM/Cogit)
- Add 20 unit tests covering happy path, missing vars, root-domain validation, normalization, and variable name alignment

## Test plan

- [x] 20/20 env-guard unit tests pass (`npx mocha --forbid-only "test/e2e/helpers/env-guard.test.ts"`)
- [x] Full test suite passes (6419 passing)
- [x] TypeScript typecheck clean (`npm run typecheck`)
