### PR TITLE
feat: [ENG-2158] dual-write runtime signals to sidecar (3/6)

### DIFF
--- a/src/agent/infra/agent/service-initializer.ts
+++ b/src/agent/infra/agent/service-initializer.ts
@@ -264,39 +264,9 @@ export async function createCipherAgentServices(
   // 7. Abstract generation queue (generator injected later via rebindCurateTools)
   const abstractQueue = new AbstractGenerationQueue(workingDirectory)
 
-  // 8. Tool provider (depends on FileSystemService, ProcessService, MemoryManager, SystemPromptManager)
-  const verbose = config.llm.verbose ?? false
-  const descriptionLoader = new ToolDescriptionLoader()
-  const toolProvider: ToolProvider = new ToolProvider(
-    {
-      abstractQueue,
-      environmentContext,
-      fileSystemService,
-      getToolProvider: (): ToolProvider => toolProvider,
-      memoryManager,
-      processService,
-      sandboxService,
-      swarmCoordinator,
-    },
-    systemPromptManager,
-    descriptionLoader,
-  )
-  await toolProvider.initialize()
-
-  // 9. Policy engine with default rules for autonomous execution
-  const policyEngine = new PolicyEngine({defaultDecision: 'ALLOW'})
-  policyEngine.addRules(DEFAULT_POLICY_RULES)
-
-  // 10. Tool scheduler (orchestrates policy check → execution)
-  const toolScheduler = new CoreToolScheduler(toolProvider, policyEngine, undefined, {
-    verbose,
-  })
-
-  // 11. Tool manager (with scheduler for policy-based execution)
-  const toolManager = new ToolManager(toolProvider, toolScheduler)
-  await toolManager.initialize()
-
-  // 11. History storage - granular file-based storage
+  // 8. Storage layer — initialised before ToolProvider so curate/search
+  // factories receive `runtimeSignalStore` via ToolServices at construction
+  // time (no late-bind workarounds).
   const keyStorage = new FileKeyStorage({
     storageDir: storageBasePath,
   })
@@ -310,6 +280,39 @@ export async function createCipherAgentServices(
   // maturity, accessCount, updateCount). Kept out of the context-tree
   // markdown so query-time bumps don't dirty version-controlled files.
   const runtimeSignalStore = new RuntimeSignalStore(keyStorage, logger)
+
+  // 9. Tool provider (depends on FileSystemService, ProcessService, MemoryManager, SystemPromptManager)
+  const verbose = config.llm.verbose ?? false
+  const descriptionLoader = new ToolDescriptionLoader()
+  const toolProvider: ToolProvider = new ToolProvider(
+    {
+      abstractQueue,
+      environmentContext,
+      fileSystemService,
+      getToolProvider: (): ToolProvider => toolProvider,
+      memoryManager,
+      processService,
+      runtimeSignalStore,
+      sandboxService,
+      swarmCoordinator,
+    },
+    systemPromptManager,
+    descriptionLoader,
+  )
+  await toolProvider.initialize()
+
+  // 10. Policy engine with default rules for autonomous execution
+  const policyEngine = new PolicyEngine({defaultDecision: 'ALLOW'})
+  policyEngine.addRules(DEFAULT_POLICY_RULES)
+
+  // 11. Tool scheduler (orchestrates policy check → execution)
+  const toolScheduler = new CoreToolScheduler(toolProvider, policyEngine, undefined, {
+    verbose,
+  })
+
+  // 12. Tool manager (with scheduler for policy-based execution)
+  const toolManager = new ToolManager(toolProvider, toolScheduler)
+  await toolManager.initialize()
 
   // CompactionService for context overflow management
   const tokenizer = new GeminiTokenizer(config.model ?? 'gemini-3-flash-preview')

--- a/src/agent/infra/sandbox/curate-service.ts
+++ b/src/agent/infra/sandbox/curate-service.ts
@@ -5,6 +5,7 @@
 
 import {resolve} from 'node:path'
 
+import type {IRuntimeSignalStore} from '../../../server/core/interfaces/storage/i-runtime-signal-store.js'
 import type {
   CurateOperation,
   CurateOperationResult,
@@ -100,7 +101,11 @@ function validateOperations(operations: CurateOperation[]): CurateOperationResul
 export class CurateService implements ICurateService {
   private readonly workingDirectory: string
 
-  constructor(workingDirectory?: string, private readonly abstractQueue?: AbstractGenerationQueue) {
+  constructor(
+    workingDirectory?: string,
+    private readonly abstractQueue?: AbstractGenerationQueue,
+    private readonly runtimeSignalStore?: IRuntimeSignalStore,
+  ) {
     this.workingDirectory = workingDirectory ?? process.cwd()
   }
 
@@ -148,7 +153,7 @@ export class CurateService implements ICurateService {
     }
 
     // Call the underlying executeCurate function from curate-tool
-    const result = await executeCurate({basePath, operations}, undefined, this.abstractQueue)
+    const result = await executeCurate({basePath, operations}, undefined, this.abstractQueue, this.runtimeSignalStore)
 
     return result
   }
@@ -194,6 +199,10 @@ export class CurateService implements ICurateService {
  * @param workingDirectory - Working directory for resolving relative paths
  * @returns CurateService instance
  */
-export function createCurateService(workingDirectory?: string, abstractQueue?: AbstractGenerationQueue): ICurateService {
-  return new CurateService(workingDirectory, abstractQueue)
+export function createCurateService(
+  workingDirectory?: string,
+  abstractQueue?: AbstractGenerationQueue,
+  runtimeSignalStore?: IRuntimeSignalStore,
+): ICurateService {
+  return new CurateService(workingDirectory, abstractQueue, runtimeSignalStore)
 }

--- a/src/agent/infra/tools/implementations/curate-tool.ts
+++ b/src/agent/infra/tools/implementations/curate-tool.ts
@@ -2,6 +2,7 @@ import {basename, dirname, join, relative, resolve} from 'node:path'
 import {z} from 'zod'
 
 import type {ContextData} from '../../../../server/core/domain/knowledge/markdown-writer.js'
+import type {IRuntimeSignalStore} from '../../../../server/core/interfaces/storage/i-runtime-signal-store.js'
 import type {Tool, ToolExecutionContext} from '../../../core/domain/tools/types.js'
 import type {AbstractGenerationQueue} from '../../map/abstract-queue.js'
 
@@ -11,8 +12,13 @@ import {MarkdownWriter, parseFrontmatterScoring} from '../../../../server/core/d
 import {
   applyDefaultScoring,
   determineTier,
+  mergeScoring,
   recordCurateUpdate,
 } from '../../../../server/core/domain/knowledge/memory-scoring.js'
+import {
+  createDefaultRuntimeSignals,
+  type RuntimeSignals,
+} from '../../../../server/core/domain/knowledge/runtime-signals-schema.js'
 import {toSnakeCase} from '../../../../server/utils/file-helpers.js'
 import {deriveImpactFromLoss, detectStructuralLoss} from '../../../core/domain/knowledge/conflict-detector.js'
 import {resolveStructuralLoss} from '../../../core/domain/knowledge/conflict-resolver.js'
@@ -23,6 +29,81 @@ import {ToolName} from '../../../core/domain/tools/constants.js'
  * enqueue abstract generation without coupling to AbstractGenerationQueue.
  */
 type WriteCallback = (contextPath: string, content: string) => void
+
+/**
+ * Derive the sidecar relPath (forward-slash, relative to the context tree
+ * root) from an absolute context-file path and the operation basePath.
+ */
+function relPathFromContextPath(contextPath: string, basePath: string): string {
+  return relative(basePath, contextPath).split('\\').join('/')
+}
+
+/**
+ * Seed the sidecar with default signals for a newly-added file.
+ * Best-effort: sidecar write failures never break the markdown operation.
+ */
+async function seedSidecarDefaults(
+  store: IRuntimeSignalStore | undefined,
+  relPath: string,
+): Promise<void> {
+  if (!store) return
+  try {
+    await store.set(relPath, createDefaultRuntimeSignals())
+  } catch {
+    // Markdown is canonical during phase 3 — log-and-swallow.
+  }
+}
+
+/**
+ * Mirror a curate UPDATE into the sidecar.
+ *
+ * Applies `recordCurateUpdate`-equivalent bumps (importance +5, recency=1,
+ * updateCount+1) and recomputes `maturity` via `determineTier` inside the
+ * atomic updater so same-path contention does not lose writes.
+ * `updatedAt` is intentionally NOT mirrored — it is a content timestamp
+ * that stays in markdown frontmatter.
+ */
+async function mirrorCurateUpdate(
+  store: IRuntimeSignalStore | undefined,
+  relPath: string,
+): Promise<void> {
+  if (!store) return
+  try {
+    await store.update(relPath, (current: RuntimeSignals): RuntimeSignals => {
+      // `recordCurateUpdate` returns a FrontmatterScoring whose fields are
+      // all concretely populated for our inputs (we pass a fully-valued
+      // RuntimeSignals). Non-null assertions reflect that invariant — no
+      // silent fallbacks that paper over unreachable branches.
+      const bumped = recordCurateUpdate(current)
+      const bumpedImportance = bumped.importance!
+      return {
+        ...current,
+        importance: bumpedImportance,
+        maturity: determineTier(bumpedImportance, current.maturity),
+        recency: bumped.recency!,
+        updateCount: bumped.updateCount!,
+      }
+    })
+  } catch {
+    // Fail-open during phase 3.
+  }
+}
+
+/**
+ * Remove a path's sidecar entry after its markdown file was deleted or moved
+ * (DELETE, MERGE source, archive). Best-effort.
+ */
+async function dropSidecar(
+  store: IRuntimeSignalStore | undefined,
+  relPath: string,
+): Promise<void> {
+  if (!store) return
+  try {
+    await store.delete(relPath)
+  } catch {
+    // Fail-open during phase 3.
+  }
+}
 
 /**
  * Operation types for curating knowledge topics.
@@ -656,7 +737,12 @@ function buildFullPath(basePath: string, knowledgePath: string): string {
 /**
  * Execute ADD operation - create new domain/topic/subtopic with {title}.md
  */
-async function executeAdd(basePath: string, operation: Operation, onAfterWrite?: WriteCallback): Promise<OperationResult> {
+async function executeAdd(
+  basePath: string,
+  operation: Operation,
+  onAfterWrite?: WriteCallback,
+  runtimeSignalStore?: IRuntimeSignalStore,
+): Promise<OperationResult> {
   const {confidence, content, domainContext, impact, path, reason, subtopicContext, summary, title, topicContext} =
     operation
   const reviewMeta = deriveReviewMetadata('ADD', confidence, impact)
@@ -735,6 +821,10 @@ async function executeAdd(basePath: string, operation: Operation, onAfterWrite?:
     await DirectoryManager.writeFileAtomic(contextPath, contextContent)
     onAfterWrite?.(contextPath, contextContent)
 
+    // Dual-write: seed the sidecar with default signals for the new file.
+    // Mirrors the default scoring applied to markdown frontmatter above.
+    await seedSidecarDefaults(runtimeSignalStore, relPathFromContextPath(contextPath, basePath))
+
     await ensureContextMd(basePath, parsed, topicContext, subtopicContext, onAfterWrite)
 
     return {
@@ -773,7 +863,12 @@ function maxImpact(
 /**
  * Execute UPDATE operation - modify existing {title}.md
  */
-async function executeUpdate(basePath: string, operation: Operation, onAfterWrite?: WriteCallback): Promise<OperationResult> {
+async function executeUpdate(
+  basePath: string,
+  operation: Operation,
+  onAfterWrite?: WriteCallback,
+  runtimeSignalStore?: IRuntimeSignalStore,
+): Promise<OperationResult> {
   const {confidence, content, domainContext, impact, path, reason, subtopicContext, summary, title, topicContext} =
     operation
   // Used for early-exit validation failures (before structural loss can be assessed)
@@ -883,6 +978,11 @@ async function executeUpdate(basePath: string, operation: Operation, onAfterWrit
     await DirectoryManager.writeFileAtomic(contextPath, contextContent)
     onAfterWrite?.(contextPath, contextContent)
 
+    // Dual-write: mirror the curate-update bumps (importance +5, recency=1,
+    // updateCount+1, maturity retiered) into the sidecar. `updatedAt` stays
+    // in markdown only — it is a content timestamp, not a runtime signal.
+    await mirrorCurateUpdate(runtimeSignalStore, relPathFromContextPath(contextPath, basePath))
+
     await ensureContextMd(basePath, parsed, topicContext, subtopicContext, onAfterWrite)
 
     return {
@@ -912,7 +1012,12 @@ async function executeUpdate(basePath: string, operation: Operation, onAfterWrit
  * Execute UPSERT operation - automatically creates or updates based on file existence
  * This is the recommended operation type as it eliminates the need for pre-checks.
  */
-async function executeUpsert(basePath: string, operation: Operation, onAfterWrite?: WriteCallback): Promise<OperationResult> {
+async function executeUpsert(
+  basePath: string,
+  operation: Operation,
+  onAfterWrite?: WriteCallback,
+  runtimeSignalStore?: IRuntimeSignalStore,
+): Promise<OperationResult> {
   const {path, reason, title} = operation
   const reviewMeta = deriveReviewMetadata('UPSERT', operation.confidence, operation.impact)
 
@@ -960,7 +1065,7 @@ async function executeUpsert(basePath: string, operation: Operation, onAfterWrit
 
     if (exists) {
       // File exists - delegate to UPDATE logic
-      const result = await executeUpdate(basePath, {...operation, type: 'UPDATE'}, onAfterWrite)
+      const result = await executeUpdate(basePath, {...operation, type: 'UPDATE'}, onAfterWrite, runtimeSignalStore)
       // Return with UPSERT type but indicate it was an update
       return {
         ...result,
@@ -970,7 +1075,7 @@ async function executeUpsert(basePath: string, operation: Operation, onAfterWrit
     }
 
     // File doesn't exist - delegate to ADD logic
-    const result = await executeAdd(basePath, {...operation, type: 'ADD'}, onAfterWrite)
+    const result = await executeAdd(basePath, {...operation, type: 'ADD'}, onAfterWrite, runtimeSignalStore)
     // Return with UPSERT type but indicate it was an add
     return {
       ...result,
@@ -992,7 +1097,12 @@ async function executeUpsert(basePath: string, operation: Operation, onAfterWrit
 /**
  * Execute MERGE operation - combine source file into target file, delete source file
  */
-async function executeMerge(basePath: string, operation: Operation, onAfterWrite?: WriteCallback): Promise<OperationResult> {
+async function executeMerge(
+  basePath: string,
+  operation: Operation,
+  onAfterWrite?: WriteCallback,
+  runtimeSignalStore?: IRuntimeSignalStore,
+): Promise<OperationResult> {
   const {
     confidence,
     domainContext,
@@ -1111,6 +1221,33 @@ async function executeMerge(basePath: string, operation: Operation, onAfterWrite
     await DirectoryManager.deleteFile(sourceContextPath)
     await deleteDerivedSiblings(sourceContextPath)
 
+    // Dual-write: merge sidecar signals by delegating to `mergeScoring`
+    // (the same policy used for markdown). This keeps the two merge paths
+    // from drifting when weights change. The merge runs inside `update`'s
+    // atomic callback so a concurrent access-hit flush on the target cannot
+    // lose bumps.
+    if (runtimeSignalStore) {
+      const sourceRelPath = relPathFromContextPath(sourceContextPath, basePath)
+      const targetRelPath = relPathFromContextPath(targetContextPath, basePath)
+      try {
+        const sourceSignals = await runtimeSignalStore.get(sourceRelPath)
+        await runtimeSignalStore.update(targetRelPath, (current: RuntimeSignals): RuntimeSignals => {
+          const merged = mergeScoring(sourceSignals, current)
+          const mergedImportance = merged.importance ?? current.importance
+          return {
+            accessCount: merged.accessCount ?? current.accessCount,
+            importance: mergedImportance,
+            maturity: determineTier(mergedImportance, merged.maturity ?? current.maturity),
+            recency: merged.recency ?? current.recency,
+            updateCount: merged.updateCount ?? current.updateCount,
+          }
+        })
+        await runtimeSignalStore.delete(sourceRelPath)
+      } catch {
+        // Best-effort — merge of markdown already succeeded.
+      }
+    }
+
     await ensureContextMd(basePath, sourceParsed, topicContext, subtopicContext, onAfterWrite)
     await ensureContextMd(basePath, targetParsed, topicContext, subtopicContext, onAfterWrite)
 
@@ -1142,7 +1279,11 @@ async function executeMerge(basePath: string, operation: Operation, onAfterWrite
  * Execute DELETE operation - remove specific file or entire folder
  * If title is provided, deletes specific file; if omitted, deletes entire folder
  */
-async function executeDelete(basePath: string, operation: Operation): Promise<OperationResult> {
+async function executeDelete(
+  basePath: string,
+  operation: Operation,
+  runtimeSignalStore?: IRuntimeSignalStore,
+): Promise<OperationResult> {
   const {path, reason, title} = operation
   const reviewMeta = deriveReviewMetadata('DELETE', operation.confidence, operation.impact)
 
@@ -1180,6 +1321,10 @@ async function executeDelete(basePath: string, operation: Operation): Promise<Op
       await backupBeforeWrite(filePath, basePath)
       await DirectoryManager.deleteFile(filePath)
       await deleteDerivedSiblings(filePath)
+
+      // Dual-write: drop the deleted file's sidecar entry so it does not
+      // become an orphan.
+      await dropSidecar(runtimeSignalStore, relPathFromContextPath(filePath, basePath))
 
       return {
         ...reviewMeta,
@@ -1262,7 +1407,12 @@ async function executeDelete(basePath: string, operation: Operation): Promise<Op
  * Execute curate operations on knowledge topics.
  * Exported for use by CurateService in sandbox.
  */
-export async function executeCurate(input: unknown, _context?: ToolExecutionContext, abstractQueue?: AbstractGenerationQueue): Promise<CurateOutput> {
+export async function executeCurate(
+  input: unknown,
+  _context?: ToolExecutionContext,
+  abstractQueue?: AbstractGenerationQueue,
+  runtimeSignalStore?: IRuntimeSignalStore,
+): Promise<CurateOutput> {
   const parseResult = CurateInputSchema.safeParse(input)
   if (!parseResult.success) {
     return {
@@ -1308,7 +1458,7 @@ export async function executeCurate(input: unknown, _context?: ToolExecutionCont
 
     switch (operation.type) {
       case 'ADD': {
-        result = await executeAdd(basePath, operation, onAfterWrite)
+        result = await executeAdd(basePath, operation, onAfterWrite, runtimeSignalStore)
 
         if (result.status === 'success') summary.added++
 
@@ -1316,7 +1466,7 @@ export async function executeCurate(input: unknown, _context?: ToolExecutionCont
       }
 
       case 'DELETE': {
-        result = await executeDelete(basePath, operation)
+        result = await executeDelete(basePath, operation, runtimeSignalStore)
 
         if (result.status === 'success') summary.deleted++
 
@@ -1324,7 +1474,7 @@ export async function executeCurate(input: unknown, _context?: ToolExecutionCont
       }
 
       case 'MERGE': {
-        result = await executeMerge(basePath, operation, onAfterWrite)
+        result = await executeMerge(basePath, operation, onAfterWrite, runtimeSignalStore)
 
         if (result.status === 'success') summary.merged++
 
@@ -1332,7 +1482,7 @@ export async function executeCurate(input: unknown, _context?: ToolExecutionCont
       }
 
       case 'UPDATE': {
-        result = await executeUpdate(basePath, operation, onAfterWrite)
+        result = await executeUpdate(basePath, operation, onAfterWrite, runtimeSignalStore)
 
         if (result.status === 'success') summary.updated++
 
@@ -1340,7 +1490,7 @@ export async function executeCurate(input: unknown, _context?: ToolExecutionCont
       }
 
       case 'UPSERT': {
-        result = await executeUpsert(basePath, operation, onAfterWrite)
+        result = await executeUpsert(basePath, operation, onAfterWrite, runtimeSignalStore)
 
         // UPSERT counts as either added or updated based on what happened
         if (result.status === 'success') {
@@ -1381,7 +1531,11 @@ export async function executeCurate(input: unknown, _context?: ToolExecutionCont
   return {applied, summary}
 }
 
-export function createCurateTool(workingDirectory?: string, abstractQueue?: AbstractGenerationQueue): Tool {
+export function createCurateTool(
+  workingDirectory?: string,
+  abstractQueue?: AbstractGenerationQueue,
+  runtimeSignalStore?: IRuntimeSignalStore,
+): Tool {
   return {
     description: `Curate knowledge topics with atomic operations. This tool manages the knowledge structure using four operation types and supports a two-part context model: Raw Concept + Narrative.
 
@@ -1583,11 +1737,11 @@ export function createCurateTool(workingDirectory?: string, abstractQueue?: Abst
         if (parseResult.success) {
           parseResult.data.basePath = resolve(workingDirectory, parseResult.data.basePath)
 
-          return executeCurate(parseResult.data, context, abstractQueue)
+          return executeCurate(parseResult.data, context, abstractQueue, runtimeSignalStore)
         }
       }
 
-      return executeCurate(input, context, abstractQueue)
+      return executeCurate(input, context, abstractQueue, runtimeSignalStore)
     },
 
     id: ToolName.CURATE,

--- a/src/agent/infra/tools/implementations/expand-knowledge-tool.ts
+++ b/src/agent/infra/tools/implementations/expand-knowledge-tool.ts
@@ -2,6 +2,7 @@ import {readFile} from 'node:fs/promises'
 import {join} from 'node:path'
 import {z} from 'zod'
 
+import type {IRuntimeSignalStore} from '../../../../server/core/interfaces/storage/i-runtime-signal-store.js'
 import type {Tool, ToolExecutionContext} from '../../../core/domain/tools/types.js'
 
 import {BRV_DIR, CONTEXT_TREE_DIR} from '../../../../server/constants.js'
@@ -42,6 +43,7 @@ const ExpandKnowledgeInputSchema = z
  */
 export interface ExpandKnowledgeToolConfig {
   baseDirectory?: string
+  runtimeSignalStore?: IRuntimeSignalStore
 }
 
 /**
@@ -55,7 +57,7 @@ export interface ExpandKnowledgeToolConfig {
  * @returns Configured expand knowledge tool
  */
 export function createExpandKnowledgeTool(config: ExpandKnowledgeToolConfig = {}): Tool {
-  const archiveService = new FileContextTreeArchiveService()
+  const archiveService = new FileContextTreeArchiveService(config.runtimeSignalStore)
 
   return {
     description:

--- a/src/agent/infra/tools/implementations/search-knowledge-service.ts
+++ b/src/agent/infra/tools/implementations/search-knowledge-service.ts
@@ -3,6 +3,7 @@ import {realpath} from 'node:fs/promises'
 import {join} from 'node:path'
 import {removeStopwords} from 'stopword'
 
+import type {IRuntimeSignalStore} from '../../../../server/core/interfaces/storage/i-runtime-signal-store.js'
 import type {IFileSystem} from '../../../core/interfaces/i-file-system.js'
 import type {ISearchKnowledgeService, SearchKnowledgeResult} from '../../sandbox/tools-sdk.js'
 
@@ -26,6 +27,7 @@ import {
   determineTier,
   recordAccessHits,
 } from '../../../../server/core/domain/knowledge/memory-scoring.js'
+import {type RuntimeSignals} from '../../../../server/core/domain/knowledge/runtime-signals-schema.js'
 import {loadSources, type SearchOrigin} from '../../../../server/core/domain/source/source-schema.js'
 import {isArchiveStub, isDerivedArtifact} from '../../../../server/infra/context-tree/derived-artifact.js'
 import {
@@ -230,6 +232,12 @@ export interface SearchKnowledgeServiceConfig {
   baseDirectory?: string
   /** Cache TTL in milliseconds (defaults to 5000) */
   cacheTtlMs?: number
+  /**
+   * Sidecar store for runtime ranking signals. When provided, `flushAccessHits`
+   * mirrors its importance/accessCount/maturity bumps to the store alongside
+   * the existing markdown writes. Phase 3 of the runtime-signals migration.
+   */
+  runtimeSignalStore?: IRuntimeSignalStore
 }
 
 /**
@@ -878,6 +886,7 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
   private readonly cacheTtlMs: number
   private readonly fileSystem: IFileSystem
   private readonly pendingAccessHits: Map<string, number> = new Map()
+  private readonly runtimeSignalStore?: IRuntimeSignalStore
   private readonly state: IndexState = {
     buildingPromise: undefined,
     cachedIndex: undefined,
@@ -887,6 +896,7 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
     this.fileSystem = fileSystem
     this.baseDirectory = config.baseDirectory ?? process.cwd()
     this.cacheTtlMs = config.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS
+    this.runtimeSignalStore = config.runtimeSignalStore
   }
 
   /**
@@ -920,6 +930,10 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
       }
     })
     await Promise.allSettled(tasks)
+
+    // Dual-write to the runtime-signal sidecar. Markdown remains canonical in
+    // phase 3; sidecar failures must not affect the flush outcome.
+    await this.mirrorHitsToSignalStore(hits)
     return true
   }
 
@@ -1127,6 +1141,49 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
       relatedPaths: backlinks?.slice(0, 3),
       symbolKind: isContextSummary ? 'summary' : symbolKind,
       symbolPath: isContextSummary ? summaryPath : symbol?.path,
+    }
+  }
+
+  /**
+   * Mirror a batch of access-hit bumps into the runtime-signal sidecar.
+   *
+   * Matches the markdown flush semantics above:
+   *   - `recordAccessHits` bumps `importance` by `ACCESS_IMPORTANCE_BONUS * count`
+   *     and `accessCount` by `count`.
+   *   - `determineTier` recomputes `maturity` from the new importance.
+   * Both steps run inside `update`'s atomic read-modify-write callback so
+   * same-path contention within the process does not lose bumps.
+   * `updatedAt` is never mirrored — it is a content timestamp, not a signal.
+   */
+  private async mirrorHitsToSignalStore(hits: Map<string, number>): Promise<void> {
+    const store = this.runtimeSignalStore
+    if (!store) return
+
+    const updates = new Map(
+      [...hits.entries()].map(([relPath, count]) => [
+        relPath,
+        (current: RuntimeSignals): RuntimeSignals => {
+          // `recordAccessHits` always returns concrete importance/accessCount
+          // when given a fully-valued RuntimeSignals; the `!` assertions
+          // reflect that invariant rather than defensive fallbacks.
+          const bumped = recordAccessHits(current, count)
+          const bumpedImportance = bumped.importance!
+          return {
+            ...current,
+            accessCount: bumped.accessCount!,
+            importance: bumpedImportance,
+            maturity: determineTier(bumpedImportance, current.maturity),
+          }
+        },
+      ]),
+    )
+
+    try {
+      await store.batchUpdate(updates)
+    } catch {
+      // Best-effort — sidecar failure must not break the flush. Markdown is
+      // still canonical during phase 3; the sidecar will re-sync on the next
+      // bump for these paths.
     }
   }
 

--- a/src/agent/infra/tools/tool-provider.ts
+++ b/src/agent/infra/tools/tool-provider.ts
@@ -43,6 +43,7 @@ export class ToolProvider implements IToolProvider {
       maxContextTokens: 0,
       memoryManager: 0,
       processService: 0,
+      runtimeSignalStore: 0,
       sandboxService: 0,
       swarmCoordinator: 0,
       todoStorage: 0,

--- a/src/agent/infra/tools/tool-registry.ts
+++ b/src/agent/infra/tools/tool-registry.ts
@@ -1,3 +1,4 @@
+import type { IRuntimeSignalStore } from '../../../server/core/interfaces/storage/i-runtime-signal-store.js'
 import type { EnvironmentContext } from '../../core/domain/environment/types.js'
 import type { KnownTool } from '../../core/domain/tools/constants.js'
 import type { Tool } from '../../core/domain/tools/types.js'
@@ -70,6 +71,13 @@ export interface ToolServices {
 
   /** Process service for command execution */
   processService?: IProcessService
+
+  /**
+   * Sidecar store for per-machine ranking signals. When provided, curate and
+   * search tools mirror their scoring writes here alongside the markdown
+   * writes. Phase 3 of the runtime-signals migration.
+   */
+  runtimeSignalStore?: IRuntimeSignalStore
 
   /** Sandbox service for code execution */
   sandboxService?: ISandboxService
@@ -166,7 +174,7 @@ export const TOOL_REGISTRY: Record<KnownTool, ToolRegistryEntry> = {
 
   [ToolName.CODE_EXEC]: {
     descriptionFile: 'code_exec',
-    factory({ abstractQueue, environmentContext, fileSystemService, sandboxService, swarmCoordinator }) {
+    factory({ abstractQueue, environmentContext, fileSystemService, runtimeSignalStore, sandboxService, swarmCoordinator }) {
       const sandbox = getRequiredService(sandboxService, 'sandboxService')
 
       // Inject file system service into sandbox for Tools SDK
@@ -176,13 +184,19 @@ export const TOOL_REGISTRY: Record<KnownTool, ToolRegistryEntry> = {
 
       // Inject search knowledge service into sandbox for Tools SDK
       if (fileSystemService && sandbox.setSearchKnowledgeService) {
-        const searchKnowledgeService = createSearchKnowledgeService(fileSystemService)
+        const searchKnowledgeService = createSearchKnowledgeService(fileSystemService, {
+          runtimeSignalStore,
+        })
         sandbox.setSearchKnowledgeService(searchKnowledgeService)
       }
 
       // Inject curate service into sandbox for Tools SDK
       if (sandbox.setCurateService) {
-        const curateService = createCurateService(environmentContext?.workingDirectory, abstractQueue)
+        const curateService = createCurateService(
+          environmentContext?.workingDirectory,
+          abstractQueue,
+          runtimeSignalStore,
+        )
         sandbox.setCurateService(curateService)
       }
 
@@ -204,8 +218,8 @@ export const TOOL_REGISTRY: Record<KnownTool, ToolRegistryEntry> = {
 
   [ToolName.CURATE]: {
     descriptionFile: 'curate',
-    factory: ({ abstractQueue, environmentContext }) =>
-      createCurateTool(environmentContext?.workingDirectory, abstractQueue),
+    factory: ({ abstractQueue, environmentContext, runtimeSignalStore }) =>
+      createCurateTool(environmentContext?.workingDirectory, abstractQueue, runtimeSignalStore),
     markers: [ToolMarker.ContextBuilding, ToolMarker.Modification],
     outputGuidance: 'curate',
     requiredServices: [],
@@ -213,8 +227,11 @@ export const TOOL_REGISTRY: Record<KnownTool, ToolRegistryEntry> = {
 
   [ToolName.EXPAND_KNOWLEDGE]: {
     descriptionFile: 'expand_knowledge',
-    factory: ({ environmentContext }) =>
-      createExpandKnowledgeTool({ baseDirectory: environmentContext?.workingDirectory }),
+    factory: ({ environmentContext, runtimeSignalStore }) =>
+      createExpandKnowledgeTool({
+        baseDirectory: environmentContext?.workingDirectory,
+        runtimeSignalStore,
+      }),
     markers: [ToolMarker.Discovery],
     requiredServices: [],
   },

--- a/src/server/infra/context-tree/file-context-tree-archive-service.ts
+++ b/src/server/infra/context-tree/file-context-tree-archive-service.ts
@@ -19,6 +19,7 @@ import type {ICipherAgent} from '../../../agent/core/interfaces/i-cipher-agent.j
 import type {FrontmatterScoring} from '../../core/domain/knowledge/markdown-writer.js'
 import type {ArchiveResult, DrillDownResult} from '../../core/domain/knowledge/summary-types.js'
 import type {IContextTreeArchiveService} from '../../core/interfaces/context-tree/i-context-tree-archive-service.js'
+import type {IRuntimeSignalStore} from '../../core/interfaces/storage/i-runtime-signal-store.js'
 
 import {
   ARCHIVE_DIR,
@@ -31,12 +32,15 @@ import {
   STUB_EXTENSION,
 } from '../../constants.js'
 import {applyDecay} from '../../core/domain/knowledge/memory-scoring.js'
+import {createDefaultRuntimeSignals} from '../../core/domain/knowledge/runtime-signals-schema.js'
 import {estimateTokens} from '../executor/pre-compaction/compaction-escalation.js'
 import {isArchiveStub, isDerivedArtifact} from './derived-artifact.js'
 import {toUnixPath} from './path-utils.js'
 import {generateArchiveStubContent, parseArchiveStubFrontmatter} from './summary-frontmatter.js'
 
 export class FileContextTreeArchiveService implements IContextTreeArchiveService {
+  constructor(private readonly runtimeSignalStore?: IRuntimeSignalStore) {}
+
   public async archiveEntry(
     relativePath: string,
     agent: ICipherAgent,
@@ -86,6 +90,16 @@ export class FileContextTreeArchiveService implements IContextTreeArchiveService
 
     // Delete original file
     await unlink(originalFullPath)
+
+    // Dual-write: drop the archived file's runtime-signal entry so the
+    // sidecar does not retain an orphan. Fail-open — markdown is canonical.
+    if (this.runtimeSignalStore) {
+      try {
+        await this.runtimeSignalStore.delete(toUnixPath(relativePath))
+      } catch {
+        // Best-effort — archive already succeeded.
+      }
+    }
 
     return {
       fullPath: toUnixPath(fullRelPath),
@@ -152,6 +166,17 @@ export class FileContextTreeArchiveService implements IContextTreeArchiveService
     // Delete stub and full archive files
     await unlink(stubFullPath)
     await unlink(fullPath)
+
+    // Dual-write: seed the restored file with default signals. Signal
+    // history from before archiving was already dropped on archive — restore
+    // is a user-initiated action, so resetting to defaults is acceptable.
+    if (this.runtimeSignalStore) {
+      try {
+        await this.runtimeSignalStore.set(toUnixPath(fm.original_path), createDefaultRuntimeSignals())
+      } catch {
+        // Best-effort — markdown restore already succeeded.
+      }
+    }
 
     return fm.original_path
   }

--- a/src/server/infra/daemon/agent-process.ts
+++ b/src/server/infra/daemon/agent-process.ts
@@ -27,12 +27,14 @@ import {join} from 'node:path'
 import type {ISearchKnowledgeService} from '../../../agent/infra/sandbox/tools-sdk.js'
 import type {BrvConfig} from '../../core/domain/entities/brv-config.js'
 import type {ProviderConfigResponse, TaskExecute} from '../../core/domain/transport/schemas.js'
+import type {IRuntimeSignalStore} from '../../core/interfaces/storage/i-runtime-signal-store.js'
 
 import {SESSIONS_DIR} from '../../../agent/core/domain/session/session-metadata.js'
 import {CipherAgent} from '../../../agent/infra/agent/index.js'
 import {FileSystemService} from '../../../agent/infra/file-system/file-system-service.js'
 import {FolderPackService} from '../../../agent/infra/folder-pack/folder-pack-service.js'
 import {SessionMetadataStore} from '../../../agent/infra/session/session-metadata-store.js'
+import {FileKeyStorage} from '../../../agent/infra/storage/file-key-storage.js'
 import {createSearchKnowledgeService} from '../../../agent/infra/tools/implementations/search-knowledge-service.js'
 import {AuthEvents} from '../../../shared/transport/events/auth-events.js'
 import {decodeSearchContent} from '../../../shared/transport/search-content.js'
@@ -47,6 +49,7 @@ import {
   TransportTaskEventNames,
 } from '../../core/domain/transport/schemas.js'
 import {FileContextTreeArchiveService} from '../context-tree/file-context-tree-archive-service.js'
+import {RuntimeSignalStore} from '../context-tree/runtime-signal-store.js'
 import {DreamLockService} from '../dream/dream-lock-service.js'
 import {DreamLogStore} from '../dream/dream-log-store.js'
 import {DreamStateService} from '../dream/dream-state-service.js'
@@ -364,7 +367,27 @@ async function start(): Promise<void> {
     workingDirectory: projectPath,
   })
   await fileSystemService.initialize()
-  const searchService = createSearchKnowledgeService(fileSystemService, {baseDirectory: projectPath})
+
+  // Runtime-signal sidecar for this daemon. FileKeyStorage is file-backed
+  // under configResult.storagePath, so the daemon and any other process for
+  // the same project write to the same on-disk store. `brv search`, curate,
+  // and archive in this daemon all mirror scoring writes through it.
+  const daemonKeyStorage = new FileKeyStorage({
+    storageDir: configResult.storagePath,
+  })
+  await daemonKeyStorage.initialize()
+  const daemonLogger = {
+    debug: (msg: string): void => agentLog(msg),
+    error: (msg: string): void => agentLog(msg),
+    info: (msg: string): void => agentLog(msg),
+    warn: (msg: string): void => agentLog(msg),
+  }
+  const daemonRuntimeSignalStore = new RuntimeSignalStore(daemonKeyStorage, daemonLogger)
+
+  const searchService = createSearchKnowledgeService(fileSystemService, {
+    baseDirectory: projectPath,
+    runtimeSignalStore: daemonRuntimeSignalStore,
+  })
 
   // 7. Create executors and listen for task:execute from pool
   const curateExecutor = new CurateExecutor()
@@ -382,7 +405,16 @@ async function start(): Promise<void> {
   transport.on<TaskExecute>(TransportTaskEventNames.EXECUTE, (task) => {
     agentLog(`task:execute received taskId=${task.taskId} type=${task.type} activeTaskCount=${activeTaskCount + 1}`)
     // eslint-disable-next-line no-void
-    void executeTask(task, curateExecutor, folderPackExecutor, queryExecutor, searchExecutor, searchService, configResult.storagePath)
+    void executeTask(
+      task,
+      curateExecutor,
+      folderPackExecutor,
+      queryExecutor,
+      searchExecutor,
+      searchService,
+      configResult.storagePath,
+      daemonRuntimeSignalStore,
+    )
   })
 
   // 8. Register with transport server (for TransportHandlers tracking)
@@ -401,6 +433,7 @@ async function executeTask(
   searchExecutor: SearchExecutor,
   searchKnowledgeService: ISearchKnowledgeService,
   storagePath: string,
+  runtimeSignalStore: IRuntimeSignalStore,
 ): Promise<void> {
   const {clientCwd, clientId, content, files, folderPath, force, taskId, trigger, type, worktreeRoot} = task
   if (!transport || !agent) return
@@ -530,7 +563,7 @@ async function executeTask(
           }
 
           const dreamExecutor = new DreamExecutor({
-            archiveService: new FileContextTreeArchiveService(),
+            archiveService: new FileContextTreeArchiveService(runtimeSignalStore),
             curateLogStore: new FileCurateLogStore({baseDir: storagePath}),
             dreamLockService,
             dreamLogStore: new DreamLogStore({baseDir: brvDir}),

--- a/test/integration/runtime-signals/dual-write-pipeline.test.ts
+++ b/test/integration/runtime-signals/dual-write-pipeline.test.ts
@@ -1,0 +1,210 @@
+import {expect} from 'chai'
+import * as fs from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+
+import type {ICipherAgent} from '../../../src/agent/core/interfaces/i-cipher-agent.js'
+import type {IFileSystem} from '../../../src/agent/core/interfaces/i-file-system.js'
+import type {IRuntimeSignalStore} from '../../../src/server/core/interfaces/storage/i-runtime-signal-store.js'
+
+import {createCurateTool} from '../../../src/agent/infra/tools/implementations/curate-tool.js'
+import {SearchKnowledgeService} from '../../../src/agent/infra/tools/implementations/search-knowledge-service.js'
+import {BRV_DIR, CONTEXT_TREE_DIR} from '../../../src/server/constants.js'
+import {createDefaultRuntimeSignals} from '../../../src/server/core/domain/knowledge/runtime-signals-schema.js'
+import {FileContextTreeArchiveService} from '../../../src/server/infra/context-tree/file-context-tree-archive-service.js'
+import {createMockRuntimeSignalStore} from '../../helpers/mock-factories.js'
+
+interface PendingAccessHitsInternals {
+  pendingAccessHits: Map<string, number>
+}
+
+function createDiskFileSystem(): IFileSystem {
+  return {
+    async readFile(path: string) {
+      return {content: await fs.readFile(path, 'utf8')}
+    },
+    async writeFile(path: string, content: string) {
+      await fs.writeFile(path, content, 'utf8')
+    },
+  } as unknown as IFileSystem
+}
+
+function createMockAgent(): ICipherAgent {
+  return {
+    async cancel() {},
+    async createTaskSession() {
+      return 'mock-session'
+    },
+    async deleteSandboxVariable() {},
+    async deleteSandboxVariableOnSession() {},
+    async deleteSession() {},
+    async deleteTaskSession() {},
+    async execute() {
+      return 'ghost cue'
+    },
+    async executeOnSession() {
+      return 'ghost cue'
+    },
+    async generate() {
+      return 'ghost cue'
+    },
+    async getSessionMetadata() {},
+    getState() {
+      return 'idle'
+    },
+    async listPersistedSessions() {
+      return []
+    },
+    async reset() {},
+    async setSandboxVariable() {},
+    async setSandboxVariableOnSession() {},
+    async start() {},
+    async *stream() {
+      yield 'ghost cue'
+    },
+  } as unknown as ICipherAgent
+}
+
+/**
+ * End-to-end integration test for commit 3 (runtime-signals dual-write).
+ *
+ * Exercises the full sequence — curate ADD, curate UPDATE, flushAccessHits,
+ * curate MERGE, archive — on the same project tree, with a shared
+ * RuntimeSignalStore. Asserts the sidecar reflects the expected end state
+ * at each stage and stays consistent with markdown where observable.
+ */
+describe('Runtime-signals dual-write pipeline', () => {
+  let projectRoot: string
+  let contextTreeDir: string
+  let signalStore: IRuntimeSignalStore
+  let curateTool: {execute(input: unknown): Promise<unknown>}
+  let searchService: SearchKnowledgeService
+  let archiveService: FileContextTreeArchiveService
+  let agent: ICipherAgent
+
+  beforeEach(async () => {
+    projectRoot = join(tmpdir(), `rs-pipeline-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    contextTreeDir = join(projectRoot, BRV_DIR, CONTEXT_TREE_DIR)
+    await fs.mkdir(contextTreeDir, {recursive: true})
+
+    signalStore = createMockRuntimeSignalStore()
+    curateTool = createCurateTool(undefined, undefined, signalStore) as {execute(input: unknown): Promise<unknown>}
+    searchService = new SearchKnowledgeService(createDiskFileSystem(), {runtimeSignalStore: signalStore})
+    archiveService = new FileContextTreeArchiveService(signalStore)
+    agent = createMockAgent()
+  })
+
+  afterEach(async () => {
+    await fs.rm(projectRoot, {force: true, recursive: true})
+  })
+
+  it('ADD → UPDATE → flushAccessHits → MERGE → archive leaves the sidecar in the expected end state', async () => {
+    // Step 1: ADD two files.
+    await curateTool.execute({
+      basePath: contextTreeDir,
+      operations: [
+        {
+          confidence: 'high',
+          content: {snippets: ['source content'], tags: ['auth']},
+          impact: 'low',
+          path: 'auth/jwt',
+          reason: 'seed',
+          title: 'Refresh',
+          type: 'ADD',
+        },
+        {
+          confidence: 'high',
+          content: {snippets: ['target content'], tags: ['auth']},
+          impact: 'low',
+          path: 'auth/jwt',
+          reason: 'seed',
+          title: 'Rotation',
+          type: 'ADD',
+        },
+      ],
+    })
+
+    const srcRel = 'auth/jwt/refresh.md'
+    const tgtRel = 'auth/jwt/rotation.md'
+
+    // Both files have default signals.
+    expect(await signalStore.get(srcRel)).to.deep.equal(createDefaultRuntimeSignals())
+    expect(await signalStore.get(tgtRel)).to.deep.equal(createDefaultRuntimeSignals())
+
+    // Step 2: UPDATE the target — bumps importance +5, updateCount +1.
+    await curateTool.execute({
+      basePath: contextTreeDir,
+      operations: [
+        {
+          confidence: 'high',
+          content: {snippets: ['updated'], tags: ['auth']},
+          impact: 'low',
+          path: 'auth/jwt',
+          reason: 'refine',
+          title: 'Rotation',
+          type: 'UPDATE',
+        },
+      ],
+    })
+
+    const afterUpdate = await signalStore.get(tgtRel)
+    expect(afterUpdate.importance).to.equal(55)
+    expect(afterUpdate.updateCount).to.equal(1)
+    expect(afterUpdate.recency).to.equal(1)
+    expect(afterUpdate.maturity).to.equal('draft')
+
+    // Step 3: flushAccessHits on both files.
+    ;(searchService as unknown as PendingAccessHitsInternals).pendingAccessHits.set(srcRel, 3)
+    ;(searchService as unknown as PendingAccessHitsInternals).pendingAccessHits.set(tgtRel, 4)
+    await searchService.flushAccessHits(contextTreeDir)
+
+    const srcAfterFlush = await signalStore.get(srcRel)
+    // Source: default(50) + 3*3 = 59
+    expect(srcAfterFlush.importance).to.equal(59)
+    expect(srcAfterFlush.accessCount).to.equal(3)
+    expect(srcAfterFlush.maturity).to.equal('draft') // 59 < 65
+
+    const tgtAfterFlush = await signalStore.get(tgtRel)
+    // Target: 55 (from UPDATE) + 3*4 = 67 → crosses PROMOTE_TO_VALIDATED (65)
+    expect(tgtAfterFlush.importance).to.equal(67)
+    expect(tgtAfterFlush.accessCount).to.equal(4)
+    expect(tgtAfterFlush.maturity).to.equal('validated')
+
+    // Step 4: MERGE source into target. Merged signals land on target;
+    // source entry is dropped.
+    await curateTool.execute({
+      basePath: contextTreeDir,
+      operations: [
+        {
+          confidence: 'high',
+          impact: 'low',
+          mergeTarget: 'auth/jwt',
+          mergeTargetTitle: 'Rotation',
+          path: 'auth/jwt',
+          reason: 'consolidate',
+          title: 'Refresh',
+          type: 'MERGE',
+        },
+      ],
+    })
+
+    // Source sidecar entry gone.
+    expect((await signalStore.list()).has(srcRel)).to.equal(false)
+
+    // Target merged: max importance = max(59, 67) = 67; accessCount sum = 3+4 = 7;
+    // updateCount = 1 + 0 + 1 = 2; maturity re-derived at 67 = validated.
+    const afterMerge = await signalStore.get(tgtRel)
+    expect(afterMerge.importance).to.equal(67)
+    expect(afterMerge.accessCount).to.equal(7)
+    expect(afterMerge.updateCount).to.equal(2)
+    expect(afterMerge.maturity).to.equal('validated')
+
+    // Step 5: Archive the merged target.
+    await archiveService.archiveEntry(tgtRel, agent, projectRoot)
+
+    // Sidecar entry for the archived path is gone.
+    expect((await signalStore.list()).has(tgtRel)).to.equal(false)
+    // No orphans remain for either path.
+    expect((await signalStore.list()).size).to.equal(0)
+  })
+})

--- a/test/unit/agent/tools/curate-tool-sidecar-dual-write.test.ts
+++ b/test/unit/agent/tools/curate-tool-sidecar-dual-write.test.ts
@@ -1,0 +1,363 @@
+import {expect} from 'chai'
+import * as fs from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+
+import type {IRuntimeSignalStore} from '../../../../src/server/core/interfaces/storage/i-runtime-signal-store.js'
+
+import {createCurateTool} from '../../../../src/agent/infra/tools/implementations/curate-tool.js'
+import {createDefaultRuntimeSignals} from '../../../../src/server/core/domain/knowledge/runtime-signals-schema.js'
+import {createMockRuntimeSignalStore} from '../../../helpers/mock-factories.js'
+
+interface CurateOutput {
+  applied: Array<{
+    message?: string
+    path: string
+    status: 'failed' | 'success'
+    type: string
+  }>
+  summary: {
+    added: number
+    deleted: number
+    failed: number
+    merged: number
+    updated: number
+  }
+}
+
+interface CurateTool {
+  execute(input: unknown): Promise<CurateOutput>
+}
+
+async function runCurate(
+  basePath: string,
+  signalStore: IRuntimeSignalStore,
+  operations: Array<Record<string, unknown>>,
+): Promise<CurateOutput> {
+  const tool = createCurateTool(undefined, undefined, signalStore) as unknown as CurateTool
+  return tool.execute({basePath, operations})
+}
+
+describe('Curate tool — runtime-signal sidecar dual-write', () => {
+  let tmpDir: string
+  let basePath: string
+  let signalStore: IRuntimeSignalStore
+
+  beforeEach(async () => {
+    tmpDir = join(tmpdir(), `curate-dual-write-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    basePath = join(tmpDir, '.brv/context-tree')
+    await fs.mkdir(basePath, {recursive: true})
+    signalStore = createMockRuntimeSignalStore()
+  })
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, {force: true, recursive: true})
+  })
+
+  describe('ADD', () => {
+    it('seeds the sidecar with default signals for the new file', async () => {
+      const result = await runCurate(basePath, signalStore, [
+        {
+          confidence: 'high',
+          content: {snippets: ['const x = 1'], tags: ['test']},
+          impact: 'low',
+          path: 'tech_stack/typescript',
+          reason: 'init',
+          title: 'TypeScript Notes',
+          type: 'ADD',
+        },
+      ])
+
+      expect(result.summary.added).to.equal(1)
+      const relPath = 'tech_stack/typescript/typescript_notes.md'
+      const signals = await signalStore.get(relPath)
+      expect(signals).to.deep.equal(createDefaultRuntimeSignals())
+    })
+  })
+
+  describe('UPDATE', () => {
+    it('bumps importance/recency/updateCount and recomputes maturity in the sidecar', async () => {
+      // Seed via ADD so markdown + sidecar both start in sync.
+      await runCurate(basePath, signalStore, [
+        {
+          confidence: 'high',
+          content: {snippets: ['a'], tags: ['t']},
+          impact: 'low',
+          path: 'domain/topic',
+          reason: 'seed',
+          title: 'My Note',
+          type: 'ADD',
+        },
+      ])
+
+      const relPath = 'domain/topic/my_note.md'
+      const before = await signalStore.get(relPath)
+      expect(before.importance).to.equal(50)
+      expect(before.updateCount).to.equal(0)
+      expect(before.recency).to.equal(1)
+
+      // Simulate a "cold" sidecar by decaying recency so the update bump is visible.
+      await signalStore.update(relPath, (current) => ({...current, recency: 0.2}))
+
+      const updateResult = await runCurate(basePath, signalStore, [
+        {
+          confidence: 'high',
+          content: {snippets: ['a', 'b'], tags: ['t']},
+          impact: 'low',
+          path: 'domain/topic',
+          reason: 'update',
+          title: 'My Note',
+          type: 'UPDATE',
+        },
+      ])
+      expect(updateResult.summary.updated).to.equal(1)
+
+      const after = await signalStore.get(relPath)
+      expect(after.importance).to.equal(55) // 50 + UPDATE_IMPORTANCE_BONUS(5)
+      expect(after.recency).to.equal(1) // reset to 1 by recordCurateUpdate
+      expect(after.updateCount).to.equal(1)
+      expect(after.maturity).to.equal('draft') // 55 < PROMOTE_TO_VALIDATED(65)
+    })
+
+    it('maturity invariant: repeated updates promote draft -> validated when importance crosses 65', async () => {
+      // Seed, then apply 3 updates (+5 each = +15) on top of an already-elevated importance.
+      await runCurate(basePath, signalStore, [
+        {
+          confidence: 'high',
+          content: {snippets: ['a'], tags: ['t']},
+          impact: 'low',
+          path: 'd/t',
+          reason: 'seed',
+          title: 'N',
+          type: 'ADD',
+        },
+      ])
+      const relPath = 'd/t/n.md'
+
+      // Pre-set importance to 55 so the first UPDATE (+5=60) still stays draft,
+      // the second (+5=65) crosses the PROMOTE_TO_VALIDATED threshold.
+      await signalStore.set(relPath, {...createDefaultRuntimeSignals(), importance: 55})
+
+      const updateOp = {
+        confidence: 'high' as const,
+        content: {snippets: ['a'], tags: ['t']},
+        impact: 'low' as const,
+        path: 'd/t',
+        reason: 'u',
+        title: 'N',
+        type: 'UPDATE' as const,
+      }
+
+      await runCurate(basePath, signalStore, [updateOp])
+      expect((await signalStore.get(relPath)).maturity).to.equal('draft')
+
+      await runCurate(basePath, signalStore, [updateOp])
+      expect((await signalStore.get(relPath)).maturity).to.equal('validated')
+    })
+  })
+
+  describe('DELETE', () => {
+    it('drops the sidecar entry for the deleted file', async () => {
+      await runCurate(basePath, signalStore, [
+        {
+          confidence: 'high',
+          content: {snippets: ['a'], tags: ['t']},
+          impact: 'low',
+          path: 'x/y',
+          reason: 'seed',
+          title: 'Z',
+          type: 'ADD',
+        },
+      ])
+      const relPath = 'x/y/z.md'
+      // Mark the sidecar entry with a non-default value so we can verify removal.
+      await signalStore.set(relPath, {...createDefaultRuntimeSignals(), importance: 87})
+
+      const delResult = await runCurate(basePath, signalStore, [
+        {
+          confidence: 'low',
+          impact: 'low',
+          path: 'x/y',
+          reason: 'clean',
+          title: 'Z',
+          type: 'DELETE',
+        },
+      ])
+      expect(delResult.summary.deleted).to.equal(1)
+
+      // After delete, sidecar get() should return defaults (entry gone).
+      const after = await signalStore.get(relPath)
+      expect(after).to.deep.equal(createDefaultRuntimeSignals())
+    })
+  })
+
+  describe('MERGE', () => {
+    it('merges source+target signals into the target and drops the source entry', async () => {
+      // Seed two files.
+      await runCurate(basePath, signalStore, [
+        {
+          confidence: 'high',
+          content: {snippets: ['a'], tags: ['t']},
+          impact: 'low',
+          path: 'auth/jwt',
+          reason: 'seed src',
+          title: 'Refresh',
+          type: 'ADD',
+        },
+        {
+          confidence: 'high',
+          content: {snippets: ['b'], tags: ['t']},
+          impact: 'low',
+          path: 'auth/jwt',
+          reason: 'seed tgt',
+          title: 'Rotation',
+          type: 'ADD',
+        },
+      ])
+
+      const srcRel = 'auth/jwt/refresh.md'
+      const tgtRel = 'auth/jwt/rotation.md'
+
+      // Give source and target distinct signal profiles.
+      await signalStore.set(srcRel, {accessCount: 3, importance: 70, maturity: 'validated', recency: 0.6, updateCount: 2})
+      await signalStore.set(tgtRel, {accessCount: 5, importance: 50, maturity: 'draft', recency: 1, updateCount: 0})
+
+      const mergeResult = await runCurate(basePath, signalStore, [
+        {
+          confidence: 'high',
+          impact: 'low',
+          mergeTarget: 'auth/jwt',
+          mergeTargetTitle: 'Rotation',
+          path: 'auth/jwt',
+          reason: 'consolidate',
+          title: 'Refresh',
+          type: 'MERGE',
+        },
+      ])
+      expect(mergeResult.summary.merged).to.equal(1)
+
+      // Source entry dropped.
+      expect(await signalStore.get(srcRel)).to.deep.equal(createDefaultRuntimeSignals())
+
+      // Target entry merged: max importance, max recency, sum counts, updateCount+1,
+      // tier re-derived from merged importance (70 -> validated by hysteresis).
+      const merged = await signalStore.get(tgtRel)
+      expect(merged.accessCount).to.equal(8)
+      expect(merged.importance).to.equal(70)
+      expect(merged.recency).to.equal(1)
+      expect(merged.updateCount).to.equal(3) // 2 + 0 + 1
+      expect(merged.maturity).to.equal('validated')
+    })
+  })
+
+  describe('markdown/sidecar consistency', () => {
+    it('ADD writes matching scoring to both markdown frontmatter and sidecar', async () => {
+      await runCurate(basePath, signalStore, [
+        {
+          confidence: 'high',
+          content: {snippets: ['code'], tags: ['t']},
+          impact: 'low',
+          path: 'd/t',
+          reason: 'seed',
+          title: 'Consistency',
+          type: 'ADD',
+        },
+      ])
+
+      const relPath = 'd/t/consistency.md'
+      const markdownPath = join(basePath, relPath)
+      const markdown = await fs.readFile(markdownPath, 'utf8')
+      const signals = await signalStore.get(relPath)
+
+      // Pull scoring fields out of the markdown frontmatter.
+      const importanceMatch = /^importance:\s*(\d+)/m.exec(markdown)
+      const maturityMatch = /^maturity:\s*(core|draft|validated)/m.exec(markdown)
+      const recencyMatch = /^recency:\s*([\d.]+)/m.exec(markdown)
+
+      expect(importanceMatch?.[1]).to.equal(String(signals.importance))
+      expect(maturityMatch?.[1]).to.equal(signals.maturity)
+      expect(recencyMatch?.[1]).to.equal(String(signals.recency))
+    })
+
+    it('UPDATE keeps markdown and sidecar in sync after a bump', async () => {
+      // Seed.
+      await runCurate(basePath, signalStore, [
+        {
+          confidence: 'high',
+          content: {snippets: ['a'], tags: ['t']},
+          impact: 'low',
+          path: 'd/t',
+          reason: 'seed',
+          title: 'Sync',
+          type: 'ADD',
+        },
+      ])
+      // Bump.
+      await runCurate(basePath, signalStore, [
+        {
+          confidence: 'high',
+          content: {snippets: ['a', 'b'], tags: ['t']},
+          impact: 'low',
+          path: 'd/t',
+          reason: 'bump',
+          title: 'Sync',
+          type: 'UPDATE',
+        },
+      ])
+
+      const relPath = 'd/t/sync.md'
+      const markdown = await fs.readFile(join(basePath, relPath), 'utf8')
+      const signals = await signalStore.get(relPath)
+
+      const importanceMatch = /^importance:\s*(\d+)/m.exec(markdown)
+      const maturityMatch = /^maturity:\s*(core|draft|validated)/m.exec(markdown)
+      const updateCountMatch = /^updateCount:\s*(\d+)/m.exec(markdown)
+
+      expect(importanceMatch?.[1]).to.equal(String(signals.importance))
+      expect(maturityMatch?.[1]).to.equal(signals.maturity)
+      expect(updateCountMatch?.[1]).to.equal(String(signals.updateCount))
+    })
+  })
+
+  describe('sidecar failure isolation', () => {
+    it('does not abort a curate ADD when the sidecar throws', async () => {
+      const throwing: IRuntimeSignalStore = {
+        async batchUpdate() {},
+        async delete() {
+          throw new Error('sidecar down')
+        },
+        async get() {
+          return createDefaultRuntimeSignals()
+        },
+        async getMany() {
+          return new Map()
+        },
+        async list() {
+          return new Map()
+        },
+        async set() {
+          throw new Error('sidecar down')
+        },
+        async update() {
+          throw new Error('sidecar down')
+        },
+      }
+
+      const result = await runCurate(basePath, throwing, [
+        {
+          confidence: 'high',
+          content: {snippets: ['a'], tags: ['t']},
+          impact: 'low',
+          path: 'd/t',
+          reason: 'test',
+          title: 'N',
+          type: 'ADD',
+        },
+      ])
+
+      // ADD completed — markdown write succeeded despite sidecar failure.
+      expect(result.summary.added).to.equal(1)
+      expect(result.summary.failed).to.equal(0)
+    })
+  })
+})

--- a/test/unit/agent/tools/search-knowledge-flush-sidecar.test.ts
+++ b/test/unit/agent/tools/search-knowledge-flush-sidecar.test.ts
@@ -1,0 +1,148 @@
+import {expect} from 'chai'
+import * as fs from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+
+import type {IFileSystem} from '../../../../src/agent/core/interfaces/i-file-system.js'
+import type {IRuntimeSignalStore} from '../../../../src/server/core/interfaces/storage/i-runtime-signal-store.js'
+
+import {SearchKnowledgeService} from '../../../../src/agent/infra/tools/implementations/search-knowledge-service.js'
+import {createDefaultRuntimeSignals} from '../../../../src/server/core/domain/knowledge/runtime-signals-schema.js'
+import {createMockRuntimeSignalStore} from '../../../helpers/mock-factories.js'
+
+// Minimal IFileSystem shim backed by real disk.
+function createDiskFileSystem(): IFileSystem {
+  return {
+    async readFile(path: string) {
+      return {content: await fs.readFile(path, 'utf8')}
+    },
+    async writeFile(path: string, content: string) {
+      await fs.writeFile(path, content, 'utf8')
+    },
+  } as unknown as IFileSystem
+}
+
+interface PendingAccessHitsInternals {
+  pendingAccessHits: Map<string, number>
+}
+
+// Narrow unsafe-cast helper: SearchKnowledgeService accumulates access hits
+// via private `pendingAccessHits`. The flush pipeline is the unit under test,
+// so we prime the map directly rather than going through the indexing path.
+function primePendingHits(service: SearchKnowledgeService, hits: Record<string, number>): void {
+  const bag = (service as unknown as PendingAccessHitsInternals).pendingAccessHits
+  bag.clear()
+  for (const [path, count] of Object.entries(hits)) {
+    bag.set(path, count)
+  }
+}
+
+const MARKDOWN_WITH_SCORING = `---
+title: Test
+importance: 50
+recency: 1
+maturity: draft
+accessCount: 0
+updateCount: 0
+---
+
+Body.
+`
+
+describe('SearchKnowledgeService — flushAccessHits dual-write', () => {
+  let tmpDir: string
+  let contextTreeDir: string
+  let signalStore: IRuntimeSignalStore
+  let service: SearchKnowledgeService
+
+  beforeEach(async () => {
+    tmpDir = join(tmpdir(), `sks-flush-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    contextTreeDir = join(tmpDir, 'ctx')
+    await fs.mkdir(contextTreeDir, {recursive: true})
+    signalStore = createMockRuntimeSignalStore()
+    service = new SearchKnowledgeService(createDiskFileSystem(), {runtimeSignalStore: signalStore})
+  })
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, {force: true, recursive: true})
+  })
+
+  it('mirrors accumulated hits into the sidecar with bumped importance and accessCount', async () => {
+    const relPath = 'auth/jwt.md'
+    const filePath = join(contextTreeDir, relPath)
+    await fs.mkdir(join(contextTreeDir, 'auth'), {recursive: true})
+    await fs.writeFile(filePath, MARKDOWN_WITH_SCORING, 'utf8')
+
+    primePendingHits(service, {[relPath]: 4})
+
+    const flushed = await service.flushAccessHits(contextTreeDir)
+    expect(flushed).to.equal(true)
+
+    const signals = await signalStore.get(relPath)
+    // importance: 50 + 3 * 4 = 62
+    expect(signals.importance).to.equal(62)
+    expect(signals.accessCount).to.equal(4)
+    // 62 < 65 -> stays draft under hysteresis
+    expect(signals.maturity).to.equal('draft')
+  })
+
+  it('promotes maturity from draft to validated once importance crosses 65', async () => {
+    const relPath = 'domain/topic.md'
+    const filePath = join(contextTreeDir, relPath)
+    await fs.mkdir(join(contextTreeDir, 'domain'), {recursive: true})
+    await fs.writeFile(filePath, MARKDOWN_WITH_SCORING, 'utf8')
+
+    // Prime the sidecar at importance 60 so 3 hits (+9) crosses the threshold.
+    await signalStore.set(relPath, {...createDefaultRuntimeSignals(), importance: 60})
+    primePendingHits(service, {[relPath]: 3})
+
+    await service.flushAccessHits(contextTreeDir)
+
+    const signals = await signalStore.get(relPath)
+    expect(signals.importance).to.equal(69)
+    expect(signals.maturity).to.equal('validated')
+  })
+
+  it('returns false and does not touch the sidecar when there are no pending hits', async () => {
+    const flushed = await service.flushAccessHits(contextTreeDir)
+    expect(flushed).to.equal(false)
+    // No side effects — signal store is empty.
+    expect((await signalStore.list()).size).to.equal(0)
+  })
+
+  it('completes the markdown flush even if the sidecar batchUpdate throws', async () => {
+    const throwing: IRuntimeSignalStore = {
+      async batchUpdate() {
+        throw new Error('sidecar down')
+      },
+      async delete() {},
+      async get() {
+        return createDefaultRuntimeSignals()
+      },
+      async getMany() {
+        return new Map()
+      },
+      async list() {
+        return new Map()
+      },
+      async set() {},
+      async update() {
+        return createDefaultRuntimeSignals()
+      },
+    }
+    const isolated = new SearchKnowledgeService(createDiskFileSystem(), {runtimeSignalStore: throwing})
+
+    const relPath = 'x.md'
+    const filePath = join(contextTreeDir, relPath)
+    await fs.writeFile(filePath, MARKDOWN_WITH_SCORING, 'utf8')
+    primePendingHits(isolated, {[relPath]: 1})
+
+    const flushed = await isolated.flushAccessHits(contextTreeDir)
+    expect(flushed).to.equal(true)
+
+    // Markdown was written despite sidecar failure — read it back and verify
+    // importance bumped (50 + 3 = 53).
+    const rewritten = await fs.readFile(filePath, 'utf8')
+    expect(rewritten).to.include('importance: 53')
+  })
+})

--- a/test/unit/infra/context-tree/archive-service-sidecar-dual-write.test.ts
+++ b/test/unit/infra/context-tree/archive-service-sidecar-dual-write.test.ts
@@ -1,0 +1,180 @@
+import {expect} from 'chai'
+import {mkdir, rm, writeFile} from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+
+import type {ICipherAgent} from '../../../../src/agent/core/interfaces/i-cipher-agent.js'
+import type {IRuntimeSignalStore} from '../../../../src/server/core/interfaces/storage/i-runtime-signal-store.js'
+
+import {BRV_DIR, CONTEXT_TREE_DIR} from '../../../../src/server/constants.js'
+import {createDefaultRuntimeSignals} from '../../../../src/server/core/domain/knowledge/runtime-signals-schema.js'
+import {FileContextTreeArchiveService} from '../../../../src/server/infra/context-tree/file-context-tree-archive-service.js'
+import {createMockRuntimeSignalStore} from '../../../helpers/mock-factories.js'
+
+function createMockAgent(ghostCue = 'ghost cue'): ICipherAgent {
+  return {
+    async cancel() {},
+    async createTaskSession() {
+      return 'mock-session-id'
+    },
+    async deleteSandboxVariable() {},
+    async deleteSandboxVariableOnSession() {},
+    async deleteSession() {},
+    async deleteTaskSession() {},
+    async execute() {
+      return ghostCue
+    },
+    async executeOnSession() {
+      return ghostCue
+    },
+    async generate() {
+      return ghostCue
+    },
+    async getSessionMetadata() {},
+    getState() {
+      return 'idle'
+    },
+    async listPersistedSessions() {
+      return []
+    },
+    async reset() {},
+    async setSandboxVariable() {},
+    async setSandboxVariableOnSession() {},
+    async start() {},
+    async *stream() {
+      yield ghostCue
+    },
+  } as unknown as ICipherAgent
+}
+
+const MARKDOWN_WITH_SCORING = `---
+title: Tokens
+importance: 45
+maturity: draft
+---
+
+# Tokens
+Content.
+`
+
+describe('FileContextTreeArchiveService — sidecar dual-write', () => {
+  let testDir: string
+  let contextTreeDir: string
+  let signalStore: IRuntimeSignalStore
+  let service: FileContextTreeArchiveService
+  let agent: ICipherAgent
+
+  beforeEach(async () => {
+    testDir = join(tmpdir(), `archive-dual-write-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    contextTreeDir = join(testDir, BRV_DIR, CONTEXT_TREE_DIR)
+    await mkdir(contextTreeDir, {recursive: true})
+    signalStore = createMockRuntimeSignalStore()
+    service = new FileContextTreeArchiveService(signalStore)
+    agent = createMockAgent()
+  })
+
+  afterEach(async () => {
+    await rm(testDir, {force: true, recursive: true})
+  })
+
+  describe('archiveEntry', () => {
+    it('drops the sidecar entry for the archived path', async () => {
+      const relPath = 'auth/tokens.md'
+      await mkdir(join(contextTreeDir, 'auth'), {recursive: true})
+      await writeFile(join(contextTreeDir, relPath), MARKDOWN_WITH_SCORING, 'utf8')
+
+      // Seed the sidecar with a non-default value so we can observe the delete.
+      await signalStore.set(relPath, {...createDefaultRuntimeSignals(), importance: 42})
+
+      await service.archiveEntry(relPath, agent, testDir)
+
+      // After archive, get() returns defaults — entry was deleted.
+      const after = await signalStore.get(relPath)
+      expect(after).to.deep.equal(createDefaultRuntimeSignals())
+      // And the map does not contain this key.
+      expect((await signalStore.list()).has(relPath)).to.equal(false)
+    })
+
+    it('succeeds even if the sidecar delete throws', async () => {
+      const throwing: IRuntimeSignalStore = {
+        async batchUpdate() {},
+        async delete() {
+          throw new Error('sidecar down')
+        },
+        async get() {
+          return createDefaultRuntimeSignals()
+        },
+        async getMany() {
+          return new Map()
+        },
+        async list() {
+          return new Map()
+        },
+        async set() {},
+        async update() {
+          return createDefaultRuntimeSignals()
+        },
+      }
+      const isolated = new FileContextTreeArchiveService(throwing)
+
+      const relPath = 'x.md'
+      await writeFile(join(contextTreeDir, relPath), MARKDOWN_WITH_SCORING, 'utf8')
+
+      // Must not throw — markdown archive completes even though sidecar fails.
+      const result = await isolated.archiveEntry(relPath, agent, testDir)
+      expect(result.originalPath).to.equal(relPath)
+      expect(result.stubPath).to.include('_archived/x.stub.md')
+    })
+  })
+
+  describe('restoreEntry', () => {
+    it('seeds default signals for the restored path', async () => {
+      const relPath = 'auth/tokens.md'
+      await mkdir(join(contextTreeDir, 'auth'), {recursive: true})
+      await writeFile(join(contextTreeDir, relPath), MARKDOWN_WITH_SCORING, 'utf8')
+
+      // Archive first so there is something to restore.
+      const archiveResult = await service.archiveEntry(relPath, agent, testDir)
+      // Sidecar is empty at this point (archive deleted any entry and there was none).
+      expect((await signalStore.list()).size).to.equal(0)
+
+      await service.restoreEntry(archiveResult.stubPath, testDir)
+
+      // Sidecar now has a default entry for the restored path.
+      const after = await signalStore.get(relPath)
+      expect(after).to.deep.equal(createDefaultRuntimeSignals())
+      expect((await signalStore.list()).has(relPath)).to.equal(true)
+    })
+
+    it('succeeds even if the sidecar set throws on restore', async () => {
+      const throwing: IRuntimeSignalStore = {
+        async batchUpdate() {},
+        async delete() {},
+        async get() {
+          return createDefaultRuntimeSignals()
+        },
+        async getMany() {
+          return new Map()
+        },
+        async list() {
+          return new Map()
+        },
+        async set() {
+          throw new Error('sidecar down')
+        },
+        async update() {
+          return createDefaultRuntimeSignals()
+        },
+      }
+      const isolated = new FileContextTreeArchiveService(throwing)
+
+      const relPath = 'y.md'
+      await writeFile(join(contextTreeDir, relPath), MARKDOWN_WITH_SCORING, 'utf8')
+      const archiveResult = await isolated.archiveEntry(relPath, agent, testDir)
+
+      // Restore must not throw even though sidecar.set rejects.
+      const restored = await isolated.restoreEntry(archiveResult.stubPath, testDir)
+      expect(restored).to.equal(relPath)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Problem: Commit 2 landed a sidecar store for per-machine ranking signals, but no code wrote to it. Signals still lived in markdown frontmatter, dirtying version control on every query.
- Why it matters: This commit populates the sidecar at every mutation site. Commit 4 switches reads over; commit 5 stops writing signals to markdown. This PR is the pivot — from commit 3 onward, both stores have the same data, so later commits can flip without losing state.
- What changed: Dual-write at 7 mutation sites (`flushAccessHits`, curate ADD/UPDATE/MERGE/DELETE, archive/restore). `ToolServices` gains `runtimeSignalStore`; the daemon builds its own store via a local `FileKeyStorage`. Initializer reordered so the store is available to `ToolProvider` at construction time.
- What did NOT change (scope boundary): No read path touches the sidecar. Ranking still reads from markdown. YAML emitter still writes all scoring fields. Cloud sync untouched. Those land in commits 4-6.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [x] Agent / Tools
- [ ] LLM Providers
- [x] Server / Daemon
- [x] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes #
- Related: runtime-signals sidecar series — ENG-2133. Commit 1 in PR #447, commit 2 in the preceding PR.

## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause: N/A
- Why this was not caught earlier: N/A

## Test plan

- Coverage added:
  - [x] Unit test
  - [x] Integration test
  - [ ] Manual verification only
- Test file(s):
  - `test/unit/agent/tools/curate-tool-sidecar-dual-write.test.ts` — 8 tests
  - `test/unit/agent/tools/search-knowledge-flush-sidecar.test.ts` — 4 tests
  - `test/unit/infra/context-tree/archive-service-sidecar-dual-write.test.ts` — 4 tests
  - `test/integration/runtime-signals/dual-write-pipeline.test.ts` — 1 end-to-end test
- Key scenario(s) covered:
  - ADD seeds default signals in sidecar
  - UPDATE bumps importance/recency/updateCount and retiered maturity; `updatedAt` not mirrored
  - DELETE drops sidecar entry
  - MERGE combines source+target signals via `mergeScoring`, drops source entry, retiered maturity
  - flushAccessHits mirrors importance/accessCount/maturity via batchUpdate
  - archive drops sidecar entry; restore seeds defaults
  - **Hysteresis invariant**: repeated UPDATE bumps promote `draft` → `validated` at importance ≥ 65
  - **Failure isolation**: throwing sidecar does not abort markdown writes at any site
  - **Markdown/sidecar consistency**: frontmatter scoring fields match sidecar after ADD and UPDATE
  - **Full pipeline**: ADD → UPDATE → flushAccessHits → MERGE → archive — sidecar state matches computed end state, no orphans remain

## User-visible changes

None. Markdown is still canonical; the sidecar shadows it. Users will not observe any behavior change until commit 4 redirects reads.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording

**New dual-write tests:**

**Full repo suite:** 6476 passing, 0 failing (commit 2 ended at 6459; +17 new tests across this series of PRs).

## Checklist

- [x] Tests added or updated and passing (`npm test`)
- [x] Lint passes (`npm run lint`) — 0 errors, 202 pre-existing warnings (none new)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated (if applicable) — N/A, internal change
- [x] No breaking changes
- [x] Branch is up to date with `main`

## Risks and mitigations

- Risk: **A caller that bumps `importance` forgets to recompute `maturity` via `determineTier`.** The store layer does not enforce the hysteresis invariant — it accepts any schema-valid combination. A bad updater would produce `{importance: 90, maturity: 'draft'}` which violates the tier rules.
  - Mitigation: Every site in this PR recomputes maturity inside the atomic updater. Hysteresis-promotion test confirms the invariant holds for both UPDATE and flushAccessHits. Merge delegates to `mergeScoring` + `determineTier` together. Reviewer must check that any future sidecar updater follows the same pattern.
- Risk: **`updatedAt` leaks into the sidecar.** `updatedAt` reflects content change, not a runtime signal — must stay in markdown only.
  - Mitigation: `RuntimeSignals` type has no `updatedAt` field. By construction the type system blocks accidental mirroring. Verified at every updater by inspection.
- Risk: **Sidecar failures silently swallowed without logging.** Each try/catch in the curate helpers and archive service swallows operational errors (disk, permissions) without a `warn` log. `RuntimeSignalStore.validateOrDefault` logs corrupt-data cases but not write failures.
  - Mitigation: Acceptable for phase 3 (markdown canonical — failures self-heal on the next bump). Documented in backlog with a trigger (fix before commit 5 ships, when sidecar becomes canonical).
- Risk: **Swarm's internal SearchKnowledgeService and `dream.ts` CLI path don't receive the store.** Two peripheral code paths still write to markdown only.
  - Mitigation: Both documented in the backlog. Primary user-facing paths (daemon search, curate tools, archive via daemon dream flow) are covered. These peripheral paths become visible gaps only when commit 5 stops writing markdown — will be resolved before that commit merges.
- Risk: **Daemon-side `FileKeyStorage` in `agent-process.ts` creates a second store instance targeting the same on-disk path as the agent-side instance.** Both processes can race on the same signal record.
  - Mitigation: Explicitly documented in the interface — cross-process contention has a narrow lost-update window, acceptable for ranking signals. The daemon and agent-side instances share the same file-backed `IKeyStorage` layout, so writes are consistent on disk; only per-read-modify-write atomicity is in-process.

## Related

- Previous commits in this series:
  - [Runtime Signals 1/6] RuntimeSignals schema and types
  - [Runtime Signals 2/6] RuntimeSignalStore implementation and wiring
- Next commit: [Runtime Signals 4/6] Switch read paths to sidecar
- Backlog: `features/runtime-signals/backlog.md` — swarm coverage, dream CLI path, sidecar failure logging, metrics

