### PR TITLE
feat: [ENG-2133] add RuntimeSignals Zod schema and types (1/6)

### DIFF
--- a/src/server/core/domain/knowledge/runtime-signals-schema.ts
+++ b/src/server/core/domain/knowledge/runtime-signals-schema.ts
@@ -1,0 +1,61 @@
+/**
+ * Runtime signals — per-machine ranking fields that live in a sidecar store
+ * rather than in shared context-tree markdown frontmatter.
+ *
+ * These fields change on every query (access hit flush) and would otherwise
+ * dirty version control state and cause merge conflicts across teammates.
+ *
+ * Related: `features/runtime-signals/plan.md`
+ */
+
+import {z} from 'zod'
+
+// ---------------------------------------------------------------------------
+// Defaults (used when a path has no sidecar entry yet)
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_IMPORTANCE = 50
+export const DEFAULT_RECENCY = 1
+export const DEFAULT_MATURITY = 'draft' as const
+export const DEFAULT_ACCESS_COUNT = 0
+export const DEFAULT_UPDATE_COUNT = 0
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+export const MaturityTierSchema = z.enum(['core', 'draft', 'validated'])
+
+export const RuntimeSignalsSchema = z.object({
+  accessCount: z.number().int().nonnegative().default(DEFAULT_ACCESS_COUNT),
+  importance: z.number().min(0).max(100).default(DEFAULT_IMPORTANCE),
+  maturity: MaturityTierSchema.default(DEFAULT_MATURITY),
+  recency: z.number().min(0).max(1).default(DEFAULT_RECENCY),
+  updateCount: z.number().int().nonnegative().default(DEFAULT_UPDATE_COUNT),
+})
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type MaturityTier = z.infer<typeof MaturityTierSchema>
+export type RuntimeSignals = z.infer<typeof RuntimeSignalsSchema>
+
+// ---------------------------------------------------------------------------
+// Factories
+// ---------------------------------------------------------------------------
+
+/**
+ * Return a fresh RuntimeSignals with default values.
+ * Used by the sidecar store when a path has no entry yet, and by curate ADD
+ * when seeding a new knowledge file.
+ */
+export function createDefaultRuntimeSignals(): RuntimeSignals {
+  return {
+    accessCount: DEFAULT_ACCESS_COUNT,
+    importance: DEFAULT_IMPORTANCE,
+    maturity: DEFAULT_MATURITY,
+    recency: DEFAULT_RECENCY,
+    updateCount: DEFAULT_UPDATE_COUNT,
+  }
+}

