### PR TITLE
feat: [ENG-2160] stop writing runtime signals to markdown (5/6)

### DIFF
--- a/src/agent/infra/tools/implementations/curate-tool.ts
+++ b/src/agent/infra/tools/implementations/curate-tool.ts
@@ -1,20 +1,18 @@
 import {basename, dirname, join, relative, resolve} from 'node:path'
 import {z} from 'zod'
 
-import type {ContextData, FrontmatterScoring} from '../../../../server/core/domain/knowledge/markdown-writer.js'
+import type {ContextData} from '../../../../server/core/domain/knowledge/markdown-writer.js'
 import type {IRuntimeSignalStore} from '../../../../server/core/interfaces/storage/i-runtime-signal-store.js'
 import type {Tool, ToolExecutionContext} from '../../../core/domain/tools/types.js'
 import type {AbstractGenerationQueue} from '../../map/abstract-queue.js'
 
 import {REVIEW_BACKUPS_DIR} from '../../../../server/constants.js'
 import {DirectoryManager} from '../../../../server/core/domain/knowledge/directory-manager.js'
-import {MarkdownWriter, parseFrontmatterScoring} from '../../../../server/core/domain/knowledge/markdown-writer.js'
+import {MarkdownWriter, parseCreatedAt} from '../../../../server/core/domain/knowledge/markdown-writer.js'
 import {
-  applyDefaultScoring,
   determineTier,
   mergeScoring,
   recordCurateUpdate,
-  UPDATE_IMPORTANCE_BONUS,
 } from '../../../../server/core/domain/knowledge/memory-scoring.js'
 import {
   createDefaultRuntimeSignals,
@@ -46,10 +44,9 @@ function relPathFromContextPath(contextPath: string, basePath: string): string {
  * when the existing file has no `createdAt` (old files or those that never
  * had it).
  */
-function existingScoringCreatedAt(existingContent: null | string | undefined): string {
+function existingCreatedAt(existingContent: null | string | undefined): string {
   if (!existingContent) return new Date().toISOString()
-  const existing = parseFrontmatterScoring(existingContent)
-  return existing?.createdAt ?? new Date().toISOString()
+  return parseCreatedAt(existingContent) ?? new Date().toISOString()
 }
 
 /**
@@ -825,10 +822,10 @@ async function executeAdd(
       rawConcept: filteredContent.rawConcept,
       reason,
       relations: filteredContent.relations,
-      scoring: applyDefaultScoring(),
       snippets: filteredContent.snippets ?? [],
       summary,
       tags: filteredContent.tags,
+      timestamps: {createdAt: new Date().toISOString(), updatedAt: new Date().toISOString()},
     })
     const filename = `${toSnakeCase(title)}.md`
     const contextPath = join(finalPath, filename)
@@ -944,23 +941,11 @@ async function executeUpdate(
     // Read existing file to detect structural loss
     const existingContent = await DirectoryManager.readFile(contextPath)
 
-    // Source of truth for scoring is the sidecar, not markdown. Markdown may
-    // carry stale values post-commit-4 (ranking bumps go to the sidecar only)
-    // so reading from markdown here would silently regress the importance /
-    // maturity we re-serialise in the dual-write path. When no sidecar store
-    // is provided, fall back to defaults — consistent with ADD semantics.
-    const baseSignals = runtimeSignalStore
-      ? await runtimeSignalStore.get(relPathFromContextPath(contextPath, basePath))
-      : createDefaultRuntimeSignals()
-    const bumpedImportance = Math.min(100, baseSignals.importance + UPDATE_IMPORTANCE_BONUS)
-    const nextTier = determineTier(bumpedImportance, baseSignals.maturity)
-    const finalScoring: FrontmatterScoring = {
-      accessCount: baseSignals.accessCount,
-      createdAt: existingScoringCreatedAt(existingContent),
-      importance: bumpedImportance,
-      maturity: nextTier,
-      recency: 1,
-      updateCount: baseSignals.updateCount + 1,
+    // Markdown only carries content timestamps post-commit-5. The sidecar
+    // handles all scoring (importance / recency / maturity / counts) via
+    // `mirrorCurateUpdate` below, inside an atomic read-modify-write.
+    const timestamps = {
+      createdAt: existingCreatedAt(existingContent),
       updatedAt: new Date().toISOString(),
     }
 
@@ -998,8 +983,8 @@ async function executeUpdate(
     const contextContent = MarkdownWriter.generateContext({
       ...resolvedContextData,
       reason,
-      scoring: finalScoring,
       summary,
+      timestamps,
     })
     await backupBeforeWrite(contextPath, basePath)
     await DirectoryManager.writeFileAtomic(contextPath, contextContent)

--- a/src/agent/infra/tools/implementations/curate-tool.ts
+++ b/src/agent/infra/tools/implementations/curate-tool.ts
@@ -81,18 +81,13 @@ async function mirrorCurateUpdate(
   if (!store) return
   try {
     await store.update(relPath, (current: RuntimeSignals): RuntimeSignals => {
-      // `recordCurateUpdate` returns a FrontmatterScoring whose fields are
-      // all concretely populated for our inputs (we pass a fully-valued
-      // RuntimeSignals). Non-null assertions reflect that invariant — no
-      // silent fallbacks that paper over unreachable branches.
       const bumped = recordCurateUpdate(current)
-      const bumpedImportance = bumped.importance!
       return {
         ...current,
-        importance: bumpedImportance,
-        maturity: determineTier(bumpedImportance, current.maturity),
-        recency: bumped.recency!,
-        updateCount: bumped.updateCount!,
+        importance: bumped.importance,
+        maturity: determineTier(bumped.importance, current.maturity),
+        recency: bumped.recency,
+        updateCount: bumped.updateCount,
       }
     })
   } catch {
@@ -1226,6 +1221,16 @@ async function executeMerge(
     await backupBeforeWrite(targetContextPath, basePath)
     await backupBeforeWrite(sourceContextPath, basePath)
 
+    // Capture source sidecar signals BEFORE any destructive operation so a
+    // mid-flow crash cannot leave the target unmerged with an orphaned
+    // source entry. The sidecar merge happens after the markdown writes
+    // succeed, using the captured snapshot.
+    const sourceRelPath = relPathFromContextPath(sourceContextPath, basePath)
+    const targetRelPath = relPathFromContextPath(targetContextPath, basePath)
+    const sourceSignalsSnapshot = runtimeSignalStore
+      ? await runtimeSignalStore.get(sourceRelPath)
+      : null
+
     const mergedContent = MarkdownWriter.mergeContexts(sourceContent, targetContent, reason, summary)
     await DirectoryManager.writeFileAtomic(targetContextPath, mergedContent)
     onAfterWrite?.(targetContextPath, mergedContent)
@@ -1233,30 +1238,24 @@ async function executeMerge(
     await DirectoryManager.deleteFile(sourceContextPath)
     await deleteDerivedSiblings(sourceContextPath)
 
-    // Dual-write: merge sidecar signals by delegating to `mergeScoring`
-    // (the same policy used for markdown). This keeps the two merge paths
-    // from drifting when weights change. The merge runs inside `update`'s
-    // atomic callback so a concurrent access-hit flush on the target cannot
-    // lose bumps.
-    if (runtimeSignalStore) {
-      const sourceRelPath = relPathFromContextPath(sourceContextPath, basePath)
-      const targetRelPath = relPathFromContextPath(targetContextPath, basePath)
+    // Dual-write: merge sidecar signals using `mergeScoring` (the canonical
+    // merge policy). Runs inside `update`'s atomic callback so a concurrent
+    // access-hit flush on the target cannot lose bumps.
+    if (runtimeSignalStore && sourceSignalsSnapshot) {
       try {
-        const sourceSignals = await runtimeSignalStore.get(sourceRelPath)
         await runtimeSignalStore.update(targetRelPath, (current: RuntimeSignals): RuntimeSignals => {
-          const merged = mergeScoring(sourceSignals, current)
-          const mergedImportance = merged.importance ?? current.importance
+          const merged = mergeScoring(sourceSignalsSnapshot, current)
           return {
-            accessCount: merged.accessCount ?? current.accessCount,
-            importance: mergedImportance,
-            maturity: determineTier(mergedImportance, merged.maturity ?? current.maturity),
-            recency: merged.recency ?? current.recency,
-            updateCount: merged.updateCount ?? current.updateCount,
+            accessCount: merged.accessCount,
+            importance: merged.importance,
+            maturity: determineTier(merged.importance, merged.maturity),
+            recency: merged.recency,
+            updateCount: merged.updateCount,
           }
         })
         await runtimeSignalStore.delete(sourceRelPath)
       } catch {
-        // Best-effort — merge of markdown already succeeded.
+        // Best-effort — markdown merge already succeeded.
       }
     }
 
@@ -1391,6 +1390,15 @@ async function executeDelete(
 
     await Promise.all(mdFiles.map((f) => backupBeforeWrite(f, basePath)))
     await DirectoryManager.deleteTopicRecursive(fullPath)
+
+    // Dual-write: drop sidecar entries for every markdown file that was
+    // deleted. Without this, folder deletes leak orphan signal entries.
+    // Best-effort — the markdown delete has already succeeded.
+    if (runtimeSignalStore) {
+      await Promise.all(
+        mdFiles.map((f) => dropSidecar(runtimeSignalStore, relPathFromContextPath(f, basePath))),
+      )
+    }
 
     return {
       ...reviewMeta,

--- a/src/agent/infra/tools/implementations/memory-symbol-tree.ts
+++ b/src/agent/infra/tools/implementations/memory-symbol-tree.ts
@@ -1,5 +1,3 @@
-import type { FrontmatterScoring } from '../../../../server/core/domain/knowledge/markdown-writer.js'
-
 import { CONTEXT_FILE } from '../../../../server/constants.js'
 import { parseRelations } from '../../../../server/core/domain/knowledge/relation-parser.js'
 
@@ -64,8 +62,6 @@ export interface SummaryDocLike {
   excerpt?: string
   /** Path to the _index.md file, e.g. "domain/topic/_index.md" */
   path: string
-  /** Frontmatter scoring parsed from _index.md — used to apply hotness/importance to propagated hits */
-  scoring?: {importance?: number; maturity?: string; recency?: number}
   tokenCount: number
 }
 
@@ -113,7 +109,6 @@ interface DocumentLike {
   content: string
   id: string
   path: string
-  scoring: FrontmatterScoring
   title: string
 }
 
@@ -146,15 +141,6 @@ function determineKind(segments: string[]): MemorySymbolKind {
       // 4+ segments: treat deepest folder as subtopic-level
       return MemorySymbolKind.Subtopic
     }
-  }
-}
-
-function extractMetadataFromScoring(scoring: FrontmatterScoring): SymbolMetadata {
-  return {
-    importance: scoring.importance ?? 50,
-    keywords: [],
-    maturity: scoring.maturity ?? 'draft',
-    tags: [],
   }
 }
 
