### PR TITLE
feat: [ENG-2157] add RuntimeSignalStore with atomic update primitive (2/6)

### DIFF
--- a/src/agent/core/interfaces/cipher-services.ts
+++ b/src/agent/core/interfaces/cipher-services.ts
@@ -1,3 +1,4 @@
+import type {IRuntimeSignalStore} from '../../../server/core/interfaces/storage/i-runtime-signal-store.js'
 import type {AgentEventBus, SessionEventBus} from '../../infra/events/event-emitter.js'
 import type {FileSystemService} from '../../infra/file-system/file-system-service.js'
 import type {CompactionService} from '../../infra/llm/context/compaction/compaction-service.js'
@@ -52,6 +53,12 @@ export interface CipherAgentServices {
   messageStorageService: MessageStorageService
   policyEngine: IPolicyEngine
   processService: ProcessService
+  /**
+   * Sidecar store for per-machine ranking signals kept out of the shared
+   * context-tree markdown (importance, recency, maturity, accessCount,
+   * updateCount). Reachable here for future wiring; no consumer uses it yet.
+   */
+  runtimeSignalStore: IRuntimeSignalStore
   sandboxService: ISandboxService
   systemPromptManager: SystemPromptManager
   toolManager: ToolManager

--- a/src/agent/infra/agent/service-initializer.ts
+++ b/src/agent/infra/agent/service-initializer.ts
@@ -18,6 +18,7 @@ import type {CipherAgentServices, SessionServices} from '../../core/interfaces/c
 import type {IContentGenerator} from '../../core/interfaces/i-content-generator.js'
 import type {ValidatedAgentConfig} from './agent-schemas.js'
 
+import { RuntimeSignalStore } from '../../../server/infra/context-tree/runtime-signal-store.js'
 import { createBlobStorage } from '../blob/blob-storage-factory.js'
 import { EnvironmentContextBuilder } from '../environment/environment-context-builder.js'
 import { AgentEventBus, SessionEventBus } from '../events/event-emitter.js'
@@ -305,6 +306,11 @@ export async function createCipherAgentServices(
   const messageStorageService = messageStorage
   const historyStorage = new GranularHistoryStorage(messageStorage)
 
+  // Sidecar store for per-machine ranking signals (importance, recency,
+  // maturity, accessCount, updateCount). Kept out of the context-tree
+  // markdown so query-time bumps don't dirty version-controlled files.
+  const runtimeSignalStore = new RuntimeSignalStore(keyStorage, logger)
+
   // CompactionService for context overflow management
   const tokenizer = new GeminiTokenizer(config.model ?? 'gemini-3-flash-preview')
   const compactionService = new CompactionService(messageStorage, tokenizer, {
@@ -332,6 +338,7 @@ export async function createCipherAgentServices(
     messageStorageService,
     policyEngine,
     processService,
+    runtimeSignalStore,
     sandboxService,
     systemPromptManager,
     toolManager,

--- a/src/server/core/domain/knowledge/runtime-signals-schema.ts
+++ b/src/server/core/domain/knowledge/runtime-signals-schema.ts
@@ -41,6 +41,23 @@ export const RuntimeSignalsSchema = z.object({
 export type MaturityTier = z.infer<typeof MaturityTierSchema>
 export type RuntimeSignals = z.infer<typeof RuntimeSignalsSchema>
 
+/**
+ * Frontmatter fields that remain in context-tree markdown after runtime
+ * signals are moved to the sidecar.
+ *
+ * `createdAt` is immutable. `updatedAt` reflects real content modifications
+ * (set by curate ADD/UPDATE and by MERGE); ranking updates never touch it.
+ */
+export interface SemanticFrontmatter {
+  createdAt?: string
+  keywords: string[]
+  related: string[]
+  summary?: string
+  tags: string[]
+  title?: string
+  updatedAt?: string
+}
+
 // ---------------------------------------------------------------------------
 // Factories
 // ---------------------------------------------------------------------------

--- a/src/server/core/interfaces/storage/i-runtime-signal-store.ts
+++ b/src/server/core/interfaces/storage/i-runtime-signal-store.ts
@@ -1,0 +1,116 @@
+/**
+ * Sidecar store for per-machine ranking signals.
+ *
+ * Keeps `importance`, `recency`, `maturity`, `accessCount`, `updateCount`
+ * out of context-tree markdown frontmatter so that query-time bumps don't
+ * dirty version-controlled files or create merge conflicts across teammates.
+ *
+ * Backed by `IKeyStorage` with composite keys of the form
+ * `["signals", ...pathSegments]`. The relative path is split on `/` so each
+ * segment satisfies the key-storage validation rules.
+ *
+ * All paths are relative to the context tree root (e.g. `auth/jwt-refresh.md`)
+ * using forward slashes, matching how paths flow through the rest of the
+ * knowledge pipeline.
+ *
+ * ## Concurrency guarantees
+ *
+ * Atomicity applies **within a single process**. Two `update` calls on the
+ * same path in the same process serialize via the per-key RWLock inside
+ * `FileKeyStorage` — no lost updates.
+ *
+ * Across processes (daemon + CLI), the per-process locks do not coordinate,
+ * so there is a narrow lost-update window when both processes race a read-
+ * modify-write on the same entry. For ranking signals this is acceptable:
+ * losing one access-hit bump has no correctness impact, only a tiny
+ * ranking drift that the next session self-heals. Do **not** rely on
+ * this interface for data where consistency is required (e.g. identifiers,
+ * counters that must never skip).
+ *
+ * ## Invariants NOT enforced here
+ *
+ * The store accepts any `RuntimeSignals` record that satisfies the schema —
+ * it does not enforce semantic invariants such as the importance ↔ maturity
+ * hysteresis defined by `determineTier`. Callers bumping `importance` must
+ * recompute `maturity` themselves (typically via `determineTier`) as part
+ * of the same updater callback.
+ */
+
+import type {RuntimeSignals} from '../../domain/knowledge/runtime-signals-schema.js'
+
+/**
+ * Pure function that derives the next signals from the current signals.
+ * Called inside an atomic read-modify-write critical section.
+ */
+export type RuntimeSignalsUpdater = (current: RuntimeSignals) => RuntimeSignals
+
+export interface IRuntimeSignalStore {
+  /**
+   * Apply an updater to many entries in parallel.
+   *
+   * Each entry is updated atomically via {@link update}; different paths run
+   * concurrently. Used by the access-hit flush path which accumulates bumps
+   * across many files between index rebuilds.
+   */
+  batchUpdate(updates: Map<string, RuntimeSignalsUpdater>): Promise<void>
+
+  /**
+   * Remove an entry. No-op if the entry does not exist.
+   *
+   * Called when a file is archived or deleted so the sidecar does not retain
+   * orphan records.
+   */
+  delete(relPath: string): Promise<void>
+
+  /**
+   * Read the signals for a path, returning defaults when no entry exists
+   * or when the stored record fails schema validation.
+   *
+   * Never throws and never returns null — callers can treat every path as
+   * having a signal record.
+   */
+  get(relPath: string): Promise<RuntimeSignals>
+
+  /**
+   * Bulk-read signals for a known set of paths.
+   *
+   * Preferred over {@link list} for ranking passes that operate on the
+   * top-N search results: O(N) where N is the number of requested paths,
+   * instead of O(all stored entries). The returned map always has an entry
+   * for every requested path — missing and corrupt records fall back to
+   * defaults, matching {@link get}.
+   */
+  getMany(relPaths: readonly string[]): Promise<Map<string, RuntimeSignals>>
+
+  /**
+   * Snapshot every stored entry as a Map keyed by relative path.
+   *
+   * Intended for administrative passes (diagnostics, orphan pruning) rather
+   * than per-query ranking — use {@link getMany} for that.
+   */
+  list(): Promise<Map<string, RuntimeSignals>>
+
+  /**
+   * Replace the signals for a path with the provided record.
+   *
+   * Used for seeding (curate ADD with defaults) and for operations that
+   * compute a full new record without needing the current value (merge,
+   * restore).
+   */
+  set(relPath: string, signals: RuntimeSignals): Promise<void>
+
+  /**
+   * Atomically read, transform, and write the signals for a path.
+   *
+   * The updater receives the current signals (defaults if none are stored)
+   * and must return the complete replacement record. Runs inside the
+   * per-key lock provided by {@link IKeyStorage.update}, so concurrent
+   * callers on the same path within one process serialize cleanly — no
+   * lost updates. See the interface-level note about cross-process
+   * behaviour.
+   *
+   * Use this for any bump semantics that depend on the current value, e.g.
+   * `accessCount += hits` or `importance = min(100, current + bonus)`.
+   */
+  update(relPath: string, updater: RuntimeSignalsUpdater): Promise<RuntimeSignals>
+}

--- a/src/server/infra/context-tree/runtime-signal-store.ts
+++ b/src/server/infra/context-tree/runtime-signal-store.ts
@@ -1,0 +1,137 @@
+/**
+ * IKeyStorage-backed implementation of {@link IRuntimeSignalStore}.
+ *
+ * Uses composite keys `["signals", ...pathSegments]`. Atomicity within a
+ * single process comes from `IKeyStorage.update`'s per-key RWLock; the
+ * interface docs cover the cross-process caveat.
+ */
+
+import type {IKeyStorage, StorageKey} from '../../../agent/core/interfaces/i-key-storage.js'
+import type {ILogger} from '../../../agent/core/interfaces/i-logger.js'
+import type {
+  IRuntimeSignalStore,
+  RuntimeSignalsUpdater,
+} from '../../core/interfaces/storage/i-runtime-signal-store.js'
+
+import {
+  createDefaultRuntimeSignals,
+  type RuntimeSignals,
+  RuntimeSignalsSchema,
+} from '../../core/domain/knowledge/runtime-signals-schema.js'
+
+const SIGNALS_PREFIX = 'signals'
+
+// TODO(runtime-signals): callers bumping `importance` must recompute
+// `maturity` via `determineTier` in the same updater — the store does not
+// enforce the hysteresis relationship. Audit call sites in commit 3.
+//
+// TODO(runtime-signals): orphan entries accumulate when markdown files are
+// deleted outside curate. Add `pruneOrphans(existingPaths)` when commit 6
+// lands, or expose via a `brv signals clean` admin command.
+
+export class RuntimeSignalStore implements IRuntimeSignalStore {
+  constructor(
+    private readonly keyStorage: IKeyStorage,
+    private readonly logger: ILogger,
+  ) {}
+
+  async batchUpdate(updates: Map<string, RuntimeSignalsUpdater>): Promise<void> {
+    // Different relPaths do not share a per-key lock, so parallel updates
+    // scale naturally. Each individual update remains atomic because
+    // IKeyStorage.update is atomic per key (within one process).
+    await Promise.all(
+      [...updates.entries()].map(([relPath, updater]) => this.update(relPath, updater)),
+    )
+  }
+
+  async delete(relPath: string): Promise<void> {
+    await this.keyStorage.delete(this.signalKey(relPath))
+  }
+
+  async get(relPath: string): Promise<RuntimeSignals> {
+    const raw = await this.keyStorage.get<unknown>(this.signalKey(relPath))
+    return this.validateOrDefault(raw, relPath)
+  }
+
+  async getMany(relPaths: readonly string[]): Promise<Map<string, RuntimeSignals>> {
+    const entries = await Promise.all(
+      relPaths.map(async (relPath) => [relPath, await this.get(relPath)] as const),
+    )
+    return new Map(entries)
+  }
+
+  async list(): Promise<Map<string, RuntimeSignals>> {
+    const entries = await this.keyStorage.listWithValues<unknown>([SIGNALS_PREFIX])
+    const result = new Map<string, RuntimeSignals>()
+
+    for (const entry of entries) {
+      const relPath = this.relPathFromKey(entry.key)
+      if (relPath === null) continue
+      result.set(relPath, this.validateOrDefault(entry.value, relPath))
+    }
+
+    return result
+  }
+
+  async set(relPath: string, signals: RuntimeSignals): Promise<void> {
+    const validated = RuntimeSignalsSchema.parse(signals)
+    await this.keyStorage.set(this.signalKey(relPath), validated)
+  }
+
+  async update(relPath: string, updater: RuntimeSignalsUpdater): Promise<RuntimeSignals> {
+    return this.keyStorage.update<RuntimeSignals>(this.signalKey(relPath), (current) => {
+      // `current` is typed as RuntimeSignals but the underlying value may be
+      // anything the disk held (missing, partial, corrupt). validateOrDefault
+      // coerces it into a valid record before the updater runs.
+      const base = this.validateOrDefault(current, relPath)
+      const merged = updater(base)
+      // Re-validate updater output so a buggy caller cannot land invalid
+      // data (e.g. importance out of range) on disk.
+      return RuntimeSignalsSchema.parse(merged)
+    })
+  }
+
+  /**
+   * Reconstruct the relative path from a `["signals", ...segments]` key.
+   * Returns null for keys that do not belong to this store (defensive against
+   * the remote chance of namespace collisions during listing).
+   */
+  private relPathFromKey(key: StorageKey): null | string {
+    if (key.length < 2 || key[0] !== SIGNALS_PREFIX) return null
+    return key.slice(1).join('/')
+  }
+
+  /**
+   * Encode a relative path into a composite storage key.
+   *
+   * FileKeyStorage rejects `/` inside segments, so each path component
+   * becomes its own segment. Empty components (from leading, trailing, or
+   * consecutive slashes) are dropped so the encoding is insensitive to
+   * path normalization variants.
+   */
+  private signalKey(relPath: string): StorageKey {
+    const segments = relPath.split('/').filter((s) => s.length > 0)
+    return [SIGNALS_PREFIX, ...segments]
+  }
+
+  /**
+   * Coerce an unknown stored value into a valid RuntimeSignals record.
+   *
+   * Missing (`undefined`) yields defaults silently — the common fresh-path
+   * case. Corrupt stored data logs a warning and also falls back to
+   * defaults so callers never have to handle read errors inline.
+   */
+  private validateOrDefault(raw: unknown, relPath: string): RuntimeSignals {
+    if (raw === undefined) {
+      return createDefaultRuntimeSignals()
+    }
+
+    const parsed = RuntimeSignalsSchema.safeParse(raw)
+    if (parsed.success) return parsed.data
+
+    this.logger.warn(
+      `RuntimeSignalStore: discarding corrupt entry for ${relPath}: ${parsed.error.message}`,
+    )
+    return createDefaultRuntimeSignals()
+  }
+}

--- a/test/helpers/mock-factories.ts
+++ b/test/helpers/mock-factories.ts
@@ -44,9 +44,11 @@ import type {IProviderConfigStore} from '../../src/server/core/interfaces/i-prov
 import type {IProviderKeychainStore} from '../../src/server/core/interfaces/i-provider-keychain-store.js'
 import type {IProviderOAuthTokenStore} from '../../src/server/core/interfaces/i-provider-oauth-token-store.js'
 import type {IAuthStateStore} from '../../src/server/core/interfaces/state/i-auth-state-store.js'
+import type {IRuntimeSignalStore} from '../../src/server/core/interfaces/storage/i-runtime-signal-store.js'
 import type {ITransportServer} from '../../src/server/core/interfaces/transport/i-transport-server.js'
 
 import {AuthToken} from '../../src/server/core/domain/entities/auth-token.js'
+import {createDefaultRuntimeSignals} from '../../src/server/core/domain/knowledge/runtime-signals-schema.js'
 
 /**
  * Type aliases for service mocks - balances type safety with readability.
@@ -353,6 +355,52 @@ export function createMockToolScheduler(
 }
 
 /**
+ * Creates an in-memory IRuntimeSignalStore backed by a Map.
+ *
+ * Behaviour mirrors RuntimeSignalStore: get returns defaults for unknown
+ * paths, update runs the updater against the current (or default) record.
+ * No atomicity guarantees are needed at the mock level — tests using this
+ * mock don't exercise concurrent writes.
+ */
+export function createMockRuntimeSignalStore(): IRuntimeSignalStore {
+  const store = new Map<string, ReturnType<typeof createDefaultRuntimeSignals>>()
+
+  const get = async (relPath: string) => store.get(relPath) ?? createDefaultRuntimeSignals()
+
+  return {
+    async batchUpdate(updates) {
+      await Promise.all(
+        [...updates.entries()].map(async ([relPath, updater]) => {
+          const current = await get(relPath)
+          store.set(relPath, updater(current))
+        }),
+      )
+    },
+    async delete(relPath) {
+      store.delete(relPath)
+    },
+    get,
+    async getMany(relPaths) {
+      const entries = await Promise.all(
+        relPaths.map(async (relPath) => [relPath, await get(relPath)] as const),
+      )
+      return new Map(entries)
+    },
+    async list() {
+      return new Map(store)
+    },
+    async set(relPath, signals) {
+      store.set(relPath, signals)
+    },
+    async update(relPath, updater) {
+      const next = updater(await get(relPath))
+      store.set(relPath, next)
+      return next
+    },
+  }
+}
+
+/**
  * Creates a properly-typed mock CipherAgentServices
  *
  * @param agentEventBus - Real or mock AgentEventBus instance
@@ -376,6 +424,7 @@ export function createMockCipherAgentServices(
     messageStorageService: {} as unknown as MessageStorageService,
     policyEngine: createMockPolicyEngine(sandbox),
     processService: createMockProcessService(sandbox),
+    runtimeSignalStore: createMockRuntimeSignalStore(),
     sandboxService: createMockSandboxService(sandbox),
     systemPromptManager: createMockSystemPromptManager(sandbox),
     toolManager: createMockToolManager(sandbox),

--- a/test/unit/agent/knowledge/runtime-signal-store.test.ts
+++ b/test/unit/agent/knowledge/runtime-signal-store.test.ts
@@ -1,0 +1,308 @@
+import {expect} from 'chai'
+import sinon from 'sinon'
+
+import type {ILogger} from '../../../../src/agent/core/interfaces/i-logger.js'
+
+import {FileKeyStorage} from '../../../../src/agent/infra/storage/file-key-storage.js'
+import {
+  createDefaultRuntimeSignals,
+  DEFAULT_IMPORTANCE,
+  type RuntimeSignals,
+} from '../../../../src/server/core/domain/knowledge/runtime-signals-schema.js'
+import {RuntimeSignalStore} from '../../../../src/server/infra/context-tree/runtime-signal-store.js'
+
+function createMockLogger(): ILogger {
+  return {
+    debug: sinon.stub(),
+    error: sinon.stub(),
+    info: sinon.stub(),
+    warn: sinon.stub(),
+  }
+}
+
+async function expectRejected(promise: Promise<unknown>): Promise<void> {
+  let threw = false
+  try {
+    await promise
+  } catch {
+    threw = true
+  }
+
+  expect(threw).to.equal(true)
+}
+
+describe('RuntimeSignalStore', () => {
+  let keyStorage: FileKeyStorage
+  let logger: ILogger
+  let store: RuntimeSignalStore
+
+  beforeEach(async () => {
+    keyStorage = new FileKeyStorage({inMemory: true})
+    await keyStorage.initialize()
+    logger = createMockLogger()
+    store = new RuntimeSignalStore(keyStorage, logger)
+  })
+
+  afterEach(() => {
+    keyStorage.close()
+  })
+
+  describe('get', () => {
+    it('returns defaults for a path with no stored entry', async () => {
+      const result = await store.get('auth/jwt.md')
+      expect(result).to.deep.equal(createDefaultRuntimeSignals())
+    })
+
+    it('returns stored values for a path that was set', async () => {
+      await store.set('auth/jwt.md', {
+        accessCount: 7,
+        importance: 78,
+        maturity: 'validated',
+        recency: 0.6,
+        updateCount: 3,
+      })
+
+      expect(await store.get('auth/jwt.md')).to.deep.equal({
+        accessCount: 7,
+        importance: 78,
+        maturity: 'validated',
+        recency: 0.6,
+        updateCount: 3,
+      })
+    })
+
+    it('returns defaults and logs a warning when stored data is corrupt', async () => {
+      // Seed a corrupt record directly, bypassing the store's set() validation.
+      await keyStorage.set(['signals', 'corrupt.md'], {importance: 'not-a-number'})
+
+      expect(await store.get('corrupt.md')).to.deep.equal(createDefaultRuntimeSignals())
+      expect((logger.warn as sinon.SinonStub).calledOnce).to.equal(true)
+    })
+
+    it('fills missing fields with defaults when a partial record is stored (forward-compat)', async () => {
+      // If a future version adds a new field, existing records should still
+      // read successfully — the Zod schema's per-field defaults cover the gap.
+      await keyStorage.set(['signals', 'partial.md'], {importance: 80})
+
+      expect(await store.get('partial.md')).to.deep.equal({
+        ...createDefaultRuntimeSignals(),
+        importance: 80,
+      })
+    })
+
+    it('handles deeply-nested paths', async () => {
+      await store.set('a/b/c/d/leaf.md', {...createDefaultRuntimeSignals(), importance: 90})
+      expect((await store.get('a/b/c/d/leaf.md')).importance).to.equal(90)
+    })
+  })
+
+  describe('set', () => {
+    it('persists a full record round-trippable via get', async () => {
+      const signals: RuntimeSignals = {...createDefaultRuntimeSignals(), importance: 90, maturity: 'core'}
+      await store.set('auth/jwt.md', signals)
+      expect(await store.get('auth/jwt.md')).to.deep.equal(signals)
+    })
+
+    it('overwrites an existing record entirely', async () => {
+      await store.set('auth/jwt.md', {...createDefaultRuntimeSignals(), importance: 60})
+      await store.set('auth/jwt.md', {...createDefaultRuntimeSignals(), importance: 20})
+
+      expect((await store.get('auth/jwt.md')).importance).to.equal(20)
+    })
+
+    it('rejects invalid records at write time', async () => {
+      const invalid = {...createDefaultRuntimeSignals(), importance: 150}
+      await expectRejected(store.set('auth/jwt.md', invalid))
+    })
+  })
+
+  describe('update', () => {
+    it('seeds defaults when no record exists and applies the updater', async () => {
+      const next = await store.update('auth/jwt.md', (current) => ({
+        ...current,
+        importance: current.importance + 5,
+      }))
+
+      expect(next.importance).to.equal(DEFAULT_IMPORTANCE + 5)
+      expect(next.accessCount).to.equal(0)
+      expect((await store.get('auth/jwt.md')).importance).to.equal(DEFAULT_IMPORTANCE + 5)
+    })
+
+    it('reads the stored record and passes it to the updater', async () => {
+      await store.set('auth/jwt.md', {
+        accessCount: 2,
+        importance: 60,
+        maturity: 'draft',
+        recency: 0.8,
+        updateCount: 1,
+      })
+
+      await store.update('auth/jwt.md', (current) => ({
+        ...current,
+        accessCount: current.accessCount + 3,
+        importance: current.importance + 10,
+      }))
+
+      expect(await store.get('auth/jwt.md')).to.deep.equal({
+        accessCount: 5,
+        importance: 70,
+        maturity: 'draft',
+        recency: 0.8,
+        updateCount: 1,
+      })
+    })
+
+    it('rejects updater output that violates the schema', async () => {
+      await expectRejected(
+        store.update('auth/jwt.md', (current) => ({...current, importance: 150})),
+      )
+    })
+
+    it('serializes concurrent updates on the same path without losing bumps', async () => {
+      // Classic lost-update test: each update reads current and adds 1.
+      // With atomic read-modify-write, the final value reflects every iteration.
+      const iterations = 20
+      await Promise.all(
+        Array.from({length: iterations}, () =>
+          store.update('hot.md', (current) => ({
+            ...current,
+            importance: current.importance + 1,
+          })),
+        ),
+      )
+
+      expect((await store.get('hot.md')).importance).to.equal(DEFAULT_IMPORTANCE + iterations)
+    })
+  })
+
+  describe('batchUpdate', () => {
+    it('applies all updaters and persists the results', async () => {
+      const updates = new Map([
+        ['auth/jwt.md', (c: RuntimeSignals) => ({...c, importance: 70})],
+        ['auth/oauth.md', (c: RuntimeSignals) => ({...c, accessCount: 3, importance: 65})],
+        ['billing/invoices.md', (c: RuntimeSignals) => ({...c, maturity: 'validated' as const})],
+      ])
+
+      await store.batchUpdate(updates)
+
+      expect((await store.get('auth/jwt.md')).importance).to.equal(70)
+      const oauth = await store.get('auth/oauth.md')
+      expect(oauth.importance).to.equal(65)
+      expect(oauth.accessCount).to.equal(3)
+      expect((await store.get('billing/invoices.md')).maturity).to.equal('validated')
+    })
+
+    it('is a no-op for an empty map', async () => {
+      await store.batchUpdate(new Map())
+      expect((await store.list()).size).to.equal(0)
+    })
+
+    it('serializes concurrent bumps on the same path across batches', async () => {
+      // Two overlapping batch flushes target the same file — both must land.
+      const batchA = new Map([
+        ['shared.md', (c: RuntimeSignals) => ({...c, accessCount: c.accessCount + 5})],
+      ])
+      const batchB = new Map([
+        ['shared.md', (c: RuntimeSignals) => ({...c, accessCount: c.accessCount + 7})],
+      ])
+
+      await Promise.all([store.batchUpdate(batchA), store.batchUpdate(batchB)])
+
+      expect((await store.get('shared.md')).accessCount).to.equal(12)
+    })
+  })
+
+  describe('getMany', () => {
+    it('returns a map with an entry for every requested path', async () => {
+      await store.set('a.md', {...createDefaultRuntimeSignals(), importance: 91})
+      await store.set('b.md', {...createDefaultRuntimeSignals(), importance: 92})
+
+      const result = await store.getMany(['a.md', 'b.md', 'missing.md'])
+
+      expect(result.size).to.equal(3)
+      expect(result.get('a.md')?.importance).to.equal(91)
+      expect(result.get('b.md')?.importance).to.equal(92)
+      expect(result.get('missing.md')).to.deep.equal(createDefaultRuntimeSignals())
+    })
+
+    it('returns an empty map for an empty input', async () => {
+      expect((await store.getMany([])).size).to.equal(0)
+    })
+
+    it('does not read entries outside the requested set', async () => {
+      await store.set('wanted.md', {...createDefaultRuntimeSignals(), importance: 77})
+      await store.set('ignored.md', {...createDefaultRuntimeSignals(), importance: 42})
+
+      const result = await store.getMany(['wanted.md'])
+      expect(result.size).to.equal(1)
+      expect(result.has('ignored.md')).to.equal(false)
+    })
+  })
+
+  describe('path encoding edge cases', () => {
+    it('normalizes leading and trailing slashes', async () => {
+      await store.set('/leading.md', {...createDefaultRuntimeSignals(), importance: 61})
+      // Same logical path, different surface form — should hit the same entry.
+      expect((await store.get('leading.md')).importance).to.equal(61)
+
+      await store.set('trailing/', {...createDefaultRuntimeSignals(), importance: 62})
+      expect((await store.get('trailing')).importance).to.equal(62)
+    })
+
+    it('collapses consecutive slashes', async () => {
+      await store.set('a//b.md', {...createDefaultRuntimeSignals(), importance: 63})
+      expect((await store.get('a/b.md')).importance).to.equal(63)
+    })
+  })
+
+  describe('delete', () => {
+    it('removes an existing entry so subsequent get returns defaults', async () => {
+      await store.set('gone.md', {...createDefaultRuntimeSignals(), importance: 90})
+      await store.delete('gone.md')
+
+      expect(await store.get('gone.md')).to.deep.equal(createDefaultRuntimeSignals())
+    })
+
+    it('is a no-op for a missing path', async () => {
+      await store.delete('never-existed.md')
+      expect(await store.get('never-existed.md')).to.deep.equal(createDefaultRuntimeSignals())
+    })
+  })
+
+  describe('list', () => {
+    it('returns an empty map when nothing is stored', async () => {
+      expect((await store.list()).size).to.equal(0)
+    })
+
+    it('returns all stored entries keyed by relPath', async () => {
+      await store.set('a.md', {...createDefaultRuntimeSignals(), importance: 51})
+      await store.set('b/nested.md', {...createDefaultRuntimeSignals(), importance: 52})
+      await store.set('c/deeper/leaf.md', {...createDefaultRuntimeSignals(), importance: 53})
+
+      const all = await store.list()
+      expect(all.size).to.equal(3)
+      expect(all.get('a.md')?.importance).to.equal(51)
+      expect(all.get('b/nested.md')?.importance).to.equal(52)
+      expect(all.get('c/deeper/leaf.md')?.importance).to.equal(53)
+    })
+
+    it('falls back to defaults for corrupt entries instead of crashing', async () => {
+      await store.set('good.md', createDefaultRuntimeSignals())
+      await keyStorage.set(['signals', 'bad.md'], {importance: 'nope'})
+
+      const all = await store.list()
+      expect(all.has('good.md')).to.equal(true)
+      expect(all.get('bad.md')).to.deep.equal(createDefaultRuntimeSignals())
+    })
+
+    it('ignores keys outside the signals namespace', async () => {
+      // Another subsystem sharing the same keyStorage must not leak into list().
+      await store.set('a.md', createDefaultRuntimeSignals())
+      await keyStorage.set(['session', 'some-session-id'], {foo: 'bar'})
+
+      const all = await store.list()
+      expect(all.size).to.equal(1)
+      expect(all.has('a.md')).to.equal(true)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Problem: Per-machine ranking signals (`importance`, `recency`, `maturity`, `accessCount`, `updateCount`) are currently stored in context-tree markdown frontmatter. Every `brv query` bumps them and rewrites the markdown, dirtying `brv vc status` and causing merge conflicts when teammates share context trees.
- Why it matters: The fix is a 6-commit series. This PR is step 2 of 6 — it introduces the sidecar store as reachable infrastructure so commits 3-6 can redirect writes and reads onto it. On its own, nothing changes for the user.
- What changed: New `IRuntimeSignalStore` interface, thin `RuntimeSignalStore` facade over the existing `IKeyStorage` (composite keys `["signals", relPath]`), 26 unit tests, wiring in `service-initializer.ts`, `runtimeSignalStore` added to `CipherAgentServices`, `SemanticFrontmatter` type added to the schema file.
- What did NOT change (scope boundary): No consumer calls the store. No mutation site redirected. No read path redirected. No YAML emitter change. No cloud sync exclusion. All of those land in commits 3-6.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [ ] Agent / Tools
- [ ] LLM Providers
- [x] Server / Daemon
- [x] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes #
- Related: runtime-signals sidecar series — ENG-2133 (commit 1 of 6 landed in PR #447)

## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause: N/A
- Why this was not caught earlier: N/A

## Test plan

- Coverage added:
  - [x] Unit test
  - [ ] Integration test
  - [ ] Manual verification only
- Test file(s):
  - `test/unit/agent/knowledge/runtime-signal-store.test.ts` — 26 tests
- Key scenario(s) covered:
  - CRUD round-trip via `set`/`get`
  - `get` returns defaults for missing path
  - `get` returns defaults and logs a warning for corrupt stored data
  - `get` fills partial records with per-field defaults (forward-compat)
  - `update` seeds defaults when no record exists and applies the updater
  - `update` rejects updater output that violates the schema
  - **20 parallel `update` calls on the same path all land with no lost bumps** (atomic read-modify-write)
  - `batchUpdate` applies all updaters; serializes concurrent bumps on shared paths across batches
  - `getMany` returns an entry for every requested path, missing ones default; does not read entries outside the requested set
  - `list` returns all entries, falls back to defaults for corrupt, ignores keys outside the signals namespace
  - `delete` removes an entry so subsequent `get` returns defaults; no-op for missing paths
  - Path encoding edge cases: leading, trailing, and consecutive slashes all normalize to the same entry
  - Deeply-nested paths round-trip correctly

## User-visible changes

None. This commit adds a module reachable via `CipherAgentServices.runtimeSignalStore` but no consumer calls it yet.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording

**Concurrent-atomicity test output:**

**Full store test output:** 26 passing (14ms)

**Full repo suite:** 6459 passing, 0 failing (no regression — +5 tests from commit 1's 6454).

## Checklist

- [x] Tests added or updated and passing (`npm test`)
- [x] Lint passes (`npm run lint`) — 0 errors, 201 pre-existing warnings (none new)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated (if applicable) — N/A, internal change
- [x] No breaking changes
- [x] Branch is up to date with `main`

## Risks and mitigations

- Risk: **Cross-process atomicity is not provided.** The daemon (flushAccessHits) and CLI (curate) can race on the same signal record; `IKeyStorage.update`'s RWLock is in-process only. Under concurrent writes, one bump may be lost.
  - Mitigation: Acceptable for ranking signals — losing one access-hit bump has no correctness impact, only a small ranking drift that the next session self-heals. Documented explicitly in the interface doc and implementation comments. Not suitable for data where strict consistency is required; noted in the backlog for future upgrade to file-level flock if drift becomes measurable.
- Risk: **Store layer does not enforce the `importance` ↔ `maturity` hysteresis invariant.** Callers bumping `importance` must recompute `maturity` via `determineTier` themselves; the store accepts any schema-valid combination.
  - Mitigation: TODO inlined in the implementation file. Audit will happen as part of commit 3 when the first real callers are wired.
- Risk: **Orphan entries accumulate.** When a markdown file is deleted outside curate (manual `rm`), its sidecar entry remains forever.
  - Mitigation: No production impact yet — `list()` is only called for admin/diagnostic use, and `getMany` is used for ranking. Pruning mechanism captured in the backlog with a clear trigger.
- Risk: Mock store in `test/helpers/mock-factories.ts` skips Zod validation — consumer tests using the mock won't catch bugs that rely on validation behaviour.
  - Mitigation: The mock is a convenience; consumer tests needing real behaviour can instantiate `RuntimeSignalStore` with `FileKeyStorage({inMemory: true})`. Captured in the backlog.

## Related

- Previous commit: [#447](https://github.com/campfirein/HITL-byterover-cli/pull/447) — Runtime Signals 1/6 (schema and types)
- Next commit: Runtime Signals 3/6 — dual-write at mutation sites