--- a/test/unit/agent/knowledge/runtime-signals-schema.test.ts
+++ b/test/unit/agent/knowledge/runtime-signals-schema.test.ts
@@ -1,0 +1,108 @@
+import {expect} from 'chai'
+
+import {
+  createDefaultRuntimeSignals,
+  DEFAULT_ACCESS_COUNT,
+  DEFAULT_IMPORTANCE,
+  DEFAULT_MATURITY,
+  DEFAULT_RECENCY,
+  DEFAULT_UPDATE_COUNT,
+  RuntimeSignalsSchema,
+} from '../../../../src/server/core/domain/knowledge/runtime-signals-schema.js'
+
+describe('runtime-signals-schema', () => {
+  describe('RuntimeSignalsSchema', () => {
+    it('accepts a fully populated record', () => {
+      const result = RuntimeSignalsSchema.parse({
+        accessCount: 5,
+        importance: 72,
+        maturity: 'validated',
+        recency: 0.8,
+        updateCount: 2,
+      })
+
+      expect(result).to.deep.equal({
+        accessCount: 5,
+        importance: 72,
+        maturity: 'validated',
+        recency: 0.8,
+        updateCount: 2,
+      })
+    })
+
+    it('fills missing fields with defaults when parsing an empty object', () => {
+      const result = RuntimeSignalsSchema.parse({})
+
+      expect(result).to.deep.equal({
+        accessCount: DEFAULT_ACCESS_COUNT,
+        importance: DEFAULT_IMPORTANCE,
+        maturity: DEFAULT_MATURITY,
+        recency: DEFAULT_RECENCY,
+        updateCount: DEFAULT_UPDATE_COUNT,
+      })
+    })
+
+    it('rejects importance above 100', () => {
+      expect(() => RuntimeSignalsSchema.parse({importance: 101})).to.throw()
+    })
+
+    it('rejects importance below 0', () => {
+      expect(() => RuntimeSignalsSchema.parse({importance: -1})).to.throw()
+    })
+
+    it('rejects recency above 1', () => {
+      expect(() => RuntimeSignalsSchema.parse({recency: 1.5})).to.throw()
+    })
+
+    it('rejects recency below 0', () => {
+      expect(() => RuntimeSignalsSchema.parse({recency: -0.1})).to.throw()
+    })
+
+    it('rejects unknown maturity tier', () => {
+      expect(() => RuntimeSignalsSchema.parse({maturity: 'mature'})).to.throw()
+    })
+
+    it('rejects non-integer accessCount', () => {
+      expect(() => RuntimeSignalsSchema.parse({accessCount: 3.5})).to.throw()
+    })
+
+    it('rejects negative accessCount', () => {
+      expect(() => RuntimeSignalsSchema.parse({accessCount: -1})).to.throw()
+    })
+
+    it('rejects non-integer updateCount', () => {
+      expect(() => RuntimeSignalsSchema.parse({updateCount: 3.5})).to.throw()
+    })
+
+    it('rejects negative updateCount', () => {
+      expect(() => RuntimeSignalsSchema.parse({updateCount: -1})).to.throw()
+    })
+  })
+
+  describe('createDefaultRuntimeSignals', () => {
+    it('returns a record with default values for all fields', () => {
+      const defaults = createDefaultRuntimeSignals()
+
+      expect(defaults).to.deep.equal({
+        accessCount: DEFAULT_ACCESS_COUNT,
+        importance: DEFAULT_IMPORTANCE,
+        maturity: DEFAULT_MATURITY,
+        recency: DEFAULT_RECENCY,
+        updateCount: DEFAULT_UPDATE_COUNT,
+      })
+    })
+
+    it('returns a fresh object on each call (not a shared reference)', () => {
+      const a = createDefaultRuntimeSignals()
+      const b = createDefaultRuntimeSignals()
+
+      a.importance = 99
+      expect(b.importance).to.equal(DEFAULT_IMPORTANCE)
+    })
+
+    it('returns values that satisfy the schema', () => {
+      const defaults = createDefaultRuntimeSignals()
+      expect(() => RuntimeSignalsSchema.parse(defaults)).to.not.throw()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Problem: Context-tree markdown files mix semantic knowledge content with per-machine ranking signals (importance, recency, maturity, accessCount, updateCount). Every `brv query` flushes bumped signals back to the markdown, which dirties `brv vc status` and causes merge conflicts when teammates share context trees.
- Why it matters: Noisy version control is a constant friction for users curating in teams. The same file can show "modified" dozens of times in a single session despite no knowledge content changing.
- What changed: This PR is step 1 of 6 — pure additive scaffolding for a sidecar `RuntimeSignals` store. Adds Zod schema, types, default constants, factory function, and unit tests. No existing code is touched.
- What did NOT change (scope boundary): No store implementation, no service wiring, no mutation sites touched, no read paths redirected, no YAML emitter changes. All of those land in commits 2-6.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [ ] Agent / Tools
- [ ] LLM Providers
- [x] Server / Daemon
- [x] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes #
- Related #: part of ENG-2133 runtime signals sidecar series (1/6)

## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause: N/A
- Why this was not caught earlier: N/A

## Test plan

- Coverage added:
  - [x] Unit test
  - [ ] Integration test
  - [ ] Manual verification only
- Test file(s):
  - `test/unit/agent/knowledge/runtime-signals-schema.test.ts`
- Key scenario(s) covered:
  - Full record parse round-trips values exactly
  - Empty object parse fills all defaults
  - Schema rejects importance <0 or >100
  - Schema rejects recency <0 or >1
  - Schema rejects unknown maturity tier
  - Schema rejects non-integer or negative accessCount/updateCount
  - Factory returns a fresh object each call (no shared reference)
  - Factory output satisfies the schema


**Test output:**

**Full suite:** 6431 passing, 16 pending, 0 failing (no regression).

## Checklist

- [x] Tests added or updated and passing (`npm test`)
- [x] Lint passes (`npm run lint`) — 0 errors, 189 pre-existing warnings
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated (if applicable) — N/A
- [x] No breaking changes
- [x] Branch is up to date with `main`

## Risks and mitigations

- Risk: Reviewer may question why this module exists if nothing imports it.
  - Mitigation: PR body and commit message both explicitly state this is 1/6 of a series. The next commit (store implementation) is the first consumer.
- Risk: Field ranges drift from the authoritative logic in `memory-scoring.ts`.
  - Mitigation: Each range was verified field-by-field against source lines (documented in `features/runtime-signals/tasks/commit-01-types-scaffolding.md`). Future changes to bounds in `memory-scoring.ts` will need to propagate here — covered by failing unit tests if values go out of range.