@@ -257,10 +243,10 @@ export function buildSymbolTree(
     const folderNode = symbolMap.get(folderPath)
 
     if (folderNode) {
-      folderNode.metadata = {
-        ...folderNode.metadata,
-        ...extractMetadataFromScoring(doc.scoring),
-      }
+      // Context metadata starts at defaults. Post-commit-5, ranking signals
+      // (importance, maturity) are read from the sidecar at query time; the
+      // symbol tree only carries structural metadata.
+      folderNode.metadata = { ...folderNode.metadata }
     }
 
     // Also register the context.md path itself for direct lookups
@@ -276,7 +262,7 @@ export function buildSymbolTree(
     const contextNode: MemorySymbol = {
       children: [],
       kind: MemorySymbolKind.Context,
-      metadata: extractMetadataFromScoring(doc.scoring),
+      metadata: { ...DEFAULT_METADATA },
       name: doc.title || segments.at(-1)!.replace(/\.md$/, ''),
       parent: parentNode,
       path: doc.path,

--- a/src/agent/infra/tools/implementations/memory-symbol-tree.ts
+++ b/src/agent/infra/tools/implementations/memory-symbol-tree.ts
@@ -242,12 +242,8 @@ export function buildSymbolTree(
     const folderPath = segments.slice(0, -1).join('/')
     const folderNode = symbolMap.get(folderPath)
 
-    if (folderNode) {
-      // Context metadata starts at defaults. Post-commit-5, ranking signals
-      // (importance, maturity) are read from the sidecar at query time; the
-      // symbol tree only carries structural metadata.
-      folderNode.metadata = { ...folderNode.metadata }
-    }
+    // Post-commit-5: ranking signals (importance, maturity) are read from the
+    // sidecar at query time; the symbol tree only carries structural metadata.
 
     // Also register the context.md path itself for direct lookups
     symbolMap.set(doc.path, folderNode ?? getOrCreateFolderNode(symbolMap, root, folderPath, segments.slice(0, -1)))

--- a/src/agent/infra/tools/implementations/search-knowledge-service.ts
+++ b/src/agent/infra/tools/implementations/search-knowledge-service.ts
@@ -1187,16 +1187,12 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
       [...hits.entries()].map(([relPath, count]) => [
         relPath,
         (current: RuntimeSignals): RuntimeSignals => {
-          // `recordAccessHits` always returns concrete importance/accessCount
-          // when given a fully-valued RuntimeSignals; the `!` assertions
-          // reflect that invariant rather than defensive fallbacks.
           const bumped = recordAccessHits(current, count)
-          const bumpedImportance = bumped.importance!
           return {
             ...current,
-            accessCount: bumped.accessCount!,
-            importance: bumpedImportance,
-            maturity: determineTier(bumpedImportance, current.maturity),
+            accessCount: bumped.accessCount,
+            importance: bumped.importance,
+            maturity: determineTier(bumped.importance, current.maturity),
           }
         },
       ]),

--- a/src/agent/infra/tools/implementations/search-knowledge-service.ts
+++ b/src/agent/infra/tools/implementations/search-knowledge-service.ts
@@ -17,13 +17,7 @@ import {
   SUMMARY_INDEX_FILE,
 } from '../../../../server/constants.js'
 import {
-  type FrontmatterScoring,
-  parseFrontmatterScoring,
-  updateScoringInContent,
-} from '../../../../server/core/domain/knowledge/markdown-writer.js'
-import {
   applyDecay,
-  applyDefaultScoring,
   compoundScore,
   determineTier,
   recordAccessHits,
@@ -190,7 +184,6 @@ interface IndexedDocument {
   /** Path to .overview.md sibling, if it exists at index-build time */
   overviewPath?: string
   path: string
-  scoring: FrontmatterScoring
   /** Path used in the merged symbol tree (namespaced for shared sources) */
   symbolPath: string
   title: string
@@ -199,7 +192,6 @@ interface IndexedDocument {
 interface SummarySource {
   excerpt: string
   path: string
-  scoring?: SummaryDocLike['scoring']
 }
 
 interface CachedIndex {
@@ -293,7 +285,6 @@ function getSummarySource(
     return {
       excerpt: summaryDoc.excerpt ?? '',
       path: summaryDoc.path,
-      scoring: summaryDoc.scoring,
     }
   }
 
@@ -304,7 +295,6 @@ function getSummarySource(
     return {
       excerpt: extractExcerpt(contextDoc.content, contextDoc.title),
       path: contextDoc.path,
-      scoring: contextDoc.scoring,
     }
   }
 
@@ -549,7 +539,6 @@ async function indexOriginDocuments(
       const fullPath = join(origin.contextTreeRoot, filePath)
       const {content} = await fileSystem.readFile(fullPath)
       const title = extractTitle(content, filePath.replace(/\.md$/, '').split('/').pop() || filePath)
-      const scoring = parseFrontmatterScoring(content) ?? applyDefaultScoring()
       const qualifiedId = `${origin.originKey}::${filePath}`
       const symbolPath = getSymbolPath(origin, filePath)
 
@@ -566,7 +555,6 @@ async function indexOriginDocuments(
         originKey: origin.originKey,
         ...(overviewPath !== undefined && {overviewPath}),
         path: filePath,
-        scoring,
         symbolPath,
         title,
       }
@@ -585,17 +573,10 @@ async function indexOriginDocuments(
       const fm = parseSummaryFrontmatter(content)
       if (!fm) return null
 
-      // Persist frontmatter scoring so propagateScoresToParents can apply hotness/tier boosts
-      const frontmatter = parseFrontmatterScoring(content)
-      const scoring = frontmatter
-        ? {importance: frontmatter.importance, maturity: frontmatter.maturity, recency: frontmatter.recency}
-        : undefined
-
       return {
         condensationOrder: fm.condensation_order,
         excerpt: stripMarkdownFrontmatter(content).slice(0, 400),
         path: getSymbolPath(origin, filePath),
-        scoring,
         tokenCount: fm.token_count,
       } satisfies SummaryDocLike
     } catch {
@@ -917,11 +898,18 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
   }
 
   /**
-   * Flush accumulated access hits to disk by updating frontmatter scoring.
-   * Called during index rebuild to batch writes and avoid write amplification.
-   * Best-effort: errors are swallowed per file.
+   * Flush accumulated access hits to the runtime-signal sidecar.
+   *
+   * Post-commit-5 this no longer writes to markdown — ranking signals
+   * live exclusively in the sidecar. The `contextTreePath` parameter is
+   * retained for signature compatibility with the cache-invalidation
+   * callback but is no longer used.
+   *
+   * Returns `true` when hits were processed so the caller knows to
+   * refresh file mtimes (historical contract); with markdown writes
+   * removed the refresh is harmless but kept for symmetry.
    */
-  async flushAccessHits(contextTreePath: string): Promise<boolean> {
+  async flushAccessHits(_contextTreePath: string): Promise<boolean> {
     if (this.pendingAccessHits.size === 0) {
       return false
     }
@@ -929,27 +917,6 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
     const hits = new Map(this.pendingAccessHits)
     this.pendingAccessHits.clear()
 
-    const tasks = [...hits.entries()].map(async ([relPath, count]) => {
-      try {
-        const fullPath = join(contextTreePath, relPath)
-        const {content} = await this.fileSystem.readFile(fullPath)
-        const scoring = parseFrontmatterScoring(content) ?? applyDefaultScoring()
-        const updated = recordAccessHits(scoring, count)
-        const newTier = determineTier(
-          updated.importance ?? 50,
-          (updated.maturity ?? 'draft') as 'core' | 'draft' | 'validated',
-        )
-        const finalScoring: FrontmatterScoring = {...updated, maturity: newTier}
-        const newContent = updateScoringInContent(content, finalScoring)
-        await this.fileSystem.writeFile(fullPath, newContent)
-      } catch {
-        // Best-effort — swallow per-file errors
-      }
-    })
-    await Promise.allSettled(tasks)
-
-    // Dual-write to the runtime-signal sidecar. Markdown remains canonical in
-    // phase 3; sidecar failures must not affect the flush outcome.
     await this.mirrorHitsToSignalStore(hits)
     return true
   }

--- a/src/server/core/domain/knowledge/markdown-writer.ts
+++ b/src/server/core/domain/knowledge/markdown-writer.ts
@@ -1,6 +1,5 @@
 import {dump as yamlDump, load as yamlLoad} from 'js-yaml'
 
-import { determineTier, mergeScoring as mergeScoringFn } from './memory-scoring.js'
 import { normalizeRelationPath, parseRelations } from './relation-parser.js'
 
 export interface RawConcept {
@@ -30,16 +29,14 @@ export interface Fact {
 }
 
 /**
- * Scoring metadata for knowledge lifecycle management (FinMem-inspired).
- * Stored in YAML frontmatter alongside existing fields.
+ * Content timestamps kept in markdown frontmatter. `createdAt` is the
+ * immutable creation time; `updatedAt` reflects the last content
+ * modification. Runtime ranking signals (importance, recency, maturity,
+ * accessCount, updateCount) live in the sidecar — see
+ * `features/runtime-signals/plan.md`.
  */
-export interface FrontmatterScoring {
-  accessCount?: number
+export interface ContextTimestamps {
   createdAt?: string
-  importance?: number
-  maturity?: 'core' | 'draft' | 'validated'
-  recency?: number
-  updateCount?: number
   updatedAt?: string
 }
 
@@ -51,24 +48,29 @@ export interface ContextData {
   rawConcept?: RawConcept
   reason?: string
   relations?: string[]
-  scoring?: FrontmatterScoring
   snippets: string[]
   summary?: string
   tags: string[]
+  timestamps?: ContextTimestamps
 }
 
+/**
+ * Fields carried in the markdown frontmatter block. Post-commit-5 this
+ * covers only semantic content and content timestamps; runtime ranking
+ * signals live in the sidecar.
+ *
+ * `parseFrontmatter` may return instances that also carry legacy fields
+ * (importance, recency, maturity, accessCount, updateCount) on files
+ * written before the migration. Those are silently ignored — the typed
+ * shape only exposes what commit 5 and later writers produce.
+ */
 interface Frontmatter {
-  accessCount?: number
   createdAt?: string
-  importance?: number
   keywords: string[]
-  maturity?: 'core' | 'draft' | 'validated'
-  recency?: number
   related: string[]
   summary?: string
   tags: string[]
   title?: string
-  updateCount?: number
   updatedAt?: string
 }
 
@@ -79,19 +81,23 @@ interface ParsedFrontmatter {
 
 /**
  * Generate YAML frontmatter block from context data.
- * Only includes fields that have values.
+ *
+ * Emits only semantic fields and content timestamps. Runtime ranking
+ * signals (importance, recency, maturity, accessCount, updateCount) are
+ * not written — they live in the sidecar store since commit 5 of the
+ * runtime-signals migration.
  */
 function generateFrontmatter(
   title: string,
   relations?: string[],
   tags: string[] = [],
   keywords: string[] = [],
-  scoring?: FrontmatterScoring,
+  timestamps?: ContextTimestamps,
   summary?: string,
 ): string {
   const normalizedRelations = (relations || []).map(rel => normalizeRelationPath(rel))
 
-  const fm: Record<string, number | string | string[]> = {}
+  const fm: Record<string, string | string[]> = {}
 
   if (title) {
     fm.title = title
@@ -109,35 +115,12 @@ function generateFrontmatter(
 
   fm.keywords = keywords
 
-  // Scoring fields — only emit when present (backward compatible)
-  if (scoring) {
-    if (scoring.importance !== undefined) {
-      fm.importance = Math.round(scoring.importance * 100) / 100
-    }
+  if (timestamps?.createdAt) {
+    fm.createdAt = timestamps.createdAt
+  }
 
-    if (scoring.recency !== undefined) {
-      fm.recency = Math.round(scoring.recency * 1000) / 1000
-    }
-
-    if (scoring.maturity) {
-      fm.maturity = scoring.maturity
-    }
-
-    if (scoring.accessCount !== undefined && scoring.accessCount > 0) {
-      fm.accessCount = scoring.accessCount
-    }
-
-    if (scoring.updateCount !== undefined && scoring.updateCount > 0) {
-      fm.updateCount = scoring.updateCount
-    }
-
-    if (scoring.createdAt) {
-      fm.createdAt = scoring.createdAt
-    }
-
-    if (scoring.updatedAt) {
-      fm.updatedAt = scoring.updatedAt
-    }
+  if (timestamps?.updatedAt) {
+    fm.updatedAt = timestamps.updatedAt
   }
 
   // Always generate frontmatter since tags and keywords are required
@@ -188,33 +171,17 @@ function parseFrontmatter(content: string): null | ParsedFrontmatter {
       frontmatter.summary = parsed.summary
     }
 
-    // Scoring fields (backward compatible — absent in old files)
-    if (typeof parsed.importance === 'number') {
-      frontmatter.importance = parsed.importance
-    }
-
-    if (typeof parsed.recency === 'number') {
-      frontmatter.recency = parsed.recency
-    }
-
-    if (typeof parsed.accessCount === 'number') {
-      frontmatter.accessCount = parsed.accessCount
-    }
-
-    if (typeof parsed.updateCount === 'number') {
-      frontmatter.updateCount = parsed.updateCount
-    }
-
+    // Content timestamps (createdAt is immutable, updatedAt tracks real
+    // content modification). Pre-migration files may also carry legacy
+    // scoring fields (importance, recency, maturity, accessCount,
+    // updateCount) — those are silently ignored here; the runtime signals
+    // they represented now live in the sidecar.
     if (typeof parsed.createdAt === 'string') {
       frontmatter.createdAt = parsed.createdAt
     }
 
     if (typeof parsed.updatedAt === 'string') {
       frontmatter.updatedAt = parsed.updatedAt
-    }
-
-    if (parsed.maturity === 'draft' || parsed.maturity === 'validated' || parsed.maturity === 'core') {
-      frontmatter.maturity = parsed.maturity
     }
 
     return { body, frontmatter }
@@ -698,81 +665,38 @@ function mergeFacts(source?: Fact[], target?: Fact[]): Fact[] | undefined {
 }
 
 /**
- * Parse content extracting relations from either frontmatter or legacy @ format.
- * Returns parsed frontmatter metadata and the body content for further parsing.
+ * Extract the createdAt timestamp from a raw markdown file's frontmatter.
+ * Used by callers (e.g. curate UPDATE) that need to preserve the immutable
+ * creation time across a write without round-tripping through the full
+ * parsed-content shape.
  */
-/**
- * Extract scoring metadata from parsed frontmatter.
- * Returns defaults for missing fields.
- */
-export function extractScoring(fm: Frontmatter): FrontmatterScoring {
-  return {
-    accessCount: fm.accessCount ?? 0,
-    createdAt: fm.createdAt,
-    importance: fm.importance ?? 50,
-    maturity: fm.maturity ?? 'draft',
-    recency: fm.recency ?? 1,
-    updateCount: fm.updateCount ?? 0,
-    updatedAt: fm.updatedAt,
-  }
-}
-
-/**
- * Parse frontmatter from raw markdown content and return scoring metadata.
- * Exported for use by search-knowledge-service to extract scoring without
- * going through the full parseContent path.
- */
-export function parseFrontmatterScoring(content: string): FrontmatterScoring | undefined {
-  const parsed = parseFrontmatter(content)
-  if (!parsed) {
-    return undefined
-  }
-
-  return extractScoring(parsed.frontmatter)
-}
-
-/**
- * Replace scoring fields in existing markdown content without touching the body.
- * If no frontmatter exists, returns the original content unchanged.
- */
-export function updateScoringInContent(content: string, scoring: FrontmatterScoring): string {
-  const parsed = parseFrontmatter(content)
-  if (!parsed) {
-    return content
-  }
-
-  const { body, frontmatter } = parsed
-  const updatedFrontmatter = generateFrontmatter(
-    frontmatter.title ?? '',
-    frontmatter.related,
-    frontmatter.tags,
-    frontmatter.keywords,
-    scoring,
-    frontmatter.summary,
-  )
-
-  return updatedFrontmatter + body
+export function parseCreatedAt(content: string): string | undefined {
+  return parseFrontmatter(content)?.frontmatter.createdAt
 }
 
 function parseContentWithFrontmatter(content: string): {
   body: string
   keywords: string[]
   relations: string[]
-  scoring?: FrontmatterScoring
   summary?: string
   tags: string[]
+  timestamps?: ContextTimestamps
   title?: string
 } {
   const parsed = parseFrontmatter(content)
 
   if (parsed) {
+    const timestamps: ContextTimestamps = {}
+    if (parsed.frontmatter.createdAt) timestamps.createdAt = parsed.frontmatter.createdAt
+    if (parsed.frontmatter.updatedAt) timestamps.updatedAt = parsed.frontmatter.updatedAt
+
     return {
       body: parsed.body,
       keywords: parsed.frontmatter.keywords,
       relations: parsed.frontmatter.related,
-      scoring: extractScoring(parsed.frontmatter),
       summary: parsed.frontmatter.summary,
       tags: parsed.frontmatter.tags,
+      timestamps: Object.keys(timestamps).length > 0 ? timestamps : undefined,
       title: parsed.frontmatter.title,
     }
   }
@@ -791,7 +715,7 @@ export const MarkdownWriter = {
     const snippets = (data.snippets || []).filter(s => s && s.trim())
     const relations = data.relations || []
 
-    const frontmatter = generateFrontmatter(data.name, relations, data.tags, data.keywords, data.scoring, data.summary)
+    const frontmatter = generateFrontmatter(data.name, relations, data.tags, data.keywords, data.timestamps, data.summary)
     const reasonSection = generateReasonSection(data.reason)
     const rawConceptSection = generateRawConceptSection(data.rawConcept)
     const narrativeSection = generateNarrativeSection(data.narrative)
@@ -835,17 +759,10 @@ export const MarkdownWriter = {
     // reason: explicit override wins, then source (newer), then target (older)
     const mergedReason = reason ?? parseReasonSection(sourceParsed.body) ?? parseReasonSection(targetParsed.body)
 
-    // Merge scoring metadata (FinMem-inspired lifecycle)
-    const defaultScoring: FrontmatterScoring = { importance: 50, maturity: 'draft', recency: 1 }
-    let mergedScoringData: FrontmatterScoring | undefined
-    if (sourceParsed.scoring || targetParsed.scoring) {
-      const merged = mergeScoringFn(sourceParsed.scoring ?? defaultScoring, targetParsed.scoring ?? defaultScoring)
-      const recalculatedTier = determineTier(
-        merged.importance ?? 50,
-        (merged.maturity ?? 'draft') as 'core' | 'draft' | 'validated',
-      )
-      mergedScoringData = { ...merged, maturity: recalculatedTier }
-    }
+    // Merge timestamps: preserve the earliest createdAt and stamp a fresh
+    // updatedAt. Scoring signals (importance/recency/maturity/counts) are
+    // merged at the sidecar layer by the merge caller — not here.
+    const mergedTimestamps = mergeTimestamps(sourceParsed.timestamps, targetParsed.timestamps)
 
     const sourceRawConcept = parseRawConceptSection(sourceParsed.body)
     const targetRawConcept = parseRawConceptSection(targetParsed.body)
@@ -880,15 +797,15 @@ export const MarkdownWriter = {
       rawConcept: mergedRawConcept,
       reason: mergedReason,
       relations: mergedRelations,
-      scoring: mergedScoringData,
       snippets: mergedSnippets,
       summary: summary ?? sourceParsed.summary ?? targetParsed.summary,
       tags: mergedTags,
+      timestamps: mergedTimestamps,
     })
   },
 
   parseContent(content: string, name: string = ''): ContextData {
-    const { body, keywords, relations, scoring, summary, tags, title } = parseContentWithFrontmatter(content)
+    const { body, keywords, relations, summary, tags, timestamps, title } = parseContentWithFrontmatter(content)
 
     return {
       facts: parseFactsSection(body),
@@ -898,10 +815,31 @@ export const MarkdownWriter = {
       rawConcept: parseRawConceptSection(body),
       reason: parseReasonSection(body),
       relations,
-      scoring,
       snippets: extractSnippetsFromContent(body),
       summary,
       tags,
+      timestamps,
     }
   },
+}
+
+/**
+ * Merge two timestamp records: earliest createdAt, fresh updatedAt.
+ *
+ * Always stamps a fresh `updatedAt` — merge is a content modification, so
+ * the output always carries an updated timestamp regardless of input shape.
+ * `createdAt` only appears in the output when at least one input had it.
+ */
+function mergeTimestamps(a?: ContextTimestamps, b?: ContextTimestamps): ContextTimestamps {
+  const out: ContextTimestamps = {updatedAt: new Date().toISOString()}
+
+  const aCreated = a?.createdAt
+  const bCreated = b?.createdAt
+  if (aCreated && bCreated) {
+    out.createdAt = new Date(aCreated).getTime() <= new Date(bCreated).getTime() ? aCreated : bCreated
+  } else if (aCreated ?? bCreated) {
+    out.createdAt = aCreated ?? bCreated
+  }
+
+  return out
 }

--- a/src/server/core/domain/knowledge/memory-scoring.ts
+++ b/src/server/core/domain/knowledge/memory-scoring.ts
@@ -10,7 +10,6 @@
  * All functions are stateless and side-effect free.
  */
 
-import type {FrontmatterScoring} from './markdown-writer.js'
 import type {RuntimeSignals} from './runtime-signals-schema.js'
 
 // ---------------------------------------------------------------------------
@@ -143,114 +142,61 @@ export function determineTier(
 }
 
 /**
- * Record a search access hit on a knowledge file.
- *
- * Increments access count and adds an importance bonus.
- *
- * @param scoring - Current scoring state
- * @returns Updated scoring (original not mutated)
- */
-export function recordAccessHit(scoring: FrontmatterScoring): FrontmatterScoring {
-  const newAccessCount = (scoring.accessCount ?? 0) + 1
-  const newImportance = Math.min(100, (scoring.importance ?? 50) + ACCESS_IMPORTANCE_BONUS)
-
-  return {
-    ...scoring,
-    accessCount: newAccessCount,
-    importance: newImportance,
-  }
-}
-
-/**
  * Record multiple accumulated access hits at once.
  *
- * @param scoring - Current scoring state
- * @param hitCount - Number of hits to record
- * @returns Updated scoring (original not mutated)
+ * Increments accessCount by `hitCount` and importance by
+ * `ACCESS_IMPORTANCE_BONUS * hitCount` (capped at 100). Caller is
+ * responsible for recomputing maturity via `determineTier` if the
+ * importance delta may cross a hysteresis threshold.
  */
-export function recordAccessHits(scoring: FrontmatterScoring, hitCount: number): FrontmatterScoring {
+export function recordAccessHits(signals: RuntimeSignals, hitCount: number): RuntimeSignals {
   if (hitCount <= 0) {
-    return scoring
+    return signals
   }
 
-  const newAccessCount = (scoring.accessCount ?? 0) + hitCount
-  const newImportance = Math.min(100, (scoring.importance ?? 50) + ACCESS_IMPORTANCE_BONUS * hitCount)
-
   return {
-    ...scoring,
-    accessCount: newAccessCount,
-    importance: newImportance,
+    ...signals,
+    accessCount: signals.accessCount + hitCount,
+    importance: Math.min(100, signals.importance + ACCESS_IMPORTANCE_BONUS * hitCount),
   }
 }
 
 /**
  * Record a curate update on a knowledge file.
  *
- * Increments update count, adds an importance bonus, resets recency to 1.0,
- * and updates the timestamp.
- *
- * @param scoring - Current scoring state
- * @returns Updated scoring (original not mutated)
+ * Increments updateCount, adds an importance bonus, resets recency to 1.0.
+ * Caller is responsible for recomputing maturity via `determineTier`.
  */
-export function recordCurateUpdate(scoring: FrontmatterScoring): FrontmatterScoring {
-  const newUpdateCount = (scoring.updateCount ?? 0) + 1
-  const newImportance = Math.min(100, (scoring.importance ?? 50) + UPDATE_IMPORTANCE_BONUS)
-  const now = new Date().toISOString()
-
+export function recordCurateUpdate(signals: RuntimeSignals): RuntimeSignals {
   return {
-    ...scoring,
-    importance: newImportance,
+    ...signals,
+    importance: Math.min(100, signals.importance + UPDATE_IMPORTANCE_BONUS),
     recency: 1,
-    updateCount: newUpdateCount,
-    updatedAt: now,
+    updateCount: signals.updateCount + 1,
   }
 }
 
 /**
- * Return default scoring values for a new or unscored knowledge file.
- */
-export function applyDefaultScoring(): FrontmatterScoring {
-  const now = new Date().toISOString()
-
-  return {
-    accessCount: 0,
-    createdAt: now,
-    importance: 50,
-    maturity: 'draft',
-    recency: 1,
-    updateCount: 0,
-    updatedAt: now,
-  }
-}
-
-/**
- * Merge two scoring states during a MERGE operation.
+ * Merge two runtime-signal snapshots during a MERGE operation.
  *
  * Strategy:
  * - importance: max of both
  * - recency: max of both
  * - accessCount: sum
  * - updateCount: sum + 1 (for the merge itself)
- * - maturity: higher tier
- * - createdAt: earlier date
- * - updatedAt: current time
+ * - maturity: higher tier (caller may refine via `determineTier`)
  */
-export function mergeScoring(source: FrontmatterScoring, target: FrontmatterScoring): FrontmatterScoring {
+export function mergeScoring(source: RuntimeSignals, target: RuntimeSignals): RuntimeSignals {
   const tierRank: Record<string, number> = {core: 3, draft: 1, validated: 2}
-  const sourceRank = tierRank[source.maturity ?? 'draft'] ?? 1
-  const targetRank = tierRank[target.maturity ?? 'draft'] ?? 1
-  const higherTier = sourceRank >= targetRank ? (source.maturity ?? 'draft') : (target.maturity ?? 'draft')
-
-  const sourceCreated = source.createdAt ? new Date(source.createdAt).getTime() : Date.now()
-  const targetCreated = target.createdAt ? new Date(target.createdAt).getTime() : Date.now()
+  const sourceRank = tierRank[source.maturity] ?? 1
+  const targetRank = tierRank[target.maturity] ?? 1
+  const higherTier = sourceRank >= targetRank ? source.maturity : target.maturity
 
   return {
-    accessCount: (source.accessCount ?? 0) + (target.accessCount ?? 0),
-    createdAt: sourceCreated <= targetCreated ? source.createdAt : target.createdAt,
-    importance: Math.max(source.importance ?? 50, target.importance ?? 50),
-    maturity: higherTier as 'core' | 'draft' | 'validated',
-    recency: Math.max(source.recency ?? 1, target.recency ?? 1),
-    updateCount: (source.updateCount ?? 0) + (target.updateCount ?? 0) + 1,
-    updatedAt: new Date().toISOString(),
+    accessCount: source.accessCount + target.accessCount,
+    importance: Math.max(source.importance, target.importance),
+    maturity: higherTier,
+    recency: Math.max(source.recency, target.recency),
+    updateCount: source.updateCount + target.updateCount + 1,
   }
 }

--- a/src/server/infra/dream/operations/prune.ts
+++ b/src/server/infra/dream/operations/prune.ts
@@ -20,6 +20,7 @@ import type {DreamOperation} from '../dream-log-schema.js'
 import type {PruneDecision} from '../dream-response-schemas.js'
 import type {DreamState} from '../dream-state-schema.js'
 
+import {DEFAULT_IMPORTANCE, DEFAULT_MATURITY} from '../../../core/domain/knowledge/runtime-signals-schema.js'
 import {isExcludedFromSync} from '../../context-tree/derived-artifact.js'
 import {toUnixPath} from '../../context-tree/path-utils.js'
 import {PruneResponseSchema} from '../dream-response-schemas.js'
@@ -41,6 +42,15 @@ export type PruneDeps = {
   projectRoot: string
   reviewBackupStore?: {
     save(relativePath: string, content: string): Promise<void>
+  }
+  /**
+   * Runtime-signal sidecar. Source of truth for `importance` and `maturity`
+   * used in prune's candidacy decisions. Absent store or missing-per-path
+   * entries are treated as defaults (importance 50, maturity 'draft') —
+   * matches the plan's "paths without entries use defaults" principle.
+   */
+  runtimeSignalStore?: {
+    list(): Promise<Map<string, {importance: number; maturity: 'core' | 'draft' | 'validated'}>>
   }
   signal?: AbortSignal
   taskId: string
@@ -88,11 +98,25 @@ async function findCandidates(deps: PruneDeps): Promise<CandidateInfo[]> {
   const candidateMap = new Map<string, CandidateInfo>()
   const now = Date.now()
 
+  // Source of truth for importance/maturity is the sidecar. Preload once per
+  // scan so per-path lookups are O(1) map reads instead of repeated regex
+  // passes over markdown content. On sidecar failure the map is empty and
+  // every path falls back to defaults (importance 50, maturity 'draft').
+  let signalsByPath: Map<string, {importance: number; maturity: 'core' | 'draft' | 'validated'}>
+  try {
+    signalsByPath = deps.runtimeSignalStore ? await deps.runtimeSignalStore.list() : new Map()
+  } catch {
+    signalsByPath = new Map()
+  }
+
   // Signal A: archive service importance decay
   try {
     const importancePaths = await deps.archiveService.findArchiveCandidates(deps.projectRoot)
     const infoResults = await Promise.all(
-      importancePaths.map(async (path) => ({info: await readCandidateInfo(deps.contextTreeDir, path, now), path})),
+      importancePaths.map(async (path) => ({
+        info: await readCandidateInfo(deps.contextTreeDir, path, now, signalsByPath),
+        path,
+      })),
     )
     for (const {info, path} of infoResults) {
       if (info && info.maturity !== 'core') {
@@ -105,7 +129,7 @@ async function findCandidates(deps: PruneDeps): Promise<CandidateInfo[]> {
 
   // Signal B: mtime staleness
   try {
-    const stalePaths = await findStaleFiles(deps.contextTreeDir, now)
+    const stalePaths = await findStaleFiles(deps.contextTreeDir, now, signalsByPath)
     for (const {info, path} of stalePaths) {
       if (candidateMap.has(path)) {
         // Already found by Signal A — mark as both
@@ -125,17 +149,22 @@ async function findCandidates(deps: PruneDeps): Promise<CandidateInfo[]> {
   return candidates.slice(0, MAX_CANDIDATES)
 }
 
-async function readCandidateInfo(contextTreeDir: string, relativePath: string, now: number): Promise<CandidateInfo | undefined> {
+async function readCandidateInfo(
+  contextTreeDir: string,
+  relativePath: string,
+  now: number,
+  signalsByPath: Map<string, {importance: number; maturity: 'core' | 'draft' | 'validated'}>,
+): Promise<CandidateInfo | undefined> {
   try {
     const fullPath = join(contextTreeDir, relativePath)
-    const content = await readFile(fullPath, 'utf8')
     const fileStat = await stat(fullPath)
     const daysSinceModified = (now - fileStat.mtimeMs) / MS_PER_DAY
+    const signals = signalsByPath.get(relativePath)
 
     return {
       daysSinceModified,
-      importance: extractImportance(content),
-      maturity: extractMaturity(content),
+      importance: signals?.importance ?? DEFAULT_IMPORTANCE,
+      maturity: signals?.maturity ?? DEFAULT_MATURITY,
       path: relativePath,
       signal: 'importance',
     }
@@ -144,15 +173,22 @@ async function readCandidateInfo(contextTreeDir: string, relativePath: string, n
   }
 }
 
-async function findStaleFiles(contextTreeDir: string, now: number): Promise<Array<{info: CandidateInfo; path: string}>> {
+async function findStaleFiles(
+  contextTreeDir: string,
+  now: number,
+  signalsByPath: Map<string, {importance: number; maturity: 'core' | 'draft' | 'validated'}>,
+): Promise<Array<{info: CandidateInfo; path: string}>> {
   const results: Array<{info: CandidateInfo; path: string}> = []
 
   await walkMdFiles(contextTreeDir, async (relativePath, fullPath) => {
     try {
-      const content = await readFile(fullPath, 'utf8')
-      const maturity = extractMaturity(content)
+      const signals = signalsByPath.get(relativePath)
+      const maturity = signals?.maturity ?? DEFAULT_MATURITY
 
-      // core files NEVER pruned
+      // core files NEVER pruned. Absent sidecar entry means maturity defaults
+      // to 'draft', so core protection depends on the sidecar being populated.
+      // That is intentional: post-migration, a file is only 'core' when the
+      // maturity tier has been earned via repeated access / curate updates.
       if (maturity === 'core') return
 
       const threshold = maturity === 'validated' ? VALIDATED_STALE_DAYS : DRAFT_STALE_DAYS
@@ -163,7 +199,7 @@ async function findStaleFiles(contextTreeDir: string, now: number): Promise<Arra
         results.push({
           info: {
             daysSinceModified,
-            importance: extractImportance(content),
+            importance: signals?.importance ?? DEFAULT_IMPORTANCE,
             maturity,
             path: relativePath,
             signal: 'mtime',
@@ -431,14 +467,3 @@ async function writePendingMerge(decision: PruneDecision, deps: PruneDeps): Prom
   })
 }
 
-// ── Frontmatter helpers ────────────────────────────────────────────────────
-
-function extractMaturity(content: string): string {
-  const match = /^maturity:\s*['"]?(core|draft|validated)['"]?/m.exec(content)
-  return match?.[1] ?? 'draft'
-}
-
-function extractImportance(content: string): number {
-  const match = /^importance:\s*(\d+(?:\.\d+)?)/m.exec(content)
-  return match ? Number.parseFloat(match[1]) : 50
-}

--- a/src/server/infra/executor/dream-executor.ts
+++ b/src/server/infra/executor/dream-executor.ts
@@ -22,6 +22,7 @@ import type {ICipherAgent} from '../../../agent/core/interfaces/i-cipher-agent.j
 import type {FileState} from '../../core/domain/entities/context-tree-snapshot.js'
 import type {CurateLogEntry} from '../../core/domain/entities/curate-log-entry.js'
 import type {CurateLogStatus} from '../../core/interfaces/storage/i-curate-log-store.js'
+import type {IRuntimeSignalStore} from '../../core/interfaces/storage/i-runtime-signal-store.js'
 import type {DreamLogEntry, DreamLogSummary, DreamOperation} from '../dream/dream-log-schema.js'
 
 import {BRV_DIR, CONTEXT_TREE_DIR} from '../../constants.js'
@@ -62,10 +63,12 @@ export type DreamExecutorDeps = {
     save(relativePath: string, content: string): Promise<void>
   }
   /**
-   * Optional. Passed through to consolidate's CROSS_REFERENCE review gate so
-   * it reads maturity from the sidecar rather than markdown frontmatter.
+   * Optional. Passed through to consolidate's CROSS_REFERENCE review gate
+   * (reads `maturity` via `get`) and to prune's candidacy scan (reads
+   * `importance`/`maturity` via `list`). The full `IRuntimeSignalStore` is
+   * accepted so both code paths can consume what they need.
    */
-  runtimeSignalStore?: ConsolidateDeps['runtimeSignalStore']
+  runtimeSignalStore?: IRuntimeSignalStore
   searchService: ConsolidateDeps['searchService']
 }
 
@@ -301,6 +304,7 @@ export class DreamExecutor {
         dreamStateService: this.deps.dreamStateService,
         projectRoot,
         reviewBackupStore: this.deps.reviewBackupStore,
+        runtimeSignalStore: this.deps.runtimeSignalStore,
         signal,
         taskId,
       })),

--- a/test/integration/runtime-signals/vc-clean-regression.test.ts
+++ b/test/integration/runtime-signals/vc-clean-regression.test.ts
@@ -1,0 +1,181 @@
+import {expect} from 'chai'
+import * as fs from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+
+import type {IFileSystem} from '../../../src/agent/core/interfaces/i-file-system.js'
+import type {IRuntimeSignalStore} from '../../../src/server/core/interfaces/storage/i-runtime-signal-store.js'
+
+import {SearchKnowledgeService} from '../../../src/agent/infra/tools/implementations/search-knowledge-service.js'
+import {BRV_DIR, CONTEXT_TREE_DIR} from '../../../src/server/constants.js'
+import {createMockRuntimeSignalStore} from '../../helpers/mock-factories.js'
+
+interface PendingAccessHitsInternals {
+  pendingAccessHits: Map<string, number>
+}
+
+function createDiskFileSystem(): IFileSystem {
+  return {
+    async readFile(path: string) {
+      return {content: await fs.readFile(path, 'utf8')}
+    },
+    async writeFile(path: string, content: string) {
+      await fs.writeFile(path, content, 'utf8')
+    },
+  } as unknown as IFileSystem
+}
+
+/**
+ * The user-facing acceptance test for commit 5:
+ * after N access-hit flushes on a populated context tree, every markdown
+ * file's on-disk content is byte-identical to its initial state.
+ *
+ * This is the test that defines "done" for the runtime-signals migration.
+ * If this fails, `brv vc status` shows noise for users after queries and
+ * the whole initiative has missed its goal.
+ */
+describe('Runtime-signals migration — VC-clean regression', () => {
+  let projectRoot: string
+  let contextTreeDir: string
+  let signalStore: IRuntimeSignalStore
+  let service: SearchKnowledgeService
+
+  beforeEach(async () => {
+    projectRoot = join(tmpdir(), `rs-vc-clean-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    contextTreeDir = join(projectRoot, BRV_DIR, CONTEXT_TREE_DIR)
+    await fs.mkdir(contextTreeDir, {recursive: true})
+    signalStore = createMockRuntimeSignalStore()
+    service = new SearchKnowledgeService(createDiskFileSystem(), {
+      baseDirectory: projectRoot,
+      runtimeSignalStore: signalStore,
+    })
+  })
+
+  afterEach(async () => {
+    await fs.rm(projectRoot, {force: true, recursive: true})
+  })
+
+  it('flushAccessHits never modifies markdown files, regardless of hit volume', async () => {
+    // Seed a context tree with 10 files that each have the post-commit-5
+    // frontmatter shape: only semantic fields + timestamps.
+    const relPaths: string[] = []
+    for (let i = 0; i < 10; i++) {
+      const domainDir = join(contextTreeDir, `domain_${i}`)
+      // eslint-disable-next-line no-await-in-loop
+      await fs.mkdir(domainDir, {recursive: true})
+
+      const relPath = `domain_${i}/entry_${i}.md`
+      const fullPath = join(contextTreeDir, relPath)
+      const content =
+        `---\n` +
+        `title: Entry ${i}\n` +
+        `tags: [test]\n` +
+        `keywords: [sample]\n` +
+        `createdAt: '2026-01-01T00:00:00.000Z'\n` +
+        `updatedAt: '2026-01-01T00:00:00.000Z'\n` +
+        `---\n\n# Entry ${i}\n\nSample content for regression test.\n`
+      // eslint-disable-next-line no-await-in-loop
+      await fs.writeFile(fullPath, content, 'utf8')
+      relPaths.push(relPath)
+    }
+
+    // Snapshot original content for every file.
+    const originals = new Map<string, string>()
+    for (const relPath of relPaths) {
+      // eslint-disable-next-line no-await-in-loop
+      originals.set(relPath, await fs.readFile(join(contextTreeDir, relPath), 'utf8'))
+    }
+
+    // Simulate 20 rounds of access-hit flushes, each touching every file.
+    const pendingMap = (service as unknown as PendingAccessHitsInternals).pendingAccessHits
+    for (let round = 0; round < 20; round++) {
+      pendingMap.clear()
+      for (const relPath of relPaths) {
+        pendingMap.set(relPath, 1)
+      }
+
+      // eslint-disable-next-line no-await-in-loop
+      const flushed = await service.flushAccessHits(contextTreeDir)
+      expect(flushed).to.equal(true)
+    }
+
+    // Every markdown file on disk is byte-identical to its initial state —
+    // no scoring fields were written, no timestamps touched, nothing.
+    for (const relPath of relPaths) {
+      // eslint-disable-next-line no-await-in-loop
+      const currentContent = await fs.readFile(join(contextTreeDir, relPath), 'utf8')
+      expect(currentContent, `file ${relPath} was modified after 20 flushes`).to.equal(originals.get(relPath))
+    }
+
+    // Meanwhile the sidecar has accumulated real signal state.
+    const signals = await signalStore.list()
+    expect(signals.size).to.equal(relPaths.length)
+    for (const relPath of relPaths) {
+      // 20 rounds × 1 hit × 3 importance bonus = 60 importance above default 50.
+      const entry = signals.get(relPath)
+      expect(entry?.importance).to.be.greaterThanOrEqual(60)
+      expect(entry?.accessCount).to.equal(20)
+    }
+  })
+
+  it('parseContent tolerates legacy files with full signal frontmatter', async () => {
+    const {MarkdownWriter} = await import('../../../src/server/core/domain/knowledge/markdown-writer.js')
+
+    // Pre-migration file: every runtime-signal field present in YAML.
+    const legacy =
+      `---\n` +
+      `title: Legacy Entry\n` +
+      `tags: [auth]\n` +
+      `keywords: [jwt]\n` +
+      `importance: 72\n` +
+      `recency: 0.8\n` +
+      `maturity: validated\n` +
+      `accessCount: 14\n` +
+      `updateCount: 3\n` +
+      `createdAt: '2026-01-01T00:00:00.000Z'\n` +
+      `updatedAt: '2026-01-15T00:00:00.000Z'\n` +
+      `---\n\n# Legacy Entry\n\nSome content.\n`
+
+    const parsed = MarkdownWriter.parseContent(legacy, 'Legacy Entry')
+
+    // Semantic fields round-trip.
+    expect(parsed.name).to.equal('Legacy Entry')
+    expect(parsed.tags).to.deep.equal(['auth'])
+    expect(parsed.keywords).to.deep.equal(['jwt'])
+    expect(parsed.timestamps?.createdAt).to.equal('2026-01-01T00:00:00.000Z')
+    expect(parsed.timestamps?.updatedAt).to.equal('2026-01-15T00:00:00.000Z')
+
+    // Legacy runtime-signal fields are silently ignored — not exposed on the
+    // semantic type (ContextData has no importance/recency/maturity fields).
+    const asRecord = parsed as unknown as Record<string, unknown>
+    expect(asRecord.importance).to.be.undefined
+    expect(asRecord.recency).to.be.undefined
+    expect(asRecord.maturity).to.be.undefined
+    expect(asRecord.accessCount).to.be.undefined
+    expect(asRecord.updateCount).to.be.undefined
+  })
+
+  it('generateFrontmatter never emits runtime-signal fields', async () => {
+    const {MarkdownWriter} = await import('../../../src/server/core/domain/knowledge/markdown-writer.js')
+
+    const output = MarkdownWriter.generateContext({
+      keywords: ['jwt'],
+      name: 'Fresh Entry',
+      snippets: [],
+      tags: ['auth'],
+      timestamps: {createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-15T00:00:00.000Z'},
+    })
+
+    expect(output).to.not.match(/^importance:/m)
+    expect(output).to.not.match(/^recency:/m)
+    expect(output).to.not.match(/^maturity:/m)
+    expect(output).to.not.match(/^accessCount:/m)
+    expect(output).to.not.match(/^updateCount:/m)
+
+    // Semantic fields and timestamps still emit.
+    expect(output).to.match(/^title: Fresh Entry/m)
+    expect(output).to.match(/^tags: \[auth\]/m)
+    expect(output).to.match(/^createdAt:/m)
+    expect(output).to.match(/^updatedAt:/m)
+  })
+})

--- a/test/unit/agent/knowledge/markdown-writer.test.ts
+++ b/test/unit/agent/knowledge/markdown-writer.test.ts
@@ -475,5 +475,109 @@ Some old content`
       expect(parsed.relations).to.have.members(['domain/new/file.md', 'domain/old/file.md'])
       expect(parsed.tags).to.deep.equal(['newtag'])
     })
+
+    describe('timestamp merge', () => {
+      it('preserves the earliest createdAt from either input', () => {
+        const source = `---
+title: Source
+tags: []
+keywords: []
+createdAt: '2026-03-10T00:00:00.000Z'
+updatedAt: '2026-04-01T00:00:00.000Z'
+---
+Source body`
+
+        const target = `---
+title: Target
+tags: []
+keywords: []
+createdAt: '2026-01-15T00:00:00.000Z'
+updatedAt: '2026-02-20T00:00:00.000Z'
+---
+Target body`
+
+        const merged = MarkdownWriter.mergeContexts(source, target)
+        const parsed = MarkdownWriter.parseContent(merged)
+
+        // Earliest createdAt wins (target's 2026-01-15 is earlier than source's 2026-03-10).
+        expect(parsed.timestamps?.createdAt).to.equal('2026-01-15T00:00:00.000Z')
+      })
+
+      it('stamps a fresh updatedAt on merge', () => {
+        const source = `---
+title: Source
+tags: []
+keywords: []
+createdAt: '2026-01-01T00:00:00.000Z'
+updatedAt: '2026-01-01T00:00:00.000Z'
+---
+Source`
+
+        const target = `---
+title: Target
+tags: []
+keywords: []
+createdAt: '2026-01-01T00:00:00.000Z'
+updatedAt: '2026-01-01T00:00:00.000Z'
+---
+Target`
+
+        const before = Date.now()
+        const merged = MarkdownWriter.mergeContexts(source, target)
+        const after = Date.now()
+        const parsed = MarkdownWriter.parseContent(merged)
+
+        expect(parsed.timestamps?.updatedAt).to.exist
+        const updatedAtMs = new Date(parsed.timestamps!.updatedAt!).getTime()
+        expect(updatedAtMs).to.be.at.least(before)
+        expect(updatedAtMs).to.be.at.most(after)
+      })
+
+      it('falls back to the single available createdAt when only one input has it', () => {
+        const source = `---
+title: Source
+tags: []
+keywords: []
+createdAt: '2026-05-01T00:00:00.000Z'
+---
+Source`
+
+        const target = `---
+title: Target
+tags: []
+keywords: []
+---
+Target`
+
+        const merged = MarkdownWriter.mergeContexts(source, target)
+        const parsed = MarkdownWriter.parseContent(merged)
+
+        expect(parsed.timestamps?.createdAt).to.equal('2026-05-01T00:00:00.000Z')
+      })
+
+      it('omits createdAt entirely when neither input carries it', () => {
+        const source = `---
+title: Source
+tags: []
+keywords: []
+---
+Source`
+
+        const target = `---
+title: Target
+tags: []
+keywords: []
+---
+Target`
+
+        const merged = MarkdownWriter.mergeContexts(source, target)
+        const parsed = MarkdownWriter.parseContent(merged)
+
+        // Neither input had createdAt — merged output has no createdAt either.
+        expect(parsed.timestamps?.createdAt).to.be.undefined
+        // updatedAt is always stamped on merge since content changed.
+        expect(parsed.timestamps?.updatedAt).to.exist
+      })
+    })
   })
 })

--- a/test/unit/agent/tools/curate-tool-sidecar-dual-write.test.ts
+++ b/test/unit/agent/tools/curate-tool-sidecar-dual-write.test.ts
@@ -250,8 +250,8 @@ describe('Curate tool — runtime-signal sidecar dual-write', () => {
     })
   })
 
-  describe('markdown/sidecar consistency', () => {
-    it('ADD writes matching scoring to both markdown frontmatter and sidecar', async () => {
+  describe('markdown/sidecar separation', () => {
+    it('ADD writes scoring only to the sidecar — markdown carries no runtime-signal fields', async () => {
       await runCurate(basePath, signalStore, [
         {
           confidence: 'high',
@@ -269,17 +269,18 @@ describe('Curate tool — runtime-signal sidecar dual-write', () => {
       const markdown = await fs.readFile(markdownPath, 'utf8')
       const signals = await signalStore.get(relPath)
 
-      // Pull scoring fields out of the markdown frontmatter.
-      const importanceMatch = /^importance:\s*(\d+)/m.exec(markdown)
-      const maturityMatch = /^maturity:\s*(core|draft|validated)/m.exec(markdown)
-      const recencyMatch = /^recency:\s*([\d.]+)/m.exec(markdown)
+      // Sidecar carries the runtime signals (default values on ADD).
+      expect(signals).to.deep.equal(createDefaultRuntimeSignals())
 
-      expect(importanceMatch?.[1]).to.equal(String(signals.importance))
-      expect(maturityMatch?.[1]).to.equal(signals.maturity)
-      expect(recencyMatch?.[1]).to.equal(String(signals.recency))
+      // Markdown carries zero runtime-signal fields — not emitted any more.
+      expect(markdown).to.not.match(/^importance:/m)
+      expect(markdown).to.not.match(/^recency:/m)
+      expect(markdown).to.not.match(/^maturity:/m)
+      expect(markdown).to.not.match(/^accessCount:/m)
+      expect(markdown).to.not.match(/^updateCount:/m)
     })
 
-    it('UPDATE keeps markdown and sidecar in sync after a bump', async () => {
+    it('UPDATE bumps the sidecar while leaving markdown scoring-free', async () => {
       // Seed.
       await runCurate(basePath, signalStore, [
         {
@@ -309,13 +310,14 @@ describe('Curate tool — runtime-signal sidecar dual-write', () => {
       const markdown = await fs.readFile(join(basePath, relPath), 'utf8')
       const signals = await signalStore.get(relPath)
 
-      const importanceMatch = /^importance:\s*(\d+)/m.exec(markdown)
-      const maturityMatch = /^maturity:\s*(core|draft|validated)/m.exec(markdown)
-      const updateCountMatch = /^updateCount:\s*(\d+)/m.exec(markdown)
+      // Sidecar reflects the bump.
+      expect(signals.importance).to.equal(55) // 50 + UPDATE_IMPORTANCE_BONUS(5)
+      expect(signals.updateCount).to.equal(1)
 
-      expect(importanceMatch?.[1]).to.equal(String(signals.importance))
-      expect(maturityMatch?.[1]).to.equal(signals.maturity)
-      expect(updateCountMatch?.[1]).to.equal(String(signals.updateCount))
+      // Markdown still carries no runtime-signal fields.
+      expect(markdown).to.not.match(/^importance:/m)
+      expect(markdown).to.not.match(/^maturity:/m)
+      expect(markdown).to.not.match(/^updateCount:/m)
     })
   })
 

--- a/test/unit/agent/tools/curate-tool-sidecar-dual-write.test.ts
+++ b/test/unit/agent/tools/curate-tool-sidecar-dual-write.test.ts
@@ -189,6 +189,55 @@ describe('Curate tool — runtime-signal sidecar dual-write', () => {
       const after = await signalStore.get(relPath)
       expect(after).to.deep.equal(createDefaultRuntimeSignals())
     })
+
+    it('drops sidecar entries for every file inside a deleted folder', async () => {
+      // Seed two files under the same topic folder.
+      await runCurate(basePath, signalStore, [
+        {
+          confidence: 'high',
+          content: {snippets: ['a'], tags: ['t']},
+          impact: 'low',
+          path: 'domain/topic',
+          reason: 'seed one',
+          title: 'File One',
+          type: 'ADD',
+        },
+        {
+          confidence: 'high',
+          content: {snippets: ['b'], tags: ['t']},
+          impact: 'low',
+          path: 'domain/topic',
+          reason: 'seed two',
+          title: 'File Two',
+          type: 'ADD',
+        },
+      ])
+
+      const relOne = 'domain/topic/file_one.md'
+      const relTwo = 'domain/topic/file_two.md'
+
+      // Mark both sidecar entries with non-default values so we can prove removal.
+      await signalStore.set(relOne, {...createDefaultRuntimeSignals(), importance: 80})
+      await signalStore.set(relTwo, {...createDefaultRuntimeSignals(), importance: 90})
+
+      // Folder delete: omit `title` so executeDelete takes the folder branch.
+      const result = await runCurate(basePath, signalStore, [
+        {
+          confidence: 'low',
+          impact: 'low',
+          path: 'domain/topic',
+          reason: 'clean folder',
+          type: 'DELETE',
+        },
+      ])
+      expect(result.summary.deleted).to.equal(1)
+
+      // Both sidecar entries must be gone — get() returns defaults on miss.
+      const afterOne = await signalStore.get(relOne)
+      const afterTwo = await signalStore.get(relTwo)
+      expect(afterOne).to.deep.equal(createDefaultRuntimeSignals())
+      expect(afterTwo).to.deep.equal(createDefaultRuntimeSignals())
+    })
   })
 
   describe('MERGE', () => {

--- a/test/unit/agent/tools/memory-symbol-tree.test.ts
+++ b/test/unit/agent/tools/memory-symbol-tree.test.ts
@@ -99,11 +99,14 @@ describe('Memory Symbol Tree & Path Matcher', () => {
       expect(refresh?.parent?.parent?.parent).to.be.undefined
     })
 
-    it('should absorb context.md files into parent folder metadata', () => {
+    it('should absorb context.md files into parent folder node (structural only)', () => {
+      // Post-commit-5: the symbol tree no longer carries per-node scoring
+      // (importance / maturity) — ranking reads those from the sidecar.
+      // Metadata collapses to structural defaults at tree-build time.
       const auth = tree.symbolMap.get('auth')
-      // context.md had importance=75, maturity='validated'
-      expect(auth?.metadata.importance).to.equal(75)
-      expect(auth?.metadata.maturity).to.equal('validated')
+      expect(auth).to.exist
+      expect(auth?.metadata.importance).to.equal(50)
+      expect(auth?.metadata.maturity).to.equal('draft')
     })
 
     it('should not create Context nodes for context.md files', () => {

--- a/test/unit/agent/tools/search-knowledge-flush-sidecar.test.ts
+++ b/test/unit/agent/tools/search-knowledge-flush-sidecar.test.ts
@@ -110,7 +110,7 @@ describe('SearchKnowledgeService — flushAccessHits dual-write', () => {
     expect((await signalStore.list()).size).to.equal(0)
   })
 
-  it('completes the markdown flush even if the sidecar batchUpdate throws', async () => {
+  it('reports completion even when the sidecar batchUpdate throws and leaves markdown untouched', async () => {
     const throwing: IRuntimeSignalStore = {
       async batchUpdate() {
         throw new Error('sidecar down')
@@ -135,14 +135,17 @@ describe('SearchKnowledgeService — flushAccessHits dual-write', () => {
     const relPath = 'x.md'
     const filePath = join(contextTreeDir, relPath)
     await fs.writeFile(filePath, MARKDOWN_WITH_SCORING, 'utf8')
+    const before = await fs.readFile(filePath, 'utf8')
     primePendingHits(isolated, {[relPath]: 1})
 
+    // Flush must not throw despite the sidecar failure — commit 5 no longer
+    // writes to markdown so `flushed` simply indicates that pending hits
+    // were processed.
     const flushed = await isolated.flushAccessHits(contextTreeDir)
     expect(flushed).to.equal(true)
 
-    // Markdown was written despite sidecar failure — read it back and verify
-    // importance bumped (50 + 3 = 53).
-    const rewritten = await fs.readFile(filePath, 'utf8')
-    expect(rewritten).to.include('importance: 53')
+    // Markdown is byte-identical — flush never touches it post-commit-5.
+    const after = await fs.readFile(filePath, 'utf8')
+    expect(after).to.equal(before)
   })
 })

--- a/test/unit/agent/tools/search-knowledge-tool.test.ts
+++ b/test/unit/agent/tools/search-knowledge-tool.test.ts
@@ -619,29 +619,27 @@ describe('Search Knowledge Tool', () => {
       expect(secondListDirCount).to.equal(firstListDirCount)
     })
 
-    it('flushes pending access hits even when the cached file mtimes are unchanged', async () => {
+    it('does not write to markdown on flush — access hits only touch the sidecar', async () => {
+      // Post-commit-5 flushAccessHits never writes to markdown. This test
+      // guards the invariant by asserting writeFile is never invoked across
+      // repeated searches, regardless of pending hits.
       const tool = createSearchKnowledgeTool(fileSystemMock, {baseDirectory: '/test', cacheTtlMs: 0})
 
       readFileStub.resolves({
         content:
-          '---\nimportance: 50\nrecency: 1\nmaturity: draft\naccessCount: 0\nupdateCount: 0\ncreatedAt: \'2026-03-27T00:00:00.000Z\'\nupdatedAt: \'2026-03-27T00:00:00.000Z\'\n---\n# Test File\n\nTest content for caching.',
+          '---\ncreatedAt: \'2026-03-27T00:00:00.000Z\'\nupdatedAt: \'2026-03-27T00:00:00.000Z\'\n---\n# Test File\n\nTest content for caching.',
         encoding: 'utf8',
-        lines: 10,
-        size: 220,
-        totalLines: 10,
+        lines: 5,
+        size: 140,
+        totalLines: 5,
         truncated: false,
       })
-      writeFileStub.resolves({bytesWritten: 240, path: '/test/.brv/context-tree/test/file.md', success: true})
+      writeFileStub.resolves({bytesWritten: 0, path: '/test/.brv/context-tree/test/file.md', success: true})
 
       await tool.execute({query: 'test'})
+      await tool.execute({query: 'test'})
+
       expect(writeFileStub.called).to.equal(false)
-
-      await tool.execute({query: 'test'})
-
-      expect(writeFileStub.calledOnce).to.equal(true)
-      expect(writeFileStub.firstCall.args[0]).to.equal('/test/.brv/context-tree/test/file.md')
-      expect(writeFileStub.firstCall.args[1]).to.include('importance: 53')
-      expect(writeFileStub.firstCall.args[1]).to.include('accessCount: 1')
     })
   })
 
@@ -906,8 +904,10 @@ describe('Search Knowledge Tool', () => {
       expect((secondBatch[0] as SearchKnowledgeOutput).results).to.be.an('array')
       expect((secondBatch[1] as SearchKnowledgeOutput).results).to.be.an('array')
 
-      // Second batch triggers one more build (not two) + one readFile from access-hit flush = 3 total
-      expect(readFileStub.callCount).to.equal(3)
+      // Second batch triggers one more build (not two). Post-commit-5 the
+      // access-hit flush no longer reads the file for a markdown rewrite,
+      // so the total readFile count is 2 (one per batch build), not 3.
+      expect(readFileStub.callCount).to.equal(2)
     })
 
     it('should not deadlock when multiple tools execute concurrently', async () => {
@@ -1233,7 +1233,20 @@ describe('Search Knowledge Tool', () => {
         })
       })
 
-      const tool = createSearchKnowledgeTool(fileSystemMock, {baseDirectory: '/test', cacheTtlMs: 0})
+      // Post-commit-5: the symbol-tree fallback for minMaturity is gone.
+      // Seed the sidecar to match the intent of the markdown fixtures: leaf
+      // is core, summary is draft, so with minMaturity='core' only the leaf
+      // survives.
+      const {createMockRuntimeSignalStore} = await import('../../../helpers/mock-factories.js')
+      const runtimeSignalStore = createMockRuntimeSignalStore()
+      await runtimeSignalStore.set('auth/jwt.md', {
+        accessCount: 0, importance: 90, maturity: 'core', recency: 1, updateCount: 0,
+      })
+      await runtimeSignalStore.set('auth/_index.md', {
+        accessCount: 0, importance: 70, maturity: 'draft', recency: 0.9, updateCount: 0,
+      })
+
+      const tool = createSearchKnowledgeTool(fileSystemMock, {baseDirectory: '/test', cacheTtlMs: 0, runtimeSignalStore})
       const result = (await tool.execute({minMaturity: 'core', query: 'security token'})) as {
         results: Array<{path: string; symbolKind?: string}>
       }

--- a/test/unit/infra/dream/operations/prune.test.ts
+++ b/test/unit/infra/dream/operations/prune.test.ts
@@ -165,23 +165,46 @@ describe('prune', () => {
   })
 
   it('finds stale validated files via mtime (threshold 120 days)', async () => {
-    await createMdFile(ctxDir, 'api/old-validated.md', '# Validated doc', {maturity: 'validated'})
+    // Post-commit-5: maturity is read from the sidecar, not markdown.
+    await createMdFile(ctxDir, 'api/old-validated.md', '# Validated doc')
     await setMtimeDaysAgo(ctxDir, 'api/old-validated.md', 121)
+
+    const runtimeSignalStore = {
+      async list() {
+        return new Map([
+          ['api/old-validated.md', {importance: 50, maturity: 'validated' as const}],
+        ])
+      },
+    }
 
     agent.executeOnSession.resolves(llmResponse([
       {decision: 'KEEP', file: 'api/old-validated.md', reason: 'Still relevant'},
     ]))
 
-    const results = await prune(deps)
+    const results = await prune({...deps, runtimeSignalStore})
     expect(results).to.have.lengthOf(1)
+    expect(agent.createTaskSession.called).to.be.true
   })
 
   it('does NOT flag validated files under 120 days old', async () => {
-    await createMdFile(ctxDir, 'api/recent-validated.md', '# Validated doc', {maturity: 'validated'})
+    // Post-commit-5: maturity is read from the sidecar, not markdown.
+    // Without a sidecar entry reporting 'validated' the file would default
+    // to 'draft' (60-day threshold) and 119 days would cross it — so we
+    // must prime the sidecar to genuinely exercise the 120-day threshold.
+    await createMdFile(ctxDir, 'api/recent-validated.md', '# Validated doc')
     await setMtimeDaysAgo(ctxDir, 'api/recent-validated.md', 119)
 
-    const results = await prune(deps)
+    const runtimeSignalStore = {
+      async list() {
+        return new Map([
+          ['api/recent-validated.md', {importance: 50, maturity: 'validated' as const}],
+        ])
+      },
+    }
+
+    const results = await prune({...deps, runtimeSignalStore})
     expect(results).to.deep.equal([])
+    expect(agent.createTaskSession.called).to.be.false
   })
 
   it('NEVER flags core files regardless of age', async () => {

--- a/test/unit/infra/dream/operations/prune.test.ts
+++ b/test/unit/infra/dream/operations/prune.test.ts
@@ -185,10 +185,21 @@ describe('prune', () => {
   })
 
   it('NEVER flags core files regardless of age', async () => {
-    await createMdFile(ctxDir, 'auth/core-doc.md', '# Core knowledge', {maturity: 'core'})
+    // Post-commit-5: core protection comes from the sidecar, not markdown.
+    // Seed a runtimeSignalStore that reports maturity='core' for this path
+    // so the prune candidacy scan excludes it.
+    await createMdFile(ctxDir, 'auth/core-doc.md', '# Core knowledge')
     await setMtimeDaysAgo(ctxDir, 'auth/core-doc.md', 365)
 
-    const results = await prune(deps)
+    const runtimeSignalStore = {
+      async list() {
+        return new Map([
+          ['auth/core-doc.md', {importance: 80, maturity: 'core' as const}],
+        ])
+      },
+    }
+
+    const results = await prune({...deps, runtimeSignalStore})
     expect(results).to.deep.equal([])
     expect(agent.createTaskSession.called).to.be.false
   })


### PR DESCRIPTION
## Summary

- Problem: Runtime ranking signals (`importance`, `recency`, `maturity`, `accessCount`, `updateCount`) were emitted into context-tree markdown frontmatter. Every `brv query` flushed bumped values back, dirtying `brv vc status` and causing merge conflicts across teammates.
- Why it matters: This is the ship commit of the runtime-signals initiative. After this merges, `brv query` produces zero modifications to markdown files on disk. The feature's user-visible promise — clean version control — lands here.
- What changed: `generateFrontmatter` no longer emits the 5 signal fields. All writer/parser/populator code for those fields is deleted (dead since commits 3-4). `parseContent` tolerates legacy files indefinitely. `prune.ts` was silently reading scoring from markdown via regex (a miss from commit 4) — fixed here as a prerequisite.
- What did NOT change (scope boundary): Sidecar cloud sync exclusion is commit 6. One-shot cleanup script to strip legacy fields from existing files is not in scope — legacy fields are inert (never read) and tolerated permanently by the parser.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [x] Agent / Tools
- [ ] LLM Providers
- [x] Server / Daemon
- [x] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes #
- Related: runtime-signals sidecar series — ENG-2133. Commits 1-4 landed in prior PRs.

## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause: N/A (shipping commit for the initiative)
- Why this was not caught earlier: N/A

## Test plan

- Coverage added:
  - [x] Unit test
  - [x] Integration test
  - [ ] Manual verification only
- Test file(s):
  - `test/integration/runtime-signals/vc-clean-regression.test.ts` — 3 integration tests (VC-clean loop, legacy tolerance, emission regex)
  - `test/unit/agent/knowledge/markdown-writer.test.ts` — 4 new mergeTimestamps tests
  - `test/unit/agent/tools/curate-tool-sidecar-dual-write.test.ts` — retooled ADD/UPDATE consistency tests
  - `test/unit/agent/tools/search-knowledge-flush-sidecar.test.ts` — flush no longer touches markdown
  - `test/unit/agent/tools/search-knowledge-tool.test.ts` — summary hotness + minMaturity + parallel-execution tests seeded via sidecar
  - `test/unit/agent/tools/memory-symbol-tree.test.ts` — context.md absorbs structural metadata only
  - `test/unit/infra/dream/operations/prune.test.ts` — core protection via sidecar
- Key scenario(s) covered:
  - 20 rounds × 10 files × flushAccessHits → every file byte-identical after
  - Legacy-format markdown (all 5 signal fields in YAML) parses successfully; semantic fields round-trip; signal fields absent from result
  - `generateFrontmatter` output regex-asserted empty of `importance:` / `recency:` / `maturity:` / `accessCount:` / `updateCount:`
  - `mergeTimestamps` preserves earliest createdAt; stamps fresh updatedAt always
  - `mergeTimestamps` with no-input-timestamps still stamps updatedAt (bug caught by new test)
  - Prune never flags files whose sidecar entry has `maturity: 'core'`
  - Symbol-tree metadata collapses to structural defaults

## User-visible changes

**This is the ship commit.** After merge, running queries no longer modifies markdown files. Concrete user-facing effect: `brv vc status` stays clean across a session.

**Behavior change for pre-migration files with `maturity: 'core'`:** see Risks below.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording

**VC-clean regression test output:**


**Full suite:** 6484 passing, 0 failing. +4 from commit 4's 6480 (new mergeTimestamps tests). Typecheck / lint / build clean.

## Checklist

- [x] Tests added or updated and passing (`npm test`)
- [x] Lint passes (`npm run lint`) — 0 errors, 205 pre-existing warnings (none new)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated (if applicable) — N/A, internal change; user-facing CHANGELOG mention recommended (see Risks)
- [x] No breaking changes to external interfaces (internal type rename `FrontmatterScoring` → `RuntimeSignals` + `ContextTimestamps`)
- [x] Branch is up to date with `main`

## Risks and mitigations

- Risk: **Pre-migration files with `maturity: 'core'` in their markdown frontmatter lose core protection until their sidecar entry is populated.** Concrete impact: prune's "core files are never candidates" gate doesn't apply; symbol-tree tier boost doesn't apply; ranking treats them as draft until access hits accumulate. Users who explicitly pinned files as core specifically to prevent archival or to boost ranking will silently lose that protection for the first few sessions after upgrade.
  - Mitigation: Consistent with the plan's explicit "no migration — signals self-heal" decision. Accepted trade-off. Should be called out in CHANGELOG / upgrade notes. Mitigation path if users report surprise: a `brv signals hydrate` command that reads legacy frontmatter and seeds the sidecar (documented in `features/runtime-signals/backlog.md`).
- Risk: **The VC-clean regression test only exercises `flushAccessHits` directly.** The full `search()` → `acquireIndex` → flush → index-rebuild chain isn't covered, and curate operations aren't chained. A missed write-to-markdown elsewhere could slip through this test.
  - Mitigation: Documented in backlog with a trigger to broaden the test. Per-site unit tests still cover the individual code paths; the integration test is the additional cross-check.
- Risk: **Function signature migrations (FrontmatterScoring → RuntimeSignals) removed defensive `?? 50` / `?? 0` fallbacks.** Callers that drift off the paved path could produce silent `NaN` values via arithmetic.
  - Mitigation: All current callers go through `createDefaultRuntimeSignals()` or sidecar reads (Zod-validated with defaults). No live bug. Documented in backlog.
- Risk: **`SymbolMetadata.importance` / `maturity` fields still exist but now always carry defaults** — dead weight wearing a useful name.
  - Mitigation: Documented in backlog; will be cleaned up in commit 6 or a follow-up.

## Related

- Previous commits in this series:
  - [Runtime Signals 1/6] Schema and types
  - [Runtime Signals 2/6] RuntimeSignalStore implementation
  - [Runtime Signals 3/6] Dual-write at mutation sites
  - [Runtime Signals 4/6] Switch read paths to sidecar
- Next commit: [Runtime Signals 6/6] Ancillary audits and cloud sync exclusion
- Backlog: `features/runtime-signals/backlog.md` — deferred items with triggers
- Task description: `features/runtime-signals/tasks/commit-05-stop-markdown-writes.md`
