### PR TITLE
feat: [ENG-2162] close series loose ends — CLI/swarm wiring + sidecar observability (6/6)

### DIFF
--- a/src/agent/infra/agent/service-initializer.ts
+++ b/src/agent/infra/agent/service-initializer.ts
@@ -215,7 +215,25 @@ export async function createCipherAgentServices(
   const mapSelectionContributor = new MapSelectionContributor('mapSelection', 16)
   systemPromptManager.registerContributor(mapSelectionContributor)
 
-  // 6b. Swarm coordinator — try to load config and build providers.
+  // 6b. Storage layer — initialised before the swarm block so the swarm
+  // SearchKnowledgeService receives `runtimeSignalStore` at construction
+  // time. Post-commit-5 the markdown fallback is gone, so a swarm search
+  // without the sidecar would silently drop every access-hit bump.
+  const keyStorage = new FileKeyStorage({
+    storageDir: storageBasePath,
+  })
+  await keyStorage.initialize()
+
+  const messageStorage = new MessageStorageService(keyStorage)
+  const messageStorageService = messageStorage
+  const historyStorage = new GranularHistoryStorage(messageStorage)
+
+  // Sidecar store for per-machine ranking signals (importance, recency,
+  // maturity, accessCount, updateCount). Kept out of the context-tree
+  // markdown so query-time bumps don't dirty version-controlled files.
+  const runtimeSignalStore = new RuntimeSignalStore(keyStorage, logger)
+
+  // 6c. Swarm coordinator — try to load config and build providers.
   // Missing config → fail-open (no swarm). Invalid config → warn but continue.
   let swarmCoordinator: SwarmCoordinator | undefined
   try {
@@ -237,7 +255,11 @@ export async function createCipherAgentServices(
     }
 
     const swarmProviders = buildProvidersFromConfig(swarmConfig, {
-      searchService: createSearchKnowledgeService(fileSystemService),
+      searchService: createSearchKnowledgeService(fileSystemService, {
+        baseDirectory: workingDirectory,
+        logger,
+        runtimeSignalStore,
+      }),
     })
 
     if (swarmProviders.length > 0) {
@@ -263,23 +285,6 @@ export async function createCipherAgentServices(
 
   // 7. Abstract generation queue (generator injected later via rebindCurateTools)
   const abstractQueue = new AbstractGenerationQueue(workingDirectory)
-
-  // 8. Storage layer — initialised before ToolProvider so curate/search
-  // factories receive `runtimeSignalStore` via ToolServices at construction
-  // time (no late-bind workarounds).
-  const keyStorage = new FileKeyStorage({
-    storageDir: storageBasePath,
-  })
-  await keyStorage.initialize()
-
-  const messageStorage = new MessageStorageService(keyStorage)
-  const messageStorageService = messageStorage
-  const historyStorage = new GranularHistoryStorage(messageStorage)
-
-  // Sidecar store for per-machine ranking signals (importance, recency,
-  // maturity, accessCount, updateCount). Kept out of the context-tree
-  // markdown so query-time bumps don't dirty version-controlled files.
-  const runtimeSignalStore = new RuntimeSignalStore(keyStorage, logger)
 
   // 9. Tool provider (depends on FileSystemService, ProcessService, MemoryManager, SystemPromptManager)
   const verbose = config.llm.verbose ?? false

--- a/src/agent/infra/tools/implementations/curate-tool.ts
+++ b/src/agent/infra/tools/implementations/curate-tool.ts
@@ -4,6 +4,7 @@ import {z} from 'zod'
 import type {ContextData} from '../../../../server/core/domain/knowledge/markdown-writer.js'
 import type {IRuntimeSignalStore} from '../../../../server/core/interfaces/storage/i-runtime-signal-store.js'
 import type {Tool, ToolExecutionContext} from '../../../core/domain/tools/types.js'
+import type {ILogger} from '../../../core/interfaces/i-logger.js'
 import type {AbstractGenerationQueue} from '../../map/abstract-queue.js'
 
 import {REVIEW_BACKUPS_DIR} from '../../../../server/constants.js'
@@ -18,6 +19,7 @@ import {
   createDefaultRuntimeSignals,
   type RuntimeSignals,
 } from '../../../../server/core/domain/knowledge/runtime-signals-schema.js'
+import {warnSidecarFailure} from '../../../../server/core/domain/knowledge/sidecar-logging.js'
 import {toSnakeCase} from '../../../../server/utils/file-helpers.js'
 import {deriveImpactFromLoss, detectStructuralLoss} from '../../../core/domain/knowledge/conflict-detector.js'
 import {resolveStructuralLoss} from '../../../core/domain/knowledge/conflict-resolver.js'
@@ -49,6 +51,8 @@ function existingCreatedAt(existingContent: null | string | undefined): string {
   return parseCreatedAt(existingContent) ?? new Date().toISOString()
 }
 
+const CURATE_SITE = 'curate-tool'
+
 /**
  * Seed the sidecar with default signals for a newly-added file.
  * Best-effort: sidecar write failures never break the markdown operation.
@@ -56,12 +60,13 @@ function existingCreatedAt(existingContent: null | string | undefined): string {
 async function seedSidecarDefaults(
   store: IRuntimeSignalStore | undefined,
   relPath: string,
+  logger?: ILogger,
 ): Promise<void> {
   if (!store) return
   try {
     await store.set(relPath, createDefaultRuntimeSignals())
-  } catch {
-    // Markdown is canonical during phase 3 — log-and-swallow.
+  } catch (error) {
+    warnSidecarFailure(logger, CURATE_SITE, 'seed', relPath, error)
   }
 }
 
@@ -77,6 +82,7 @@ async function seedSidecarDefaults(
 async function mirrorCurateUpdate(
   store: IRuntimeSignalStore | undefined,
   relPath: string,
+  logger?: ILogger,
 ): Promise<void> {
   if (!store) return
   try {
@@ -90,8 +96,8 @@ async function mirrorCurateUpdate(
         updateCount: bumped.updateCount,
       }
     })
-  } catch {
-    // Fail-open during phase 3.
+  } catch (error) {
+    warnSidecarFailure(logger, CURATE_SITE, 'update', relPath, error)
   }
 }
 
@@ -102,12 +108,13 @@ async function mirrorCurateUpdate(
 async function dropSidecar(
   store: IRuntimeSignalStore | undefined,
   relPath: string,
+  logger?: ILogger,
 ): Promise<void> {
   if (!store) return
   try {
     await store.delete(relPath)
-  } catch {
-    // Fail-open during phase 3.
+  } catch (error) {
+    warnSidecarFailure(logger, CURATE_SITE, 'drop', relPath, error)
   }
 }
 
@@ -748,6 +755,7 @@ async function executeAdd(
   operation: Operation,
   onAfterWrite?: WriteCallback,
   runtimeSignalStore?: IRuntimeSignalStore,
+  logger?: ILogger,
 ): Promise<OperationResult> {
   const {confidence, content, domainContext, impact, path, reason, subtopicContext, summary, title, topicContext} =
     operation
@@ -829,7 +837,7 @@ async function executeAdd(
 
     // Dual-write: seed the sidecar with default signals for the new file.
     // Mirrors the default scoring applied to markdown frontmatter above.
-    await seedSidecarDefaults(runtimeSignalStore, relPathFromContextPath(contextPath, basePath))
+    await seedSidecarDefaults(runtimeSignalStore, relPathFromContextPath(contextPath, basePath), logger)
 
     await ensureContextMd(basePath, parsed, topicContext, subtopicContext, onAfterWrite)
 
@@ -874,6 +882,7 @@ async function executeUpdate(
   operation: Operation,
   onAfterWrite?: WriteCallback,
   runtimeSignalStore?: IRuntimeSignalStore,
+  logger?: ILogger,
 ): Promise<OperationResult> {
   const {confidence, content, domainContext, impact, path, reason, subtopicContext, summary, title, topicContext} =
     operation
@@ -988,7 +997,7 @@ async function executeUpdate(
     // Dual-write: mirror the curate-update bumps (importance +5, recency=1,
     // updateCount+1, maturity retiered) into the sidecar. `updatedAt` stays
     // in markdown only — it is a content timestamp, not a runtime signal.
-    await mirrorCurateUpdate(runtimeSignalStore, relPathFromContextPath(contextPath, basePath))
+    await mirrorCurateUpdate(runtimeSignalStore, relPathFromContextPath(contextPath, basePath), logger)
 
     await ensureContextMd(basePath, parsed, topicContext, subtopicContext, onAfterWrite)
 
@@ -1024,6 +1033,7 @@ async function executeUpsert(
   operation: Operation,
   onAfterWrite?: WriteCallback,
   runtimeSignalStore?: IRuntimeSignalStore,
+  logger?: ILogger,
 ): Promise<OperationResult> {
   const {path, reason, title} = operation
   const reviewMeta = deriveReviewMetadata('UPSERT', operation.confidence, operation.impact)
@@ -1072,7 +1082,7 @@ async function executeUpsert(
 
     if (exists) {
       // File exists - delegate to UPDATE logic
-      const result = await executeUpdate(basePath, {...operation, type: 'UPDATE'}, onAfterWrite, runtimeSignalStore)
+      const result = await executeUpdate(basePath, {...operation, type: 'UPDATE'}, onAfterWrite, runtimeSignalStore, logger)
       // Return with UPSERT type but indicate it was an update
       return {
         ...result,
@@ -1082,7 +1092,7 @@ async function executeUpsert(
     }
 
     // File doesn't exist - delegate to ADD logic
-    const result = await executeAdd(basePath, {...operation, type: 'ADD'}, onAfterWrite, runtimeSignalStore)
+    const result = await executeAdd(basePath, {...operation, type: 'ADD'}, onAfterWrite, runtimeSignalStore, logger)
     // Return with UPSERT type but indicate it was an add
     return {
       ...result,
@@ -1109,6 +1119,7 @@ async function executeMerge(
   operation: Operation,
   onAfterWrite?: WriteCallback,
   runtimeSignalStore?: IRuntimeSignalStore,
+  logger?: ILogger,
 ): Promise<OperationResult> {
   const {
     confidence,
@@ -1254,8 +1265,9 @@ async function executeMerge(
           }
         })
         await runtimeSignalStore.delete(sourceRelPath)
-      } catch {
+      } catch (error) {
         // Best-effort — markdown merge already succeeded.
+        warnSidecarFailure(logger, CURATE_SITE, 'merge', `${sourceRelPath} -> ${targetRelPath}`, error)
       }
     }
 
@@ -1294,6 +1306,7 @@ async function executeDelete(
   basePath: string,
   operation: Operation,
   runtimeSignalStore?: IRuntimeSignalStore,
+  logger?: ILogger,
 ): Promise<OperationResult> {
   const {path, reason, title} = operation
   const reviewMeta = deriveReviewMetadata('DELETE', operation.confidence, operation.impact)
@@ -1335,7 +1348,7 @@ async function executeDelete(
 
       // Dual-write: drop the deleted file's sidecar entry so it does not
       // become an orphan.
-      await dropSidecar(runtimeSignalStore, relPathFromContextPath(filePath, basePath))
+      await dropSidecar(runtimeSignalStore, relPathFromContextPath(filePath, basePath), logger)
 
       return {
         ...reviewMeta,
@@ -1396,7 +1409,7 @@ async function executeDelete(
     // Best-effort — the markdown delete has already succeeded.
     if (runtimeSignalStore) {
       await Promise.all(
-        mdFiles.map((f) => dropSidecar(runtimeSignalStore, relPathFromContextPath(f, basePath))),
+        mdFiles.map((f) => dropSidecar(runtimeSignalStore, relPathFromContextPath(f, basePath), logger)),
       )
     }
 
@@ -1432,6 +1445,7 @@ export async function executeCurate(
   _context?: ToolExecutionContext,
   abstractQueue?: AbstractGenerationQueue,
   runtimeSignalStore?: IRuntimeSignalStore,
+  logger?: ILogger,
 ): Promise<CurateOutput> {
   const parseResult = CurateInputSchema.safeParse(input)
   if (!parseResult.success) {
@@ -1478,7 +1492,7 @@ export async function executeCurate(
 
     switch (operation.type) {
       case 'ADD': {
-        result = await executeAdd(basePath, operation, onAfterWrite, runtimeSignalStore)
+        result = await executeAdd(basePath, operation, onAfterWrite, runtimeSignalStore, logger)
 
         if (result.status === 'success') summary.added++
 
@@ -1486,7 +1500,7 @@ export async function executeCurate(
       }
 
       case 'DELETE': {
-        result = await executeDelete(basePath, operation, runtimeSignalStore)
+        result = await executeDelete(basePath, operation, runtimeSignalStore, logger)
 
         if (result.status === 'success') summary.deleted++
 
@@ -1494,7 +1508,7 @@ export async function executeCurate(
       }
 
       case 'MERGE': {
-        result = await executeMerge(basePath, operation, onAfterWrite, runtimeSignalStore)
+        result = await executeMerge(basePath, operation, onAfterWrite, runtimeSignalStore, logger)
 
         if (result.status === 'success') summary.merged++
 
@@ -1502,7 +1516,7 @@ export async function executeCurate(
       }
 
       case 'UPDATE': {
-        result = await executeUpdate(basePath, operation, onAfterWrite, runtimeSignalStore)
+        result = await executeUpdate(basePath, operation, onAfterWrite, runtimeSignalStore, logger)
 
         if (result.status === 'success') summary.updated++
 
@@ -1510,7 +1524,7 @@ export async function executeCurate(
       }
 
       case 'UPSERT': {
-        result = await executeUpsert(basePath, operation, onAfterWrite, runtimeSignalStore)
+        result = await executeUpsert(basePath, operation, onAfterWrite, runtimeSignalStore, logger)
 
         // UPSERT counts as either added or updated based on what happened
         if (result.status === 'success') {
@@ -1555,6 +1569,7 @@ export function createCurateTool(
   workingDirectory?: string,
   abstractQueue?: AbstractGenerationQueue,
   runtimeSignalStore?: IRuntimeSignalStore,
+  logger?: ILogger,
 ): Tool {
   return {
     description: `Curate knowledge topics with atomic operations. This tool manages the knowledge structure using four operation types and supports a two-part context model: Raw Concept + Narrative.
@@ -1757,11 +1772,11 @@ export function createCurateTool(
         if (parseResult.success) {
           parseResult.data.basePath = resolve(workingDirectory, parseResult.data.basePath)
 
-          return executeCurate(parseResult.data, context, abstractQueue, runtimeSignalStore)
+          return executeCurate(parseResult.data, context, abstractQueue, runtimeSignalStore, logger)
         }
       }
 
-      return executeCurate(input, context, abstractQueue, runtimeSignalStore)
+      return executeCurate(input, context, abstractQueue, runtimeSignalStore, logger)
     },
 
     id: ToolName.CURATE,

--- a/src/agent/infra/tools/tool-registry.ts
+++ b/src/agent/infra/tools/tool-registry.ts
@@ -218,8 +218,8 @@ export const TOOL_REGISTRY: Record<KnownTool, ToolRegistryEntry> = {
 
   [ToolName.CURATE]: {
     descriptionFile: 'curate',
-    factory: ({ abstractQueue, environmentContext, runtimeSignalStore }) =>
-      createCurateTool(environmentContext?.workingDirectory, abstractQueue, runtimeSignalStore),
+    factory: ({ abstractQueue, environmentContext, logger, runtimeSignalStore }) =>
+      createCurateTool(environmentContext?.workingDirectory, abstractQueue, runtimeSignalStore, logger),
     markers: [ToolMarker.ContextBuilding, ToolMarker.Modification],
     outputGuidance: 'curate',
     requiredServices: [],

--- a/src/oclif/commands/dream.ts
+++ b/src/oclif/commands/dream.ts
@@ -4,10 +4,16 @@ import {Command, Flags} from '@oclif/core'
 import {randomUUID} from 'node:crypto'
 import {join} from 'node:path'
 
+import type {ILogger} from '../../agent/core/interfaces/i-logger.js'
+
+import {NoOpLogger} from '../../agent/core/interfaces/i-logger.js'
+import {ConsoleLogger} from '../../agent/infra/logger/console-logger.js'
+import {FileKeyStorage} from '../../agent/infra/storage/file-key-storage.js'
 import {BRV_DIR, CONTEXT_TREE_DIR} from '../../server/constants.js'
 import {type ProviderConfigResponse, TransportStateEventNames} from '../../server/core/domain/transport/schemas.js'
 import {FileContextTreeArchiveService} from '../../server/infra/context-tree/file-context-tree-archive-service.js'
 import {FileContextTreeManifestService} from '../../server/infra/context-tree/file-context-tree-manifest-service.js'
+import {RuntimeSignalStore} from '../../server/infra/context-tree/runtime-signal-store.js'
 import {DreamLogStore} from '../../server/infra/dream/dream-log-store.js'
 import {DreamStateService} from '../../server/infra/dream/dream-state-service.js'
 import {undoLastDream} from '../../server/infra/dream/dream-undo.js'
@@ -26,6 +32,34 @@ import {
 } from '../lib/daemon-client.js'
 import {writeJsonResponse} from '../lib/json-response.js'
 import {DEFAULT_TIMEOUT_SECONDS, MAX_TIMEOUT_SECONDS, MIN_TIMEOUT_SECONDS, waitForTaskCompletion} from '../lib/task-client.js'
+
+/** Build the dep bundle for `undoLastDream` on the CLI-direct path; exported for wiring tests. */
+export async function buildUndoDeps(
+  projectRoot: string,
+  logger: ILogger = new ConsoleLogger(),
+): Promise<Parameters<typeof undoLastDream>[0]> {
+  const brvDir = join(projectRoot, BRV_DIR)
+  const contextTreeDir = join(brvDir, CONTEXT_TREE_DIR)
+  const projectDataDir = getProjectDataDir(projectRoot)
+
+  // Runtime-signal sidecar — keeps archive/restore from leaking orphan
+  // signal entries on the CLI-direct `brv dream --undo` path. Mirrors the
+  // daemon wiring in agent-process.ts.
+  const keyStorage = new FileKeyStorage({storageDir: projectDataDir})
+  await keyStorage.initialize()
+  const runtimeSignalStore = new RuntimeSignalStore(keyStorage, logger)
+
+  return {
+    archiveService: new FileContextTreeArchiveService(runtimeSignalStore),
+    contextTreeDir,
+    curateLogStore: new FileCurateLogStore({baseDir: projectDataDir}),
+    dreamLogStore: new DreamLogStore({baseDir: brvDir}),
+    dreamStateService: new DreamStateService({baseDir: brvDir}),
+    manifestService: new FileContextTreeManifestService({baseDirectory: projectRoot, runtimeSignalStore}),
+    projectRoot,
+    reviewBackupStore: new FileReviewBackupStore(brvDir),
+  }
+}
 
 export default class Dream extends Command {
   public static description = 'Run background memory consolidation on the context tree'
@@ -149,21 +183,13 @@ export default class Dream extends Command {
 
   private async runUndo(format: 'json' | 'text'): Promise<void> {
     const projectRoot = resolveProject()?.projectRoot ?? process.cwd()
-    const brvDir = join(projectRoot, BRV_DIR)
-    const contextTreeDir = join(brvDir, CONTEXT_TREE_DIR)
-    const projectDataDir = getProjectDataDir(projectRoot)
+    // JSON mode: route sidecar warnings to a no-op so structured stdout
+    // is never paired with stderr noise that breaks downstream parsers.
+    const logger: ILogger = format === 'json' ? new NoOpLogger() : new ConsoleLogger()
+    const deps = await buildUndoDeps(projectRoot, logger)
 
     try {
-      const result = await undoLastDream({
-        archiveService: new FileContextTreeArchiveService(),
-        contextTreeDir,
-        curateLogStore: new FileCurateLogStore({baseDir: projectDataDir}),
-        dreamLogStore: new DreamLogStore({baseDir: brvDir}),
-        dreamStateService: new DreamStateService({baseDir: brvDir}),
-        manifestService: new FileContextTreeManifestService({baseDirectory: projectRoot}),
-        projectRoot,
-        reviewBackupStore: new FileReviewBackupStore(brvDir),
-      })
+      const result = await undoLastDream(deps)
 
       if (format === 'json') {
         writeJsonResponse({command: 'dream', data: {...result, status: 'undone'}, success: true})

--- a/src/server/core/domain/knowledge/sidecar-logging.ts
+++ b/src/server/core/domain/knowledge/sidecar-logging.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared helper for observing swallowed sidecar failures.
+ *
+ * Runtime-signals dual-write is best-effort: failures never break the
+ * caller's primary operation (markdown write, ranking read, etc.). After
+ * commit 5 the sidecar is the canonical source for ranking signals, so
+ * silent swallows hide real outages from operators. Every site that
+ * swallows a sidecar error should call this helper from inside the catch.
+ *
+ * The log message shape is stable across call sites so operators can
+ * grep for `sidecar <verb> failed` to surface every occurrence.
+ */
+
+import type {ILogger} from '../../../../agent/core/interfaces/i-logger.js'
+
+export function warnSidecarFailure(
+  logger: ILogger | undefined,
+  site: string,
+  verb: string,
+  target: string,
+  error: unknown,
+): void {
+  if (!logger) return
+  const message = error instanceof Error ? error.message : String(error)
+  logger.warn(`${site}: sidecar ${verb} failed for ${target}: ${message}`)
+}

--- a/src/server/infra/context-tree/file-context-tree-archive-service.ts
+++ b/src/server/infra/context-tree/file-context-tree-archive-service.ts
@@ -16,6 +16,7 @@ import {mkdir, readFile, unlink, writeFile} from 'node:fs/promises'
 import {dirname, extname, join} from 'node:path'
 
 import type {ICipherAgent} from '../../../agent/core/interfaces/i-cipher-agent.js'
+import type {ILogger} from '../../../agent/core/interfaces/i-logger.js'
 import type {RuntimeSignals} from '../../core/domain/knowledge/runtime-signals-schema.js'
 import type {ArchiveResult, DrillDownResult} from '../../core/domain/knowledge/summary-types.js'
 import type {IContextTreeArchiveService} from '../../core/interfaces/context-tree/i-context-tree-archive-service.js'
@@ -33,13 +34,17 @@ import {
 } from '../../constants.js'
 import {applyDecay} from '../../core/domain/knowledge/memory-scoring.js'
 import {createDefaultRuntimeSignals} from '../../core/domain/knowledge/runtime-signals-schema.js'
+import {warnSidecarFailure} from '../../core/domain/knowledge/sidecar-logging.js'
 import {estimateTokens} from '../executor/pre-compaction/compaction-escalation.js'
 import {isArchiveStub, isDerivedArtifact} from './derived-artifact.js'
 import {toUnixPath} from './path-utils.js'
 import {generateArchiveStubContent, parseArchiveStubFrontmatter} from './summary-frontmatter.js'
 
 export class FileContextTreeArchiveService implements IContextTreeArchiveService {
-  constructor(private readonly runtimeSignalStore?: IRuntimeSignalStore) {}
+  constructor(
+    private readonly runtimeSignalStore?: IRuntimeSignalStore,
+    private readonly logger?: ILogger,
+  ) {}
 
   public async archiveEntry(
     relativePath: string,
@@ -99,8 +104,9 @@ export class FileContextTreeArchiveService implements IContextTreeArchiveService
     if (this.runtimeSignalStore) {
       try {
         await this.runtimeSignalStore.delete(toUnixPath(relativePath))
-      } catch {
+      } catch (error) {
         // Best-effort — archive already succeeded.
+        warnSidecarFailure(this.logger, 'archive-service', 'delete', relativePath, error)
       }
     }
 
@@ -148,7 +154,8 @@ export class FileContextTreeArchiveService implements IContextTreeArchiveService
     let signalsByPath: Map<string, RuntimeSignals>
     try {
       signalsByPath = this.runtimeSignalStore ? await this.runtimeSignalStore.list() : new Map()
-    } catch {
+    } catch (error) {
+      warnSidecarFailure(this.logger, 'archive-service', 'list', 'candidate scan', error)
       signalsByPath = new Map()
     }
 
@@ -189,8 +196,9 @@ export class FileContextTreeArchiveService implements IContextTreeArchiveService
     if (this.runtimeSignalStore) {
       try {
         await this.runtimeSignalStore.set(toUnixPath(fm.original_path), createDefaultRuntimeSignals())
-      } catch {
+      } catch (error) {
         // Best-effort — markdown restore already succeeded.
+        warnSidecarFailure(this.logger, 'archive-service', 'seed', fm.original_path, error)
       }
     }
 
@@ -257,7 +265,14 @@ ${content.slice(0, 8000)}
     try {
       const signals = await this.runtimeSignalStore.get(relativePath)
       return signals.importance
-    } catch {
+    } catch (error) {
+      warnSidecarFailure(
+        this.logger,
+        'archive-service',
+        'get',
+        `${relativePath} (archive metadata read)`,
+        error,
+      )
       return createDefaultRuntimeSignals().importance
     }
   }

--- a/src/server/infra/context-tree/file-context-tree-manifest-service.ts
+++ b/src/server/infra/context-tree/file-context-tree-manifest-service.ts
@@ -17,6 +17,7 @@
 import {readdir, readFile, stat, writeFile} from 'node:fs/promises'
 import {join, relative} from 'node:path'
 
+import type {ILogger} from '../../../agent/core/interfaces/i-logger.js'
 import type {RuntimeSignals} from '../../core/domain/knowledge/runtime-signals-schema.js'
 import type {
   ContextManifest,
@@ -37,6 +38,7 @@ import {
   STUB_EXTENSION,
   SUMMARY_INDEX_FILE,
 } from '../../constants.js'
+import {warnSidecarFailure} from '../../core/domain/knowledge/sidecar-logging.js'
 import {DEFAULT_LANE_BUDGETS} from '../../core/domain/knowledge/summary-types.js'
 import {estimateTokens} from '../executor/pre-compaction/compaction-escalation.js'
 import {isArchiveStub, isDerivedArtifact} from './derived-artifact.js'
@@ -46,6 +48,11 @@ import {parseSummaryFrontmatter} from './summary-frontmatter.js'
 
 export interface ManifestServiceConfig {
   baseDirectory?: string
+  /**
+   * Optional logger. When provided, sidecar list failures during manifest
+   * build emit a warn so the fail-open degradation is visible.
+   */
+  logger?: ILogger
   /**
    * Optional. Source of truth for per-context `importance` used in lane
    * allocation. When absent or when a path has no entry, the default
@@ -73,7 +80,8 @@ export class FileContextTreeManifestService implements IContextTreeManifestServi
     let signalsByPath: Map<string, RuntimeSignals>
     try {
       signalsByPath = this.config.runtimeSignalStore ? await this.config.runtimeSignalStore.list() : new Map()
-    } catch {
+    } catch (error) {
+      warnSidecarFailure(this.config.logger, 'manifest-service', 'list', 'buildManifest', error)
       signalsByPath = new Map()
     }
 

--- a/src/server/infra/dream/operations/consolidate.ts
+++ b/src/server/infra/dream/operations/consolidate.ts
@@ -17,10 +17,12 @@ import {access, mkdir, readdir, readFile, rename, unlink, writeFile} from 'node:
 import {dirname, join} from 'node:path'
 
 import type {ICipherAgent} from '../../../../agent/core/interfaces/i-cipher-agent.js'
+import type {ILogger} from '../../../../agent/core/interfaces/i-logger.js'
 import type {DreamOperation} from '../dream-log-schema.js'
 import type {ConsolidationAction} from '../dream-response-schemas.js'
 import type {DreamState, PendingMerge} from '../dream-state-schema.js'
 
+import {warnSidecarFailure} from '../../../core/domain/knowledge/sidecar-logging.js'
 import {ConsolidateResponseSchema} from '../dream-response-schemas.js'
 import {parseDreamResponse} from '../parse-dream-response.js'
 
@@ -38,6 +40,11 @@ export type ConsolidateDeps = {
     update(updater: (state: DreamState) => DreamState): Promise<DreamState>
     write(state: DreamState): Promise<void>
   }
+  /**
+   * Optional logger. When provided, per-file sidecar failures during the
+   * CROSS_REFERENCE review gate emit a warn so silent swallows are visible.
+   */
+  logger?: ILogger
   reviewBackupStore?: {
     save(relativePath: string, content: string): Promise<void>
   }
@@ -205,7 +212,13 @@ async function processDomain(domain: string, files: string[], deps: ConsolidateD
     for (const action of parsed.actions) {
       try {
         // eslint-disable-next-line no-await-in-loop
-        const op = await executeAction(action, contextTreeDir, fileContents, deps.runtimeSignalStore, deps.reviewBackupStore)
+        const op = await executeAction(action, {
+          contextTreeDir,
+          fileContents,
+          logger: deps.logger,
+          reviewBackupStore: deps.reviewBackupStore,
+          runtimeSignalStore: deps.runtimeSignalStore,
+        })
         if (op) results.push(op)
       } catch {
         // Skip failed action, continue with others
@@ -455,20 +468,25 @@ function buildPrompt(
   return lines.join('\n')
 }
 
+type ActionContext = {
+  contextTreeDir: string
+  fileContents: Map<string, string>
+  logger?: ConsolidateDeps['logger']
+  reviewBackupStore?: ConsolidateDeps['reviewBackupStore']
+  runtimeSignalStore: ConsolidateDeps['runtimeSignalStore']
+}
+
 async function executeAction(
   action: ConsolidationAction,
-  contextTreeDir: string,
-  fileContents: Map<string, string>,
-  runtimeSignalStore: ConsolidateDeps['runtimeSignalStore'],
-  reviewBackupStore?: ConsolidateDeps['reviewBackupStore'],
+  ctx: ActionContext,
 ): Promise<DreamOperation | undefined> {
   switch (action.type) {
     case 'CROSS_REFERENCE': {
-      return executeCrossReference(action, contextTreeDir, fileContents, runtimeSignalStore, reviewBackupStore)
+      return executeCrossReference(action, ctx)
     }
 
     case 'MERGE': {
-      return executeMerge(action, contextTreeDir, fileContents, runtimeSignalStore, reviewBackupStore)
+      return executeMerge(action, ctx)
     }
 
     case 'SKIP': {
@@ -476,18 +494,13 @@ async function executeAction(
     }
 
     case 'TEMPORAL_UPDATE': {
-      return executeTemporalUpdate(action, contextTreeDir, fileContents, runtimeSignalStore, reviewBackupStore)
+      return executeTemporalUpdate(action, ctx)
     }
   }
 }
 
-async function executeMerge(
-  action: ConsolidationAction,
-  contextTreeDir: string,
-  fileContents: Map<string, string>,
-  runtimeSignalStore: ConsolidateDeps['runtimeSignalStore'],
-  reviewBackupStore?: ConsolidateDeps['reviewBackupStore'],
-): Promise<DreamOperation> {
+async function executeMerge(action: ConsolidationAction, ctx: ActionContext): Promise<DreamOperation> {
+  const {contextTreeDir, fileContents, reviewBackupStore, runtimeSignalStore} = ctx
   const outputFile = action.outputFile ?? action.files[0]
   if (!action.mergedContent) {
     throw new Error(`MERGE action missing mergedContent for ${outputFile}`)
@@ -529,7 +542,7 @@ async function executeMerge(
   await Promise.all(toDelete.map((f) => unlink(join(contextTreeDir, f)).catch(() => {})))
 
   // Determine needsReview
-  const needsReview = await determineNeedsReview('MERGE', action.files, runtimeSignalStore)
+  const needsReview = await determineNeedsReview('MERGE', action.files, {runtimeSignalStore})
 
   return {
     action: 'MERGE',
@@ -542,13 +555,8 @@ async function executeMerge(
   }
 }
 
-async function executeTemporalUpdate(
-  action: ConsolidationAction,
-  contextTreeDir: string,
-  fileContents: Map<string, string>,
-  runtimeSignalStore: ConsolidateDeps['runtimeSignalStore'],
-  reviewBackupStore?: ConsolidateDeps['reviewBackupStore'],
-): Promise<DreamOperation> {
+async function executeTemporalUpdate(action: ConsolidationAction, ctx: ActionContext): Promise<DreamOperation> {
+  const {contextTreeDir, fileContents, reviewBackupStore, runtimeSignalStore} = ctx
   const targetFile = action.files[0]
   if (!action.updatedContent) {
     throw new Error(`TEMPORAL_UPDATE action missing updatedContent for ${targetFile}`)
@@ -563,7 +571,10 @@ async function executeTemporalUpdate(
     previousTexts[targetFile] = original
   }
 
-  const needsReview = await determineNeedsReview('TEMPORAL_UPDATE', action.files, runtimeSignalStore, action.confidence)
+  const needsReview = await determineNeedsReview('TEMPORAL_UPDATE', action.files, {
+    confidence: action.confidence,
+    runtimeSignalStore,
+  })
 
   // Create review backup only when the operation needs human review
   if (reviewBackupStore && original !== undefined && needsReview) {
@@ -589,13 +600,8 @@ async function executeTemporalUpdate(
   }
 }
 
-async function executeCrossReference(
-  action: ConsolidationAction,
-  contextTreeDir: string,
-  fileContents: Map<string, string>,
-  runtimeSignalStore: ConsolidateDeps['runtimeSignalStore'],
-  reviewBackupStore?: ConsolidateDeps['reviewBackupStore'],
-): Promise<DreamOperation> {
+async function executeCrossReference(action: ConsolidationAction, ctx: ActionContext): Promise<DreamOperation> {
+  const {contextTreeDir, fileContents, logger, reviewBackupStore, runtimeSignalStore} = ctx
   const previousTexts: Record<string, string> = {}
   for (const file of action.files) {
     const content = fileContents.get(file)
@@ -604,7 +610,7 @@ async function executeCrossReference(
     }
   }
 
-  const needsReview = await determineNeedsReview('CROSS_REFERENCE', action.files, runtimeSignalStore)
+  const needsReview = await determineNeedsReview('CROSS_REFERENCE', action.files, {logger, runtimeSignalStore})
   if (needsReview && reviewBackupStore) {
     await Promise.all(
       Object.entries(previousTexts).map(([file, content]) =>
@@ -673,26 +679,31 @@ async function addRelatedLinks(filePath: string, relatedPaths: string[]): Promis
 async function determineNeedsReview(
   actionType: 'CROSS_REFERENCE' | 'MERGE' | 'TEMPORAL_UPDATE',
   files: string[],
-  runtimeSignalStore: ConsolidateDeps['runtimeSignalStore'],
-  confidence?: number,
+  opts: {
+    confidence?: number
+    logger?: ConsolidateDeps['logger']
+    runtimeSignalStore: ConsolidateDeps['runtimeSignalStore']
+  },
 ): Promise<boolean> {
   // MERGE always needs review
   if (actionType === 'MERGE') return true
 
   // TEMPORAL_UPDATE: needs review when confidence is low or absent
-  if (actionType === 'TEMPORAL_UPDATE') return (confidence ?? 0) < 0.7
+  if (actionType === 'TEMPORAL_UPDATE') return (opts.confidence ?? 0) < 0.7
 
   // CROSS_REFERENCE: only if any file has core maturity in the sidecar.
   // Without a store, no file can qualify as core — review is skipped, which
   // matches the pre-migration default when no scoring was present.
+  const {logger, runtimeSignalStore} = opts
   if (!runtimeSignalStore) return false
   for (const file of files) {
     try {
       // eslint-disable-next-line no-await-in-loop
       const signals = await runtimeSignalStore.get(file)
       if (signals.maturity === 'core') return true
-    } catch {
+    } catch (error) {
       // Ignore per-file sidecar failures — continue checking remaining files.
+      warnSidecarFailure(logger, 'consolidate', 'get', `${file} (CROSS_REFERENCE gate)`, error)
     }
   }
 

--- a/src/server/infra/dream/operations/prune.ts
+++ b/src/server/infra/dream/operations/prune.ts
@@ -16,11 +16,13 @@ import {readdir, readFile, stat, utimes} from 'node:fs/promises'
 import {join} from 'node:path'
 
 import type {ICipherAgent} from '../../../../agent/core/interfaces/i-cipher-agent.js'
+import type {ILogger} from '../../../../agent/core/interfaces/i-logger.js'
 import type {DreamOperation} from '../dream-log-schema.js'
 import type {PruneDecision} from '../dream-response-schemas.js'
 import type {DreamState} from '../dream-state-schema.js'
 
 import {DEFAULT_IMPORTANCE, DEFAULT_MATURITY} from '../../../core/domain/knowledge/runtime-signals-schema.js'
+import {warnSidecarFailure} from '../../../core/domain/knowledge/sidecar-logging.js'
 import {isExcludedFromSync} from '../../context-tree/derived-artifact.js'
 import {toUnixPath} from '../../context-tree/path-utils.js'
 import {PruneResponseSchema} from '../dream-response-schemas.js'
@@ -39,6 +41,11 @@ export type PruneDeps = {
     update(updater: (state: DreamState) => DreamState): Promise<DreamState>
     write(state: DreamState): Promise<void>
   }
+  /**
+   * Optional logger. When provided, sidecar failures in the candidate scan
+   * emit a warn so the fail-open degradation is visible.
+   */
+  logger?: ILogger
   projectRoot: string
   reviewBackupStore?: {
     save(relativePath: string, content: string): Promise<void>
@@ -105,7 +112,8 @@ async function findCandidates(deps: PruneDeps): Promise<CandidateInfo[]> {
   let signalsByPath: Map<string, {importance: number; maturity: 'core' | 'draft' | 'validated'}>
   try {
     signalsByPath = deps.runtimeSignalStore ? await deps.runtimeSignalStore.list() : new Map()
-  } catch {
+  } catch (error) {
+    warnSidecarFailure(deps.logger, 'prune', 'list', 'findCandidates', error)
     signalsByPath = new Map()
   }
 

--- a/test/unit/infra/runtime-signals/sidecar-failure-logging.test.ts
+++ b/test/unit/infra/runtime-signals/sidecar-failure-logging.test.ts
@@ -1,0 +1,548 @@
+/**
+ * Commit 6 — runtime-signals sidecar-failure logging.
+ *
+ * Post-commit-5 the sidecar is the canonical source for ranking signals.
+ * Operational failures (disk error, permission denied, backend outage) on
+ * sidecar writes continue to be swallowed at every mutation site — they are
+ * documented as best-effort and the next bump self-heals. But swallow-only
+ * leaves operators blind to outages in production. This suite proves that
+ * each of the 11 sidecar-swallow sites now emits exactly one `warn` log
+ * with the operation name and the affected path when the store throws.
+ */
+
+import {expect} from 'chai'
+import * as fs from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+import {restore, type SinonStub, stub} from 'sinon'
+
+import type {ICipherAgent} from '../../../../src/agent/core/interfaces/i-cipher-agent.js'
+import type {ILogger} from '../../../../src/agent/core/interfaces/i-logger.js'
+import type {IRuntimeSignalStore} from '../../../../src/server/core/interfaces/storage/i-runtime-signal-store.js'
+
+import {createCurateTool} from '../../../../src/agent/infra/tools/implementations/curate-tool.js'
+import {createDefaultRuntimeSignals} from '../../../../src/server/core/domain/knowledge/runtime-signals-schema.js'
+import {FileContextTreeArchiveService} from '../../../../src/server/infra/context-tree/file-context-tree-archive-service.js'
+import {FileContextTreeManifestService} from '../../../../src/server/infra/context-tree/file-context-tree-manifest-service.js'
+import {EMPTY_DREAM_STATE} from '../../../../src/server/infra/dream/dream-state-schema.js'
+import {consolidate} from '../../../../src/server/infra/dream/operations/consolidate.js'
+import {prune} from '../../../../src/server/infra/dream/operations/prune.js'
+import {createMockRuntimeSignalStore} from '../../../helpers/mock-factories.js'
+
+interface CurateOutput {
+  applied: Array<{message?: string; path: string; status: 'failed' | 'success'; type: string}>
+  summary: {added: number; deleted: number; failed: number; merged: number; updated: number}
+}
+
+interface CurateTool {
+  execute(input: unknown): Promise<CurateOutput>
+}
+
+function createCapturingLogger(): {logger: ILogger; warnings: string[]} {
+  const warnings: string[] = []
+  const logger: ILogger = {
+    debug() {},
+    error() {},
+    info() {},
+    warn(message) {
+      warnings.push(message)
+    },
+  }
+  return {logger, warnings}
+}
+
+/**
+ * Build a throwing-on-one-method wrapper around a healthy store. Lets us
+ * target exactly the failure path a site exercises without replacing the
+ * entire store (the healthy calls in other paths still succeed).
+ */
+function wrapThrowingMethod(
+  store: IRuntimeSignalStore,
+  method: keyof IRuntimeSignalStore,
+  error = new Error('sidecar down'),
+): IRuntimeSignalStore {
+  return new Proxy(store, {
+    get(target, prop, receiver) {
+      if (prop === method) {
+        return async () => {
+          throw error
+        }
+      }
+
+      return Reflect.get(target, prop, receiver)
+    },
+  })
+}
+
+async function runCurateWithFailingStore(
+  tmpRoot: string,
+  failingMethod: keyof IRuntimeSignalStore,
+  operations: Array<Record<string, unknown>>,
+): Promise<{warnings: string[]}> {
+  const basePath = join(tmpRoot, '.brv/context-tree')
+  await fs.mkdir(basePath, {recursive: true})
+  const healthy = createMockRuntimeSignalStore()
+  const failing = wrapThrowingMethod(healthy, failingMethod)
+  const {logger, warnings} = createCapturingLogger()
+  const tool = createCurateTool(undefined, undefined, failing, logger) as unknown as CurateTool
+  await tool.execute({basePath, operations})
+  return {warnings}
+}
+
+describe('Runtime-signals — sidecar-failure logging at swallow sites', () => {
+  let tmpDir: string
+
+  beforeEach(async () => {
+    tmpDir = join(tmpdir(), `sidecar-log-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    await fs.mkdir(tmpDir, {recursive: true})
+  })
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, {force: true, recursive: true})
+    restore()
+  })
+
+  describe('curate-tool helpers', () => {
+    it('seedSidecarDefaults — warns with operation name and path on set() failure', async () => {
+      const {warnings} = await runCurateWithFailingStore(tmpDir, 'set', [
+        {
+          confidence: 'high',
+          content: {snippets: ['x'], tags: ['t']},
+          impact: 'low',
+          path: 'domain/topic',
+          reason: 'seed',
+          title: 'My Note',
+          type: 'ADD',
+        },
+      ])
+      expect(warnings).to.have.lengthOf(1)
+      expect(warnings[0]).to.include('sidecar seed failed')
+      expect(warnings[0]).to.include('domain/topic/my_note.md')
+    })
+
+    it('mirrorCurateUpdate — warns on update() failure during UPDATE', async () => {
+      const basePath = join(tmpDir, '.brv/context-tree')
+      await fs.mkdir(basePath, {recursive: true})
+      const healthy = createMockRuntimeSignalStore()
+      const {logger, warnings} = createCapturingLogger()
+      // Seed through a healthy store first so the file exists on disk.
+      let tool = createCurateTool(undefined, undefined, healthy, logger) as unknown as CurateTool
+      await tool.execute({
+        basePath,
+        operations: [
+          {
+            confidence: 'high',
+            content: {snippets: ['x'], tags: ['t']},
+            impact: 'low',
+            path: 'domain/topic',
+            reason: 'seed',
+            title: 'My Note',
+            type: 'ADD',
+          },
+        ],
+      })
+      warnings.length = 0
+
+      const failing = wrapThrowingMethod(healthy, 'update')
+      tool = createCurateTool(undefined, undefined, failing, logger) as unknown as CurateTool
+      await tool.execute({
+        basePath,
+        operations: [
+          {
+            confidence: 'high',
+            content: {snippets: ['y'], tags: ['t']},
+            impact: 'low',
+            path: 'domain/topic',
+            reason: 'bump',
+            title: 'My Note',
+            type: 'UPDATE',
+          },
+        ],
+      })
+      expect(warnings).to.have.lengthOf(1)
+      expect(warnings[0]).to.include('sidecar update failed')
+      expect(warnings[0]).to.include('domain/topic/my_note.md')
+    })
+
+    it('dropSidecar — warns on delete() failure during DELETE', async () => {
+      const basePath = join(tmpDir, '.brv/context-tree')
+      await fs.mkdir(basePath, {recursive: true})
+      const healthy = createMockRuntimeSignalStore()
+      const {logger, warnings} = createCapturingLogger()
+      let tool = createCurateTool(undefined, undefined, healthy, logger) as unknown as CurateTool
+      await tool.execute({
+        basePath,
+        operations: [
+          {
+            confidence: 'high',
+            content: {snippets: ['x'], tags: ['t']},
+            impact: 'low',
+            path: 'domain/topic',
+            reason: 'seed',
+            title: 'My Note',
+            type: 'ADD',
+          },
+        ],
+      })
+      warnings.length = 0
+
+      const failing = wrapThrowingMethod(healthy, 'delete')
+      tool = createCurateTool(undefined, undefined, failing, logger) as unknown as CurateTool
+      await tool.execute({
+        basePath,
+        operations: [
+          {
+            confidence: 'low',
+            impact: 'low',
+            path: 'domain/topic',
+            reason: 'clean',
+            title: 'My Note',
+            type: 'DELETE',
+          },
+        ],
+      })
+      expect(warnings).to.have.lengthOf(1)
+      expect(warnings[0]).to.include('sidecar drop failed')
+      expect(warnings[0]).to.include('domain/topic/my_note.md')
+    })
+
+    it('executeMerge sidecar block — warns on update() failure during MERGE', async () => {
+      const basePath = join(tmpDir, '.brv/context-tree')
+      await fs.mkdir(basePath, {recursive: true})
+      const healthy = createMockRuntimeSignalStore()
+      const {logger, warnings} = createCapturingLogger()
+      let tool = createCurateTool(undefined, undefined, healthy, logger) as unknown as CurateTool
+      // Seed source + target.
+      await tool.execute({
+        basePath,
+        operations: [
+          {
+            confidence: 'high',
+            content: {snippets: ['a'], tags: ['t']},
+            impact: 'low',
+            path: 'auth/jwt',
+            reason: 's1',
+            title: 'Refresh',
+            type: 'ADD',
+          },
+          {
+            confidence: 'high',
+            content: {snippets: ['b'], tags: ['t']},
+            impact: 'low',
+            path: 'auth/jwt',
+            reason: 's2',
+            title: 'Rotation',
+            type: 'ADD',
+          },
+        ],
+      })
+      warnings.length = 0
+
+      const failing = wrapThrowingMethod(healthy, 'update')
+      tool = createCurateTool(undefined, undefined, failing, logger) as unknown as CurateTool
+      await tool.execute({
+        basePath,
+        operations: [
+          {
+            confidence: 'high',
+            impact: 'low',
+            mergeTarget: 'auth/jwt',
+            mergeTargetTitle: 'Rotation',
+            path: 'auth/jwt',
+            reason: 'dedupe',
+            title: 'Refresh',
+            type: 'MERGE',
+          },
+        ],
+      })
+      expect(warnings).to.have.lengthOf(1)
+      expect(warnings[0]).to.include('sidecar merge failed')
+      expect(warnings[0]).to.include('auth/jwt/refresh.md')
+      expect(warnings[0]).to.include('auth/jwt/rotation.md')
+    })
+  })
+
+  describe('FileContextTreeArchiveService', () => {
+    it('archiveEntry — warns on delete() failure after markdown archive succeeds', async () => {
+      const contextTreeDir = join(tmpDir, '.brv/context-tree')
+      await fs.mkdir(join(contextTreeDir, 'auth'), {recursive: true})
+      const relPath = 'auth/token.md'
+      await fs.writeFile(join(contextTreeDir, relPath), '# Token\n', 'utf8')
+
+      const healthy = createMockRuntimeSignalStore()
+      const failing = wrapThrowingMethod(healthy, 'delete')
+      const {logger, warnings} = createCapturingLogger()
+      const svc = new FileContextTreeArchiveService(failing, logger)
+
+      const fakeAgent = {
+        createTaskSession: async () => 'sess',
+        async deleteTaskSession() {},
+        executeOnSession: async () => '```json\n{"title":"Ghost","summary":"g","tags":[]}\n```',
+        async setSandboxVariableOnSession() {},
+      } as unknown as ICipherAgent
+
+      await svc.archiveEntry(relPath, fakeAgent, tmpDir)
+
+      const match = warnings.find((w) => w.includes('archive-service: sidecar delete failed'))
+      expect(match, `expected warn for archive delete, got: ${warnings.join(' | ')}`).to.not.be.undefined
+      expect(match).to.include(relPath)
+    })
+
+    it('restoreEntry — warns on set() failure after markdown restore succeeds', async () => {
+      const contextTreeDir = join(tmpDir, '.brv/context-tree')
+      const archivedDir = join(contextTreeDir, '_archived/auth')
+      await fs.mkdir(archivedDir, {recursive: true})
+      const stubRel = '_archived/auth/token.stub.md'
+      const fullRel = '_archived/auth/token.full.md'
+      const stubContent = [
+        '---',
+        'type: archive_stub',
+        'original_path: auth/token.md',
+        'original_token_count: 10',
+        'evicted_at: 2026-04-19T00:00:00.000Z',
+        'evicted_importance: 20',
+        'points_to: _archived/auth/token.full.md',
+        '---',
+        '# Ghost\n',
+      ].join('\n')
+      await fs.writeFile(join(contextTreeDir, stubRel), stubContent, 'utf8')
+      await fs.writeFile(join(contextTreeDir, fullRel), '# Full\n', 'utf8')
+
+      const healthy = createMockRuntimeSignalStore()
+      const failing = wrapThrowingMethod(healthy, 'set')
+      const {logger, warnings} = createCapturingLogger()
+      const svc = new FileContextTreeArchiveService(failing, logger)
+
+      await svc.restoreEntry(stubRel, tmpDir)
+
+      const match = warnings.find((w) => w.includes('archive-service: sidecar seed failed'))
+      expect(match, `expected warn for archive seed, got: ${warnings.join(' | ')}`).to.not.be.undefined
+      expect(match).to.include('auth/token.md')
+    })
+
+    it('findArchiveCandidates — warns on list() failure during candidate scan', async () => {
+      const contextTreeDir = join(tmpDir, '.brv/context-tree')
+      await fs.mkdir(contextTreeDir, {recursive: true})
+
+      const healthy = createMockRuntimeSignalStore()
+      const failing = wrapThrowingMethod(healthy, 'list')
+      const {logger, warnings} = createCapturingLogger()
+      const svc = new FileContextTreeArchiveService(failing, logger)
+
+      await svc.findArchiveCandidates(tmpDir)
+
+      const match = warnings.find((w) => w.includes('archive-service: sidecar list failed'))
+      expect(match, `expected warn for archive list, got: ${warnings.join(' | ')}`).to.not.be.undefined
+    })
+
+    it('readImportanceForArchiveMetadata — warns on get() failure during archive flow', async () => {
+      const contextTreeDir = join(tmpDir, '.brv/context-tree')
+      await fs.mkdir(join(contextTreeDir, 'auth'), {recursive: true})
+      const relPath = 'auth/token.md'
+      await fs.writeFile(join(contextTreeDir, relPath), '# Token\n', 'utf8')
+
+      const healthy = createMockRuntimeSignalStore()
+      // `archiveEntry` calls `readImportanceForArchiveMetadata` (get) and
+      // later `delete`. Fail only `get` to isolate this site from the
+      // archiveEntry-delete site already covered above.
+      const failing = wrapThrowingMethod(healthy, 'get')
+      const {logger, warnings} = createCapturingLogger()
+      const svc = new FileContextTreeArchiveService(failing, logger)
+
+      const fakeAgent = {
+        async createTaskSession() {
+          return 'sess'
+        },
+        async deleteTaskSession() {},
+        async executeOnSession() {
+          return '```json\n{"title":"Ghost","summary":"g","tags":[]}\n```'
+        },
+        async setSandboxVariableOnSession() {},
+      } as unknown as ICipherAgent
+
+      await svc.archiveEntry(relPath, fakeAgent, tmpDir)
+
+      const match = warnings.find((w) =>
+        w.includes('archive-service: sidecar get failed') && w.includes('archive metadata read'),
+      )
+      expect(match, `expected warn for archive get, got: ${warnings.join(' | ')}`).to.not.be.undefined
+      expect(match).to.include(relPath)
+    })
+  })
+
+  describe('dream operations', () => {
+    it('consolidate.determineNeedsReview — warns on per-file get() failure during CROSS_REFERENCE gate', async () => {
+      const contextTreeDir = join(tmpDir, '.brv/context-tree')
+      await fs.mkdir(join(contextTreeDir, 'auth'), {recursive: true})
+      await fs.writeFile(join(contextTreeDir, 'auth/a.md'), '# A\nBody.', 'utf8')
+      await fs.writeFile(join(contextTreeDir, 'auth/b.md'), '# B\nBody.', 'utf8')
+
+      const failingGet: {get: (path: string) => Promise<{maturity: 'core' | 'draft' | 'validated'}>} = {
+        async get() {
+          throw new Error('sidecar down')
+        },
+      }
+
+      const {logger, warnings} = createCapturingLogger()
+
+      const agent = {
+        createTaskSession: stub().resolves('sess'),
+        deleteTaskSession: stub().resolves(),
+        executeOnSession: stub().resolves(
+          '```json\n' +
+            JSON.stringify({
+              actions: [
+                {
+                  files: ['auth/a.md', 'auth/b.md'],
+                  reason: 'related',
+                  type: 'CROSS_REFERENCE',
+                },
+              ],
+            }) +
+            '\n```',
+        ),
+        setSandboxVariableOnSession: stub(),
+      }
+
+      await consolidate(['auth/a.md', 'auth/b.md'], {
+        agent: agent as unknown as ICipherAgent,
+        contextTreeDir,
+        logger,
+        runtimeSignalStore: failingGet,
+        searchService: {search: async () => ({results: []})},
+        taskId: 't1',
+      })
+
+      const match = warnings.find((w) => w.includes('consolidate: sidecar get failed'))
+      expect(match, `expected warn for consolidate get, got: ${warnings.join(' | ')}`).to.not.be.undefined
+      expect(match).to.satisfy((m: string) => m.includes('auth/a.md') || m.includes('auth/b.md'))
+    })
+
+    it('prune.findCandidates — warns on list() failure (fail-open to defaults)', async () => {
+      const contextTreeDir = join(tmpDir, '.brv/context-tree')
+      await fs.mkdir(contextTreeDir, {recursive: true})
+
+      const failingList: {list: () => Promise<Map<string, never>>} = {
+        async list() {
+          throw new Error('list broken')
+        },
+      }
+
+      const {logger, warnings} = createCapturingLogger()
+
+      const updateStub: SinonStub = stub().callsFake(
+        async (updater: (s: typeof EMPTY_DREAM_STATE) => typeof EMPTY_DREAM_STATE) => updater({...EMPTY_DREAM_STATE}),
+      )
+
+      await prune({
+        agent: {
+          createTaskSession: stub().resolves('s'),
+          deleteTaskSession: stub().resolves(),
+          executeOnSession: stub().resolves('```json\n{"decisions":[]}\n```'),
+          setSandboxVariableOnSession: stub(),
+        } as unknown as ICipherAgent,
+        archiveService: {
+          archiveEntry: stub(),
+          findArchiveCandidates: stub().resolves([]),
+        },
+        contextTreeDir,
+        dreamLogId: 'd1',
+        dreamStateService: {
+          read: stub().resolves({...EMPTY_DREAM_STATE}),
+          update: updateStub,
+          write: stub().resolves(),
+        },
+        logger,
+        projectRoot: contextTreeDir,
+        runtimeSignalStore: failingList,
+        signal: undefined,
+        taskId: 't1',
+      })
+
+      const match = warnings.find((w) => w.includes('prune: sidecar list failed'))
+      expect(match, `expected warn for prune list, got: ${warnings.join(' | ')}`).to.not.be.undefined
+    })
+  })
+
+  describe('FileContextTreeManifestService', () => {
+    it('buildManifest — warns on list() failure (fail-open to defaults)', async () => {
+      const baseDirectory = tmpDir
+      await fs.mkdir(join(baseDirectory, '.brv/context-tree'), {recursive: true})
+
+      const failingList = {
+        async batchUpdate() {},
+        async delete() {},
+        async get() {
+          return createDefaultRuntimeSignals()
+        },
+        async getMany() {
+          return new Map()
+        },
+        async list() {
+          throw new Error('list broken')
+        },
+        async set() {},
+        async update() {
+          return createDefaultRuntimeSignals()
+        },
+      }
+
+      const {logger, warnings} = createCapturingLogger()
+
+      const svc = new FileContextTreeManifestService({
+        baseDirectory,
+        logger,
+        runtimeSignalStore: failingList,
+      })
+
+      await svc.buildManifest()
+
+      const match = warnings.find((w) => w.includes('manifest-service: sidecar list failed'))
+      expect(match, `expected warn for manifest list, got: ${warnings.join(' | ')}`).to.not.be.undefined
+    })
+  })
+
+  describe('commit 6 wiring', () => {
+    it('buildUndoDeps (CLI dream-undo) threads the runtime-signal sidecar into archive + manifest services', async () => {
+      const {buildUndoDeps} = await import('../../../../src/oclif/commands/dream.js')
+      const root = await fs.mkdtemp(join(tmpdir(), 'undo-wiring-'))
+
+      try {
+        const deps = await buildUndoDeps(root)
+
+        // The archive service receives the sidecar as its first (and only)
+        // constructor arg. We assert on the instance shape via a private-field
+        // cast because the public surface deliberately hides implementation.
+        const archiveService = deps.archiveService as unknown as {runtimeSignalStore?: unknown}
+        expect(archiveService.runtimeSignalStore, 'archiveService sidecar wiring').to.not.be.undefined
+
+        // The manifest service takes its config via constructor; we inspect
+        // the `config` field (the only property the implementation keeps).
+        const manifestService = deps.manifestService as unknown as {config: {runtimeSignalStore?: unknown}}
+        expect(manifestService.config.runtimeSignalStore, 'manifestService sidecar wiring').to.not.be.undefined
+      } finally {
+        await fs.rm(root, {force: true, recursive: true})
+      }
+    })
+
+    it('service-initializer threads runtimeSignalStore into the swarm SearchKnowledgeService (source regression)', async () => {
+      const sourcePath = join(
+        process.cwd(),
+        'src/agent/infra/agent/service-initializer.ts',
+      )
+      const source = await fs.readFile(sourcePath, 'utf8')
+
+      // Locate the buildProvidersFromConfig block and slice the next few lines
+      // so the assertion fails loudly if a refactor drops the store — without
+      // mocking the entire agent bootstrap.
+      const anchor = source.indexOf('buildProvidersFromConfig(swarmConfig')
+      expect(anchor, 'buildProvidersFromConfig block missing').to.be.greaterThan(-1)
+      const window = source.slice(anchor, anchor + 400)
+
+      expect(window, 'swarm search service must receive runtimeSignalStore').to.match(/runtimeSignalStore/)
+      expect(window, 'swarm search service call must use config object form').to.match(
+        /createSearchKnowledgeService\(\s*fileSystemService\s*,/,
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Problem: Commit 5 removed the markdown fallback that was implicitly protecting the swarm query path and the CLI-direct `brv dream --undo` path. Both construct sidecar-dependent services without the store, silently dropping access-hit bumps (swarm) and leaking orphan sidecar entries (dream-undo). Additionally, sidecar failures across 11 mutation/read sites were swallowed silently with no observability.
- Why it matters: Post-commit-5 the sidecar is the canonical source for ranking signals. Silent regressions in swarm + dream-CLI code paths degrade ranking quality invisibly. Silent swallows across the knowledge pipeline leave operators blind to sidecar outages.
- What changed:
  - `brv dream --undo` builds FileKeyStorage + RuntimeSignalStore and threads the store into archive + manifest services. `buildUndoDeps` extracted as exported helper for wiring tests.
  - `service-initializer.ts` reordered so keyStorage + runtimeSignalStore construct before the swarm-provider block; swarm `createSearchKnowledgeService` call receives the store.
  - 11 sidecar swallow sites (curate seed/update/drop/merge, archive delete/seed/list/get, consolidate CROSS_REFERENCE gate, prune candidate scan, manifest buildManifest) emit `logger.warn` via a shared `warnSidecarFailure` helper.
  - New shared module `src/server/core/domain/knowledge/sidecar-logging.ts` keeps log shape consistent.
  - 13 new tests (11 logging sites + 2 wiring regressions) in `test/unit/infra/runtime-signals/sidecar-failure-logging.test.ts`.
- What did NOT change (scope boundary):
  - No behavior change at swallow sites — failures are still swallowed, only now visible.
  - Cloud sync exclusion: verified architecturally N/A. Push enumerates context-tree files only; IKeyStorage lives outside `.brv/context-tree`. No exclusion rule needed. Audit-only, no code change.
  - No migration of pre-migration `maturity: 'core'` files from markdown to sidecar (deferred; backlog trigger: first user report).
  - `parseCreatedAt` consolidation with `parseContent`: deferred (tech debt, no trigger).
  - `SymbolMetadata.importance/maturity` dead fields: deferred (public interface change, no trigger).

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor (no behavior change)  — logging extraction + logger typing unification
- [ ] Documentation
- [x] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [x] Agent / Tools  — curate-tool.ts + tool-registry
- [ ] LLM Providers
- [x] Server / Daemon  — service-initializer, archive/manifest/consolidate/prune
- [ ] Shared (constants, types, transport events)
- [x] CLI Commands (oclif)  — dream.ts runUndo
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes ENG-2161
- Related: ENG-2160 (commit 5 — stop writing signals to markdown), ENG-2159 (commit 4 — switch reads), ENG-2158 (commit 3 — dual-write)

## Root cause (bug fixes only)

- Root cause: The markdown-fallback safety net in `flushAccessHits` and ranking-read paths was implicitly protecting `SearchKnowledgeService` and `ArchiveService` instances constructed without a `runtimeSignalStore`. Commit 5 removed that safety net to ship `brv vc status` cleanliness. Any call site still missing the wiring silently broke — swarm queries drop hits, dream-CLI archive operations leak orphans.
- Why this was not caught earlier: Commit 3's wiring audit covered the daemon path (`agent-process.ts`) but missed (a) the CLI-direct `brv dream --undo` path, which is a secondary flow, and (b) the swarm-provider construction site, which runs before `runtimeSignalStore` exists in service-initializer due to block ordering. Both were flagged in the commit 3 backlog as "trigger: commit 4/5 lands" but not promoted to must-do at that time.

## Test plan

- Coverage added:
  - [x] Unit test
  - [ ] Integration test
  - [ ] Manual verification only
- Test file(s): `test/unit/infra/runtime-signals/sidecar-failure-logging.test.ts` (13 tests)
- Key scenario(s) covered:
  - Each of 11 sidecar swallow sites emits a `warn` with operation name + path when the store throws (Proxy wraps the store to fail on a single method).
  - `buildUndoDeps` returns an archive service and manifest service with `runtimeSignalStore` wired (private-field inspection via cast).
  - service-initializer.ts source contains the expected wiring pattern in the buildProvidersFromConfig call window (source regression guard).

## User-visible changes

- `brv dream --undo` in text mode: sidecar failures now emit a yellow `WARN` line to stderr. JSON mode uses NoOpLogger to keep stdout clean for parsers. No other CLI output changes.
- Ops logs: `logger.warn` now fires on sidecar failures across the knowledge pipeline. Grep pattern: `sidecar <verb> failed for <path>`.

## Evidence

**Grep audit** — zero sidecar-adjacent silent swallows remain:


**Test results**:


Full suite: `6497 passing, 0 failing` (env config test flakes on ordering, unrelated; passes in isolation).

## Checklist

- [x] Tests added or updated and passing (`npm test`)
- [x] Lint passes (`npm run lint`) — 0 errors
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow Conventional Commits format
- [ ] Documentation updated — N/A (internal wiring, no user docs affected)
- [x] No breaking changes
- [x] Branch is up to date with `main`

## Risks and mitigations

- Risk: service-initializer reorder — construction dependency not obvious from the diff. If any service built between the old and new storage-block positions depended on swarm being initialized first, the reorder would create a silent init bug.
  - Mitigation: Reviewed line-by-line. Nothing between the two positions references swarm. Swarm state contributor is registered AFTER the storage block in both the old and new orderings. Agent-process path (daemon) unaffected because it uses its own storage setup.

- Risk: `warnSidecarFailure` message shape change — prior log message format (ad-hoc per-site) differs from the new shared format. Downstream log-parsing tools keyed on the exact old string would break.
  - Mitigation: Only two sites previously emitted warn logs (search-knowledge-service.loadSignalsByPath was the only live one; everything else was silent). The logger helper's format matches loadSignalsByPath's prefix convention. New format: `<site>: sidecar <verb> failed for <target>: <message>`. No known downstream parsers.

- Risk: Pre-migration `maturity: 'core'` files lose protection — documented in the backlog from commit 5. Not introduced here but carried forward.
  - Mitigation: Tracked in backlog with trigger condition "first user report." Out of scope for this commit.

- Risk: dream-CLI JSON mode previously had no sidecar failures surfaced, now also has none (NoOpLogger). An operator debugging a silent sidecar outage during `brv dream --undo --format json` would see nothing.
  - Mitigation: Operators running in JSON mode are scripting the output — they should consult the daemon/agent-process logs for sidecar failures, which already emit warns via `createAgentLogger`. Text mode preserves full observability.
