### PR TITLE
feat: [ENG-2159] switch all ranking read paths to sidecar (4/6)

### DIFF
--- a/src/agent/infra/tools/implementations/curate-tool.ts
+++ b/src/agent/infra/tools/implementations/curate-tool.ts
@@ -1,7 +1,7 @@
 import {basename, dirname, join, relative, resolve} from 'node:path'
 import {z} from 'zod'
 
-import type {ContextData} from '../../../../server/core/domain/knowledge/markdown-writer.js'
+import type {ContextData, FrontmatterScoring} from '../../../../server/core/domain/knowledge/markdown-writer.js'
 import type {IRuntimeSignalStore} from '../../../../server/core/interfaces/storage/i-runtime-signal-store.js'
 import type {Tool, ToolExecutionContext} from '../../../core/domain/tools/types.js'
 import type {AbstractGenerationQueue} from '../../map/abstract-queue.js'
@@ -14,6 +14,7 @@ import {
   determineTier,
   mergeScoring,
   recordCurateUpdate,
+  UPDATE_IMPORTANCE_BONUS,
 } from '../../../../server/core/domain/knowledge/memory-scoring.js'
 import {
   createDefaultRuntimeSignals,
@@ -36,6 +37,19 @@ type WriteCallback = (contextPath: string, content: string) => void
  */
 function relPathFromContextPath(contextPath: string, basePath: string): string {
   return relative(basePath, contextPath).split('\\').join('/')
+}
+
+/**
+ * Preserve the original `createdAt` from the existing markdown frontmatter on
+ * UPDATE. `createdAt` is immutable content metadata, not a runtime signal, so
+ * it stays in the markdown source-of-truth. Falls back to a fresh timestamp
+ * when the existing file has no `createdAt` (old files or those that never
+ * had it).
+ */
+function existingScoringCreatedAt(existingContent: null | string | undefined): string {
+  if (!existingContent) return new Date().toISOString()
+  const existing = parseFrontmatterScoring(existingContent)
+  return existing?.createdAt ?? new Date().toISOString()
 }
 
 /**
@@ -927,15 +941,28 @@ async function executeUpdate(
 
     await createDomainContextIfMissing(basePath, parsed.domain, domainContext, onAfterWrite)
 
-    // Read existing file to preserve scoring metadata and detect structural loss
+    // Read existing file to detect structural loss
     const existingContent = await DirectoryManager.readFile(contextPath)
-    const existingScoring = existingContent ? parseFrontmatterScoring(existingContent) : undefined
-    const updatedScoring = existingScoring ? recordCurateUpdate(existingScoring) : applyDefaultScoring()
-    const newTier = determineTier(
-      updatedScoring.importance ?? 50,
-      (updatedScoring.maturity ?? 'draft') as 'core' | 'draft' | 'validated',
-    )
-    const finalScoring = {...updatedScoring, maturity: newTier}
+
+    // Source of truth for scoring is the sidecar, not markdown. Markdown may
+    // carry stale values post-commit-4 (ranking bumps go to the sidecar only)
+    // so reading from markdown here would silently regress the importance /
+    // maturity we re-serialise in the dual-write path. When no sidecar store
+    // is provided, fall back to defaults — consistent with ADD semantics.
+    const baseSignals = runtimeSignalStore
+      ? await runtimeSignalStore.get(relPathFromContextPath(contextPath, basePath))
+      : createDefaultRuntimeSignals()
+    const bumpedImportance = Math.min(100, baseSignals.importance + UPDATE_IMPORTANCE_BONUS)
+    const nextTier = determineTier(bumpedImportance, baseSignals.maturity)
+    const finalScoring: FrontmatterScoring = {
+      accessCount: baseSignals.accessCount,
+      createdAt: existingScoringCreatedAt(existingContent),
+      importance: bumpedImportance,
+      maturity: nextTier,
+      recency: 1,
+      updateCount: baseSignals.updateCount + 1,
+      updatedAt: new Date().toISOString(),
+    }
 
     // Filter out non-existent files from rawConcept.files
     const filteredContent = await filterValidFiles(content)

--- a/src/agent/infra/tools/implementations/search-knowledge-service.ts
+++ b/src/agent/infra/tools/implementations/search-knowledge-service.ts
@@ -5,6 +5,7 @@ import {removeStopwords} from 'stopword'
 
 import type {IRuntimeSignalStore} from '../../../../server/core/interfaces/storage/i-runtime-signal-store.js'
 import type {IFileSystem} from '../../../core/interfaces/i-file-system.js'
+import type {ILogger} from '../../../core/interfaces/i-logger.js'
 import type {ISearchKnowledgeService, SearchKnowledgeResult} from '../../sandbox/tools-sdk.js'
 
 import {
@@ -27,7 +28,10 @@ import {
   determineTier,
   recordAccessHits,
 } from '../../../../server/core/domain/knowledge/memory-scoring.js'
-import {type RuntimeSignals} from '../../../../server/core/domain/knowledge/runtime-signals-schema.js'
+import {
+  createDefaultRuntimeSignals,
+  type RuntimeSignals,
+} from '../../../../server/core/domain/knowledge/runtime-signals-schema.js'
 import {loadSources, type SearchOrigin} from '../../../../server/core/domain/source/source-schema.js'
 import {isArchiveStub, isDerivedArtifact} from '../../../../server/infra/context-tree/derived-artifact.js'
 import {
@@ -108,6 +112,7 @@ function propagateScoresToParents(
   symbolTree: MemorySymbolTree,
   summaryMap: Map<string, SummaryDocLike>,
   symbolPathDocMap: Map<string, IndexedDocument>,
+  signalsByPath: Map<string, RuntimeSignals>,
   propagationFactor = 0.55,
 ): SearchKnowledgeResult['results'] {
   const boosts = new Map<string, number>()
@@ -132,11 +137,15 @@ function propagateScoresToParents(
     const doc = getSummarySource(parentPath, summaryMap, symbolPathDocMap)
     if (!doc) continue
 
-    // Propagate the strongest child BM25 signal upward, then apply the parent
-    // summary's own scoring exactly once. This avoids double-counting lifecycle
-    // weights that are already baked into child compound scores.
-    const finalScore = doc.scoring
-      ? compoundScore(score, doc.scoring.importance ?? 50, doc.scoring.recency ?? 0.5, doc.scoring.maturity ?? 'draft')
+    // Propagate the strongest child BM25 signal upward. Apply the parent
+    // summary's own scoring boost only when the sidecar has a concrete entry
+    // for this path — matches the pre-migration behaviour where summaries
+    // without scoring in their frontmatter were not boosted. Lookup uses the
+    // summary doc's file path (e.g. `auth/jwt/_index.md`) which matches the
+    // sidecar's relPath key scheme.
+    const sidecarSignals = signalsByPath.get(doc.path)
+    const finalScore = sidecarSignals
+      ? compoundScore(score, sidecarSignals)
       : score
 
     boosted.push({
@@ -232,6 +241,12 @@ export interface SearchKnowledgeServiceConfig {
   baseDirectory?: string
   /** Cache TTL in milliseconds (defaults to 5000) */
   cacheTtlMs?: number
+  /**
+   * Optional logger. When provided, sidecar read failures on the ranking
+   * path emit a `warn` so the fail-open degradation is observable rather
+   * than silent.
+   */
+  logger?: ILogger
   /**
    * Sidecar store for runtime ranking signals. When provided, `flushAccessHits`
    * mirrors its importance/accessCount/maturity bumps to the store alongside
@@ -885,6 +900,7 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
   private readonly baseDirectory: string
   private readonly cacheTtlMs: number
   private readonly fileSystem: IFileSystem
+  private readonly logger?: ILogger
   private readonly pendingAccessHits: Map<string, number> = new Map()
   private readonly runtimeSignalStore?: IRuntimeSignalStore
   private readonly state: IndexState = {
@@ -896,6 +912,7 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
     this.fileSystem = fileSystem
     this.baseDirectory = config.baseDirectory ?? process.cwd()
     this.cacheTtlMs = config.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS
+    this.logger = config.logger
     this.runtimeSignalStore = config.runtimeSignalStore
   }
 
@@ -985,6 +1002,14 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
       return this.buildOverviewResult(symbolTree, referenceIndex, normalizedScope, options.overviewDepth)
     }
 
+    // Load the runtime-signal sidecar map for the specific paths this query
+    // touches: all document paths in the index plus their summary siblings.
+    // This is O(k) per search instead of O(all entries). Entries are present
+    // only for paths with stored signals — callers use `.has()` to distinguish
+    // missing from default, and `.get(path) ?? defaults` for ergonomic
+    // default-on-miss. On sidecar failure, degrade to BM25-only ranking.
+    const signalsByPath = await this.loadSignalsByPath(documentMap, summaryMap)
+
     // Symbolic path resolution: try path-based query first
     if (isPathLikeQuery(query, symbolTree)) {
       const symbolicResult = this.trySymbolicSearch(
@@ -997,6 +1022,7 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
         pathToDocumentId,
         summaryMap,
         symbolPathDocMap,
+        signalsByPath,
         options,
       )
 
@@ -1027,6 +1053,7 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
       referenceIndex,
       summaryMap,
       symbolPathDocMap,
+      signalsByPath,
       options,
     )
 
@@ -1043,6 +1070,7 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
         referenceIndex,
         summaryMap,
         symbolPathDocMap,
+        signalsByPath,
         options,
       )
     }
@@ -1145,6 +1173,35 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
   }
 
   /**
+   * Load the runtime-signal map for this search via `getMany`, limiting the
+   * request to paths that this search could possibly rank: every indexed
+   * document plus every summary sibling (parent-propagation can touch any
+   * summary). The returned map contains entries only for paths with stored
+   * signals; callers use `.has()` / `.get()` to distinguish missing from
+   * default. Returns an empty map on sidecar failure so ranking degrades to
+   * BM25 alone rather than erroring out mid-query.
+   */
+  private async loadSignalsByPath(
+    documentMap: Map<string, IndexedDocument>,
+    summaryMap: Map<string, SummaryDocLike>,
+  ): Promise<Map<string, RuntimeSignals>> {
+    if (!this.runtimeSignalStore) return new Map()
+
+    const paths = new Set<string>()
+    for (const doc of documentMap.values()) paths.add(doc.path)
+    for (const summary of summaryMap.values()) paths.add(summary.path)
+
+    try {
+      return await this.runtimeSignalStore.getMany([...paths])
+    } catch (error) {
+      this.logger?.warn(
+        `SearchKnowledgeService: sidecar getMany failed, falling back to BM25-only ranking: ${error instanceof Error ? error.message : String(error)}`,
+      )
+      return new Map()
+    }
+  }
+
+  /**
    * Mirror a batch of access-hit bumps into the runtime-signal sidecar.
    *
    * Matches the markdown flush semantics above:
@@ -1201,6 +1258,7 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
     referenceIndex: ReferenceIndex,
     summaryMap: Map<string, SummaryDocLike>,
     symbolPathDocMap: Map<string, IndexedDocument>,
+    signalsByPath: Map<string, RuntimeSignals>,
     options?: SearchOptions,
   ): SearchKnowledgeResult {
     const filteredQuery = filterStopWords(query)
@@ -1243,14 +1301,19 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
     // Normalize BM25 scores to [0, 1) then blend with importance + recency via compound scoring.
     // Decay is computed lazily from file mtime — no disk writes during search.
     // Local results get a configurable score boost to prefer local knowledge over shared.
+    //
+    // Runtime signals (importance / recency / maturity) come from the sidecar
+    // `signalsByPath` map. Paths with no sidecar entry fall back to defaults —
+    // matches the pre-migration behaviour where missing-frontmatter files used
+    // applyDefaultScoring().
     const now = Date.now()
     const searchResults = rawResults.map((r) => {
       const doc = documentMap.get(r.id)
-      const scoring = doc?.scoring ?? applyDefaultScoring()
+      const signals = (doc && signalsByPath.get(doc.path)) ?? createDefaultRuntimeSignals()
       const daysSince = doc ? Math.max(0, (now - doc.mtime) / 86_400_000) : 0
-      const decayed = applyDecay(scoring, daysSince)
+      const decayed = applyDecay(signals, daysSince)
       const bm25 = normalizeScore(r.score)
-      let finalScore = compoundScore(bm25, decayed.importance ?? 50, decayed.recency ?? 1, decayed.maturity ?? 'draft')
+      let finalScore = compoundScore(bm25, decayed)
 
       // Local score boost: prefer local results over shared when scores are close
       if (doc?.origin === 'local') {
@@ -1336,10 +1399,17 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
           if (options?.minMaturity && enriched.symbolKind) {
             const docMaturity =
               enriched.symbolKind === 'summary'
-                ? (getSummarySource(enriched.path, summaryMap, symbolPathDocMap)?.scoring?.maturity ??
-                  symbolTree.symbolMap.get(enriched.path)?.metadata.maturity ??
+                ? (() => {
+                    const summaryDoc = getSummarySource(enriched.path, summaryMap, symbolPathDocMap)
+                    return (
+                      (summaryDoc && signalsByPath.get(summaryDoc.path)?.maturity) ??
+                      symbolTree.symbolMap.get(enriched.path)?.metadata.maturity ??
+                      'draft'
+                    )
+                  })()
+                : (signalsByPath.get(document.path)?.maturity ??
+                  symbolTree.symbolMap.get(document.symbolPath)?.metadata.maturity ??
                   'draft')
-                : (symbolTree.symbolMap.get(document.symbolPath)?.metadata.maturity ?? 'draft')
             if ((MATURITY_TIER_RANK[docMaturity] ?? 1) < (MATURITY_TIER_RANK[options.minMaturity] ?? 1)) {
               continue
             }
@@ -1355,7 +1425,13 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
     }
 
     // Propagate scores upward to parent domain/topic nodes (hierarchical retrieval)
-    const propagated = propagateScoresToParents(propagationInputs, symbolTree, summaryMap, symbolPathDocMap)
+    const propagated = propagateScoresToParents(
+      propagationInputs,
+      symbolTree,
+      summaryMap,
+      symbolPathDocMap,
+      signalsByPath,
+    )
     for (const p of propagated) {
       // Apply local score boost to propagated summaries so they stay competitive
       // with boosted direct BM25 hits (the boost was already applied to direct hits above)
@@ -1366,7 +1442,7 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
       if (options?.excludeKinds && p.symbolKind && options.excludeKinds.includes(p.symbolKind)) continue
       if (options?.minMaturity && p.symbolKind === 'summary') {
         const summaryDoc = getSummarySource(p.path, summaryMap, symbolPathDocMap)
-        const summaryMaturity = summaryDoc?.scoring?.maturity ?? 'draft'
+        const summaryMaturity = (summaryDoc && signalsByPath.get(summaryDoc.path)?.maturity) ?? 'draft'
         if ((MATURITY_TIER_RANK[summaryMaturity] ?? 1) < (MATURITY_TIER_RANK[options.minMaturity] ?? 1)) continue
       }
 
@@ -1413,6 +1489,7 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
     pathToDocumentId: Map<string, string>,
     summaryMap: Map<string, SummaryDocLike>,
     symbolPathDocMap: Map<string, IndexedDocument>,
+    signalsByPath: Map<string, RuntimeSignals>,
     options?: SearchOptions,
   ): null | SearchKnowledgeResult {
     const pathMatches = matchMemoryPath(symbolTree, query.split(/\s+/)[0].includes('/') ? query.split(/\s+/)[0] : query)
@@ -1467,6 +1544,7 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
         referenceIndex,
         summaryMap,
         symbolPathDocMap,
+        signalsByPath,
         options,
       )
     }

--- a/src/agent/infra/tools/implementations/search-knowledge-tool.ts
+++ b/src/agent/infra/tools/implementations/search-knowledge-tool.ts
@@ -1,5 +1,6 @@
 import {z} from 'zod'
 
+import type {IRuntimeSignalStore} from '../../../../server/core/interfaces/storage/i-runtime-signal-store.js'
 import type {Tool, ToolExecutionContext} from '../../../core/domain/tools/types.js'
 import type {IFileSystem} from '../../../core/interfaces/i-file-system.js'
 
@@ -60,6 +61,7 @@ const SearchKnowledgeInputSchema = z
 export interface SearchKnowledgeToolConfig {
   baseDirectory?: string
   cacheTtlMs?: number
+  runtimeSignalStore?: IRuntimeSignalStore
 }
 
 /**

--- a/src/agent/infra/tools/tool-registry.ts
+++ b/src/agent/infra/tools/tool-registry.ts
@@ -291,7 +291,9 @@ export const TOOL_REGISTRY: Record<KnownTool, ToolRegistryEntry> = {
   [ToolName.SEARCH_KNOWLEDGE]: {
     descriptionFile: 'search_knowledge',
     factory: (services) =>
-      createSearchKnowledgeTool(getRequiredService(services.fileSystemService, 'fileSystemService')),
+      createSearchKnowledgeTool(getRequiredService(services.fileSystemService, 'fileSystemService'), {
+        runtimeSignalStore: services.runtimeSignalStore,
+      }),
     markers: [ToolMarker.ContextBuilding, ToolMarker.Discovery],
     requiredServices: ['fileSystemService'],
   },

--- a/src/server/core/domain/knowledge/memory-scoring.ts
+++ b/src/server/core/domain/knowledge/memory-scoring.ts
@@ -11,6 +11,7 @@
  */
 
 import type {FrontmatterScoring} from './markdown-writer.js'
+import type {RuntimeSignals} from './runtime-signals-schema.js'
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -67,40 +68,37 @@ export const TIER_BOOST: Record<string, number> = {
  * then applies a tier-based boost.
  *
  * @param bm25Normalized - Normalized BM25 score in [0, 1)
- * @param importance - Importance score in [0, 100]
- * @param recency - Recency score in [0, 1]
- * @param maturity - Maturity tier ('draft' | 'validated' | 'core')
+ * @param signals - RuntimeSignals snapshot (importance, recency, maturity)
  * @returns Compound score (typically in [0, ~1.15])
  */
-export function compoundScore(bm25Normalized: number, importance: number, recency: number, maturity: string): number {
-  const normalizedImportance = Math.min(importance, 100) / 100
-  const base = W_RELEVANCE * bm25Normalized + W_IMPORTANCE * normalizedImportance + W_RECENCY * recency
-  const boost = TIER_BOOST[maturity] ?? TIER_BOOST.draft
+export function compoundScore(bm25Normalized: number, signals: RuntimeSignals): number {
+  const normalizedImportance = Math.min(signals.importance, 100) / 100
+  const base = W_RELEVANCE * bm25Normalized + W_IMPORTANCE * normalizedImportance + W_RECENCY * signals.recency
+  const boost = TIER_BOOST[signals.maturity] ?? TIER_BOOST.draft
 
   return base * boost
 }
 
 /**
- * Apply time-based exponential decay to scoring fields.
+ * Apply time-based exponential decay to a signals snapshot.
  *
  * Recency decays as exp(-days / DECAY_RECENCY_FACTOR).
  * Importance decays as importance * DECAY_IMPORTANCE_FACTOR^days.
  *
- * @param scoring - Current scoring state
+ * @param signals - Current RuntimeSignals snapshot
  * @param daysSinceLastUpdate - Days since the file was last updated
- * @returns New scoring with decayed values (original not mutated)
+ * @returns New signals with decayed values (original not mutated)
  */
-export function applyDecay(scoring: FrontmatterScoring, daysSinceLastUpdate: number): FrontmatterScoring {
+export function applyDecay(signals: RuntimeSignals, daysSinceLastUpdate: number): RuntimeSignals {
   if (daysSinceLastUpdate <= 0) {
-    return scoring
+    return signals
   }
 
-  const currentImportance = scoring.importance ?? 50
   const newRecency = Math.exp(-daysSinceLastUpdate / DECAY_RECENCY_FACTOR)
-  const newImportance = currentImportance * DECAY_IMPORTANCE_FACTOR ** daysSinceLastUpdate
+  const newImportance = signals.importance * DECAY_IMPORTANCE_FACTOR ** daysSinceLastUpdate
 
   return {
-    ...scoring,
+    ...signals,
     importance: Math.max(0, newImportance),
     recency: newRecency,
   }

--- a/src/server/core/interfaces/storage/i-runtime-signal-store.ts
+++ b/src/server/core/interfaces/storage/i-runtime-signal-store.ts
@@ -75,10 +75,14 @@ export interface IRuntimeSignalStore {
    * Bulk-read signals for a known set of paths.
    *
    * Preferred over {@link list} for ranking passes that operate on the
-   * top-N search results: O(N) where N is the number of requested paths,
-   * instead of O(all stored entries). The returned map always has an entry
-   * for every requested path — missing and corrupt records fall back to
-   * defaults, matching {@link get}.
+   * top-N search results: O(k) where k is the number of requested paths,
+   * instead of O(all stored entries).
+   *
+   * The returned map contains entries **only for paths that have a stored
+   * record**. Missing or corrupt records are omitted so callers can
+   * distinguish "no entry yet" from "entry with default values" via
+   * `.has(path)`. Use `map.get(path) ?? createDefaultRuntimeSignals()` when
+   * the caller wants defaults on miss.
    */
   getMany(relPaths: readonly string[]): Promise<Map<string, RuntimeSignals>>
 

--- a/src/server/infra/context-tree/file-context-tree-archive-service.ts
+++ b/src/server/infra/context-tree/file-context-tree-archive-service.ts
@@ -16,7 +16,7 @@ import {mkdir, readFile, unlink, writeFile} from 'node:fs/promises'
 import {dirname, extname, join} from 'node:path'
 
 import type {ICipherAgent} from '../../../agent/core/interfaces/i-cipher-agent.js'
-import type {FrontmatterScoring} from '../../core/domain/knowledge/markdown-writer.js'
+import type {RuntimeSignals} from '../../core/domain/knowledge/runtime-signals-schema.js'
 import type {ArchiveResult, DrillDownResult} from '../../core/domain/knowledge/summary-types.js'
 import type {IContextTreeArchiveService} from '../../core/interfaces/context-tree/i-context-tree-archive-service.js'
 import type {IRuntimeSignalStore} from '../../core/interfaces/storage/i-runtime-signal-store.js'
@@ -71,8 +71,11 @@ export class FileContextTreeArchiveService implements IContextTreeArchiveService
     const ghostCue = await this.generateGhostCue(agent, content)
     const ghostCueTokenCount = estimateTokens(ghostCue)
 
-    // Parse frontmatter to get importance for eviction metadata
-    const importance = this.extractImportance(content)
+    // Capture current importance from the sidecar for the archive stub's
+    // eviction metadata. Falls back to the default when no sidecar entry
+    // exists (pre-migration files, or a sidecar that hasn't been written to
+    // for this path). Fail-open on sidecar errors.
+    const importance = await this.readImportanceForArchiveMetadata(toUnixPath(relativePath))
 
     // Write .stub.md with archive stub frontmatter
     const stubContent = generateArchiveStubContent(
@@ -136,8 +139,21 @@ export class FileContextTreeArchiveService implements IContextTreeArchiveService
     const baseDir = directory ?? process.cwd()
     const contextTreeDir = join(baseDir, BRV_DIR, CONTEXT_TREE_DIR)
 
+    // Preload the runtime-signal map once per scan. `list()` returns only
+    // paths with stored entries; paths without one fall back to defaults at
+    // the comparison site. On sidecar failure, scan with an empty map —
+    // archive candidacy then depends on defaults only (importance 50), which
+    // keeps all draft entries above the threshold and archives nothing. That
+    // is the safest fallback when scoring data is unavailable.
+    let signalsByPath: Map<string, RuntimeSignals>
+    try {
+      signalsByPath = this.runtimeSignalStore ? await this.runtimeSignalStore.list() : new Map()
+    } catch {
+      signalsByPath = new Map()
+    }
+
     const candidates: string[] = []
-    await this.scanForCandidates(contextTreeDir, contextTreeDir, candidates)
+    await this.scanForCandidates(contextTreeDir, contextTreeDir, candidates, signalsByPath)
 
     return candidates
   }
@@ -182,15 +198,6 @@ export class FileContextTreeArchiveService implements IContextTreeArchiveService
   }
 
   /**
-   * Extract importance score from frontmatter. Returns 50 if not found.
-   */
-  private extractImportance(content: string): number {
-    const match = /^importance:\s*(\d+(?:\.\d+)?)/m.exec(content)
-
-    return match ? Number.parseFloat(match[1]) : 50
-  }
-
-  /**
    * Generate a ghost cue using LLM with deterministic fallback.
    */
   private async generateGhostCue(agent: ICipherAgent, content: string): Promise<string> {
@@ -230,21 +237,29 @@ ${content.slice(0, 8000)}
   }
 
   /**
-   * Parse FrontmatterScoring fields from content frontmatter.
+   * Extract the `updatedAt` timestamp from markdown frontmatter. This is
+   * the one scoring-adjacent field that stays in markdown (it tracks real
+   * content modification, not a runtime signal).
    */
-  private parseScoring(content: string): FrontmatterScoring {
-    const scoring: FrontmatterScoring = {}
+  private parseUpdatedAt(content: string): string | undefined {
+    const match = /^updatedAt:\s*['"]?(.+?)['"]?\s*$/m.exec(content)
+    return match ? match[1] : undefined
+  }
 
-    const importanceMatch = /^importance:\s*(\d+(?:\.\d+)?)/m.exec(content)
-    if (importanceMatch) scoring.importance = Number.parseFloat(importanceMatch[1])
-
-    const maturityMatch = /^maturity:\s*['"]?(core|draft|validated)['"]?/m.exec(content)
-    if (maturityMatch) scoring.maturity = maturityMatch[1] as FrontmatterScoring['maturity']
-
-    const updatedMatch = /^updatedAt:\s*['"]?(.+?)['"]?\s*$/m.exec(content)
-    if (updatedMatch) scoring.updatedAt = updatedMatch[1]
-
-    return scoring
+  /**
+   * Read the importance value to embed in an archive stub's eviction metadata.
+   * Pulls from the runtime-signal sidecar (source of truth post-commit-4),
+   * falling back to the default when no entry exists or the store is
+   * unavailable.
+   */
+  private async readImportanceForArchiveMetadata(relativePath: string): Promise<number> {
+    if (!this.runtimeSignalStore) return createDefaultRuntimeSignals().importance
+    try {
+      const signals = await this.runtimeSignalStore.get(relativePath)
+      return signals.importance
+    } catch {
+      return createDefaultRuntimeSignals().importance
+    }
   }
 
   /**
@@ -254,6 +269,7 @@ ${content.slice(0, 8000)}
     currentDir: string,
     contextTreeDir: string,
     candidates: string[],
+    signalsByPath: Map<string, RuntimeSignals>,
   ): Promise<void> {
     const {readdir: readdirFs} = await import('node:fs/promises')
     let entries: import('node:fs').Dirent[]
@@ -272,24 +288,31 @@ ${content.slice(0, 8000)}
 
       if (entry.isDirectory()) {
         if (entryName === ARCHIVE_DIR) continue
-        await this.scanForCandidates(fullPath, contextTreeDir, candidates)
+        await this.scanForCandidates(fullPath, contextTreeDir, candidates, signalsByPath)
       } else if (entry.isFile() && entryName.endsWith(CONTEXT_FILE_EXTENSION)) {
         const relativePath = toUnixPath(fullPath.slice(contextTreeDir.length + 1))
         if (isDerivedArtifact(relativePath) || isArchiveStub(relativePath)) continue
 
         try {
-          const content = await readFile(fullPath, 'utf8')
-          const scoring = this.parseScoring(content)
+          // Runtime signals come from the sidecar; `updatedAt` stays in
+          // markdown because it reflects content modification time, not a
+          // ranking signal. Paths without a sidecar entry use defaults —
+          // maturity 'draft' passes the gate, importance 50 stays above
+          // ARCHIVE_IMPORTANCE_THRESHOLD (which is < 50), so files without
+          // recorded signals are correctly excluded from archival.
+          const signals = signalsByPath.get(relativePath) ?? createDefaultRuntimeSignals()
 
           // Only archive draft entries below importance threshold
-          if (scoring.maturity !== 'draft') continue
+          if (signals.maturity !== 'draft') continue
 
-          const daysSinceUpdate = scoring.updatedAt
-            ? (now - new Date(scoring.updatedAt).getTime()) / (1000 * 60 * 60 * 24)
+          const content = await readFile(fullPath, 'utf8')
+          const updatedAt = this.parseUpdatedAt(content)
+          const daysSinceUpdate = updatedAt
+            ? (now - new Date(updatedAt).getTime()) / (1000 * 60 * 60 * 24)
             : 0
-          const decayed = applyDecay(scoring, daysSinceUpdate)
+          const decayed = applyDecay(signals, daysSinceUpdate)
 
-          if ((decayed.importance ?? 50) < ARCHIVE_IMPORTANCE_THRESHOLD) {
+          if (decayed.importance < ARCHIVE_IMPORTANCE_THRESHOLD) {
             candidates.push(relativePath)
           }
         } catch {

--- a/src/server/infra/context-tree/file-context-tree-manifest-service.ts
+++ b/src/server/infra/context-tree/file-context-tree-manifest-service.ts
@@ -17,6 +17,7 @@
 import {readdir, readFile, stat, writeFile} from 'node:fs/promises'
 import {join, relative} from 'node:path'
 
+import type {RuntimeSignals} from '../../core/domain/knowledge/runtime-signals-schema.js'
 import type {
   ContextManifest,
   LaneTokens,
@@ -24,6 +25,7 @@ import type {
   ResolvedEntry,
 } from '../../core/domain/knowledge/summary-types.js'
 import type {IContextTreeManifestService} from '../../core/interfaces/context-tree/i-context-tree-manifest-service.js'
+import type {IRuntimeSignalStore} from '../../core/interfaces/storage/i-runtime-signal-store.js'
 
 import {
   ABSTRACT_EXTENSION,
@@ -35,7 +37,6 @@ import {
   STUB_EXTENSION,
   SUMMARY_INDEX_FILE,
 } from '../../constants.js'
-import {parseFrontmatterScoring} from '../../core/domain/knowledge/markdown-writer.js'
 import {DEFAULT_LANE_BUDGETS} from '../../core/domain/knowledge/summary-types.js'
 import {estimateTokens} from '../executor/pre-compaction/compaction-escalation.js'
 import {isArchiveStub, isDerivedArtifact} from './derived-artifact.js'
@@ -45,6 +46,13 @@ import {parseSummaryFrontmatter} from './summary-frontmatter.js'
 
 export interface ManifestServiceConfig {
   baseDirectory?: string
+  /**
+   * Optional. Source of truth for per-context `importance` used in lane
+   * allocation. When absent or when a path has no entry, the default
+   * importance (50) is used — same effective sort as the pre-migration
+   * fallback of `scoring?.importance ?? 50`.
+   */
+  runtimeSignalStore?: IRuntimeSignalStore
 }
 
 export class FileContextTreeManifestService implements IContextTreeManifestService {
@@ -59,12 +67,22 @@ export class FileContextTreeManifestService implements IContextTreeManifestServi
     const contextTreeDir = join(baseDir, BRV_DIR, CONTEXT_TREE_DIR)
     const budgets = laneBudgets ?? DEFAULT_LANE_BUDGETS
 
+    // Preload sidecar signals once — used to read `importance` per context.
+    // Fail-open: on sidecar error we treat every path as having no entry,
+    // which falls back to default importance (50) at the read site.
+    let signalsByPath: Map<string, RuntimeSignals>
+    try {
+      signalsByPath = this.config.runtimeSignalStore ? await this.config.runtimeSignalStore.list() : new Map()
+    } catch {
+      signalsByPath = new Map()
+    }
+
     // Scan all entries
     const summaries: ManifestEntry[] = []
     const contexts: ManifestEntry[] = []
     const stubs: ManifestEntry[] = []
 
-    await this.scanForManifest(contextTreeDir, contextTreeDir, summaries, contexts, stubs)
+    await this.scanForManifest(contextTreeDir, contextTreeDir, summaries, contexts, stubs, signalsByPath)
 
     // Lane allocation with prioritized fill
     const activeSummaries = this.allocateLane(
@@ -263,6 +281,7 @@ export class FileContextTreeManifestService implements IContextTreeManifestServi
     summaries: ManifestEntry[],
     contexts: ManifestEntry[],
     stubs: ManifestEntry[],
+    signalsByPath: Map<string, RuntimeSignals>,
   ): Promise<void> {
     let entries: import('node:fs').Dirent[]
     try {
@@ -289,7 +308,7 @@ export class FileContextTreeManifestService implements IContextTreeManifestServi
         // Scan _archived/ for .stub.md files only; recurse otherwise
         await (entryName === ARCHIVE_DIR
           ? this.scanArchivedStubs(fullPath, contextTreeDir, stubs)
-          : this.scanForManifest(fullPath, contextTreeDir, summaries, contexts, stubs))
+          : this.scanForManifest(fullPath, contextTreeDir, summaries, contexts, stubs, signalsByPath))
       } else if (entry.isFile() && entryName.endsWith(CONTEXT_FILE_EXTENSION)) {
         const relativePath = toUnixPath(relative(contextTreeDir, fullPath))
 
@@ -308,10 +327,12 @@ export class FileContextTreeManifestService implements IContextTreeManifestServi
             // Skip unreadable summaries
           }
         } else if (!isDerivedArtifact(relativePath) && !isArchiveStub(relativePath)) {
-          // Regular context entry — extract importance from frontmatter
+          // Regular context entry — importance comes from the sidecar, not
+          // markdown frontmatter. Paths without a sidecar entry fall back to
+          // default importance (50), matching the prior `?? 50` behaviour.
           try {
             const content = await readFile(fullPath, 'utf8')
-            const scoring = parseFrontmatterScoring(content)
+            const importance = signalsByPath.get(relativePath)?.importance ?? 50
 
             // Use abstract sibling for token budgeting only if it is known to exist
             // (checked via abstractsInDir set, avoiding ENOENT as control flow).
@@ -328,7 +349,7 @@ export class FileContextTreeManifestService implements IContextTreeManifestServi
             contexts.push({
               abstractPath: abstractTokens === undefined ? undefined : abstractRelPath,
               abstractTokens,
-              importance: scoring?.importance ?? 50,
+              importance,
               path: relativePath,
               tokens: abstractTokens ?? estimateTokens(content),
               type: 'context',

--- a/src/server/infra/context-tree/runtime-signal-store.ts
+++ b/src/server/infra/context-tree/runtime-signal-store.ts
@@ -54,10 +54,25 @@ export class RuntimeSignalStore implements IRuntimeSignalStore {
   }
 
   async getMany(relPaths: readonly string[]): Promise<Map<string, RuntimeSignals>> {
+    // Only include paths that have a stored record. Callers distinguish
+    // missing via `.has(path)`; ergonomic default-on-miss via
+    // `map.get(path) ?? createDefaultRuntimeSignals()`.
     const entries = await Promise.all(
-      relPaths.map(async (relPath) => [relPath, await this.get(relPath)] as const),
+      relPaths.map(async (relPath) => {
+        const raw = await this.keyStorage.get<unknown>(this.signalKey(relPath))
+        if (raw === undefined) return null
+        const parsed = RuntimeSignalsSchema.safeParse(raw)
+        if (parsed.success) {
+          return [relPath, parsed.data] as const
+        }
+
+        this.logger.warn(
+          `RuntimeSignalStore: discarding corrupt entry for ${relPath}: ${parsed.error.message}`,
+        )
+        return null
+      }),
     )
-    return new Map(entries)
+    return new Map(entries.filter((entry): entry is readonly [string, RuntimeSignals] => entry !== null))
   }
 
   async list(): Promise<Map<string, RuntimeSignals>> {

--- a/src/server/infra/daemon/agent-process.ts
+++ b/src/server/infra/daemon/agent-process.ts
@@ -569,6 +569,7 @@ async function executeTask(
             dreamLogStore: new DreamLogStore({baseDir: brvDir}),
             dreamStateService,
             reviewBackupStore: new FileReviewBackupStore(brvDir),
+            runtimeSignalStore,
             searchService: searchKnowledgeService,
           })
           const dreamResult = await dreamExecutor.executeWithAgent(agent, {

--- a/src/server/infra/dream/operations/consolidate.ts
+++ b/src/server/infra/dream/operations/consolidate.ts
@@ -21,7 +21,6 @@ import type {DreamOperation} from '../dream-log-schema.js'
 import type {ConsolidationAction} from '../dream-response-schemas.js'
 import type {DreamState, PendingMerge} from '../dream-state-schema.js'
 
-import {parseFrontmatterScoring} from '../../../core/domain/knowledge/markdown-writer.js'
 import {ConsolidateResponseSchema} from '../dream-response-schemas.js'
 import {parseDreamResponse} from '../parse-dream-response.js'
 
@@ -41,6 +40,15 @@ export type ConsolidateDeps = {
   }
   reviewBackupStore?: {
     save(relativePath: string, content: string): Promise<void>
+  }
+  /**
+   * Optional. When present, the CROSS_REFERENCE review-gate consults the
+   * sidecar to check whether any input file has `maturity === 'core'`. Absent
+   * store or missing entries mean no file qualifies as core — review is
+   * skipped, matching the pre-migration behaviour for paths without scoring.
+   */
+  runtimeSignalStore?: {
+    get(relPath: string): Promise<{maturity: 'core' | 'draft' | 'validated'}>
   }
   searchService: {
     search(query: string, options?: {limit?: number; scope?: string}): Promise<{results: Array<{path: string; score: number; title: string}>}>
@@ -197,7 +205,7 @@ async function processDomain(domain: string, files: string[], deps: ConsolidateD
     for (const action of parsed.actions) {
       try {
         // eslint-disable-next-line no-await-in-loop
-        const op = await executeAction(action, contextTreeDir, fileContents, deps.reviewBackupStore)
+        const op = await executeAction(action, contextTreeDir, fileContents, deps.runtimeSignalStore, deps.reviewBackupStore)
         if (op) results.push(op)
       } catch {
         // Skip failed action, continue with others
@@ -451,15 +459,16 @@ async function executeAction(
   action: ConsolidationAction,
   contextTreeDir: string,
   fileContents: Map<string, string>,
+  runtimeSignalStore: ConsolidateDeps['runtimeSignalStore'],
   reviewBackupStore?: ConsolidateDeps['reviewBackupStore'],
 ): Promise<DreamOperation | undefined> {
   switch (action.type) {
     case 'CROSS_REFERENCE': {
-      return executeCrossReference(action, contextTreeDir, fileContents, reviewBackupStore)
+      return executeCrossReference(action, contextTreeDir, fileContents, runtimeSignalStore, reviewBackupStore)
     }
 
     case 'MERGE': {
-      return executeMerge(action, contextTreeDir, fileContents, reviewBackupStore)
+      return executeMerge(action, contextTreeDir, fileContents, runtimeSignalStore, reviewBackupStore)
     }
 
     case 'SKIP': {
@@ -467,7 +476,7 @@ async function executeAction(
     }
 
     case 'TEMPORAL_UPDATE': {
-      return executeTemporalUpdate(action, contextTreeDir, fileContents, reviewBackupStore)
+      return executeTemporalUpdate(action, contextTreeDir, fileContents, runtimeSignalStore, reviewBackupStore)
     }
   }
 }
@@ -476,6 +485,7 @@ async function executeMerge(
   action: ConsolidationAction,
   contextTreeDir: string,
   fileContents: Map<string, string>,
+  runtimeSignalStore: ConsolidateDeps['runtimeSignalStore'],
   reviewBackupStore?: ConsolidateDeps['reviewBackupStore'],
 ): Promise<DreamOperation> {
   const outputFile = action.outputFile ?? action.files[0]
@@ -519,7 +529,7 @@ async function executeMerge(
   await Promise.all(toDelete.map((f) => unlink(join(contextTreeDir, f)).catch(() => {})))
 
   // Determine needsReview
-  const needsReview = determineNeedsReview('MERGE', action.files, fileContents)
+  const needsReview = await determineNeedsReview('MERGE', action.files, runtimeSignalStore)
 
   return {
     action: 'MERGE',
@@ -536,6 +546,7 @@ async function executeTemporalUpdate(
   action: ConsolidationAction,
   contextTreeDir: string,
   fileContents: Map<string, string>,
+  runtimeSignalStore: ConsolidateDeps['runtimeSignalStore'],
   reviewBackupStore?: ConsolidateDeps['reviewBackupStore'],
 ): Promise<DreamOperation> {
   const targetFile = action.files[0]
@@ -552,7 +563,7 @@ async function executeTemporalUpdate(
     previousTexts[targetFile] = original
   }
 
-  const needsReview = determineNeedsReview('TEMPORAL_UPDATE', action.files, fileContents, action.confidence)
+  const needsReview = await determineNeedsReview('TEMPORAL_UPDATE', action.files, runtimeSignalStore, action.confidence)
 
   // Create review backup only when the operation needs human review
   if (reviewBackupStore && original !== undefined && needsReview) {
@@ -582,6 +593,7 @@ async function executeCrossReference(
   action: ConsolidationAction,
   contextTreeDir: string,
   fileContents: Map<string, string>,
+  runtimeSignalStore: ConsolidateDeps['runtimeSignalStore'],
   reviewBackupStore?: ConsolidateDeps['reviewBackupStore'],
 ): Promise<DreamOperation> {
   const previousTexts: Record<string, string> = {}
@@ -592,7 +604,7 @@ async function executeCrossReference(
     }
   }
 
-  const needsReview = determineNeedsReview('CROSS_REFERENCE', action.files, fileContents)
+  const needsReview = await determineNeedsReview('CROSS_REFERENCE', action.files, runtimeSignalStore)
   if (needsReview && reviewBackupStore) {
     await Promise.all(
       Object.entries(previousTexts).map(([file, content]) =>
@@ -658,24 +670,29 @@ async function addRelatedLinks(filePath: string, relatedPaths: string[]): Promis
   await atomicWrite(filePath, `---\n${yaml}\n---\n${content}`)
 }
 
-function determineNeedsReview(
+async function determineNeedsReview(
   actionType: 'CROSS_REFERENCE' | 'MERGE' | 'TEMPORAL_UPDATE',
   files: string[],
-  fileContents: Map<string, string>,
+  runtimeSignalStore: ConsolidateDeps['runtimeSignalStore'],
   confidence?: number,
-): boolean {
+): Promise<boolean> {
   // MERGE always needs review
   if (actionType === 'MERGE') return true
 
   // TEMPORAL_UPDATE: needs review when confidence is low or absent
   if (actionType === 'TEMPORAL_UPDATE') return (confidence ?? 0) < 0.7
 
-  // CROSS_REFERENCE: only if any file has core maturity
+  // CROSS_REFERENCE: only if any file has core maturity in the sidecar.
+  // Without a store, no file can qualify as core — review is skipped, which
+  // matches the pre-migration default when no scoring was present.
+  if (!runtimeSignalStore) return false
   for (const file of files) {
-    const content = fileContents.get(file)
-    if (content) {
-      const scoring = parseFrontmatterScoring(content)
-      if (scoring?.maturity === 'core') return true
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const signals = await runtimeSignalStore.get(file)
+      if (signals.maturity === 'core') return true
+    } catch {
+      // Ignore per-file sidecar failures — continue checking remaining files.
     }
   }
 

--- a/src/server/infra/executor/dream-executor.ts
+++ b/src/server/infra/executor/dream-executor.ts
@@ -61,6 +61,11 @@ export type DreamExecutorDeps = {
   reviewBackupStore?: {
     save(relativePath: string, content: string): Promise<void>
   }
+  /**
+   * Optional. Passed through to consolidate's CROSS_REFERENCE review gate so
+   * it reads maturity from the sidecar rather than markdown frontmatter.
+   */
+  runtimeSignalStore?: ConsolidateDeps['runtimeSignalStore']
   searchService: ConsolidateDeps['searchService']
 }
 
@@ -268,6 +273,7 @@ export class DreamExecutor {
         contextTreeDir,
         dreamStateService: this.deps.dreamStateService,
         reviewBackupStore: this.deps.reviewBackupStore,
+        runtimeSignalStore: this.deps.runtimeSignalStore,
         searchService: this.deps.searchService,
         signal,
         taskId,

--- a/test/helpers/mock-factories.ts
+++ b/test/helpers/mock-factories.ts
@@ -381,9 +381,14 @@ export function createMockRuntimeSignalStore(): IRuntimeSignalStore {
     },
     get,
     async getMany(relPaths) {
-      const entries = await Promise.all(
-        relPaths.map(async (relPath) => [relPath, await get(relPath)] as const),
-      )
+      // Mirror the real store: only return entries for paths that have a
+      // stored record. Callers distinguish missing via `.has(path)`.
+      const entries: Array<readonly [string, ReturnType<typeof createDefaultRuntimeSignals>]> = []
+      for (const relPath of relPaths) {
+        const value = store.get(relPath)
+        if (value !== undefined) entries.push([relPath, value])
+      }
+
       return new Map(entries)
     },
     async list() {

--- a/test/unit/agent/knowledge/runtime-signal-store.test.ts
+++ b/test/unit/agent/knowledge/runtime-signal-store.test.ts
@@ -213,16 +213,21 @@ describe('RuntimeSignalStore', () => {
   })
 
   describe('getMany', () => {
-    it('returns a map with an entry for every requested path', async () => {
+    it('returns entries only for paths that have a stored record', async () => {
+      // Callers distinguish "no entry yet" from "entry with default values"
+      // via `.has(path)` — missing paths must be absent from the map so the
+      // distinction is expressible.
       await store.set('a.md', {...createDefaultRuntimeSignals(), importance: 91})
       await store.set('b.md', {...createDefaultRuntimeSignals(), importance: 92})
 
       const result = await store.getMany(['a.md', 'b.md', 'missing.md'])
 
-      expect(result.size).to.equal(3)
+      expect(result.size).to.equal(2)
+      expect(result.has('a.md')).to.equal(true)
       expect(result.get('a.md')?.importance).to.equal(91)
+      expect(result.has('b.md')).to.equal(true)
       expect(result.get('b.md')?.importance).to.equal(92)
-      expect(result.get('missing.md')).to.deep.equal(createDefaultRuntimeSignals())
+      expect(result.has('missing.md')).to.equal(false)
     })
 
     it('returns an empty map for an empty input', async () => {
@@ -236,6 +241,16 @@ describe('RuntimeSignalStore', () => {
       const result = await store.getMany(['wanted.md'])
       expect(result.size).to.equal(1)
       expect(result.has('ignored.md')).to.equal(false)
+    })
+
+    it('omits corrupt entries with a logged warning', async () => {
+      await keyStorage.set(['signals', 'good.md'], createDefaultRuntimeSignals())
+      await keyStorage.set(['signals', 'bad.md'], {importance: 'nope'})
+
+      const result = await store.getMany(['good.md', 'bad.md'])
+      expect(result.has('good.md')).to.equal(true)
+      expect(result.has('bad.md')).to.equal(false)
+      expect((logger.warn as sinon.SinonStub).calledOnce).to.equal(true)
     })
   })
 

--- a/test/unit/agent/tools/search-knowledge-tool.test.ts
+++ b/test/unit/agent/tools/search-knowledge-tool.test.ts
@@ -1160,7 +1160,25 @@ describe('Search Knowledge Tool', () => {
         })
       })
 
-      const tool = createSearchKnowledgeTool(fileSystemMock, {baseDirectory: '/test', cacheTtlMs: 0})
+      // Post-migration: ranking reads scoring from the sidecar, not markdown.
+      // Seed the sidecar to match the intent of the markdown fixtures — both
+      // the summary _index.md entries (for propagation boost) and the leaves
+      // (so main-ranking scoreFloor is computed from the same signal state).
+      const {createMockRuntimeSignalStore} = await import('../../../helpers/mock-factories.js')
+      const runtimeSignalStore = createMockRuntimeSignalStore()
+      await runtimeSignalStore.set('auth/_index.md', {
+        accessCount: 0, importance: 90, maturity: 'core', recency: 0.9, updateCount: 0,
+      })
+      await runtimeSignalStore.set('api/_index.md', {
+        accessCount: 0, importance: 20, maturity: 'draft', recency: 0.2, updateCount: 0,
+      })
+      // Leaves have identical signals to isolate the summary-scoring
+      // differential — mirrors the old test's equal-BM25 intent.
+      const leafSignals = {accessCount: 0, importance: 50, maturity: 'draft' as const, recency: 1, updateCount: 0}
+      await runtimeSignalStore.set('auth/jwt.md', leafSignals)
+      await runtimeSignalStore.set('api/design.md', leafSignals)
+
+      const tool = createSearchKnowledgeTool(fileSystemMock, {baseDirectory: '/test', cacheTtlMs: 0, runtimeSignalStore})
       const result = (await tool.execute({query: 'security token'})) as {
         message: string
         results: Array<{excerpt: string; path: string; score: number; symbolKind?: string; title: string}>
@@ -1260,7 +1278,20 @@ describe('Search Knowledge Tool', () => {
         })
       })
 
-      const tool = createSearchKnowledgeTool(fileSystemMock, {baseDirectory: '/test', cacheTtlMs: 0})
+      // Post-migration: ranking reads scoring from the sidecar, so both the
+      // summary and the leaf need entries that mirror the markdown fixtures.
+      // Without a leaf entry, jwt would fall back to default scoring and
+      // scoreFloor would drop low enough for the weak summary to survive.
+      const {createMockRuntimeSignalStore} = await import('../../../helpers/mock-factories.js')
+      const runtimeSignalStore = createMockRuntimeSignalStore()
+      await runtimeSignalStore.set('auth/_index.md', {
+        accessCount: 0, importance: 5, maturity: 'draft', recency: 0.1, updateCount: 0,
+      })
+      await runtimeSignalStore.set('auth/jwt.md', {
+        accessCount: 0, importance: 95, maturity: 'core', recency: 1, updateCount: 0,
+      })
+
+      const tool = createSearchKnowledgeTool(fileSystemMock, {baseDirectory: '/test', cacheTtlMs: 0, runtimeSignalStore})
       const result = (await tool.execute({query: 'security token'})) as {
         results: Array<{path: string; symbolKind?: string}>
       }

--- a/test/unit/infra/context-tree/file-context-tree-archive-service.test.ts
+++ b/test/unit/infra/context-tree/file-context-tree-archive-service.test.ts
@@ -108,12 +108,26 @@ describe('FileContextTreeArchiveService', () => {
       expect(await fileExists(join(contextTreeDir, ARCHIVE_DIR, 'api', 'endpoints', 'legacy-v1.stub.md'))).to.be.true
     })
 
-    it('should extract importance from frontmatter', async () => {
+    it('captures importance from the runtime-signal sidecar in the archive stub', async () => {
+      // Post-migration: evicted_importance is read from the sidecar, not
+      // markdown. Seed the sidecar with a known value, then assert the stub
+      // preserves it.
+      const {createMockRuntimeSignalStore} = await import('../../../helpers/mock-factories.js')
+      const signalStore = createMockRuntimeSignalStore()
+      await signalStore.set('auth/tokens.md', {
+        accessCount: 0,
+        importance: 25,
+        maturity: 'draft',
+        recency: 1,
+        updateCount: 0,
+      })
+      const scopedService = new FileContextTreeArchiveService(signalStore)
+
       const domainDir = join(contextTreeDir, 'auth')
       await mkdir(domainDir, {recursive: true})
-      await writeFile(join(domainDir, 'tokens.md'), '---\nimportance: 25\nmaturity: draft\n---\n# Tokens')
+      await writeFile(join(domainDir, 'tokens.md'), '# Tokens')
 
-      await service.archiveEntry('auth/tokens.md', mockAgent, testDir)
+      await scopedService.archiveEntry('auth/tokens.md', mockAgent, testDir)
 
       const stubContent = await readFile(join(contextTreeDir, ARCHIVE_DIR, 'auth', 'tokens.stub.md'), 'utf8')
       const fm = parseArchiveStubFrontmatter(stubContent)

--- a/test/unit/infra/dream/operations/consolidate.test.ts
+++ b/test/unit/infra/dream/operations/consolidate.test.ts
@@ -298,10 +298,19 @@ describe('consolidate', () => {
 
   it('sets needsReview=true when file has core maturity', async () => {
     await createMdFile(ctxDir, 'auth/core-auth.md', '# Core Auth', {
-      keywords: [], maturity: 'core', related: [], tags: [], title: 'Core Auth',
+      keywords: [], related: [], tags: [], title: 'Core Auth',
     })
     await createMdFile(ctxDir, 'auth/helper.md', '# Helper')
     const reviewBackupStore = {save: stub().resolves()}
+
+    // Post-migration: maturity is read from the sidecar, not markdown.
+    // Seed the sidecar with `maturity: 'core'` for the file that should
+    // trigger the review gate.
+    const runtimeSignalStore = {
+      get: stub().callsFake(async (path: string) => ({
+        maturity: path === 'auth/core-auth.md' ? 'core' : 'draft',
+      })),
+    }
 
     agent.executeOnSession.resolves(llmResponse([{
       files: ['auth/core-auth.md', 'auth/helper.md'],
@@ -309,12 +318,15 @@ describe('consolidate', () => {
       type: 'CROSS_REFERENCE',
     }]))
 
-    const results = await consolidate(['auth/core-auth.md', 'auth/helper.md'], {...deps, reviewBackupStore})
+    const results = await consolidate(
+      ['auth/core-auth.md', 'auth/helper.md'],
+      {...deps, reviewBackupStore, runtimeSignalStore},
+    )
 
     // CROSS_REFERENCE is normally needsReview=false, but core maturity overrides
     expect(results[0].needsReview).to.be.true
     expect(asConsolidate(results[0]).previousTexts).to.deep.equal({
-      'auth/core-auth.md': '---\nkeywords: []\nmaturity: core\nrelated: []\ntags: []\ntitle: Core Auth\n---\n# Core Auth',
+      'auth/core-auth.md': '---\nkeywords: []\nrelated: []\ntags: []\ntitle: Core Auth\n---\n# Core Auth',
       'auth/helper.md': '# Helper',
     })
     expect(reviewBackupStore.save.calledTwice).to.be.true


### PR DESCRIPTION
## Summary

- Problem: After commit 3, both markdown and the sidecar held the same scoring data, but ranking code still read from markdown. This commit flips reads to the sidecar so commit 5 can stop writing markdown scoring entirely.
- Why it matters: This is the pivot — from commit 4 onward, the sidecar is the canonical source of truth for `importance`, `recency`, `maturity`, `accessCount`, `updateCount`. Commit 5 will safely drop those fields from markdown because nothing reads them anymore.
- What changed: `compoundScore` and `applyDecay` signatures take `RuntimeSignals`. Six read sites redirected. `getMany` contract tightened. Optional logger on SearchKnowledgeService for sidecar-failure observability. `executeUpdate` reads base scoring from the sidecar, not stale markdown.
- What did NOT change (scope boundary): Writes to markdown frontmatter continue (commit 5 stops them). `parseFrontmatterScoring` still exists and is still called by index-build and dual-write paths — those go away in commit 5. Cloud sync untouched (commit 6).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [x] Agent / Tools
- [ ] LLM Providers
- [x] Server / Daemon
- [x] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes #
- Related: runtime-signals sidecar series — ENG-2133. Commits 1-3 landed in prior PRs.

## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause: N/A
- Why this was not caught earlier: N/A

## Test plan

- Coverage added:
  - [x] Unit test
  - [ ] Integration test
  - [ ] Manual verification only
- Test file(s):
  - `test/unit/agent/knowledge/runtime-signal-store.test.ts` — getMany semantics tightened (entries only for stored paths), new corrupt-entry test
  - `test/helpers/mock-factories.ts` — mock getMany updated to match real contract
  - `test/unit/infra/context-tree/file-context-tree-archive-service.test.ts` — "extract importance from frontmatter" retitled to "captures importance from the runtime-signal sidecar"; seeds the sidecar
  - `test/unit/infra/dream/operations/consolidate.test.ts` — "sets needsReview=true when file has core maturity" now seeds the sidecar store stub
  - `test/unit/agent/tools/search-knowledge-tool.test.ts` — Summary-hotness tests seed both summary AND leaf sidecar entries
- Key scenario(s) covered:
  - compoundScore accepts RuntimeSignals; all callers updated
  - applyDecay takes/returns RuntimeSignals; no callers of old form
  - Main ranking + parent propagation + minMaturity filter read from `signalsByPath`
  - Archive scanForCandidates reads from sidecar; `updatedAt` from markdown only
  - Consolidate CROSS_REFERENCE gate reads maturity via `store.get`
  - Manifest lane sort reads importance from sidecar
  - `getMany` returns entries only for stored paths; `.has()` distinguishes missing
  - Corrupt sidecar entries are omitted from `getMany` with a `warn` logged
  - `executeUpdate` bumps from sidecar signals, not stale markdown
  - Sidecar failure on ranking path logs `warn` and falls back to BM25-only

## User-visible changes

None in normal operation. Behaviour change that could surface:
- Files without sidecar entries (pre-commit-3 data that's never been touched since upgrade) rank using default signals — matches the plan's "no migration, signals self-heal" stance.
- Sidecar backend failures are now observable in logs (`warn` level) rather than silently degraded. No user-facing message.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording

**Grep audit output (must be empty outside of expected cleanup targets):**


**Suite:** 6477 passing, 0 failing. Typecheck / lint / build clean.

## Checklist

- [x] Tests added or updated and passing (`npm test`)
- [x] Lint passes (`npm run lint`) — 0 errors, 206 pre-existing warnings (none new)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated (if applicable) — N/A, internal change
- [x] No breaking changes (IRuntimeSignalStore.getMany contract tightens; only consumer before this commit was Mock + Test, both updated)
- [x] Branch is up to date with `main`

## Risks and mitigations

- Risk: **A missed read site silently uses stale markdown values.** Once commit 5 lands and markdown stops carrying scoring, any missed read path returns `undefined` and the rank is wrong.
  - Mitigation: Grep audit in the PR body enumerates every remaining non-test `parseFrontmatterScoring` caller and classifies each (index-build populating an unused field, or commit-3 dual-write writer). Reviewer can verify no ranking path is hiding in that list.
- Risk: **`memory-symbol-tree.extractMetadataFromScoring` still reads `scoring.importance/maturity`** to populate SymbolMetadata. The `minMaturity` filter uses this as a fallback when the sidecar misses. Post-commit-5 this fallback becomes all-defaults.
  - Mitigation: Explicitly deferred to commit 5. Documented in `features/runtime-signals/backlog.md` with trigger ("drop fallback explicitly, or rebuild symbol metadata from sidecar at index time"). Current behaviour preserves pre-migration ranking during the transition window.
- Risk: **`getMany` contract changed from "entries for every requested path with defaults" to "entries only for stored paths".**
  - Mitigation: Only consumer before this commit was the commit-2 store test and the mock factory — both updated in-place. Store test now asserts `.has()` distinguishes missing; mock factory mirrors the real semantics.
- Risk: **Sidecar failures on curate, archive, consolidate, manifest are still silent swallows** (only the search ranking path got a `warn` in this PR). Commit-3 landed with the same gap.
  - Mitigation: Documented in backlog. Commit 6's ancillary audit will thread a logger through the remaining sites systematically rather than ad-hoc-ing it here.
- Risk: **No ranking parity test.** Hard to construct meaningfully (signal state has already drifted in commit 3). Per-site unit tests plus the hotness-ranking integration-style tests are the compensating controls.
  - Mitigation: Deferred with explicit rationale in backlog. Build a fixture-backed parity test if a production bug alleges ranking regression.

## Related

- Previous commits in this series:
  - [Runtime Signals 1/6] RuntimeSignals schema and types
  - [Runtime Signals 2/6] RuntimeSignalStore implementation and wiring
  - [Runtime Signals 3/6] Dual-write at all mutation sites
- Next commit: [Runtime Signals 5/6] Stop writing signals to markdown
- Backlog: `features/runtime-signals/backlog.md` — deferred items with triggers
