### PR TITLE
Proj/runtime signal

### DIFF
--- a/src/agent/core/interfaces/cipher-services.ts
+++ b/src/agent/core/interfaces/cipher-services.ts
@@ -1,3 +1,4 @@
+import type {IRuntimeSignalStore} from '../../../server/core/interfaces/storage/i-runtime-signal-store.js'
 import type {AgentEventBus, SessionEventBus} from '../../infra/events/event-emitter.js'
 import type {FileSystemService} from '../../infra/file-system/file-system-service.js'
 import type {CompactionService} from '../../infra/llm/context/compaction/compaction-service.js'
@@ -52,6 +53,12 @@ export interface CipherAgentServices {
   messageStorageService: MessageStorageService
   policyEngine: IPolicyEngine
   processService: ProcessService
+  /**
+   * Sidecar store for per-machine ranking signals kept out of the shared
+   * context-tree markdown (importance, recency, maturity, accessCount,
+   * updateCount). Reachable here for future wiring; no consumer uses it yet.
+   */
+  runtimeSignalStore: IRuntimeSignalStore
   sandboxService: ISandboxService
   systemPromptManager: SystemPromptManager
   toolManager: ToolManager

--- a/src/agent/infra/agent/cipher-agent.ts
+++ b/src/agent/infra/agent/cipher-agent.ts
@@ -1213,8 +1213,14 @@ export class CipherAgent extends BaseAgent implements ICipherAgent {
       })
     }
 
-    // Rebuild sandbox CurateService with the queue — reuses existing hot-swap path
-    const newCurateService = createCurateService(services.workingDirectory, services.abstractQueue)
+    // Rebuild sandbox CurateService with the queue — reuses existing hot-swap path.
+    // runtimeSignalStore is threaded so agent-driven curate ADD/UPDATE seed +
+    // bump the sidecar (matches the tool-registry wiring at construction time).
+    const newCurateService = createCurateService(
+      services.workingDirectory,
+      services.abstractQueue,
+      services.runtimeSignalStore,
+    )
     services.sandboxService.setCurateService?.(newCurateService)
 
     // Atomically rebuild CURATE + INGEST_RESOURCE tools so both enqueue abstracts

--- a/src/agent/infra/agent/service-initializer.ts
+++ b/src/agent/infra/agent/service-initializer.ts
@@ -264,39 +264,9 @@ export async function createCipherAgentServices(
   // 7. Abstract generation queue (generator injected later via rebindCurateTools)
   const abstractQueue = new AbstractGenerationQueue(workingDirectory)
 
-  // 8. Tool provider (depends on FileSystemService, ProcessService, MemoryManager, SystemPromptManager)
-  const verbose = config.llm.verbose ?? false
-  const descriptionLoader = new ToolDescriptionLoader()
-  const toolProvider: ToolProvider = new ToolProvider(
-    {
-      abstractQueue,
-      environmentContext,
-      fileSystemService,
-      getToolProvider: (): ToolProvider => toolProvider,
-      memoryManager,
-      processService,
-      sandboxService,
-      swarmCoordinator,
-    },
-    systemPromptManager,
-    descriptionLoader,
-  )
-  await toolProvider.initialize()
-
-  // 9. Policy engine with default rules for autonomous execution
-  const policyEngine = new PolicyEngine({defaultDecision: 'ALLOW'})
-  policyEngine.addRules(DEFAULT_POLICY_RULES)
-
-  // 10. Tool scheduler (orchestrates policy check → execution)
-  const toolScheduler = new CoreToolScheduler(toolProvider, policyEngine, undefined, {
-    verbose,
-  })
-
-  // 11. Tool manager (with scheduler for policy-based execution)
-  const toolManager = new ToolManager(toolProvider, toolScheduler)
-  await toolManager.initialize()
-
-  // 11. History storage - granular file-based storage
+  // 8. Storage layer — initialised before ToolProvider so curate/search
+  // factories receive `runtimeSignalStore` via ToolServices at construction
+  // time (no late-bind workarounds).
   const keyStorage = new FileKeyStorage({
     storageDir: storageBasePath,
   })
@@ -310,6 +280,39 @@ export async function createCipherAgentServices(
   // maturity, accessCount, updateCount). Kept out of the context-tree
   // markdown so query-time bumps don't dirty version-controlled files.
   const runtimeSignalStore = new RuntimeSignalStore(keyStorage, logger)
+
+  // 9. Tool provider (depends on FileSystemService, ProcessService, MemoryManager, SystemPromptManager)
+  const verbose = config.llm.verbose ?? false
+  const descriptionLoader = new ToolDescriptionLoader()
+  const toolProvider: ToolProvider = new ToolProvider(
+    {
+      abstractQueue,
+      environmentContext,
+      fileSystemService,
+      getToolProvider: (): ToolProvider => toolProvider,
+      memoryManager,
+      processService,
+      runtimeSignalStore,
+      sandboxService,
+      swarmCoordinator,
+    },
+    systemPromptManager,
+    descriptionLoader,
+  )
+  await toolProvider.initialize()
+
+  // 10. Policy engine with default rules for autonomous execution
+  const policyEngine = new PolicyEngine({defaultDecision: 'ALLOW'})
+  policyEngine.addRules(DEFAULT_POLICY_RULES)
+
+  // 11. Tool scheduler (orchestrates policy check → execution)
+  const toolScheduler = new CoreToolScheduler(toolProvider, policyEngine, undefined, {
+    verbose,
+  })
+
+  // 12. Tool manager (with scheduler for policy-based execution)
+  const toolManager = new ToolManager(toolProvider, toolScheduler)
+  await toolManager.initialize()
 
   // CompactionService for context overflow management
   const tokenizer = new GeminiTokenizer(config.model ?? 'gemini-3-flash-preview')

--- a/src/agent/infra/agent/service-initializer.ts
+++ b/src/agent/infra/agent/service-initializer.ts
@@ -215,7 +215,25 @@ export async function createCipherAgentServices(
   const mapSelectionContributor = new MapSelectionContributor('mapSelection', 16)
   systemPromptManager.registerContributor(mapSelectionContributor)
 
-  // 6b. Swarm coordinator — try to load config and build providers.
+  // 6b. Storage layer — initialised before the swarm block so the swarm
+  // SearchKnowledgeService receives `runtimeSignalStore` at construction
+  // time. Post-commit-5 the markdown fallback is gone, so a swarm search
+  // without the sidecar would silently drop every access-hit bump.
+  const keyStorage = new FileKeyStorage({
+    storageDir: storageBasePath,
+  })
+  await keyStorage.initialize()
+
+  const messageStorage = new MessageStorageService(keyStorage)
+  const messageStorageService = messageStorage
+  const historyStorage = new GranularHistoryStorage(messageStorage)
+
+  // Sidecar store for per-machine ranking signals (importance, recency,
+  // maturity, accessCount, updateCount). Kept out of the context-tree
+  // markdown so query-time bumps don't dirty version-controlled files.
+  const runtimeSignalStore = new RuntimeSignalStore(keyStorage, logger)
+
+  // 6c. Swarm coordinator — try to load config and build providers.
   // Missing config → fail-open (no swarm). Invalid config → warn but continue.
   let swarmCoordinator: SwarmCoordinator | undefined
   try {
@@ -237,7 +255,11 @@ export async function createCipherAgentServices(
     }
 
     const swarmProviders = buildProvidersFromConfig(swarmConfig, {
-      searchService: createSearchKnowledgeService(fileSystemService),
+      searchService: createSearchKnowledgeService(fileSystemService, {
+        baseDirectory: workingDirectory,
+        logger,
+        runtimeSignalStore,
+      }),
     })
 
     if (swarmProviders.length > 0) {
@@ -263,23 +285,6 @@ export async function createCipherAgentServices(
 
   // 7. Abstract generation queue (generator injected later via rebindCurateTools)
   const abstractQueue = new AbstractGenerationQueue(workingDirectory)
-
-  // 8. Storage layer — initialised before ToolProvider so curate/search
-  // factories receive `runtimeSignalStore` via ToolServices at construction
-  // time (no late-bind workarounds).
-  const keyStorage = new FileKeyStorage({
-    storageDir: storageBasePath,
-  })
-  await keyStorage.initialize()
-
-  const messageStorage = new MessageStorageService(keyStorage)
-  const messageStorageService = messageStorage
-  const historyStorage = new GranularHistoryStorage(messageStorage)
-
-  // Sidecar store for per-machine ranking signals (importance, recency,
-  // maturity, accessCount, updateCount). Kept out of the context-tree
-  // markdown so query-time bumps don't dirty version-controlled files.
-  const runtimeSignalStore = new RuntimeSignalStore(keyStorage, logger)
 
   // 9. Tool provider (depends on FileSystemService, ProcessService, MemoryManager, SystemPromptManager)
   const verbose = config.llm.verbose ?? false

--- a/src/agent/infra/agent/service-initializer.ts
+++ b/src/agent/infra/agent/service-initializer.ts
@@ -18,6 +18,7 @@ import type {CipherAgentServices, SessionServices} from '../../core/interfaces/c
 import type {IContentGenerator} from '../../core/interfaces/i-content-generator.js'
 import type {ValidatedAgentConfig} from './agent-schemas.js'
 
+import { RuntimeSignalStore } from '../../../server/infra/context-tree/runtime-signal-store.js'
 import { createBlobStorage } from '../blob/blob-storage-factory.js'
 import { EnvironmentContextBuilder } from '../environment/environment-context-builder.js'
 import { AgentEventBus, SessionEventBus } from '../events/event-emitter.js'
@@ -305,6 +306,11 @@ export async function createCipherAgentServices(
   const messageStorageService = messageStorage
   const historyStorage = new GranularHistoryStorage(messageStorage)
 
+  // Sidecar store for per-machine ranking signals (importance, recency,
+  // maturity, accessCount, updateCount). Kept out of the context-tree
+  // markdown so query-time bumps don't dirty version-controlled files.
+  const runtimeSignalStore = new RuntimeSignalStore(keyStorage, logger)
+
   // CompactionService for context overflow management
   const tokenizer = new GeminiTokenizer(config.model ?? 'gemini-3-flash-preview')
   const compactionService = new CompactionService(messageStorage, tokenizer, {
@@ -332,6 +338,7 @@ export async function createCipherAgentServices(
     messageStorageService,
     policyEngine,
     processService,
+    runtimeSignalStore,
     sandboxService,
     systemPromptManager,
     toolManager,

--- a/src/agent/infra/sandbox/curate-service.ts
+++ b/src/agent/infra/sandbox/curate-service.ts
@@ -5,6 +5,7 @@
 
 import {resolve} from 'node:path'
 
+import type {IRuntimeSignalStore} from '../../../server/core/interfaces/storage/i-runtime-signal-store.js'
 import type {
   CurateOperation,
   CurateOperationResult,
@@ -100,7 +101,11 @@ function validateOperations(operations: CurateOperation[]): CurateOperationResul
 export class CurateService implements ICurateService {
   private readonly workingDirectory: string
 
-  constructor(workingDirectory?: string, private readonly abstractQueue?: AbstractGenerationQueue) {
+  constructor(
+    workingDirectory?: string,
+    private readonly abstractQueue?: AbstractGenerationQueue,
+    private readonly runtimeSignalStore?: IRuntimeSignalStore,
+  ) {
     this.workingDirectory = workingDirectory ?? process.cwd()
   }
 
@@ -148,7 +153,7 @@ export class CurateService implements ICurateService {
     }
 
     // Call the underlying executeCurate function from curate-tool
-    const result = await executeCurate({basePath, operations}, undefined, this.abstractQueue)
+    const result = await executeCurate({basePath, operations}, undefined, this.abstractQueue, this.runtimeSignalStore)
 
     return result
   }
@@ -194,6 +199,10 @@ export class CurateService implements ICurateService {
  * @param workingDirectory - Working directory for resolving relative paths
  * @returns CurateService instance
  */
-export function createCurateService(workingDirectory?: string, abstractQueue?: AbstractGenerationQueue): ICurateService {
-  return new CurateService(workingDirectory, abstractQueue)
+export function createCurateService(
+  workingDirectory?: string,
+  abstractQueue?: AbstractGenerationQueue,
+  runtimeSignalStore?: IRuntimeSignalStore,
+): ICurateService {
+  return new CurateService(workingDirectory, abstractQueue, runtimeSignalStore)
 }

--- a/src/agent/infra/tools/implementations/curate-tool.ts
+++ b/src/agent/infra/tools/implementations/curate-tool.ts
@@ -2,6 +2,7 @@ import {basename, dirname, join, relative, resolve} from 'node:path'
 import {z} from 'zod'
 
 import type {ContextData} from '../../../../server/core/domain/knowledge/markdown-writer.js'
+import type {IRuntimeSignalStore} from '../../../../server/core/interfaces/storage/i-runtime-signal-store.js'
 import type {Tool, ToolExecutionContext} from '../../../core/domain/tools/types.js'
 import type {AbstractGenerationQueue} from '../../map/abstract-queue.js'
 
@@ -11,8 +12,13 @@ import {MarkdownWriter, parseFrontmatterScoring} from '../../../../server/core/d
 import {
   applyDefaultScoring,
   determineTier,
+  mergeScoring,
   recordCurateUpdate,
 } from '../../../../server/core/domain/knowledge/memory-scoring.js'
+import {
+  createDefaultRuntimeSignals,
+  type RuntimeSignals,
+} from '../../../../server/core/domain/knowledge/runtime-signals-schema.js'
 import {toSnakeCase} from '../../../../server/utils/file-helpers.js'
 import {deriveImpactFromLoss, detectStructuralLoss} from '../../../core/domain/knowledge/conflict-detector.js'
 import {resolveStructuralLoss} from '../../../core/domain/knowledge/conflict-resolver.js'
@@ -23,6 +29,81 @@ import {ToolName} from '../../../core/domain/tools/constants.js'
  * enqueue abstract generation without coupling to AbstractGenerationQueue.
  */
 type WriteCallback = (contextPath: string, content: string) => void
+
+/**
+ * Derive the sidecar relPath (forward-slash, relative to the context tree
+ * root) from an absolute context-file path and the operation basePath.
+ */
+function relPathFromContextPath(contextPath: string, basePath: string): string {
+  return relative(basePath, contextPath).split('\\').join('/')
+}
+
+/**
+ * Seed the sidecar with default signals for a newly-added file.
+ * Best-effort: sidecar write failures never break the markdown operation.
+ */
+async function seedSidecarDefaults(
+  store: IRuntimeSignalStore | undefined,
+  relPath: string,
+): Promise<void> {
+  if (!store) return
+  try {
+    await store.set(relPath, createDefaultRuntimeSignals())
+  } catch {
+    // Markdown is canonical during phase 3 — log-and-swallow.
+  }
+}
+
+/**
+ * Mirror a curate UPDATE into the sidecar.
+ *
+ * Applies `recordCurateUpdate`-equivalent bumps (importance +5, recency=1,
+ * updateCount+1) and recomputes `maturity` via `determineTier` inside the
+ * atomic updater so same-path contention does not lose writes.
+ * `updatedAt` is intentionally NOT mirrored — it is a content timestamp
+ * that stays in markdown frontmatter.
+ */
+async function mirrorCurateUpdate(
+  store: IRuntimeSignalStore | undefined,
+  relPath: string,
+): Promise<void> {
+  if (!store) return
+  try {
+    await store.update(relPath, (current: RuntimeSignals): RuntimeSignals => {
+      // `recordCurateUpdate` returns a FrontmatterScoring whose fields are
+      // all concretely populated for our inputs (we pass a fully-valued
+      // RuntimeSignals). Non-null assertions reflect that invariant — no
+      // silent fallbacks that paper over unreachable branches.
+      const bumped = recordCurateUpdate(current)
+      const bumpedImportance = bumped.importance!
+      return {
+        ...current,
+        importance: bumpedImportance,
+        maturity: determineTier(bumpedImportance, current.maturity),
+        recency: bumped.recency!,
+        updateCount: bumped.updateCount!,
+      }
+    })
+  } catch {
+    // Fail-open during phase 3.
+  }
+}
+
+/**
+ * Remove a path's sidecar entry after its markdown file was deleted or moved
+ * (DELETE, MERGE source, archive). Best-effort.
+ */
+async function dropSidecar(
+  store: IRuntimeSignalStore | undefined,
+  relPath: string,
+): Promise<void> {
+  if (!store) return
+  try {
+    await store.delete(relPath)
+  } catch {
+    // Fail-open during phase 3.
+  }
+}
 
 /**
  * Operation types for curating knowledge topics.
@@ -656,7 +737,12 @@ function buildFullPath(basePath: string, knowledgePath: string): string {
 /**
  * Execute ADD operation - create new domain/topic/subtopic with {title}.md
  */
-async function executeAdd(basePath: string, operation: Operation, onAfterWrite?: WriteCallback): Promise<OperationResult> {
+async function executeAdd(
+  basePath: string,
+  operation: Operation,
+  onAfterWrite?: WriteCallback,
+  runtimeSignalStore?: IRuntimeSignalStore,
+): Promise<OperationResult> {
   const {confidence, content, domainContext, impact, path, reason, subtopicContext, summary, title, topicContext} =
     operation
   const reviewMeta = deriveReviewMetadata('ADD', confidence, impact)
@@ -735,6 +821,10 @@ async function executeAdd(basePath: string, operation: Operation, onAfterWrite?:
     await DirectoryManager.writeFileAtomic(contextPath, contextContent)
     onAfterWrite?.(contextPath, contextContent)
 
+    // Dual-write: seed the sidecar with default signals for the new file.
+    // Mirrors the default scoring applied to markdown frontmatter above.
+    await seedSidecarDefaults(runtimeSignalStore, relPathFromContextPath(contextPath, basePath))
+
     await ensureContextMd(basePath, parsed, topicContext, subtopicContext, onAfterWrite)
 
     return {
@@ -773,7 +863,12 @@ function maxImpact(
 /**
  * Execute UPDATE operation - modify existing {title}.md
  */
-async function executeUpdate(basePath: string, operation: Operation, onAfterWrite?: WriteCallback): Promise<OperationResult> {
+async function executeUpdate(
+  basePath: string,
+  operation: Operation,
+  onAfterWrite?: WriteCallback,
+  runtimeSignalStore?: IRuntimeSignalStore,
+): Promise<OperationResult> {
   const {confidence, content, domainContext, impact, path, reason, subtopicContext, summary, title, topicContext} =
     operation
   // Used for early-exit validation failures (before structural loss can be assessed)
@@ -883,6 +978,11 @@ async function executeUpdate(basePath: string, operation: Operation, onAfterWrit
     await DirectoryManager.writeFileAtomic(contextPath, contextContent)
     onAfterWrite?.(contextPath, contextContent)
 
+    // Dual-write: mirror the curate-update bumps (importance +5, recency=1,
+    // updateCount+1, maturity retiered) into the sidecar. `updatedAt` stays
+    // in markdown only — it is a content timestamp, not a runtime signal.
+    await mirrorCurateUpdate(runtimeSignalStore, relPathFromContextPath(contextPath, basePath))
+
     await ensureContextMd(basePath, parsed, topicContext, subtopicContext, onAfterWrite)
 
     return {
@@ -912,7 +1012,12 @@ async function executeUpdate(basePath: string, operation: Operation, onAfterWrit
  * Execute UPSERT operation - automatically creates or updates based on file existence
  * This is the recommended operation type as it eliminates the need for pre-checks.
  */
-async function executeUpsert(basePath: string, operation: Operation, onAfterWrite?: WriteCallback): Promise<OperationResult> {
+async function executeUpsert(
+  basePath: string,
+  operation: Operation,
+  onAfterWrite?: WriteCallback,
+  runtimeSignalStore?: IRuntimeSignalStore,
+): Promise<OperationResult> {
   const {path, reason, title} = operation
   const reviewMeta = deriveReviewMetadata('UPSERT', operation.confidence, operation.impact)
 
@@ -960,7 +1065,7 @@ async function executeUpsert(basePath: string, operation: Operation, onAfterWrit
 
     if (exists) {
       // File exists - delegate to UPDATE logic
-      const result = await executeUpdate(basePath, {...operation, type: 'UPDATE'}, onAfterWrite)
+      const result = await executeUpdate(basePath, {...operation, type: 'UPDATE'}, onAfterWrite, runtimeSignalStore)
       // Return with UPSERT type but indicate it was an update
       return {
         ...result,
@@ -970,7 +1075,7 @@ async function executeUpsert(basePath: string, operation: Operation, onAfterWrit
     }
 
     // File doesn't exist - delegate to ADD logic
-    const result = await executeAdd(basePath, {...operation, type: 'ADD'}, onAfterWrite)
+    const result = await executeAdd(basePath, {...operation, type: 'ADD'}, onAfterWrite, runtimeSignalStore)
     // Return with UPSERT type but indicate it was an add
     return {
       ...result,
@@ -992,7 +1097,12 @@ async function executeUpsert(basePath: string, operation: Operation, onAfterWrit
 /**
  * Execute MERGE operation - combine source file into target file, delete source file
  */
-async function executeMerge(basePath: string, operation: Operation, onAfterWrite?: WriteCallback): Promise<OperationResult> {
+async function executeMerge(
+  basePath: string,
+  operation: Operation,
+  onAfterWrite?: WriteCallback,
+  runtimeSignalStore?: IRuntimeSignalStore,
+): Promise<OperationResult> {
   const {
     confidence,
     domainContext,
@@ -1111,6 +1221,33 @@ async function executeMerge(basePath: string, operation: Operation, onAfterWrite
     await DirectoryManager.deleteFile(sourceContextPath)
     await deleteDerivedSiblings(sourceContextPath)
 
+    // Dual-write: merge sidecar signals by delegating to `mergeScoring`
+    // (the same policy used for markdown). This keeps the two merge paths
+    // from drifting when weights change. The merge runs inside `update`'s
+    // atomic callback so a concurrent access-hit flush on the target cannot
+    // lose bumps.
+    if (runtimeSignalStore) {
+      const sourceRelPath = relPathFromContextPath(sourceContextPath, basePath)
+      const targetRelPath = relPathFromContextPath(targetContextPath, basePath)
+      try {
+        const sourceSignals = await runtimeSignalStore.get(sourceRelPath)
+        await runtimeSignalStore.update(targetRelPath, (current: RuntimeSignals): RuntimeSignals => {
+          const merged = mergeScoring(sourceSignals, current)
+          const mergedImportance = merged.importance ?? current.importance
+          return {
+            accessCount: merged.accessCount ?? current.accessCount,
+            importance: mergedImportance,
+            maturity: determineTier(mergedImportance, merged.maturity ?? current.maturity),
+            recency: merged.recency ?? current.recency,
+            updateCount: merged.updateCount ?? current.updateCount,
+          }
+        })
+        await runtimeSignalStore.delete(sourceRelPath)
+      } catch {
+        // Best-effort — merge of markdown already succeeded.
+      }
+    }
+
     await ensureContextMd(basePath, sourceParsed, topicContext, subtopicContext, onAfterWrite)
     await ensureContextMd(basePath, targetParsed, topicContext, subtopicContext, onAfterWrite)
 
@@ -1142,7 +1279,11 @@ async function executeMerge(basePath: string, operation: Operation, onAfterWrite
  * Execute DELETE operation - remove specific file or entire folder
  * If title is provided, deletes specific file; if omitted, deletes entire folder
  */
-async function executeDelete(basePath: string, operation: Operation): Promise<OperationResult> {
+async function executeDelete(
+  basePath: string,
+  operation: Operation,
+  runtimeSignalStore?: IRuntimeSignalStore,
+): Promise<OperationResult> {
   const {path, reason, title} = operation
   const reviewMeta = deriveReviewMetadata('DELETE', operation.confidence, operation.impact)
 
@@ -1180,6 +1321,10 @@ async function executeDelete(basePath: string, operation: Operation): Promise<Op
       await backupBeforeWrite(filePath, basePath)
       await DirectoryManager.deleteFile(filePath)
       await deleteDerivedSiblings(filePath)
+
+      // Dual-write: drop the deleted file's sidecar entry so it does not
+      // become an orphan.
+      await dropSidecar(runtimeSignalStore, relPathFromContextPath(filePath, basePath))
 
       return {
         ...reviewMeta,
@@ -1262,7 +1407,12 @@ async function executeDelete(basePath: string, operation: Operation): Promise<Op
  * Execute curate operations on knowledge topics.
  * Exported for use by CurateService in sandbox.
  */
-export async function executeCurate(input: unknown, _context?: ToolExecutionContext, abstractQueue?: AbstractGenerationQueue): Promise<CurateOutput> {
+export async function executeCurate(
+  input: unknown,
+  _context?: ToolExecutionContext,
+  abstractQueue?: AbstractGenerationQueue,
+  runtimeSignalStore?: IRuntimeSignalStore,
+): Promise<CurateOutput> {
   const parseResult = CurateInputSchema.safeParse(input)
   if (!parseResult.success) {
     return {
@@ -1308,7 +1458,7 @@ export async function executeCurate(input: unknown, _context?: ToolExecutionCont
 
     switch (operation.type) {
       case 'ADD': {
-        result = await executeAdd(basePath, operation, onAfterWrite)
+        result = await executeAdd(basePath, operation, onAfterWrite, runtimeSignalStore)
 
         if (result.status === 'success') summary.added++
 
@@ -1316,7 +1466,7 @@ export async function executeCurate(input: unknown, _context?: ToolExecutionCont
       }
 
       case 'DELETE': {
-        result = await executeDelete(basePath, operation)
+        result = await executeDelete(basePath, operation, runtimeSignalStore)
 
         if (result.status === 'success') summary.deleted++
 
@@ -1324,7 +1474,7 @@ export async function executeCurate(input: unknown, _context?: ToolExecutionCont
       }
 
       case 'MERGE': {
-        result = await executeMerge(basePath, operation, onAfterWrite)
+        result = await executeMerge(basePath, operation, onAfterWrite, runtimeSignalStore)
 
         if (result.status === 'success') summary.merged++
 
@@ -1332,7 +1482,7 @@ export async function executeCurate(input: unknown, _context?: ToolExecutionCont
       }
 
       case 'UPDATE': {
-        result = await executeUpdate(basePath, operation, onAfterWrite)
+        result = await executeUpdate(basePath, operation, onAfterWrite, runtimeSignalStore)
 
         if (result.status === 'success') summary.updated++
 
@@ -1340,7 +1490,7 @@ export async function executeCurate(input: unknown, _context?: ToolExecutionCont
       }
 
       case 'UPSERT': {
-        result = await executeUpsert(basePath, operation, onAfterWrite)
+        result = await executeUpsert(basePath, operation, onAfterWrite, runtimeSignalStore)
 
         // UPSERT counts as either added or updated based on what happened
         if (result.status === 'success') {
@@ -1381,7 +1531,11 @@ export async function executeCurate(input: unknown, _context?: ToolExecutionCont
   return {applied, summary}
 }
 
-export function createCurateTool(workingDirectory?: string, abstractQueue?: AbstractGenerationQueue): Tool {
+export function createCurateTool(
+  workingDirectory?: string,
+  abstractQueue?: AbstractGenerationQueue,
+  runtimeSignalStore?: IRuntimeSignalStore,
+): Tool {
   return {
     description: `Curate knowledge topics with atomic operations. This tool manages the knowledge structure using four operation types and supports a two-part context model: Raw Concept + Narrative.
 
@@ -1583,11 +1737,11 @@ export function createCurateTool(workingDirectory?: string, abstractQueue?: Abst
         if (parseResult.success) {
           parseResult.data.basePath = resolve(workingDirectory, parseResult.data.basePath)
 
-          return executeCurate(parseResult.data, context, abstractQueue)
+          return executeCurate(parseResult.data, context, abstractQueue, runtimeSignalStore)
         }
       }
 
-      return executeCurate(input, context, abstractQueue)
+      return executeCurate(input, context, abstractQueue, runtimeSignalStore)
     },
 
     id: ToolName.CURATE,

--- a/src/agent/infra/tools/implementations/curate-tool.ts
+++ b/src/agent/infra/tools/implementations/curate-tool.ts
@@ -1252,7 +1252,14 @@ async function executeMerge(
     // Dual-write: merge sidecar signals using `mergeScoring` (the canonical
     // merge policy). Runs inside `update`'s atomic callback so a concurrent
     // access-hit flush on the target cannot lose bumps.
+    //
+    // The target-update and source-delete are wrapped in separate try/catch
+    // blocks so an operator can tell which half failed. If update succeeds
+    // but delete throws the source sidecar entry becomes an orphan (source
+    // markdown is already gone, nothing will ever overwrite it). Tracked by
+    // pruneOrphans in the backlog.
     if (runtimeSignalStore && sourceSignalsSnapshot) {
+      let targetUpdated = false
       try {
         await runtimeSignalStore.update(targetRelPath, (current: RuntimeSignals): RuntimeSignals => {
           const merged = mergeScoring(sourceSignalsSnapshot, current)
@@ -1264,10 +1271,19 @@ async function executeMerge(
             updateCount: merged.updateCount,
           }
         })
-        await runtimeSignalStore.delete(sourceRelPath)
+        targetUpdated = true
       } catch (error) {
         // Best-effort — markdown merge already succeeded.
-        warnSidecarFailure(logger, CURATE_SITE, 'merge', `${sourceRelPath} -> ${targetRelPath}`, error)
+        warnSidecarFailure(logger, CURATE_SITE, 'merge-update', `${sourceRelPath} -> ${targetRelPath}`, error)
+      }
+
+      if (targetUpdated) {
+        try {
+          await runtimeSignalStore.delete(sourceRelPath)
+        } catch (error) {
+          // Source sidecar is now a permanent orphan until pruneOrphans runs.
+          warnSidecarFailure(logger, CURATE_SITE, 'merge-delete', sourceRelPath, error)
+        }
       }
     }
 

--- a/src/agent/infra/tools/implementations/curate-tool.ts
+++ b/src/agent/infra/tools/implementations/curate-tool.ts
@@ -1,7 +1,7 @@
 import {basename, dirname, join, relative, resolve} from 'node:path'
 import {z} from 'zod'
 
-import type {ContextData} from '../../../../server/core/domain/knowledge/markdown-writer.js'
+import type {ContextData, FrontmatterScoring} from '../../../../server/core/domain/knowledge/markdown-writer.js'
 import type {IRuntimeSignalStore} from '../../../../server/core/interfaces/storage/i-runtime-signal-store.js'
 import type {Tool, ToolExecutionContext} from '../../../core/domain/tools/types.js'
 import type {AbstractGenerationQueue} from '../../map/abstract-queue.js'
@@ -14,6 +14,7 @@ import {
   determineTier,
   mergeScoring,
   recordCurateUpdate,
+  UPDATE_IMPORTANCE_BONUS,
 } from '../../../../server/core/domain/knowledge/memory-scoring.js'
 import {
   createDefaultRuntimeSignals,
@@ -36,6 +37,19 @@ type WriteCallback = (contextPath: string, content: string) => void
  */
 function relPathFromContextPath(contextPath: string, basePath: string): string {
   return relative(basePath, contextPath).split('\\').join('/')
+}
+
+/**
+ * Preserve the original `createdAt` from the existing markdown frontmatter on
+ * UPDATE. `createdAt` is immutable content metadata, not a runtime signal, so
+ * it stays in the markdown source-of-truth. Falls back to a fresh timestamp
+ * when the existing file has no `createdAt` (old files or those that never
+ * had it).
+ */
+function existingScoringCreatedAt(existingContent: null | string | undefined): string {
+  if (!existingContent) return new Date().toISOString()
+  const existing = parseFrontmatterScoring(existingContent)
+  return existing?.createdAt ?? new Date().toISOString()
 }
 
 /**
@@ -927,15 +941,28 @@ async function executeUpdate(
 
     await createDomainContextIfMissing(basePath, parsed.domain, domainContext, onAfterWrite)
 
-    // Read existing file to preserve scoring metadata and detect structural loss
+    // Read existing file to detect structural loss
     const existingContent = await DirectoryManager.readFile(contextPath)
-    const existingScoring = existingContent ? parseFrontmatterScoring(existingContent) : undefined
-    const updatedScoring = existingScoring ? recordCurateUpdate(existingScoring) : applyDefaultScoring()
-    const newTier = determineTier(
-      updatedScoring.importance ?? 50,
-      (updatedScoring.maturity ?? 'draft') as 'core' | 'draft' | 'validated',
-    )
-    const finalScoring = {...updatedScoring, maturity: newTier}
+
+    // Source of truth for scoring is the sidecar, not markdown. Markdown may
+    // carry stale values post-commit-4 (ranking bumps go to the sidecar only)
+    // so reading from markdown here would silently regress the importance /
+    // maturity we re-serialise in the dual-write path. When no sidecar store
+    // is provided, fall back to defaults — consistent with ADD semantics.
+    const baseSignals = runtimeSignalStore
+      ? await runtimeSignalStore.get(relPathFromContextPath(contextPath, basePath))
+      : createDefaultRuntimeSignals()
+    const bumpedImportance = Math.min(100, baseSignals.importance + UPDATE_IMPORTANCE_BONUS)
+    const nextTier = determineTier(bumpedImportance, baseSignals.maturity)
+    const finalScoring: FrontmatterScoring = {
+      accessCount: baseSignals.accessCount,
+      createdAt: existingScoringCreatedAt(existingContent),
+      importance: bumpedImportance,
+      maturity: nextTier,
+      recency: 1,
+      updateCount: baseSignals.updateCount + 1,
+      updatedAt: new Date().toISOString(),
+    }
 
     // Filter out non-existent files from rawConcept.files
     const filteredContent = await filterValidFiles(content)

--- a/src/agent/infra/tools/implementations/curate-tool.ts
+++ b/src/agent/infra/tools/implementations/curate-tool.ts
@@ -4,6 +4,7 @@ import {z} from 'zod'
 import type {ContextData} from '../../../../server/core/domain/knowledge/markdown-writer.js'
 import type {IRuntimeSignalStore} from '../../../../server/core/interfaces/storage/i-runtime-signal-store.js'
 import type {Tool, ToolExecutionContext} from '../../../core/domain/tools/types.js'
+import type {ILogger} from '../../../core/interfaces/i-logger.js'
 import type {AbstractGenerationQueue} from '../../map/abstract-queue.js'
 
 import {REVIEW_BACKUPS_DIR} from '../../../../server/constants.js'
@@ -18,6 +19,7 @@ import {
   createDefaultRuntimeSignals,
   type RuntimeSignals,
 } from '../../../../server/core/domain/knowledge/runtime-signals-schema.js'
+import {warnSidecarFailure} from '../../../../server/core/domain/knowledge/sidecar-logging.js'
 import {toSnakeCase} from '../../../../server/utils/file-helpers.js'
 import {deriveImpactFromLoss, detectStructuralLoss} from '../../../core/domain/knowledge/conflict-detector.js'
 import {resolveStructuralLoss} from '../../../core/domain/knowledge/conflict-resolver.js'
@@ -49,6 +51,8 @@ function existingCreatedAt(existingContent: null | string | undefined): string {
   return parseCreatedAt(existingContent) ?? new Date().toISOString()
 }
 
+const CURATE_SITE = 'curate-tool'
+
 /**
  * Seed the sidecar with default signals for a newly-added file.
  * Best-effort: sidecar write failures never break the markdown operation.
@@ -56,12 +60,13 @@ function existingCreatedAt(existingContent: null | string | undefined): string {
 async function seedSidecarDefaults(
   store: IRuntimeSignalStore | undefined,
   relPath: string,
+  logger?: ILogger,
 ): Promise<void> {
   if (!store) return
   try {
     await store.set(relPath, createDefaultRuntimeSignals())
-  } catch {
-    // Markdown is canonical during phase 3 — log-and-swallow.
+  } catch (error) {
+    warnSidecarFailure(logger, CURATE_SITE, 'seed', relPath, error)
   }
 }
 
@@ -77,6 +82,7 @@ async function seedSidecarDefaults(
 async function mirrorCurateUpdate(
   store: IRuntimeSignalStore | undefined,
   relPath: string,
+  logger?: ILogger,
 ): Promise<void> {
   if (!store) return
   try {
@@ -90,8 +96,8 @@ async function mirrorCurateUpdate(
         updateCount: bumped.updateCount,
       }
     })
-  } catch {
-    // Fail-open during phase 3.
+  } catch (error) {
+    warnSidecarFailure(logger, CURATE_SITE, 'update', relPath, error)
   }
 }
 
@@ -102,12 +108,13 @@ async function mirrorCurateUpdate(
 async function dropSidecar(
   store: IRuntimeSignalStore | undefined,
   relPath: string,
+  logger?: ILogger,
 ): Promise<void> {
   if (!store) return
   try {
     await store.delete(relPath)
-  } catch {
-    // Fail-open during phase 3.
+  } catch (error) {
+    warnSidecarFailure(logger, CURATE_SITE, 'drop', relPath, error)
   }
 }
 
@@ -748,6 +755,7 @@ async function executeAdd(
   operation: Operation,
   onAfterWrite?: WriteCallback,
   runtimeSignalStore?: IRuntimeSignalStore,
+  logger?: ILogger,
 ): Promise<OperationResult> {
   const {confidence, content, domainContext, impact, path, reason, subtopicContext, summary, title, topicContext} =
     operation
@@ -829,7 +837,7 @@ async function executeAdd(
 
     // Dual-write: seed the sidecar with default signals for the new file.
     // Mirrors the default scoring applied to markdown frontmatter above.
-    await seedSidecarDefaults(runtimeSignalStore, relPathFromContextPath(contextPath, basePath))
+    await seedSidecarDefaults(runtimeSignalStore, relPathFromContextPath(contextPath, basePath), logger)
 
     await ensureContextMd(basePath, parsed, topicContext, subtopicContext, onAfterWrite)
 
@@ -874,6 +882,7 @@ async function executeUpdate(
   operation: Operation,
   onAfterWrite?: WriteCallback,
   runtimeSignalStore?: IRuntimeSignalStore,
+  logger?: ILogger,
 ): Promise<OperationResult> {
   const {confidence, content, domainContext, impact, path, reason, subtopicContext, summary, title, topicContext} =
     operation
@@ -988,7 +997,7 @@ async function executeUpdate(
     // Dual-write: mirror the curate-update bumps (importance +5, recency=1,
     // updateCount+1, maturity retiered) into the sidecar. `updatedAt` stays
     // in markdown only — it is a content timestamp, not a runtime signal.
-    await mirrorCurateUpdate(runtimeSignalStore, relPathFromContextPath(contextPath, basePath))
+    await mirrorCurateUpdate(runtimeSignalStore, relPathFromContextPath(contextPath, basePath), logger)
 
     await ensureContextMd(basePath, parsed, topicContext, subtopicContext, onAfterWrite)
 
@@ -1024,6 +1033,7 @@ async function executeUpsert(
   operation: Operation,
   onAfterWrite?: WriteCallback,
   runtimeSignalStore?: IRuntimeSignalStore,
+  logger?: ILogger,
 ): Promise<OperationResult> {
   const {path, reason, title} = operation
   const reviewMeta = deriveReviewMetadata('UPSERT', operation.confidence, operation.impact)
@@ -1072,7 +1082,7 @@ async function executeUpsert(
 
     if (exists) {
       // File exists - delegate to UPDATE logic
-      const result = await executeUpdate(basePath, {...operation, type: 'UPDATE'}, onAfterWrite, runtimeSignalStore)
+      const result = await executeUpdate(basePath, {...operation, type: 'UPDATE'}, onAfterWrite, runtimeSignalStore, logger)
       // Return with UPSERT type but indicate it was an update
       return {
         ...result,
@@ -1082,7 +1092,7 @@ async function executeUpsert(
     }
 
     // File doesn't exist - delegate to ADD logic
-    const result = await executeAdd(basePath, {...operation, type: 'ADD'}, onAfterWrite, runtimeSignalStore)
+    const result = await executeAdd(basePath, {...operation, type: 'ADD'}, onAfterWrite, runtimeSignalStore, logger)
     // Return with UPSERT type but indicate it was an add
     return {
       ...result,
@@ -1109,6 +1119,7 @@ async function executeMerge(
   operation: Operation,
   onAfterWrite?: WriteCallback,
   runtimeSignalStore?: IRuntimeSignalStore,
+  logger?: ILogger,
 ): Promise<OperationResult> {
   const {
     confidence,
@@ -1254,8 +1265,9 @@ async function executeMerge(
           }
         })
         await runtimeSignalStore.delete(sourceRelPath)
-      } catch {
+      } catch (error) {
         // Best-effort — markdown merge already succeeded.
+        warnSidecarFailure(logger, CURATE_SITE, 'merge', `${sourceRelPath} -> ${targetRelPath}`, error)
       }
     }
 
@@ -1294,6 +1306,7 @@ async function executeDelete(
   basePath: string,
   operation: Operation,
   runtimeSignalStore?: IRuntimeSignalStore,
+  logger?: ILogger,
 ): Promise<OperationResult> {
   const {path, reason, title} = operation
   const reviewMeta = deriveReviewMetadata('DELETE', operation.confidence, operation.impact)
@@ -1335,7 +1348,7 @@ async function executeDelete(
 
       // Dual-write: drop the deleted file's sidecar entry so it does not
       // become an orphan.
-      await dropSidecar(runtimeSignalStore, relPathFromContextPath(filePath, basePath))
+      await dropSidecar(runtimeSignalStore, relPathFromContextPath(filePath, basePath), logger)
 
       return {
         ...reviewMeta,
@@ -1396,7 +1409,7 @@ async function executeDelete(
     // Best-effort — the markdown delete has already succeeded.
     if (runtimeSignalStore) {
       await Promise.all(
-        mdFiles.map((f) => dropSidecar(runtimeSignalStore, relPathFromContextPath(f, basePath))),
+        mdFiles.map((f) => dropSidecar(runtimeSignalStore, relPathFromContextPath(f, basePath), logger)),
       )
     }
 
@@ -1432,6 +1445,7 @@ export async function executeCurate(
   _context?: ToolExecutionContext,
   abstractQueue?: AbstractGenerationQueue,
   runtimeSignalStore?: IRuntimeSignalStore,
+  logger?: ILogger,
 ): Promise<CurateOutput> {
   const parseResult = CurateInputSchema.safeParse(input)
   if (!parseResult.success) {
@@ -1478,7 +1492,7 @@ export async function executeCurate(
 
     switch (operation.type) {
       case 'ADD': {
-        result = await executeAdd(basePath, operation, onAfterWrite, runtimeSignalStore)
+        result = await executeAdd(basePath, operation, onAfterWrite, runtimeSignalStore, logger)
 
         if (result.status === 'success') summary.added++
 
@@ -1486,7 +1500,7 @@ export async function executeCurate(
       }
 
       case 'DELETE': {
-        result = await executeDelete(basePath, operation, runtimeSignalStore)
+        result = await executeDelete(basePath, operation, runtimeSignalStore, logger)
 
         if (result.status === 'success') summary.deleted++
 
@@ -1494,7 +1508,7 @@ export async function executeCurate(
       }
 
       case 'MERGE': {
-        result = await executeMerge(basePath, operation, onAfterWrite, runtimeSignalStore)
+        result = await executeMerge(basePath, operation, onAfterWrite, runtimeSignalStore, logger)
 
         if (result.status === 'success') summary.merged++
 
@@ -1502,7 +1516,7 @@ export async function executeCurate(
       }
 
       case 'UPDATE': {
-        result = await executeUpdate(basePath, operation, onAfterWrite, runtimeSignalStore)
+        result = await executeUpdate(basePath, operation, onAfterWrite, runtimeSignalStore, logger)
 
         if (result.status === 'success') summary.updated++
 
@@ -1510,7 +1524,7 @@ export async function executeCurate(
       }
 
       case 'UPSERT': {
-        result = await executeUpsert(basePath, operation, onAfterWrite, runtimeSignalStore)
+        result = await executeUpsert(basePath, operation, onAfterWrite, runtimeSignalStore, logger)
 
         // UPSERT counts as either added or updated based on what happened
         if (result.status === 'success') {
@@ -1555,6 +1569,7 @@ export function createCurateTool(
   workingDirectory?: string,
   abstractQueue?: AbstractGenerationQueue,
   runtimeSignalStore?: IRuntimeSignalStore,
+  logger?: ILogger,
 ): Tool {
   return {
     description: `Curate knowledge topics with atomic operations. This tool manages the knowledge structure using four operation types and supports a two-part context model: Raw Concept + Narrative.
@@ -1757,11 +1772,11 @@ export function createCurateTool(
         if (parseResult.success) {
           parseResult.data.basePath = resolve(workingDirectory, parseResult.data.basePath)
 
-          return executeCurate(parseResult.data, context, abstractQueue, runtimeSignalStore)
+          return executeCurate(parseResult.data, context, abstractQueue, runtimeSignalStore, logger)
         }
       }
 
-      return executeCurate(input, context, abstractQueue, runtimeSignalStore)
+      return executeCurate(input, context, abstractQueue, runtimeSignalStore, logger)
     },
 
     id: ToolName.CURATE,

--- a/src/agent/infra/tools/implementations/curate-tool.ts
+++ b/src/agent/infra/tools/implementations/curate-tool.ts
@@ -1,20 +1,18 @@
 import {basename, dirname, join, relative, resolve} from 'node:path'
 import {z} from 'zod'
 
-import type {ContextData, FrontmatterScoring} from '../../../../server/core/domain/knowledge/markdown-writer.js'
+import type {ContextData} from '../../../../server/core/domain/knowledge/markdown-writer.js'
 import type {IRuntimeSignalStore} from '../../../../server/core/interfaces/storage/i-runtime-signal-store.js'
 import type {Tool, ToolExecutionContext} from '../../../core/domain/tools/types.js'
 import type {AbstractGenerationQueue} from '../../map/abstract-queue.js'
 
 import {REVIEW_BACKUPS_DIR} from '../../../../server/constants.js'
 import {DirectoryManager} from '../../../../server/core/domain/knowledge/directory-manager.js'
-import {MarkdownWriter, parseFrontmatterScoring} from '../../../../server/core/domain/knowledge/markdown-writer.js'
+import {MarkdownWriter, parseCreatedAt} from '../../../../server/core/domain/knowledge/markdown-writer.js'
 import {
-  applyDefaultScoring,
   determineTier,
   mergeScoring,
   recordCurateUpdate,
-  UPDATE_IMPORTANCE_BONUS,
 } from '../../../../server/core/domain/knowledge/memory-scoring.js'
 import {
   createDefaultRuntimeSignals,
@@ -46,10 +44,9 @@ function relPathFromContextPath(contextPath: string, basePath: string): string {
  * when the existing file has no `createdAt` (old files or those that never
  * had it).
  */
-function existingScoringCreatedAt(existingContent: null | string | undefined): string {
+function existingCreatedAt(existingContent: null | string | undefined): string {
   if (!existingContent) return new Date().toISOString()
-  const existing = parseFrontmatterScoring(existingContent)
-  return existing?.createdAt ?? new Date().toISOString()
+  return parseCreatedAt(existingContent) ?? new Date().toISOString()
 }
 
 /**
@@ -825,10 +822,10 @@ async function executeAdd(
       rawConcept: filteredContent.rawConcept,
       reason,
       relations: filteredContent.relations,
-      scoring: applyDefaultScoring(),
       snippets: filteredContent.snippets ?? [],
       summary,
       tags: filteredContent.tags,
+      timestamps: {createdAt: new Date().toISOString(), updatedAt: new Date().toISOString()},
     })
     const filename = `${toSnakeCase(title)}.md`
     const contextPath = join(finalPath, filename)
@@ -944,23 +941,11 @@ async function executeUpdate(
     // Read existing file to detect structural loss
     const existingContent = await DirectoryManager.readFile(contextPath)
 
-    // Source of truth for scoring is the sidecar, not markdown. Markdown may
-    // carry stale values post-commit-4 (ranking bumps go to the sidecar only)
-    // so reading from markdown here would silently regress the importance /
-    // maturity we re-serialise in the dual-write path. When no sidecar store
-    // is provided, fall back to defaults — consistent with ADD semantics.
-    const baseSignals = runtimeSignalStore
-      ? await runtimeSignalStore.get(relPathFromContextPath(contextPath, basePath))
-      : createDefaultRuntimeSignals()
-    const bumpedImportance = Math.min(100, baseSignals.importance + UPDATE_IMPORTANCE_BONUS)
-    const nextTier = determineTier(bumpedImportance, baseSignals.maturity)
-    const finalScoring: FrontmatterScoring = {
-      accessCount: baseSignals.accessCount,
-      createdAt: existingScoringCreatedAt(existingContent),
-      importance: bumpedImportance,
-      maturity: nextTier,
-      recency: 1,
-      updateCount: baseSignals.updateCount + 1,
+    // Markdown only carries content timestamps post-commit-5. The sidecar
+    // handles all scoring (importance / recency / maturity / counts) via
+    // `mirrorCurateUpdate` below, inside an atomic read-modify-write.
+    const timestamps = {
+      createdAt: existingCreatedAt(existingContent),
       updatedAt: new Date().toISOString(),
     }
 
@@ -998,8 +983,8 @@ async function executeUpdate(
     const contextContent = MarkdownWriter.generateContext({
       ...resolvedContextData,
       reason,
-      scoring: finalScoring,
       summary,
+      timestamps,
     })
     await backupBeforeWrite(contextPath, basePath)
     await DirectoryManager.writeFileAtomic(contextPath, contextContent)

--- a/src/agent/infra/tools/implementations/curate-tool.ts
+++ b/src/agent/infra/tools/implementations/curate-tool.ts
@@ -81,18 +81,13 @@ async function mirrorCurateUpdate(
   if (!store) return
   try {
     await store.update(relPath, (current: RuntimeSignals): RuntimeSignals => {
-      // `recordCurateUpdate` returns a FrontmatterScoring whose fields are
-      // all concretely populated for our inputs (we pass a fully-valued
-      // RuntimeSignals). Non-null assertions reflect that invariant — no
-      // silent fallbacks that paper over unreachable branches.
       const bumped = recordCurateUpdate(current)
-      const bumpedImportance = bumped.importance!
       return {
         ...current,
-        importance: bumpedImportance,
-        maturity: determineTier(bumpedImportance, current.maturity),
-        recency: bumped.recency!,
-        updateCount: bumped.updateCount!,
+        importance: bumped.importance,
+        maturity: determineTier(bumped.importance, current.maturity),
+        recency: bumped.recency,
+        updateCount: bumped.updateCount,
       }
     })
   } catch {
@@ -1226,6 +1221,16 @@ async function executeMerge(
     await backupBeforeWrite(targetContextPath, basePath)
     await backupBeforeWrite(sourceContextPath, basePath)
 
+    // Capture source sidecar signals BEFORE any destructive operation so a
+    // mid-flow crash cannot leave the target unmerged with an orphaned
+    // source entry. The sidecar merge happens after the markdown writes
+    // succeed, using the captured snapshot.
+    const sourceRelPath = relPathFromContextPath(sourceContextPath, basePath)
+    const targetRelPath = relPathFromContextPath(targetContextPath, basePath)
+    const sourceSignalsSnapshot = runtimeSignalStore
+      ? await runtimeSignalStore.get(sourceRelPath)
+      : null
+
     const mergedContent = MarkdownWriter.mergeContexts(sourceContent, targetContent, reason, summary)
     await DirectoryManager.writeFileAtomic(targetContextPath, mergedContent)
     onAfterWrite?.(targetContextPath, mergedContent)
@@ -1233,30 +1238,24 @@ async function executeMerge(
     await DirectoryManager.deleteFile(sourceContextPath)
     await deleteDerivedSiblings(sourceContextPath)
 
-    // Dual-write: merge sidecar signals by delegating to `mergeScoring`
-    // (the same policy used for markdown). This keeps the two merge paths
-    // from drifting when weights change. The merge runs inside `update`'s
-    // atomic callback so a concurrent access-hit flush on the target cannot
-    // lose bumps.
-    if (runtimeSignalStore) {
-      const sourceRelPath = relPathFromContextPath(sourceContextPath, basePath)
-      const targetRelPath = relPathFromContextPath(targetContextPath, basePath)
+    // Dual-write: merge sidecar signals using `mergeScoring` (the canonical
+    // merge policy). Runs inside `update`'s atomic callback so a concurrent
+    // access-hit flush on the target cannot lose bumps.
+    if (runtimeSignalStore && sourceSignalsSnapshot) {
       try {
-        const sourceSignals = await runtimeSignalStore.get(sourceRelPath)
         await runtimeSignalStore.update(targetRelPath, (current: RuntimeSignals): RuntimeSignals => {
-          const merged = mergeScoring(sourceSignals, current)
-          const mergedImportance = merged.importance ?? current.importance
+          const merged = mergeScoring(sourceSignalsSnapshot, current)
           return {
-            accessCount: merged.accessCount ?? current.accessCount,
-            importance: mergedImportance,
-            maturity: determineTier(mergedImportance, merged.maturity ?? current.maturity),
-            recency: merged.recency ?? current.recency,
-            updateCount: merged.updateCount ?? current.updateCount,
+            accessCount: merged.accessCount,
+            importance: merged.importance,
+            maturity: determineTier(merged.importance, merged.maturity),
+            recency: merged.recency,
+            updateCount: merged.updateCount,
           }
         })
         await runtimeSignalStore.delete(sourceRelPath)
       } catch {
-        // Best-effort — merge of markdown already succeeded.
+        // Best-effort — markdown merge already succeeded.
       }
     }
 
@@ -1391,6 +1390,15 @@ async function executeDelete(
 
     await Promise.all(mdFiles.map((f) => backupBeforeWrite(f, basePath)))
     await DirectoryManager.deleteTopicRecursive(fullPath)
+
+    // Dual-write: drop sidecar entries for every markdown file that was
+    // deleted. Without this, folder deletes leak orphan signal entries.
+    // Best-effort — the markdown delete has already succeeded.
+    if (runtimeSignalStore) {
+      await Promise.all(
+        mdFiles.map((f) => dropSidecar(runtimeSignalStore, relPathFromContextPath(f, basePath))),
+      )
+    }
 
     return {
       ...reviewMeta,

--- a/src/agent/infra/tools/implementations/expand-knowledge-tool.ts
+++ b/src/agent/infra/tools/implementations/expand-knowledge-tool.ts
@@ -2,6 +2,7 @@ import {readFile} from 'node:fs/promises'
 import {join} from 'node:path'
 import {z} from 'zod'
 
+import type {IRuntimeSignalStore} from '../../../../server/core/interfaces/storage/i-runtime-signal-store.js'
 import type {Tool, ToolExecutionContext} from '../../../core/domain/tools/types.js'
 
 import {BRV_DIR, CONTEXT_TREE_DIR} from '../../../../server/constants.js'
@@ -42,6 +43,7 @@ const ExpandKnowledgeInputSchema = z
  */
 export interface ExpandKnowledgeToolConfig {
   baseDirectory?: string
+  runtimeSignalStore?: IRuntimeSignalStore
 }
 
 /**
@@ -55,7 +57,7 @@ export interface ExpandKnowledgeToolConfig {
  * @returns Configured expand knowledge tool
  */
 export function createExpandKnowledgeTool(config: ExpandKnowledgeToolConfig = {}): Tool {
-  const archiveService = new FileContextTreeArchiveService()
+  const archiveService = new FileContextTreeArchiveService(config.runtimeSignalStore)
 
   return {
     description:

--- a/src/agent/infra/tools/implementations/memory-symbol-tree.ts
+++ b/src/agent/infra/tools/implementations/memory-symbol-tree.ts
@@ -1,5 +1,3 @@
-import type { FrontmatterScoring } from '../../../../server/core/domain/knowledge/markdown-writer.js'
-
 import { CONTEXT_FILE } from '../../../../server/constants.js'
 import { parseRelations } from '../../../../server/core/domain/knowledge/relation-parser.js'
 
@@ -64,8 +62,6 @@ export interface SummaryDocLike {
   excerpt?: string
   /** Path to the _index.md file, e.g. "domain/topic/_index.md" */
   path: string
-  /** Frontmatter scoring parsed from _index.md — used to apply hotness/importance to propagated hits */
-  scoring?: {importance?: number; maturity?: string; recency?: number}
   tokenCount: number
 }
 
@@ -113,7 +109,6 @@ interface DocumentLike {
   content: string
   id: string
   path: string
-  scoring: FrontmatterScoring
   title: string
 }
 
@@ -146,15 +141,6 @@ function determineKind(segments: string[]): MemorySymbolKind {
       // 4+ segments: treat deepest folder as subtopic-level
       return MemorySymbolKind.Subtopic
     }
-  }
-}
-
-function extractMetadataFromScoring(scoring: FrontmatterScoring): SymbolMetadata {
-  return {
-    importance: scoring.importance ?? 50,
-    keywords: [],
-    maturity: scoring.maturity ?? 'draft',
-    tags: [],
   }
 }
 
@@ -257,10 +243,10 @@ export function buildSymbolTree(
     const folderNode = symbolMap.get(folderPath)
 
     if (folderNode) {
-      folderNode.metadata = {
-        ...folderNode.metadata,
-        ...extractMetadataFromScoring(doc.scoring),
-      }
+      // Context metadata starts at defaults. Post-commit-5, ranking signals
+      // (importance, maturity) are read from the sidecar at query time; the
+      // symbol tree only carries structural metadata.
+      folderNode.metadata = { ...folderNode.metadata }
     }
 
     // Also register the context.md path itself for direct lookups
@@ -276,7 +262,7 @@ export function buildSymbolTree(
     const contextNode: MemorySymbol = {
       children: [],
       kind: MemorySymbolKind.Context,
-      metadata: extractMetadataFromScoring(doc.scoring),
+      metadata: { ...DEFAULT_METADATA },
       name: doc.title || segments.at(-1)!.replace(/\.md$/, ''),
       parent: parentNode,
       path: doc.path,

--- a/src/agent/infra/tools/implementations/memory-symbol-tree.ts
+++ b/src/agent/infra/tools/implementations/memory-symbol-tree.ts
@@ -242,12 +242,8 @@ export function buildSymbolTree(
     const folderPath = segments.slice(0, -1).join('/')
     const folderNode = symbolMap.get(folderPath)
 
-    if (folderNode) {
-      // Context metadata starts at defaults. Post-commit-5, ranking signals
-      // (importance, maturity) are read from the sidecar at query time; the
-      // symbol tree only carries structural metadata.
-      folderNode.metadata = { ...folderNode.metadata }
-    }
+    // Post-commit-5: ranking signals (importance, maturity) are read from the
+    // sidecar at query time; the symbol tree only carries structural metadata.
 
     // Also register the context.md path itself for direct lookups
     symbolMap.set(doc.path, folderNode ?? getOrCreateFolderNode(symbolMap, root, folderPath, segments.slice(0, -1)))

--- a/src/agent/infra/tools/implementations/search-knowledge-service.ts
+++ b/src/agent/infra/tools/implementations/search-knowledge-service.ts
@@ -1187,16 +1187,12 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
       [...hits.entries()].map(([relPath, count]) => [
         relPath,
         (current: RuntimeSignals): RuntimeSignals => {
-          // `recordAccessHits` always returns concrete importance/accessCount
-          // when given a fully-valued RuntimeSignals; the `!` assertions
-          // reflect that invariant rather than defensive fallbacks.
           const bumped = recordAccessHits(current, count)
-          const bumpedImportance = bumped.importance!
           return {
             ...current,
-            accessCount: bumped.accessCount!,
-            importance: bumpedImportance,
-            maturity: determineTier(bumpedImportance, current.maturity),
+            accessCount: bumped.accessCount,
+            importance: bumped.importance,
+            maturity: determineTier(bumped.importance, current.maturity),
           }
         },
       ]),

--- a/src/agent/infra/tools/implementations/search-knowledge-service.ts
+++ b/src/agent/infra/tools/implementations/search-knowledge-service.ts
@@ -3,6 +3,7 @@ import {realpath} from 'node:fs/promises'
 import {join} from 'node:path'
 import {removeStopwords} from 'stopword'
 
+import type {IRuntimeSignalStore} from '../../../../server/core/interfaces/storage/i-runtime-signal-store.js'
 import type {IFileSystem} from '../../../core/interfaces/i-file-system.js'
 import type {ISearchKnowledgeService, SearchKnowledgeResult} from '../../sandbox/tools-sdk.js'
 
@@ -26,6 +27,7 @@ import {
   determineTier,
   recordAccessHits,
 } from '../../../../server/core/domain/knowledge/memory-scoring.js'
+import {type RuntimeSignals} from '../../../../server/core/domain/knowledge/runtime-signals-schema.js'
 import {loadSources, type SearchOrigin} from '../../../../server/core/domain/source/source-schema.js'
 import {isArchiveStub, isDerivedArtifact} from '../../../../server/infra/context-tree/derived-artifact.js'
 import {
@@ -230,6 +232,12 @@ export interface SearchKnowledgeServiceConfig {
   baseDirectory?: string
   /** Cache TTL in milliseconds (defaults to 5000) */
   cacheTtlMs?: number
+  /**
+   * Sidecar store for runtime ranking signals. When provided, `flushAccessHits`
+   * mirrors its importance/accessCount/maturity bumps to the store alongside
+   * the existing markdown writes. Phase 3 of the runtime-signals migration.
+   */
+  runtimeSignalStore?: IRuntimeSignalStore
 }
 
 /**
@@ -878,6 +886,7 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
   private readonly cacheTtlMs: number
   private readonly fileSystem: IFileSystem
   private readonly pendingAccessHits: Map<string, number> = new Map()
+  private readonly runtimeSignalStore?: IRuntimeSignalStore
   private readonly state: IndexState = {
     buildingPromise: undefined,
     cachedIndex: undefined,
@@ -887,6 +896,7 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
     this.fileSystem = fileSystem
     this.baseDirectory = config.baseDirectory ?? process.cwd()
     this.cacheTtlMs = config.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS
+    this.runtimeSignalStore = config.runtimeSignalStore
   }
 
   /**
@@ -920,6 +930,10 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
       }
     })
     await Promise.allSettled(tasks)
+
+    // Dual-write to the runtime-signal sidecar. Markdown remains canonical in
+    // phase 3; sidecar failures must not affect the flush outcome.
+    await this.mirrorHitsToSignalStore(hits)
     return true
   }
 
@@ -1127,6 +1141,49 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
       relatedPaths: backlinks?.slice(0, 3),
       symbolKind: isContextSummary ? 'summary' : symbolKind,
       symbolPath: isContextSummary ? summaryPath : symbol?.path,
+    }
+  }
+
+  /**
+   * Mirror a batch of access-hit bumps into the runtime-signal sidecar.
+   *
+   * Matches the markdown flush semantics above:
+   *   - `recordAccessHits` bumps `importance` by `ACCESS_IMPORTANCE_BONUS * count`
+   *     and `accessCount` by `count`.
+   *   - `determineTier` recomputes `maturity` from the new importance.
+   * Both steps run inside `update`'s atomic read-modify-write callback so
+   * same-path contention within the process does not lose bumps.
+   * `updatedAt` is never mirrored — it is a content timestamp, not a signal.
+   */
+  private async mirrorHitsToSignalStore(hits: Map<string, number>): Promise<void> {
+    const store = this.runtimeSignalStore
+    if (!store) return
+
+    const updates = new Map(
+      [...hits.entries()].map(([relPath, count]) => [
+        relPath,
+        (current: RuntimeSignals): RuntimeSignals => {
+          // `recordAccessHits` always returns concrete importance/accessCount
+          // when given a fully-valued RuntimeSignals; the `!` assertions
+          // reflect that invariant rather than defensive fallbacks.
+          const bumped = recordAccessHits(current, count)
+          const bumpedImportance = bumped.importance!
+          return {
+            ...current,
+            accessCount: bumped.accessCount!,
+            importance: bumpedImportance,
+            maturity: determineTier(bumpedImportance, current.maturity),
+          }
+        },
+      ]),
+    )
+
+    try {
+      await store.batchUpdate(updates)
+    } catch {
+      // Best-effort — sidecar failure must not break the flush. Markdown is
+      // still canonical during phase 3; the sidecar will re-sync on the next
+      // bump for these paths.
     }
   }
 

--- a/src/agent/infra/tools/implementations/search-knowledge-service.ts
+++ b/src/agent/infra/tools/implementations/search-knowledge-service.ts
@@ -26,6 +26,7 @@ import {
   createDefaultRuntimeSignals,
   type RuntimeSignals,
 } from '../../../../server/core/domain/knowledge/runtime-signals-schema.js'
+import {warnSidecarFailure} from '../../../../server/core/domain/knowledge/sidecar-logging.js'
 import {loadSources, type SearchOrigin} from '../../../../server/core/domain/source/source-schema.js'
 import {isArchiveStub, isDerivedArtifact} from '../../../../server/infra/context-tree/derived-artifact.js'
 import {
@@ -1200,10 +1201,17 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
 
     try {
       await store.batchUpdate(updates)
-    } catch {
-      // Best-effort — sidecar failure must not break the flush. Markdown is
-      // still canonical during phase 3; the sidecar will re-sync on the next
-      // bump for these paths.
+    } catch (error) {
+      // Best-effort — sidecar failure must not break the flush. The sidecar
+      // will re-sync on the next bump for these paths; the warn makes the
+      // fail-open visible to operators.
+      warnSidecarFailure(
+        this.logger,
+        'search-knowledge-flush',
+        'batchUpdate',
+        `${updates.size} path(s)`,
+        error,
+      )
     }
   }
 

--- a/src/agent/infra/tools/implementations/search-knowledge-service.ts
+++ b/src/agent/infra/tools/implementations/search-knowledge-service.ts
@@ -17,13 +17,7 @@ import {
   SUMMARY_INDEX_FILE,
 } from '../../../../server/constants.js'
 import {
-  type FrontmatterScoring,
-  parseFrontmatterScoring,
-  updateScoringInContent,
-} from '../../../../server/core/domain/knowledge/markdown-writer.js'
-import {
   applyDecay,
-  applyDefaultScoring,
   compoundScore,
   determineTier,
   recordAccessHits,
@@ -190,7 +184,6 @@ interface IndexedDocument {
   /** Path to .overview.md sibling, if it exists at index-build time */
   overviewPath?: string
   path: string
-  scoring: FrontmatterScoring
   /** Path used in the merged symbol tree (namespaced for shared sources) */
   symbolPath: string
   title: string
@@ -199,7 +192,6 @@ interface IndexedDocument {
 interface SummarySource {
   excerpt: string
   path: string
-  scoring?: SummaryDocLike['scoring']
 }
 
 interface CachedIndex {
@@ -293,7 +285,6 @@ function getSummarySource(
     return {
       excerpt: summaryDoc.excerpt ?? '',
       path: summaryDoc.path,
-      scoring: summaryDoc.scoring,
     }
   }
 
@@ -304,7 +295,6 @@ function getSummarySource(
     return {
       excerpt: extractExcerpt(contextDoc.content, contextDoc.title),
       path: contextDoc.path,
-      scoring: contextDoc.scoring,
     }
   }
 
@@ -549,7 +539,6 @@ async function indexOriginDocuments(
       const fullPath = join(origin.contextTreeRoot, filePath)
       const {content} = await fileSystem.readFile(fullPath)
       const title = extractTitle(content, filePath.replace(/\.md$/, '').split('/').pop() || filePath)
-      const scoring = parseFrontmatterScoring(content) ?? applyDefaultScoring()
       const qualifiedId = `${origin.originKey}::${filePath}`
       const symbolPath = getSymbolPath(origin, filePath)
 
@@ -566,7 +555,6 @@ async function indexOriginDocuments(
         originKey: origin.originKey,
         ...(overviewPath !== undefined && {overviewPath}),
         path: filePath,
-        scoring,
         symbolPath,
         title,
       }
@@ -585,17 +573,10 @@ async function indexOriginDocuments(
       const fm = parseSummaryFrontmatter(content)
       if (!fm) return null
 
-      // Persist frontmatter scoring so propagateScoresToParents can apply hotness/tier boosts
-      const frontmatter = parseFrontmatterScoring(content)
-      const scoring = frontmatter
-        ? {importance: frontmatter.importance, maturity: frontmatter.maturity, recency: frontmatter.recency}
-        : undefined
-
       return {
         condensationOrder: fm.condensation_order,
         excerpt: stripMarkdownFrontmatter(content).slice(0, 400),
         path: getSymbolPath(origin, filePath),
-        scoring,
         tokenCount: fm.token_count,
       } satisfies SummaryDocLike
     } catch {
@@ -917,11 +898,18 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
   }
 
   /**
-   * Flush accumulated access hits to disk by updating frontmatter scoring.
-   * Called during index rebuild to batch writes and avoid write amplification.
-   * Best-effort: errors are swallowed per file.
+   * Flush accumulated access hits to the runtime-signal sidecar.
+   *
+   * Post-commit-5 this no longer writes to markdown — ranking signals
+   * live exclusively in the sidecar. The `contextTreePath` parameter is
+   * retained for signature compatibility with the cache-invalidation
+   * callback but is no longer used.
+   *
+   * Returns `true` when hits were processed so the caller knows to
+   * refresh file mtimes (historical contract); with markdown writes
+   * removed the refresh is harmless but kept for symmetry.
    */
-  async flushAccessHits(contextTreePath: string): Promise<boolean> {
+  async flushAccessHits(_contextTreePath: string): Promise<boolean> {
     if (this.pendingAccessHits.size === 0) {
       return false
     }
@@ -929,27 +917,6 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
     const hits = new Map(this.pendingAccessHits)
     this.pendingAccessHits.clear()
 
-    const tasks = [...hits.entries()].map(async ([relPath, count]) => {
-      try {
-        const fullPath = join(contextTreePath, relPath)
-        const {content} = await this.fileSystem.readFile(fullPath)
-        const scoring = parseFrontmatterScoring(content) ?? applyDefaultScoring()
-        const updated = recordAccessHits(scoring, count)
-        const newTier = determineTier(
-          updated.importance ?? 50,
-          (updated.maturity ?? 'draft') as 'core' | 'draft' | 'validated',
-        )
-        const finalScoring: FrontmatterScoring = {...updated, maturity: newTier}
-        const newContent = updateScoringInContent(content, finalScoring)
-        await this.fileSystem.writeFile(fullPath, newContent)
-      } catch {
-        // Best-effort — swallow per-file errors
-      }
-    })
-    await Promise.allSettled(tasks)
-
-    // Dual-write to the runtime-signal sidecar. Markdown remains canonical in
-    // phase 3; sidecar failures must not affect the flush outcome.
     await this.mirrorHitsToSignalStore(hits)
     return true
   }

--- a/src/agent/infra/tools/implementations/search-knowledge-service.ts
+++ b/src/agent/infra/tools/implementations/search-knowledge-service.ts
@@ -5,6 +5,7 @@ import {removeStopwords} from 'stopword'
 
 import type {IRuntimeSignalStore} from '../../../../server/core/interfaces/storage/i-runtime-signal-store.js'
 import type {IFileSystem} from '../../../core/interfaces/i-file-system.js'
+import type {ILogger} from '../../../core/interfaces/i-logger.js'
 import type {ISearchKnowledgeService, SearchKnowledgeResult} from '../../sandbox/tools-sdk.js'
 
 import {
@@ -27,7 +28,10 @@ import {
   determineTier,
   recordAccessHits,
 } from '../../../../server/core/domain/knowledge/memory-scoring.js'
-import {type RuntimeSignals} from '../../../../server/core/domain/knowledge/runtime-signals-schema.js'
+import {
+  createDefaultRuntimeSignals,
+  type RuntimeSignals,
+} from '../../../../server/core/domain/knowledge/runtime-signals-schema.js'
 import {loadSources, type SearchOrigin} from '../../../../server/core/domain/source/source-schema.js'
 import {isArchiveStub, isDerivedArtifact} from '../../../../server/infra/context-tree/derived-artifact.js'
 import {
@@ -108,6 +112,7 @@ function propagateScoresToParents(
   symbolTree: MemorySymbolTree,
   summaryMap: Map<string, SummaryDocLike>,
   symbolPathDocMap: Map<string, IndexedDocument>,
+  signalsByPath: Map<string, RuntimeSignals>,
   propagationFactor = 0.55,
 ): SearchKnowledgeResult['results'] {
   const boosts = new Map<string, number>()
@@ -132,11 +137,15 @@ function propagateScoresToParents(
     const doc = getSummarySource(parentPath, summaryMap, symbolPathDocMap)
     if (!doc) continue
 
-    // Propagate the strongest child BM25 signal upward, then apply the parent
-    // summary's own scoring exactly once. This avoids double-counting lifecycle
-    // weights that are already baked into child compound scores.
-    const finalScore = doc.scoring
-      ? compoundScore(score, doc.scoring.importance ?? 50, doc.scoring.recency ?? 0.5, doc.scoring.maturity ?? 'draft')
+    // Propagate the strongest child BM25 signal upward. Apply the parent
+    // summary's own scoring boost only when the sidecar has a concrete entry
+    // for this path — matches the pre-migration behaviour where summaries
+    // without scoring in their frontmatter were not boosted. Lookup uses the
+    // summary doc's file path (e.g. `auth/jwt/_index.md`) which matches the
+    // sidecar's relPath key scheme.
+    const sidecarSignals = signalsByPath.get(doc.path)
+    const finalScore = sidecarSignals
+      ? compoundScore(score, sidecarSignals)
       : score
 
     boosted.push({
@@ -232,6 +241,12 @@ export interface SearchKnowledgeServiceConfig {
   baseDirectory?: string
   /** Cache TTL in milliseconds (defaults to 5000) */
   cacheTtlMs?: number
+  /**
+   * Optional logger. When provided, sidecar read failures on the ranking
+   * path emit a `warn` so the fail-open degradation is observable rather
+   * than silent.
+   */
+  logger?: ILogger
   /**
    * Sidecar store for runtime ranking signals. When provided, `flushAccessHits`
    * mirrors its importance/accessCount/maturity bumps to the store alongside
@@ -885,6 +900,7 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
   private readonly baseDirectory: string
   private readonly cacheTtlMs: number
   private readonly fileSystem: IFileSystem
+  private readonly logger?: ILogger
   private readonly pendingAccessHits: Map<string, number> = new Map()
   private readonly runtimeSignalStore?: IRuntimeSignalStore
   private readonly state: IndexState = {
@@ -896,6 +912,7 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
     this.fileSystem = fileSystem
     this.baseDirectory = config.baseDirectory ?? process.cwd()
     this.cacheTtlMs = config.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS
+    this.logger = config.logger
     this.runtimeSignalStore = config.runtimeSignalStore
   }
 
@@ -985,6 +1002,14 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
       return this.buildOverviewResult(symbolTree, referenceIndex, normalizedScope, options.overviewDepth)
     }
 
+    // Load the runtime-signal sidecar map for the specific paths this query
+    // touches: all document paths in the index plus their summary siblings.
+    // This is O(k) per search instead of O(all entries). Entries are present
+    // only for paths with stored signals — callers use `.has()` to distinguish
+    // missing from default, and `.get(path) ?? defaults` for ergonomic
+    // default-on-miss. On sidecar failure, degrade to BM25-only ranking.
+    const signalsByPath = await this.loadSignalsByPath(documentMap, summaryMap)
+
     // Symbolic path resolution: try path-based query first
     if (isPathLikeQuery(query, symbolTree)) {
       const symbolicResult = this.trySymbolicSearch(
@@ -997,6 +1022,7 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
         pathToDocumentId,
         summaryMap,
         symbolPathDocMap,
+        signalsByPath,
         options,
       )
 
@@ -1027,6 +1053,7 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
       referenceIndex,
       summaryMap,
       symbolPathDocMap,
+      signalsByPath,
       options,
     )
 
@@ -1043,6 +1070,7 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
         referenceIndex,
         summaryMap,
         symbolPathDocMap,
+        signalsByPath,
         options,
       )
     }
@@ -1145,6 +1173,35 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
   }
 
   /**
+   * Load the runtime-signal map for this search via `getMany`, limiting the
+   * request to paths that this search could possibly rank: every indexed
+   * document plus every summary sibling (parent-propagation can touch any
+   * summary). The returned map contains entries only for paths with stored
+   * signals; callers use `.has()` / `.get()` to distinguish missing from
+   * default. Returns an empty map on sidecar failure so ranking degrades to
+   * BM25 alone rather than erroring out mid-query.
+   */
+  private async loadSignalsByPath(
+    documentMap: Map<string, IndexedDocument>,
+    summaryMap: Map<string, SummaryDocLike>,
+  ): Promise<Map<string, RuntimeSignals>> {
+    if (!this.runtimeSignalStore) return new Map()
+
+    const paths = new Set<string>()
+    for (const doc of documentMap.values()) paths.add(doc.path)
+    for (const summary of summaryMap.values()) paths.add(summary.path)
+
+    try {
+      return await this.runtimeSignalStore.getMany([...paths])
+    } catch (error) {
+      this.logger?.warn(
+        `SearchKnowledgeService: sidecar getMany failed, falling back to BM25-only ranking: ${error instanceof Error ? error.message : String(error)}`,
+      )
+      return new Map()
+    }
+  }
+
+  /**
    * Mirror a batch of access-hit bumps into the runtime-signal sidecar.
    *
    * Matches the markdown flush semantics above:
@@ -1201,6 +1258,7 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
     referenceIndex: ReferenceIndex,
     summaryMap: Map<string, SummaryDocLike>,
     symbolPathDocMap: Map<string, IndexedDocument>,
+    signalsByPath: Map<string, RuntimeSignals>,
     options?: SearchOptions,
   ): SearchKnowledgeResult {
     const filteredQuery = filterStopWords(query)
@@ -1243,14 +1301,19 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
     // Normalize BM25 scores to [0, 1) then blend with importance + recency via compound scoring.
     // Decay is computed lazily from file mtime — no disk writes during search.
     // Local results get a configurable score boost to prefer local knowledge over shared.
+    //
+    // Runtime signals (importance / recency / maturity) come from the sidecar
+    // `signalsByPath` map. Paths with no sidecar entry fall back to defaults —
+    // matches the pre-migration behaviour where missing-frontmatter files used
+    // applyDefaultScoring().
     const now = Date.now()
     const searchResults = rawResults.map((r) => {
       const doc = documentMap.get(r.id)
-      const scoring = doc?.scoring ?? applyDefaultScoring()
+      const signals = (doc && signalsByPath.get(doc.path)) ?? createDefaultRuntimeSignals()
       const daysSince = doc ? Math.max(0, (now - doc.mtime) / 86_400_000) : 0
-      const decayed = applyDecay(scoring, daysSince)
+      const decayed = applyDecay(signals, daysSince)
       const bm25 = normalizeScore(r.score)
-      let finalScore = compoundScore(bm25, decayed.importance ?? 50, decayed.recency ?? 1, decayed.maturity ?? 'draft')
+      let finalScore = compoundScore(bm25, decayed)
 
       // Local score boost: prefer local results over shared when scores are close
       if (doc?.origin === 'local') {
@@ -1336,10 +1399,17 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
           if (options?.minMaturity && enriched.symbolKind) {
             const docMaturity =
               enriched.symbolKind === 'summary'
-                ? (getSummarySource(enriched.path, summaryMap, symbolPathDocMap)?.scoring?.maturity ??
-                  symbolTree.symbolMap.get(enriched.path)?.metadata.maturity ??
+                ? (() => {
+                    const summaryDoc = getSummarySource(enriched.path, summaryMap, symbolPathDocMap)
+                    return (
+                      (summaryDoc && signalsByPath.get(summaryDoc.path)?.maturity) ??
+                      symbolTree.symbolMap.get(enriched.path)?.metadata.maturity ??
+                      'draft'
+                    )
+                  })()
+                : (signalsByPath.get(document.path)?.maturity ??
+                  symbolTree.symbolMap.get(document.symbolPath)?.metadata.maturity ??
                   'draft')
-                : (symbolTree.symbolMap.get(document.symbolPath)?.metadata.maturity ?? 'draft')
             if ((MATURITY_TIER_RANK[docMaturity] ?? 1) < (MATURITY_TIER_RANK[options.minMaturity] ?? 1)) {
               continue
             }
@@ -1355,7 +1425,13 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
     }
 
     // Propagate scores upward to parent domain/topic nodes (hierarchical retrieval)
-    const propagated = propagateScoresToParents(propagationInputs, symbolTree, summaryMap, symbolPathDocMap)
+    const propagated = propagateScoresToParents(
+      propagationInputs,
+      symbolTree,
+      summaryMap,
+      symbolPathDocMap,
+      signalsByPath,
+    )
     for (const p of propagated) {
       // Apply local score boost to propagated summaries so they stay competitive
       // with boosted direct BM25 hits (the boost was already applied to direct hits above)
@@ -1366,7 +1442,7 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
       if (options?.excludeKinds && p.symbolKind && options.excludeKinds.includes(p.symbolKind)) continue
       if (options?.minMaturity && p.symbolKind === 'summary') {
         const summaryDoc = getSummarySource(p.path, summaryMap, symbolPathDocMap)
-        const summaryMaturity = summaryDoc?.scoring?.maturity ?? 'draft'
+        const summaryMaturity = (summaryDoc && signalsByPath.get(summaryDoc.path)?.maturity) ?? 'draft'
         if ((MATURITY_TIER_RANK[summaryMaturity] ?? 1) < (MATURITY_TIER_RANK[options.minMaturity] ?? 1)) continue
       }
 
@@ -1413,6 +1489,7 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
     pathToDocumentId: Map<string, string>,
     summaryMap: Map<string, SummaryDocLike>,
     symbolPathDocMap: Map<string, IndexedDocument>,
+    signalsByPath: Map<string, RuntimeSignals>,
     options?: SearchOptions,
   ): null | SearchKnowledgeResult {
     const pathMatches = matchMemoryPath(symbolTree, query.split(/\s+/)[0].includes('/') ? query.split(/\s+/)[0] : query)
@@ -1467,6 +1544,7 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
         referenceIndex,
         summaryMap,
         symbolPathDocMap,
+        signalsByPath,
         options,
       )
     }

--- a/src/agent/infra/tools/implementations/search-knowledge-tool.ts
+++ b/src/agent/infra/tools/implementations/search-knowledge-tool.ts
@@ -1,5 +1,6 @@
 import {z} from 'zod'
 
+import type {IRuntimeSignalStore} from '../../../../server/core/interfaces/storage/i-runtime-signal-store.js'
 import type {Tool, ToolExecutionContext} from '../../../core/domain/tools/types.js'
 import type {IFileSystem} from '../../../core/interfaces/i-file-system.js'
 
@@ -60,6 +61,7 @@ const SearchKnowledgeInputSchema = z
 export interface SearchKnowledgeToolConfig {
   baseDirectory?: string
   cacheTtlMs?: number
+  runtimeSignalStore?: IRuntimeSignalStore
 }
 
 /**

--- a/src/agent/infra/tools/tool-provider.ts
+++ b/src/agent/infra/tools/tool-provider.ts
@@ -43,6 +43,7 @@ export class ToolProvider implements IToolProvider {
       maxContextTokens: 0,
       memoryManager: 0,
       processService: 0,
+      runtimeSignalStore: 0,
       sandboxService: 0,
       swarmCoordinator: 0,
       todoStorage: 0,

--- a/src/agent/infra/tools/tool-registry.ts
+++ b/src/agent/infra/tools/tool-registry.ts
@@ -291,7 +291,9 @@ export const TOOL_REGISTRY: Record<KnownTool, ToolRegistryEntry> = {
   [ToolName.SEARCH_KNOWLEDGE]: {
     descriptionFile: 'search_knowledge',
     factory: (services) =>
-      createSearchKnowledgeTool(getRequiredService(services.fileSystemService, 'fileSystemService')),
+      createSearchKnowledgeTool(getRequiredService(services.fileSystemService, 'fileSystemService'), {
+        runtimeSignalStore: services.runtimeSignalStore,
+      }),
     markers: [ToolMarker.ContextBuilding, ToolMarker.Discovery],
     requiredServices: ['fileSystemService'],
   },

--- a/src/agent/infra/tools/tool-registry.ts
+++ b/src/agent/infra/tools/tool-registry.ts
@@ -218,8 +218,8 @@ export const TOOL_REGISTRY: Record<KnownTool, ToolRegistryEntry> = {
 
   [ToolName.CURATE]: {
     descriptionFile: 'curate',
-    factory: ({ abstractQueue, environmentContext, runtimeSignalStore }) =>
-      createCurateTool(environmentContext?.workingDirectory, abstractQueue, runtimeSignalStore),
+    factory: ({ abstractQueue, environmentContext, logger, runtimeSignalStore }) =>
+      createCurateTool(environmentContext?.workingDirectory, abstractQueue, runtimeSignalStore, logger),
     markers: [ToolMarker.ContextBuilding, ToolMarker.Modification],
     outputGuidance: 'curate',
     requiredServices: [],

--- a/src/agent/infra/tools/tool-registry.ts
+++ b/src/agent/infra/tools/tool-registry.ts
@@ -1,3 +1,4 @@
+import type { IRuntimeSignalStore } from '../../../server/core/interfaces/storage/i-runtime-signal-store.js'
 import type { EnvironmentContext } from '../../core/domain/environment/types.js'
 import type { KnownTool } from '../../core/domain/tools/constants.js'
 import type { Tool } from '../../core/domain/tools/types.js'
@@ -70,6 +71,13 @@ export interface ToolServices {
 
   /** Process service for command execution */
   processService?: IProcessService
+
+  /**
+   * Sidecar store for per-machine ranking signals. When provided, curate and
+   * search tools mirror their scoring writes here alongside the markdown
+   * writes. Phase 3 of the runtime-signals migration.
+   */
+  runtimeSignalStore?: IRuntimeSignalStore
 
   /** Sandbox service for code execution */
   sandboxService?: ISandboxService
@@ -166,7 +174,7 @@ export const TOOL_REGISTRY: Record<KnownTool, ToolRegistryEntry> = {
 
   [ToolName.CODE_EXEC]: {
     descriptionFile: 'code_exec',
-    factory({ abstractQueue, environmentContext, fileSystemService, sandboxService, swarmCoordinator }) {
+    factory({ abstractQueue, environmentContext, fileSystemService, runtimeSignalStore, sandboxService, swarmCoordinator }) {
       const sandbox = getRequiredService(sandboxService, 'sandboxService')
 
       // Inject file system service into sandbox for Tools SDK
@@ -176,13 +184,19 @@ export const TOOL_REGISTRY: Record<KnownTool, ToolRegistryEntry> = {
 
       // Inject search knowledge service into sandbox for Tools SDK
       if (fileSystemService && sandbox.setSearchKnowledgeService) {
-        const searchKnowledgeService = createSearchKnowledgeService(fileSystemService)
+        const searchKnowledgeService = createSearchKnowledgeService(fileSystemService, {
+          runtimeSignalStore,
+        })
         sandbox.setSearchKnowledgeService(searchKnowledgeService)
       }
 
       // Inject curate service into sandbox for Tools SDK
       if (sandbox.setCurateService) {
-        const curateService = createCurateService(environmentContext?.workingDirectory, abstractQueue)
+        const curateService = createCurateService(
+          environmentContext?.workingDirectory,
+          abstractQueue,
+          runtimeSignalStore,
+        )
         sandbox.setCurateService(curateService)
       }
 
@@ -204,8 +218,8 @@ export const TOOL_REGISTRY: Record<KnownTool, ToolRegistryEntry> = {
 
   [ToolName.CURATE]: {
     descriptionFile: 'curate',
-    factory: ({ abstractQueue, environmentContext }) =>
-      createCurateTool(environmentContext?.workingDirectory, abstractQueue),
+    factory: ({ abstractQueue, environmentContext, runtimeSignalStore }) =>
+      createCurateTool(environmentContext?.workingDirectory, abstractQueue, runtimeSignalStore),
     markers: [ToolMarker.ContextBuilding, ToolMarker.Modification],
     outputGuidance: 'curate',
     requiredServices: [],
@@ -213,8 +227,11 @@ export const TOOL_REGISTRY: Record<KnownTool, ToolRegistryEntry> = {
 
   [ToolName.EXPAND_KNOWLEDGE]: {
     descriptionFile: 'expand_knowledge',
-    factory: ({ environmentContext }) =>
-      createExpandKnowledgeTool({ baseDirectory: environmentContext?.workingDirectory }),
+    factory: ({ environmentContext, runtimeSignalStore }) =>
+      createExpandKnowledgeTool({
+        baseDirectory: environmentContext?.workingDirectory,
+        runtimeSignalStore,
+      }),
     markers: [ToolMarker.Discovery],
     requiredServices: [],
   },

--- a/src/oclif/commands/dream.ts
+++ b/src/oclif/commands/dream.ts
@@ -4,10 +4,16 @@ import {Command, Flags} from '@oclif/core'
 import {randomUUID} from 'node:crypto'
 import {join} from 'node:path'
 
+import type {ILogger} from '../../agent/core/interfaces/i-logger.js'
+
+import {NoOpLogger} from '../../agent/core/interfaces/i-logger.js'
+import {ConsoleLogger} from '../../agent/infra/logger/console-logger.js'
+import {FileKeyStorage} from '../../agent/infra/storage/file-key-storage.js'
 import {BRV_DIR, CONTEXT_TREE_DIR} from '../../server/constants.js'
 import {type ProviderConfigResponse, TransportStateEventNames} from '../../server/core/domain/transport/schemas.js'
 import {FileContextTreeArchiveService} from '../../server/infra/context-tree/file-context-tree-archive-service.js'
 import {FileContextTreeManifestService} from '../../server/infra/context-tree/file-context-tree-manifest-service.js'
+import {RuntimeSignalStore} from '../../server/infra/context-tree/runtime-signal-store.js'
 import {DreamLogStore} from '../../server/infra/dream/dream-log-store.js'
 import {DreamStateService} from '../../server/infra/dream/dream-state-service.js'
 import {undoLastDream} from '../../server/infra/dream/dream-undo.js'
@@ -26,6 +32,34 @@ import {
 } from '../lib/daemon-client.js'
 import {writeJsonResponse} from '../lib/json-response.js'
 import {DEFAULT_TIMEOUT_SECONDS, MAX_TIMEOUT_SECONDS, MIN_TIMEOUT_SECONDS, waitForTaskCompletion} from '../lib/task-client.js'
+
+/** Build the dep bundle for `undoLastDream` on the CLI-direct path; exported for wiring tests. */
+export async function buildUndoDeps(
+  projectRoot: string,
+  logger: ILogger = new ConsoleLogger(),
+): Promise<Parameters<typeof undoLastDream>[0]> {
+  const brvDir = join(projectRoot, BRV_DIR)
+  const contextTreeDir = join(brvDir, CONTEXT_TREE_DIR)
+  const projectDataDir = getProjectDataDir(projectRoot)
+
+  // Runtime-signal sidecar — keeps archive/restore from leaking orphan
+  // signal entries on the CLI-direct `brv dream --undo` path. Mirrors the
+  // daemon wiring in agent-process.ts.
+  const keyStorage = new FileKeyStorage({storageDir: projectDataDir})
+  await keyStorage.initialize()
+  const runtimeSignalStore = new RuntimeSignalStore(keyStorage, logger)
+
+  return {
+    archiveService: new FileContextTreeArchiveService(runtimeSignalStore),
+    contextTreeDir,
+    curateLogStore: new FileCurateLogStore({baseDir: projectDataDir}),
+    dreamLogStore: new DreamLogStore({baseDir: brvDir}),
+    dreamStateService: new DreamStateService({baseDir: brvDir}),
+    manifestService: new FileContextTreeManifestService({baseDirectory: projectRoot, runtimeSignalStore}),
+    projectRoot,
+    reviewBackupStore: new FileReviewBackupStore(brvDir),
+  }
+}
 
 export default class Dream extends Command {
   public static description = 'Run background memory consolidation on the context tree'
@@ -149,21 +183,13 @@ export default class Dream extends Command {
 
   private async runUndo(format: 'json' | 'text'): Promise<void> {
     const projectRoot = resolveProject()?.projectRoot ?? process.cwd()
-    const brvDir = join(projectRoot, BRV_DIR)
-    const contextTreeDir = join(brvDir, CONTEXT_TREE_DIR)
-    const projectDataDir = getProjectDataDir(projectRoot)
+    // JSON mode: route sidecar warnings to a no-op so structured stdout
+    // is never paired with stderr noise that breaks downstream parsers.
+    const logger: ILogger = format === 'json' ? new NoOpLogger() : new ConsoleLogger()
+    const deps = await buildUndoDeps(projectRoot, logger)
 
     try {
-      const result = await undoLastDream({
-        archiveService: new FileContextTreeArchiveService(),
-        contextTreeDir,
-        curateLogStore: new FileCurateLogStore({baseDir: projectDataDir}),
-        dreamLogStore: new DreamLogStore({baseDir: brvDir}),
-        dreamStateService: new DreamStateService({baseDir: brvDir}),
-        manifestService: new FileContextTreeManifestService({baseDirectory: projectRoot}),
-        projectRoot,
-        reviewBackupStore: new FileReviewBackupStore(brvDir),
-      })
+      const result = await undoLastDream(deps)
 
       if (format === 'json') {
         writeJsonResponse({command: 'dream', data: {...result, status: 'undone'}, success: true})

--- a/src/server/core/domain/knowledge/markdown-writer.ts
+++ b/src/server/core/domain/knowledge/markdown-writer.ts
@@ -1,6 +1,5 @@
 import {dump as yamlDump, load as yamlLoad} from 'js-yaml'
 
-import { determineTier, mergeScoring as mergeScoringFn } from './memory-scoring.js'
 import { normalizeRelationPath, parseRelations } from './relation-parser.js'
 
 export interface RawConcept {
@@ -30,16 +29,14 @@ export interface Fact {
 }
 
 /**
- * Scoring metadata for knowledge lifecycle management (FinMem-inspired).
- * Stored in YAML frontmatter alongside existing fields.
+ * Content timestamps kept in markdown frontmatter. `createdAt` is the
+ * immutable creation time; `updatedAt` reflects the last content
+ * modification. Runtime ranking signals (importance, recency, maturity,
+ * accessCount, updateCount) live in the sidecar — see
+ * `features/runtime-signals/plan.md`.
  */
-export interface FrontmatterScoring {
-  accessCount?: number
+export interface ContextTimestamps {
   createdAt?: string
-  importance?: number
-  maturity?: 'core' | 'draft' | 'validated'
-  recency?: number
-  updateCount?: number
   updatedAt?: string
 }
 
@@ -51,24 +48,29 @@ export interface ContextData {
   rawConcept?: RawConcept
   reason?: string
   relations?: string[]
-  scoring?: FrontmatterScoring
   snippets: string[]
   summary?: string
   tags: string[]
+  timestamps?: ContextTimestamps
 }
 
+/**
+ * Fields carried in the markdown frontmatter block. Post-commit-5 this
+ * covers only semantic content and content timestamps; runtime ranking
+ * signals live in the sidecar.
+ *
+ * `parseFrontmatter` may return instances that also carry legacy fields
+ * (importance, recency, maturity, accessCount, updateCount) on files
+ * written before the migration. Those are silently ignored — the typed
+ * shape only exposes what commit 5 and later writers produce.
+ */
 interface Frontmatter {
-  accessCount?: number
   createdAt?: string
-  importance?: number
   keywords: string[]
-  maturity?: 'core' | 'draft' | 'validated'
-  recency?: number
   related: string[]
   summary?: string
   tags: string[]
   title?: string
-  updateCount?: number
   updatedAt?: string
 }
 
@@ -79,19 +81,23 @@ interface ParsedFrontmatter {
 
 /**
  * Generate YAML frontmatter block from context data.
- * Only includes fields that have values.
+ *
+ * Emits only semantic fields and content timestamps. Runtime ranking
+ * signals (importance, recency, maturity, accessCount, updateCount) are
+ * not written — they live in the sidecar store since commit 5 of the
+ * runtime-signals migration.
  */
 function generateFrontmatter(
   title: string,
   relations?: string[],
   tags: string[] = [],
   keywords: string[] = [],
-  scoring?: FrontmatterScoring,
+  timestamps?: ContextTimestamps,
   summary?: string,
 ): string {
   const normalizedRelations = (relations || []).map(rel => normalizeRelationPath(rel))
 
-  const fm: Record<string, number | string | string[]> = {}
+  const fm: Record<string, string | string[]> = {}
 
   if (title) {
     fm.title = title
@@ -109,35 +115,12 @@ function generateFrontmatter(
 
   fm.keywords = keywords
 
-  // Scoring fields — only emit when present (backward compatible)
-  if (scoring) {
-    if (scoring.importance !== undefined) {
-      fm.importance = Math.round(scoring.importance * 100) / 100
-    }
+  if (timestamps?.createdAt) {
+    fm.createdAt = timestamps.createdAt
+  }
 
-    if (scoring.recency !== undefined) {
-      fm.recency = Math.round(scoring.recency * 1000) / 1000
-    }
-
-    if (scoring.maturity) {
-      fm.maturity = scoring.maturity
-    }
-
-    if (scoring.accessCount !== undefined && scoring.accessCount > 0) {
-      fm.accessCount = scoring.accessCount
-    }
-
-    if (scoring.updateCount !== undefined && scoring.updateCount > 0) {
-      fm.updateCount = scoring.updateCount
-    }
-
-    if (scoring.createdAt) {
-      fm.createdAt = scoring.createdAt
-    }
-
-    if (scoring.updatedAt) {
-      fm.updatedAt = scoring.updatedAt
-    }
+  if (timestamps?.updatedAt) {
+    fm.updatedAt = timestamps.updatedAt
   }
 
   // Always generate frontmatter since tags and keywords are required
@@ -188,33 +171,17 @@ function parseFrontmatter(content: string): null | ParsedFrontmatter {
       frontmatter.summary = parsed.summary
     }
 
-    // Scoring fields (backward compatible — absent in old files)
-    if (typeof parsed.importance === 'number') {
-      frontmatter.importance = parsed.importance
-    }
-
-    if (typeof parsed.recency === 'number') {
-      frontmatter.recency = parsed.recency
-    }
-
-    if (typeof parsed.accessCount === 'number') {
-      frontmatter.accessCount = parsed.accessCount
-    }
-
-    if (typeof parsed.updateCount === 'number') {
-      frontmatter.updateCount = parsed.updateCount
-    }
-
+    // Content timestamps (createdAt is immutable, updatedAt tracks real
+    // content modification). Pre-migration files may also carry legacy
+    // scoring fields (importance, recency, maturity, accessCount,
+    // updateCount) — those are silently ignored here; the runtime signals
+    // they represented now live in the sidecar.
     if (typeof parsed.createdAt === 'string') {
       frontmatter.createdAt = parsed.createdAt
     }
 
     if (typeof parsed.updatedAt === 'string') {
       frontmatter.updatedAt = parsed.updatedAt
-    }
-
-    if (parsed.maturity === 'draft' || parsed.maturity === 'validated' || parsed.maturity === 'core') {
-      frontmatter.maturity = parsed.maturity
     }
 
     return { body, frontmatter }
@@ -698,81 +665,38 @@ function mergeFacts(source?: Fact[], target?: Fact[]): Fact[] | undefined {
 }
 
 /**
- * Parse content extracting relations from either frontmatter or legacy @ format.
- * Returns parsed frontmatter metadata and the body content for further parsing.
+ * Extract the createdAt timestamp from a raw markdown file's frontmatter.
+ * Used by callers (e.g. curate UPDATE) that need to preserve the immutable
+ * creation time across a write without round-tripping through the full
+ * parsed-content shape.
  */
-/**
- * Extract scoring metadata from parsed frontmatter.
- * Returns defaults for missing fields.
- */
-export function extractScoring(fm: Frontmatter): FrontmatterScoring {
-  return {
-    accessCount: fm.accessCount ?? 0,
-    createdAt: fm.createdAt,
-    importance: fm.importance ?? 50,
-    maturity: fm.maturity ?? 'draft',
-    recency: fm.recency ?? 1,
-    updateCount: fm.updateCount ?? 0,
-    updatedAt: fm.updatedAt,
-  }
-}
-
-/**
- * Parse frontmatter from raw markdown content and return scoring metadata.
- * Exported for use by search-knowledge-service to extract scoring without
- * going through the full parseContent path.
- */
-export function parseFrontmatterScoring(content: string): FrontmatterScoring | undefined {
-  const parsed = parseFrontmatter(content)
-  if (!parsed) {
-    return undefined
-  }
-
-  return extractScoring(parsed.frontmatter)
-}
-
-/**
- * Replace scoring fields in existing markdown content without touching the body.
- * If no frontmatter exists, returns the original content unchanged.
- */
-export function updateScoringInContent(content: string, scoring: FrontmatterScoring): string {
-  const parsed = parseFrontmatter(content)
-  if (!parsed) {
-    return content
-  }
-
-  const { body, frontmatter } = parsed
-  const updatedFrontmatter = generateFrontmatter(
-    frontmatter.title ?? '',
-    frontmatter.related,
-    frontmatter.tags,
-    frontmatter.keywords,
-    scoring,
-    frontmatter.summary,
-  )
-
-  return updatedFrontmatter + body
+export function parseCreatedAt(content: string): string | undefined {
+  return parseFrontmatter(content)?.frontmatter.createdAt
 }
 
 function parseContentWithFrontmatter(content: string): {
   body: string
   keywords: string[]
   relations: string[]
-  scoring?: FrontmatterScoring
   summary?: string
   tags: string[]
+  timestamps?: ContextTimestamps
   title?: string
 } {
   const parsed = parseFrontmatter(content)
 
   if (parsed) {
+    const timestamps: ContextTimestamps = {}
+    if (parsed.frontmatter.createdAt) timestamps.createdAt = parsed.frontmatter.createdAt
+    if (parsed.frontmatter.updatedAt) timestamps.updatedAt = parsed.frontmatter.updatedAt
+
     return {
       body: parsed.body,
       keywords: parsed.frontmatter.keywords,
       relations: parsed.frontmatter.related,
-      scoring: extractScoring(parsed.frontmatter),
       summary: parsed.frontmatter.summary,
       tags: parsed.frontmatter.tags,
+      timestamps: Object.keys(timestamps).length > 0 ? timestamps : undefined,
       title: parsed.frontmatter.title,
     }
   }
@@ -791,7 +715,7 @@ export const MarkdownWriter = {
     const snippets = (data.snippets || []).filter(s => s && s.trim())
     const relations = data.relations || []
 
-    const frontmatter = generateFrontmatter(data.name, relations, data.tags, data.keywords, data.scoring, data.summary)
+    const frontmatter = generateFrontmatter(data.name, relations, data.tags, data.keywords, data.timestamps, data.summary)
     const reasonSection = generateReasonSection(data.reason)
     const rawConceptSection = generateRawConceptSection(data.rawConcept)
     const narrativeSection = generateNarrativeSection(data.narrative)
@@ -835,17 +759,10 @@ export const MarkdownWriter = {
     // reason: explicit override wins, then source (newer), then target (older)
     const mergedReason = reason ?? parseReasonSection(sourceParsed.body) ?? parseReasonSection(targetParsed.body)
 
-    // Merge scoring metadata (FinMem-inspired lifecycle)
-    const defaultScoring: FrontmatterScoring = { importance: 50, maturity: 'draft', recency: 1 }
-    let mergedScoringData: FrontmatterScoring | undefined
-    if (sourceParsed.scoring || targetParsed.scoring) {
-      const merged = mergeScoringFn(sourceParsed.scoring ?? defaultScoring, targetParsed.scoring ?? defaultScoring)
-      const recalculatedTier = determineTier(
-        merged.importance ?? 50,
-        (merged.maturity ?? 'draft') as 'core' | 'draft' | 'validated',
-      )
-      mergedScoringData = { ...merged, maturity: recalculatedTier }
-    }
+    // Merge timestamps: preserve the earliest createdAt and stamp a fresh
+    // updatedAt. Scoring signals (importance/recency/maturity/counts) are
+    // merged at the sidecar layer by the merge caller — not here.
+    const mergedTimestamps = mergeTimestamps(sourceParsed.timestamps, targetParsed.timestamps)
 
     const sourceRawConcept = parseRawConceptSection(sourceParsed.body)
     const targetRawConcept = parseRawConceptSection(targetParsed.body)
@@ -880,15 +797,15 @@ export const MarkdownWriter = {
       rawConcept: mergedRawConcept,
       reason: mergedReason,
       relations: mergedRelations,
-      scoring: mergedScoringData,
       snippets: mergedSnippets,
       summary: summary ?? sourceParsed.summary ?? targetParsed.summary,
       tags: mergedTags,
+      timestamps: mergedTimestamps,
     })
   },
 
   parseContent(content: string, name: string = ''): ContextData {
-    const { body, keywords, relations, scoring, summary, tags, title } = parseContentWithFrontmatter(content)
+    const { body, keywords, relations, summary, tags, timestamps, title } = parseContentWithFrontmatter(content)
 
     return {
       facts: parseFactsSection(body),
@@ -898,10 +815,31 @@ export const MarkdownWriter = {
       rawConcept: parseRawConceptSection(body),
       reason: parseReasonSection(body),
       relations,
-      scoring,
       snippets: extractSnippetsFromContent(body),
       summary,
       tags,
+      timestamps,
     }
   },
+}
+
+/**
+ * Merge two timestamp records: earliest createdAt, fresh updatedAt.
+ *
+ * Always stamps a fresh `updatedAt` — merge is a content modification, so
+ * the output always carries an updated timestamp regardless of input shape.
+ * `createdAt` only appears in the output when at least one input had it.
+ */
+function mergeTimestamps(a?: ContextTimestamps, b?: ContextTimestamps): ContextTimestamps {
+  const out: ContextTimestamps = {updatedAt: new Date().toISOString()}
+
+  const aCreated = a?.createdAt
+  const bCreated = b?.createdAt
+  if (aCreated && bCreated) {
+    out.createdAt = new Date(aCreated).getTime() <= new Date(bCreated).getTime() ? aCreated : bCreated
+  } else if (aCreated ?? bCreated) {
+    out.createdAt = aCreated ?? bCreated
+  }
+
+  return out
 }

--- a/src/server/core/domain/knowledge/memory-scoring.ts
+++ b/src/server/core/domain/knowledge/memory-scoring.ts
@@ -11,6 +11,7 @@
  */
 
 import type {FrontmatterScoring} from './markdown-writer.js'
+import type {RuntimeSignals} from './runtime-signals-schema.js'
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -67,40 +68,37 @@ export const TIER_BOOST: Record<string, number> = {
  * then applies a tier-based boost.
  *
  * @param bm25Normalized - Normalized BM25 score in [0, 1)
- * @param importance - Importance score in [0, 100]
- * @param recency - Recency score in [0, 1]
- * @param maturity - Maturity tier ('draft' | 'validated' | 'core')
+ * @param signals - RuntimeSignals snapshot (importance, recency, maturity)
  * @returns Compound score (typically in [0, ~1.15])
  */
-export function compoundScore(bm25Normalized: number, importance: number, recency: number, maturity: string): number {
-  const normalizedImportance = Math.min(importance, 100) / 100
-  const base = W_RELEVANCE * bm25Normalized + W_IMPORTANCE * normalizedImportance + W_RECENCY * recency
-  const boost = TIER_BOOST[maturity] ?? TIER_BOOST.draft
+export function compoundScore(bm25Normalized: number, signals: RuntimeSignals): number {
+  const normalizedImportance = Math.min(signals.importance, 100) / 100
+  const base = W_RELEVANCE * bm25Normalized + W_IMPORTANCE * normalizedImportance + W_RECENCY * signals.recency
+  const boost = TIER_BOOST[signals.maturity] ?? TIER_BOOST.draft
 
   return base * boost
 }
 
 /**
- * Apply time-based exponential decay to scoring fields.
+ * Apply time-based exponential decay to a signals snapshot.
  *
  * Recency decays as exp(-days / DECAY_RECENCY_FACTOR).
  * Importance decays as importance * DECAY_IMPORTANCE_FACTOR^days.
  *
- * @param scoring - Current scoring state
+ * @param signals - Current RuntimeSignals snapshot
  * @param daysSinceLastUpdate - Days since the file was last updated
- * @returns New scoring with decayed values (original not mutated)
+ * @returns New signals with decayed values (original not mutated)
  */
-export function applyDecay(scoring: FrontmatterScoring, daysSinceLastUpdate: number): FrontmatterScoring {
+export function applyDecay(signals: RuntimeSignals, daysSinceLastUpdate: number): RuntimeSignals {
   if (daysSinceLastUpdate <= 0) {
-    return scoring
+    return signals
   }
 
-  const currentImportance = scoring.importance ?? 50
   const newRecency = Math.exp(-daysSinceLastUpdate / DECAY_RECENCY_FACTOR)
-  const newImportance = currentImportance * DECAY_IMPORTANCE_FACTOR ** daysSinceLastUpdate
+  const newImportance = signals.importance * DECAY_IMPORTANCE_FACTOR ** daysSinceLastUpdate
 
   return {
-    ...scoring,
+    ...signals,
     importance: Math.max(0, newImportance),
     recency: newRecency,
   }

--- a/src/server/core/domain/knowledge/memory-scoring.ts
+++ b/src/server/core/domain/knowledge/memory-scoring.ts
@@ -10,7 +10,6 @@
  * All functions are stateless and side-effect free.
  */
 
-import type {FrontmatterScoring} from './markdown-writer.js'
 import type {RuntimeSignals} from './runtime-signals-schema.js'
 
 // ---------------------------------------------------------------------------
@@ -143,114 +142,61 @@ export function determineTier(
 }
 
 /**
- * Record a search access hit on a knowledge file.
- *
- * Increments access count and adds an importance bonus.
- *
- * @param scoring - Current scoring state
- * @returns Updated scoring (original not mutated)
- */
-export function recordAccessHit(scoring: FrontmatterScoring): FrontmatterScoring {
-  const newAccessCount = (scoring.accessCount ?? 0) + 1
-  const newImportance = Math.min(100, (scoring.importance ?? 50) + ACCESS_IMPORTANCE_BONUS)
-
-  return {
-    ...scoring,
-    accessCount: newAccessCount,
-    importance: newImportance,
-  }
-}
-
-/**
  * Record multiple accumulated access hits at once.
  *
- * @param scoring - Current scoring state
- * @param hitCount - Number of hits to record
- * @returns Updated scoring (original not mutated)
+ * Increments accessCount by `hitCount` and importance by
+ * `ACCESS_IMPORTANCE_BONUS * hitCount` (capped at 100). Caller is
+ * responsible for recomputing maturity via `determineTier` if the
+ * importance delta may cross a hysteresis threshold.
  */
-export function recordAccessHits(scoring: FrontmatterScoring, hitCount: number): FrontmatterScoring {
+export function recordAccessHits(signals: RuntimeSignals, hitCount: number): RuntimeSignals {
   if (hitCount <= 0) {
-    return scoring
+    return signals
   }
 
-  const newAccessCount = (scoring.accessCount ?? 0) + hitCount
-  const newImportance = Math.min(100, (scoring.importance ?? 50) + ACCESS_IMPORTANCE_BONUS * hitCount)
-
   return {
-    ...scoring,
-    accessCount: newAccessCount,
-    importance: newImportance,
+    ...signals,
+    accessCount: signals.accessCount + hitCount,
+    importance: Math.min(100, signals.importance + ACCESS_IMPORTANCE_BONUS * hitCount),
   }
 }
 
 /**
  * Record a curate update on a knowledge file.
  *
- * Increments update count, adds an importance bonus, resets recency to 1.0,
- * and updates the timestamp.
- *
- * @param scoring - Current scoring state
- * @returns Updated scoring (original not mutated)
+ * Increments updateCount, adds an importance bonus, resets recency to 1.0.
+ * Caller is responsible for recomputing maturity via `determineTier`.
  */
-export function recordCurateUpdate(scoring: FrontmatterScoring): FrontmatterScoring {
-  const newUpdateCount = (scoring.updateCount ?? 0) + 1
-  const newImportance = Math.min(100, (scoring.importance ?? 50) + UPDATE_IMPORTANCE_BONUS)
-  const now = new Date().toISOString()
-
+export function recordCurateUpdate(signals: RuntimeSignals): RuntimeSignals {
   return {
-    ...scoring,
-    importance: newImportance,
+    ...signals,
+    importance: Math.min(100, signals.importance + UPDATE_IMPORTANCE_BONUS),
     recency: 1,
-    updateCount: newUpdateCount,
-    updatedAt: now,
+    updateCount: signals.updateCount + 1,
   }
 }
 
 /**
- * Return default scoring values for a new or unscored knowledge file.
- */
-export function applyDefaultScoring(): FrontmatterScoring {
-  const now = new Date().toISOString()
-
-  return {
-    accessCount: 0,
-    createdAt: now,
-    importance: 50,
-    maturity: 'draft',
-    recency: 1,
-    updateCount: 0,
-    updatedAt: now,
-  }
-}
-
-/**
- * Merge two scoring states during a MERGE operation.
+ * Merge two runtime-signal snapshots during a MERGE operation.
  *
  * Strategy:
  * - importance: max of both
  * - recency: max of both
  * - accessCount: sum
  * - updateCount: sum + 1 (for the merge itself)
- * - maturity: higher tier
- * - createdAt: earlier date
- * - updatedAt: current time
+ * - maturity: higher tier (caller may refine via `determineTier`)
  */
-export function mergeScoring(source: FrontmatterScoring, target: FrontmatterScoring): FrontmatterScoring {
+export function mergeScoring(source: RuntimeSignals, target: RuntimeSignals): RuntimeSignals {
   const tierRank: Record<string, number> = {core: 3, draft: 1, validated: 2}
-  const sourceRank = tierRank[source.maturity ?? 'draft'] ?? 1
-  const targetRank = tierRank[target.maturity ?? 'draft'] ?? 1
-  const higherTier = sourceRank >= targetRank ? (source.maturity ?? 'draft') : (target.maturity ?? 'draft')
-
-  const sourceCreated = source.createdAt ? new Date(source.createdAt).getTime() : Date.now()
-  const targetCreated = target.createdAt ? new Date(target.createdAt).getTime() : Date.now()
+  const sourceRank = tierRank[source.maturity] ?? 1
+  const targetRank = tierRank[target.maturity] ?? 1
+  const higherTier = sourceRank >= targetRank ? source.maturity : target.maturity
 
   return {
-    accessCount: (source.accessCount ?? 0) + (target.accessCount ?? 0),
-    createdAt: sourceCreated <= targetCreated ? source.createdAt : target.createdAt,
-    importance: Math.max(source.importance ?? 50, target.importance ?? 50),
-    maturity: higherTier as 'core' | 'draft' | 'validated',
-    recency: Math.max(source.recency ?? 1, target.recency ?? 1),
-    updateCount: (source.updateCount ?? 0) + (target.updateCount ?? 0) + 1,
-    updatedAt: new Date().toISOString(),
+    accessCount: source.accessCount + target.accessCount,
+    importance: Math.max(source.importance, target.importance),
+    maturity: higherTier,
+    recency: Math.max(source.recency, target.recency),
+    updateCount: source.updateCount + target.updateCount + 1,
   }
 }

--- a/src/server/core/domain/knowledge/runtime-signals-schema.ts
+++ b/src/server/core/domain/knowledge/runtime-signals-schema.ts
@@ -41,6 +41,23 @@ export const RuntimeSignalsSchema = z.object({
 export type MaturityTier = z.infer<typeof MaturityTierSchema>
 export type RuntimeSignals = z.infer<typeof RuntimeSignalsSchema>
 
+/**
+ * Frontmatter fields that remain in context-tree markdown after runtime
+ * signals are moved to the sidecar.
+ *
+ * `createdAt` is immutable. `updatedAt` reflects real content modifications
+ * (set by curate ADD/UPDATE and by MERGE); ranking updates never touch it.
+ */
+export interface SemanticFrontmatter {
+  createdAt?: string
+  keywords: string[]
+  related: string[]
+  summary?: string
+  tags: string[]
+  title?: string
+  updatedAt?: string
+}
+
 // ---------------------------------------------------------------------------
 // Factories
 // ---------------------------------------------------------------------------

--- a/src/server/core/domain/knowledge/runtime-signals-schema.ts
+++ b/src/server/core/domain/knowledge/runtime-signals-schema.ts
@@ -1,0 +1,61 @@
+/**
+ * Runtime signals — per-machine ranking fields that live in a sidecar store
+ * rather than in shared context-tree markdown frontmatter.
+ *
+ * These fields change on every query (access hit flush) and would otherwise
+ * dirty version control state and cause merge conflicts across teammates.
+ *
+ * Related: `features/runtime-signals/plan.md`
+ */
+
+import {z} from 'zod'
+
+// ---------------------------------------------------------------------------
+// Defaults (used when a path has no sidecar entry yet)
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_IMPORTANCE = 50
+export const DEFAULT_RECENCY = 1
+export const DEFAULT_MATURITY = 'draft' as const
+export const DEFAULT_ACCESS_COUNT = 0
+export const DEFAULT_UPDATE_COUNT = 0
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+export const MaturityTierSchema = z.enum(['core', 'draft', 'validated'])
+
+export const RuntimeSignalsSchema = z.object({
+  accessCount: z.number().int().nonnegative().default(DEFAULT_ACCESS_COUNT),
+  importance: z.number().min(0).max(100).default(DEFAULT_IMPORTANCE),
+  maturity: MaturityTierSchema.default(DEFAULT_MATURITY),
+  recency: z.number().min(0).max(1).default(DEFAULT_RECENCY),
+  updateCount: z.number().int().nonnegative().default(DEFAULT_UPDATE_COUNT),
+})
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type MaturityTier = z.infer<typeof MaturityTierSchema>
+export type RuntimeSignals = z.infer<typeof RuntimeSignalsSchema>
+
+// ---------------------------------------------------------------------------
+// Factories
+// ---------------------------------------------------------------------------
+
+/**
+ * Return a fresh RuntimeSignals with default values.
+ * Used by the sidecar store when a path has no entry yet, and by curate ADD
+ * when seeding a new knowledge file.
+ */
+export function createDefaultRuntimeSignals(): RuntimeSignals {
+  return {
+    accessCount: DEFAULT_ACCESS_COUNT,
+    importance: DEFAULT_IMPORTANCE,
+    maturity: DEFAULT_MATURITY,
+    recency: DEFAULT_RECENCY,
+    updateCount: DEFAULT_UPDATE_COUNT,
+  }
+}

--- a/src/server/core/domain/knowledge/sidecar-logging.ts
+++ b/src/server/core/domain/knowledge/sidecar-logging.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared helper for observing swallowed sidecar failures.
+ *
+ * Runtime-signals dual-write is best-effort: failures never break the
+ * caller's primary operation (markdown write, ranking read, etc.). After
+ * commit 5 the sidecar is the canonical source for ranking signals, so
+ * silent swallows hide real outages from operators. Every site that
+ * swallows a sidecar error should call this helper from inside the catch.
+ *
+ * The log message shape is stable across call sites so operators can
+ * grep for `sidecar <verb> failed` to surface every occurrence.
+ */
+
+import type {ILogger} from '../../../../agent/core/interfaces/i-logger.js'
+
+export function warnSidecarFailure(
+  logger: ILogger | undefined,
+  site: string,
+  verb: string,
+  target: string,
+  error: unknown,
+): void {
+  if (!logger) return
+  const message = error instanceof Error ? error.message : String(error)
+  logger.warn(`${site}: sidecar ${verb} failed for ${target}: ${message}`)
+}

--- a/src/server/core/interfaces/storage/i-runtime-signal-store.ts
+++ b/src/server/core/interfaces/storage/i-runtime-signal-store.ts
@@ -1,0 +1,116 @@
+/**
+ * Sidecar store for per-machine ranking signals.
+ *
+ * Keeps `importance`, `recency`, `maturity`, `accessCount`, `updateCount`
+ * out of context-tree markdown frontmatter so that query-time bumps don't
+ * dirty version-controlled files or create merge conflicts across teammates.
+ *
+ * Backed by `IKeyStorage` with composite keys of the form
+ * `["signals", ...pathSegments]`. The relative path is split on `/` so each
+ * segment satisfies the key-storage validation rules.
+ *
+ * All paths are relative to the context tree root (e.g. `auth/jwt-refresh.md`)
+ * using forward slashes, matching how paths flow through the rest of the
+ * knowledge pipeline.
+ *
+ * ## Concurrency guarantees
+ *
+ * Atomicity applies **within a single process**. Two `update` calls on the
+ * same path in the same process serialize via the per-key RWLock inside
+ * `FileKeyStorage` — no lost updates.
+ *
+ * Across processes (daemon + CLI), the per-process locks do not coordinate,
+ * so there is a narrow lost-update window when both processes race a read-
+ * modify-write on the same entry. For ranking signals this is acceptable:
+ * losing one access-hit bump has no correctness impact, only a tiny
+ * ranking drift that the next session self-heals. Do **not** rely on
+ * this interface for data where consistency is required (e.g. identifiers,
+ * counters that must never skip).
+ *
+ * ## Invariants NOT enforced here
+ *
+ * The store accepts any `RuntimeSignals` record that satisfies the schema —
+ * it does not enforce semantic invariants such as the importance ↔ maturity
+ * hysteresis defined by `determineTier`. Callers bumping `importance` must
+ * recompute `maturity` themselves (typically via `determineTier`) as part
+ * of the same updater callback.
+ */
+
+import type {RuntimeSignals} from '../../domain/knowledge/runtime-signals-schema.js'
+
+/**
+ * Pure function that derives the next signals from the current signals.
+ * Called inside an atomic read-modify-write critical section.
+ */
+export type RuntimeSignalsUpdater = (current: RuntimeSignals) => RuntimeSignals
+
+export interface IRuntimeSignalStore {
+  /**
+   * Apply an updater to many entries in parallel.
+   *
+   * Each entry is updated atomically via {@link update}; different paths run
+   * concurrently. Used by the access-hit flush path which accumulates bumps
+   * across many files between index rebuilds.
+   */
+  batchUpdate(updates: Map<string, RuntimeSignalsUpdater>): Promise<void>
+
+  /**
+   * Remove an entry. No-op if the entry does not exist.
+   *
+   * Called when a file is archived or deleted so the sidecar does not retain
+   * orphan records.
+   */
+  delete(relPath: string): Promise<void>
+
+  /**
+   * Read the signals for a path, returning defaults when no entry exists
+   * or when the stored record fails schema validation.
+   *
+   * Never throws and never returns null — callers can treat every path as
+   * having a signal record.
+   */
+  get(relPath: string): Promise<RuntimeSignals>
+
+  /**
+   * Bulk-read signals for a known set of paths.
+   *
+   * Preferred over {@link list} for ranking passes that operate on the
+   * top-N search results: O(N) where N is the number of requested paths,
+   * instead of O(all stored entries). The returned map always has an entry
+   * for every requested path — missing and corrupt records fall back to
+   * defaults, matching {@link get}.
+   */
+  getMany(relPaths: readonly string[]): Promise<Map<string, RuntimeSignals>>
+
+  /**
+   * Snapshot every stored entry as a Map keyed by relative path.
+   *
+   * Intended for administrative passes (diagnostics, orphan pruning) rather
+   * than per-query ranking — use {@link getMany} for that.
+   */
+  list(): Promise<Map<string, RuntimeSignals>>
+
+  /**
+   * Replace the signals for a path with the provided record.
+   *
+   * Used for seeding (curate ADD with defaults) and for operations that
+   * compute a full new record without needing the current value (merge,
+   * restore).
+   */
+  set(relPath: string, signals: RuntimeSignals): Promise<void>
+
+  /**
+   * Atomically read, transform, and write the signals for a path.
+   *
+   * The updater receives the current signals (defaults if none are stored)
+   * and must return the complete replacement record. Runs inside the
+   * per-key lock provided by {@link IKeyStorage.update}, so concurrent
+   * callers on the same path within one process serialize cleanly — no
+   * lost updates. See the interface-level note about cross-process
+   * behaviour.
+   *
+   * Use this for any bump semantics that depend on the current value, e.g.
+   * `accessCount += hits` or `importance = min(100, current + bonus)`.
+   */
+  update(relPath: string, updater: RuntimeSignalsUpdater): Promise<RuntimeSignals>
+}

--- a/src/server/core/interfaces/storage/i-runtime-signal-store.ts
+++ b/src/server/core/interfaces/storage/i-runtime-signal-store.ts
@@ -75,10 +75,14 @@ export interface IRuntimeSignalStore {
    * Bulk-read signals for a known set of paths.
    *
    * Preferred over {@link list} for ranking passes that operate on the
-   * top-N search results: O(N) where N is the number of requested paths,
-   * instead of O(all stored entries). The returned map always has an entry
-   * for every requested path — missing and corrupt records fall back to
-   * defaults, matching {@link get}.
+   * top-N search results: O(k) where k is the number of requested paths,
+   * instead of O(all stored entries).
+   *
+   * The returned map contains entries **only for paths that have a stored
+   * record**. Missing or corrupt records are omitted so callers can
+   * distinguish "no entry yet" from "entry with default values" via
+   * `.has(path)`. Use `map.get(path) ?? createDefaultRuntimeSignals()` when
+   * the caller wants defaults on miss.
    */
   getMany(relPaths: readonly string[]): Promise<Map<string, RuntimeSignals>>
 

--- a/src/server/infra/context-tree/file-context-tree-archive-service.ts
+++ b/src/server/infra/context-tree/file-context-tree-archive-service.ts
@@ -16,7 +16,7 @@ import {mkdir, readFile, unlink, writeFile} from 'node:fs/promises'
 import {dirname, extname, join} from 'node:path'
 
 import type {ICipherAgent} from '../../../agent/core/interfaces/i-cipher-agent.js'
-import type {FrontmatterScoring} from '../../core/domain/knowledge/markdown-writer.js'
+import type {RuntimeSignals} from '../../core/domain/knowledge/runtime-signals-schema.js'
 import type {ArchiveResult, DrillDownResult} from '../../core/domain/knowledge/summary-types.js'
 import type {IContextTreeArchiveService} from '../../core/interfaces/context-tree/i-context-tree-archive-service.js'
 import type {IRuntimeSignalStore} from '../../core/interfaces/storage/i-runtime-signal-store.js'
@@ -71,8 +71,11 @@ export class FileContextTreeArchiveService implements IContextTreeArchiveService
     const ghostCue = await this.generateGhostCue(agent, content)
     const ghostCueTokenCount = estimateTokens(ghostCue)
 
-    // Parse frontmatter to get importance for eviction metadata
-    const importance = this.extractImportance(content)
+    // Capture current importance from the sidecar for the archive stub's
+    // eviction metadata. Falls back to the default when no sidecar entry
+    // exists (pre-migration files, or a sidecar that hasn't been written to
+    // for this path). Fail-open on sidecar errors.
+    const importance = await this.readImportanceForArchiveMetadata(toUnixPath(relativePath))
 
     // Write .stub.md with archive stub frontmatter
     const stubContent = generateArchiveStubContent(
@@ -136,8 +139,21 @@ export class FileContextTreeArchiveService implements IContextTreeArchiveService
     const baseDir = directory ?? process.cwd()
     const contextTreeDir = join(baseDir, BRV_DIR, CONTEXT_TREE_DIR)
 
+    // Preload the runtime-signal map once per scan. `list()` returns only
+    // paths with stored entries; paths without one fall back to defaults at
+    // the comparison site. On sidecar failure, scan with an empty map —
+    // archive candidacy then depends on defaults only (importance 50), which
+    // keeps all draft entries above the threshold and archives nothing. That
+    // is the safest fallback when scoring data is unavailable.
+    let signalsByPath: Map<string, RuntimeSignals>
+    try {
+      signalsByPath = this.runtimeSignalStore ? await this.runtimeSignalStore.list() : new Map()
+    } catch {
+      signalsByPath = new Map()
+    }
+
     const candidates: string[] = []
-    await this.scanForCandidates(contextTreeDir, contextTreeDir, candidates)
+    await this.scanForCandidates(contextTreeDir, contextTreeDir, candidates, signalsByPath)
 
     return candidates
   }
@@ -182,15 +198,6 @@ export class FileContextTreeArchiveService implements IContextTreeArchiveService
   }
 
   /**
-   * Extract importance score from frontmatter. Returns 50 if not found.
-   */
-  private extractImportance(content: string): number {
-    const match = /^importance:\s*(\d+(?:\.\d+)?)/m.exec(content)
-
-    return match ? Number.parseFloat(match[1]) : 50
-  }
-
-  /**
    * Generate a ghost cue using LLM with deterministic fallback.
    */
   private async generateGhostCue(agent: ICipherAgent, content: string): Promise<string> {
@@ -230,21 +237,29 @@ ${content.slice(0, 8000)}
   }
 
   /**
-   * Parse FrontmatterScoring fields from content frontmatter.
+   * Extract the `updatedAt` timestamp from markdown frontmatter. This is
+   * the one scoring-adjacent field that stays in markdown (it tracks real
+   * content modification, not a runtime signal).
    */
-  private parseScoring(content: string): FrontmatterScoring {
-    const scoring: FrontmatterScoring = {}
+  private parseUpdatedAt(content: string): string | undefined {
+    const match = /^updatedAt:\s*['"]?(.+?)['"]?\s*$/m.exec(content)
+    return match ? match[1] : undefined
+  }
 
-    const importanceMatch = /^importance:\s*(\d+(?:\.\d+)?)/m.exec(content)
-    if (importanceMatch) scoring.importance = Number.parseFloat(importanceMatch[1])
-
-    const maturityMatch = /^maturity:\s*['"]?(core|draft|validated)['"]?/m.exec(content)
-    if (maturityMatch) scoring.maturity = maturityMatch[1] as FrontmatterScoring['maturity']
-
-    const updatedMatch = /^updatedAt:\s*['"]?(.+?)['"]?\s*$/m.exec(content)
-    if (updatedMatch) scoring.updatedAt = updatedMatch[1]
-
-    return scoring
+  /**
+   * Read the importance value to embed in an archive stub's eviction metadata.
+   * Pulls from the runtime-signal sidecar (source of truth post-commit-4),
+   * falling back to the default when no entry exists or the store is
+   * unavailable.
+   */
+  private async readImportanceForArchiveMetadata(relativePath: string): Promise<number> {
+    if (!this.runtimeSignalStore) return createDefaultRuntimeSignals().importance
+    try {
+      const signals = await this.runtimeSignalStore.get(relativePath)
+      return signals.importance
+    } catch {
+      return createDefaultRuntimeSignals().importance
+    }
   }
 
   /**
@@ -254,6 +269,7 @@ ${content.slice(0, 8000)}
     currentDir: string,
     contextTreeDir: string,
     candidates: string[],
+    signalsByPath: Map<string, RuntimeSignals>,
   ): Promise<void> {
     const {readdir: readdirFs} = await import('node:fs/promises')
     let entries: import('node:fs').Dirent[]
@@ -272,24 +288,31 @@ ${content.slice(0, 8000)}
 
       if (entry.isDirectory()) {
         if (entryName === ARCHIVE_DIR) continue
-        await this.scanForCandidates(fullPath, contextTreeDir, candidates)
+        await this.scanForCandidates(fullPath, contextTreeDir, candidates, signalsByPath)
       } else if (entry.isFile() && entryName.endsWith(CONTEXT_FILE_EXTENSION)) {
         const relativePath = toUnixPath(fullPath.slice(contextTreeDir.length + 1))
         if (isDerivedArtifact(relativePath) || isArchiveStub(relativePath)) continue
 
         try {
-          const content = await readFile(fullPath, 'utf8')
-          const scoring = this.parseScoring(content)
+          // Runtime signals come from the sidecar; `updatedAt` stays in
+          // markdown because it reflects content modification time, not a
+          // ranking signal. Paths without a sidecar entry use defaults —
+          // maturity 'draft' passes the gate, importance 50 stays above
+          // ARCHIVE_IMPORTANCE_THRESHOLD (which is < 50), so files without
+          // recorded signals are correctly excluded from archival.
+          const signals = signalsByPath.get(relativePath) ?? createDefaultRuntimeSignals()
 
           // Only archive draft entries below importance threshold
-          if (scoring.maturity !== 'draft') continue
+          if (signals.maturity !== 'draft') continue
 
-          const daysSinceUpdate = scoring.updatedAt
-            ? (now - new Date(scoring.updatedAt).getTime()) / (1000 * 60 * 60 * 24)
+          const content = await readFile(fullPath, 'utf8')
+          const updatedAt = this.parseUpdatedAt(content)
+          const daysSinceUpdate = updatedAt
+            ? (now - new Date(updatedAt).getTime()) / (1000 * 60 * 60 * 24)
             : 0
-          const decayed = applyDecay(scoring, daysSinceUpdate)
+          const decayed = applyDecay(signals, daysSinceUpdate)
 
-          if ((decayed.importance ?? 50) < ARCHIVE_IMPORTANCE_THRESHOLD) {
+          if (decayed.importance < ARCHIVE_IMPORTANCE_THRESHOLD) {
             candidates.push(relativePath)
           }
         } catch {

--- a/src/server/infra/context-tree/file-context-tree-archive-service.ts
+++ b/src/server/infra/context-tree/file-context-tree-archive-service.ts
@@ -16,6 +16,7 @@ import {mkdir, readFile, unlink, writeFile} from 'node:fs/promises'
 import {dirname, extname, join} from 'node:path'
 
 import type {ICipherAgent} from '../../../agent/core/interfaces/i-cipher-agent.js'
+import type {ILogger} from '../../../agent/core/interfaces/i-logger.js'
 import type {RuntimeSignals} from '../../core/domain/knowledge/runtime-signals-schema.js'
 import type {ArchiveResult, DrillDownResult} from '../../core/domain/knowledge/summary-types.js'
 import type {IContextTreeArchiveService} from '../../core/interfaces/context-tree/i-context-tree-archive-service.js'
@@ -33,13 +34,17 @@ import {
 } from '../../constants.js'
 import {applyDecay} from '../../core/domain/knowledge/memory-scoring.js'
 import {createDefaultRuntimeSignals} from '../../core/domain/knowledge/runtime-signals-schema.js'
+import {warnSidecarFailure} from '../../core/domain/knowledge/sidecar-logging.js'
 import {estimateTokens} from '../executor/pre-compaction/compaction-escalation.js'
 import {isArchiveStub, isDerivedArtifact} from './derived-artifact.js'
 import {toUnixPath} from './path-utils.js'
 import {generateArchiveStubContent, parseArchiveStubFrontmatter} from './summary-frontmatter.js'
 
 export class FileContextTreeArchiveService implements IContextTreeArchiveService {
-  constructor(private readonly runtimeSignalStore?: IRuntimeSignalStore) {}
+  constructor(
+    private readonly runtimeSignalStore?: IRuntimeSignalStore,
+    private readonly logger?: ILogger,
+  ) {}
 
   public async archiveEntry(
     relativePath: string,
@@ -99,8 +104,9 @@ export class FileContextTreeArchiveService implements IContextTreeArchiveService
     if (this.runtimeSignalStore) {
       try {
         await this.runtimeSignalStore.delete(toUnixPath(relativePath))
-      } catch {
+      } catch (error) {
         // Best-effort — archive already succeeded.
+        warnSidecarFailure(this.logger, 'archive-service', 'delete', relativePath, error)
       }
     }
 
@@ -148,7 +154,8 @@ export class FileContextTreeArchiveService implements IContextTreeArchiveService
     let signalsByPath: Map<string, RuntimeSignals>
     try {
       signalsByPath = this.runtimeSignalStore ? await this.runtimeSignalStore.list() : new Map()
-    } catch {
+    } catch (error) {
+      warnSidecarFailure(this.logger, 'archive-service', 'list', 'candidate scan', error)
       signalsByPath = new Map()
     }
 
@@ -189,8 +196,9 @@ export class FileContextTreeArchiveService implements IContextTreeArchiveService
     if (this.runtimeSignalStore) {
       try {
         await this.runtimeSignalStore.set(toUnixPath(fm.original_path), createDefaultRuntimeSignals())
-      } catch {
+      } catch (error) {
         // Best-effort — markdown restore already succeeded.
+        warnSidecarFailure(this.logger, 'archive-service', 'seed', fm.original_path, error)
       }
     }
 
@@ -257,7 +265,14 @@ ${content.slice(0, 8000)}
     try {
       const signals = await this.runtimeSignalStore.get(relativePath)
       return signals.importance
-    } catch {
+    } catch (error) {
+      warnSidecarFailure(
+        this.logger,
+        'archive-service',
+        'get',
+        `${relativePath} (archive metadata read)`,
+        error,
+      )
       return createDefaultRuntimeSignals().importance
     }
   }

--- a/src/server/infra/context-tree/file-context-tree-archive-service.ts
+++ b/src/server/infra/context-tree/file-context-tree-archive-service.ts
@@ -19,6 +19,7 @@ import type {ICipherAgent} from '../../../agent/core/interfaces/i-cipher-agent.j
 import type {FrontmatterScoring} from '../../core/domain/knowledge/markdown-writer.js'
 import type {ArchiveResult, DrillDownResult} from '../../core/domain/knowledge/summary-types.js'
 import type {IContextTreeArchiveService} from '../../core/interfaces/context-tree/i-context-tree-archive-service.js'
+import type {IRuntimeSignalStore} from '../../core/interfaces/storage/i-runtime-signal-store.js'
 
 import {
   ARCHIVE_DIR,
@@ -31,12 +32,15 @@ import {
   STUB_EXTENSION,
 } from '../../constants.js'
 import {applyDecay} from '../../core/domain/knowledge/memory-scoring.js'
+import {createDefaultRuntimeSignals} from '../../core/domain/knowledge/runtime-signals-schema.js'
 import {estimateTokens} from '../executor/pre-compaction/compaction-escalation.js'
 import {isArchiveStub, isDerivedArtifact} from './derived-artifact.js'
 import {toUnixPath} from './path-utils.js'
 import {generateArchiveStubContent, parseArchiveStubFrontmatter} from './summary-frontmatter.js'
 
 export class FileContextTreeArchiveService implements IContextTreeArchiveService {
+  constructor(private readonly runtimeSignalStore?: IRuntimeSignalStore) {}
+
   public async archiveEntry(
     relativePath: string,
     agent: ICipherAgent,
@@ -86,6 +90,16 @@ export class FileContextTreeArchiveService implements IContextTreeArchiveService
 
     // Delete original file
     await unlink(originalFullPath)
+
+    // Dual-write: drop the archived file's runtime-signal entry so the
+    // sidecar does not retain an orphan. Fail-open — markdown is canonical.
+    if (this.runtimeSignalStore) {
+      try {
+        await this.runtimeSignalStore.delete(toUnixPath(relativePath))
+      } catch {
+        // Best-effort — archive already succeeded.
+      }
+    }
 
     return {
       fullPath: toUnixPath(fullRelPath),
@@ -152,6 +166,17 @@ export class FileContextTreeArchiveService implements IContextTreeArchiveService
     // Delete stub and full archive files
     await unlink(stubFullPath)
     await unlink(fullPath)
+
+    // Dual-write: seed the restored file with default signals. Signal
+    // history from before archiving was already dropped on archive — restore
+    // is a user-initiated action, so resetting to defaults is acceptable.
+    if (this.runtimeSignalStore) {
+      try {
+        await this.runtimeSignalStore.set(toUnixPath(fm.original_path), createDefaultRuntimeSignals())
+      } catch {
+        // Best-effort — markdown restore already succeeded.
+      }
+    }
 
     return fm.original_path
   }

--- a/src/server/infra/context-tree/file-context-tree-manifest-service.ts
+++ b/src/server/infra/context-tree/file-context-tree-manifest-service.ts
@@ -17,6 +17,7 @@
 import {readdir, readFile, stat, writeFile} from 'node:fs/promises'
 import {join, relative} from 'node:path'
 
+import type {ILogger} from '../../../agent/core/interfaces/i-logger.js'
 import type {RuntimeSignals} from '../../core/domain/knowledge/runtime-signals-schema.js'
 import type {
   ContextManifest,
@@ -37,6 +38,7 @@ import {
   STUB_EXTENSION,
   SUMMARY_INDEX_FILE,
 } from '../../constants.js'
+import {warnSidecarFailure} from '../../core/domain/knowledge/sidecar-logging.js'
 import {DEFAULT_LANE_BUDGETS} from '../../core/domain/knowledge/summary-types.js'
 import {estimateTokens} from '../executor/pre-compaction/compaction-escalation.js'
 import {isArchiveStub, isDerivedArtifact} from './derived-artifact.js'
@@ -46,6 +48,11 @@ import {parseSummaryFrontmatter} from './summary-frontmatter.js'
 
 export interface ManifestServiceConfig {
   baseDirectory?: string
+  /**
+   * Optional logger. When provided, sidecar list failures during manifest
+   * build emit a warn so the fail-open degradation is visible.
+   */
+  logger?: ILogger
   /**
    * Optional. Source of truth for per-context `importance` used in lane
    * allocation. When absent or when a path has no entry, the default
@@ -73,7 +80,8 @@ export class FileContextTreeManifestService implements IContextTreeManifestServi
     let signalsByPath: Map<string, RuntimeSignals>
     try {
       signalsByPath = this.config.runtimeSignalStore ? await this.config.runtimeSignalStore.list() : new Map()
-    } catch {
+    } catch (error) {
+      warnSidecarFailure(this.config.logger, 'manifest-service', 'list', 'buildManifest', error)
       signalsByPath = new Map()
     }
 

--- a/src/server/infra/context-tree/file-context-tree-manifest-service.ts
+++ b/src/server/infra/context-tree/file-context-tree-manifest-service.ts
@@ -17,6 +17,7 @@
 import {readdir, readFile, stat, writeFile} from 'node:fs/promises'
 import {join, relative} from 'node:path'
 
+import type {RuntimeSignals} from '../../core/domain/knowledge/runtime-signals-schema.js'
 import type {
   ContextManifest,
   LaneTokens,
@@ -24,6 +25,7 @@ import type {
   ResolvedEntry,
 } from '../../core/domain/knowledge/summary-types.js'
 import type {IContextTreeManifestService} from '../../core/interfaces/context-tree/i-context-tree-manifest-service.js'
+import type {IRuntimeSignalStore} from '../../core/interfaces/storage/i-runtime-signal-store.js'
 
 import {
   ABSTRACT_EXTENSION,
@@ -35,7 +37,6 @@ import {
   STUB_EXTENSION,
   SUMMARY_INDEX_FILE,
 } from '../../constants.js'
-import {parseFrontmatterScoring} from '../../core/domain/knowledge/markdown-writer.js'
 import {DEFAULT_LANE_BUDGETS} from '../../core/domain/knowledge/summary-types.js'
 import {estimateTokens} from '../executor/pre-compaction/compaction-escalation.js'
 import {isArchiveStub, isDerivedArtifact} from './derived-artifact.js'
@@ -45,6 +46,13 @@ import {parseSummaryFrontmatter} from './summary-frontmatter.js'
 
 export interface ManifestServiceConfig {
   baseDirectory?: string
+  /**
+   * Optional. Source of truth for per-context `importance` used in lane
+   * allocation. When absent or when a path has no entry, the default
+   * importance (50) is used — same effective sort as the pre-migration
+   * fallback of `scoring?.importance ?? 50`.
+   */
+  runtimeSignalStore?: IRuntimeSignalStore
 }
 
 export class FileContextTreeManifestService implements IContextTreeManifestService {
@@ -59,12 +67,22 @@ export class FileContextTreeManifestService implements IContextTreeManifestServi
     const contextTreeDir = join(baseDir, BRV_DIR, CONTEXT_TREE_DIR)
     const budgets = laneBudgets ?? DEFAULT_LANE_BUDGETS
 
+    // Preload sidecar signals once — used to read `importance` per context.
+    // Fail-open: on sidecar error we treat every path as having no entry,
+    // which falls back to default importance (50) at the read site.
+    let signalsByPath: Map<string, RuntimeSignals>
+    try {
+      signalsByPath = this.config.runtimeSignalStore ? await this.config.runtimeSignalStore.list() : new Map()
+    } catch {
+      signalsByPath = new Map()
+    }
+
     // Scan all entries
     const summaries: ManifestEntry[] = []
     const contexts: ManifestEntry[] = []
     const stubs: ManifestEntry[] = []
 
-    await this.scanForManifest(contextTreeDir, contextTreeDir, summaries, contexts, stubs)
+    await this.scanForManifest(contextTreeDir, contextTreeDir, summaries, contexts, stubs, signalsByPath)
 
     // Lane allocation with prioritized fill
     const activeSummaries = this.allocateLane(
@@ -263,6 +281,7 @@ export class FileContextTreeManifestService implements IContextTreeManifestServi
     summaries: ManifestEntry[],
     contexts: ManifestEntry[],
     stubs: ManifestEntry[],
+    signalsByPath: Map<string, RuntimeSignals>,
   ): Promise<void> {
     let entries: import('node:fs').Dirent[]
     try {
@@ -289,7 +308,7 @@ export class FileContextTreeManifestService implements IContextTreeManifestServi
         // Scan _archived/ for .stub.md files only; recurse otherwise
         await (entryName === ARCHIVE_DIR
           ? this.scanArchivedStubs(fullPath, contextTreeDir, stubs)
-          : this.scanForManifest(fullPath, contextTreeDir, summaries, contexts, stubs))
+          : this.scanForManifest(fullPath, contextTreeDir, summaries, contexts, stubs, signalsByPath))
       } else if (entry.isFile() && entryName.endsWith(CONTEXT_FILE_EXTENSION)) {
         const relativePath = toUnixPath(relative(contextTreeDir, fullPath))
 
@@ -308,10 +327,12 @@ export class FileContextTreeManifestService implements IContextTreeManifestServi
             // Skip unreadable summaries
           }
         } else if (!isDerivedArtifact(relativePath) && !isArchiveStub(relativePath)) {
-          // Regular context entry — extract importance from frontmatter
+          // Regular context entry — importance comes from the sidecar, not
+          // markdown frontmatter. Paths without a sidecar entry fall back to
+          // default importance (50), matching the prior `?? 50` behaviour.
           try {
             const content = await readFile(fullPath, 'utf8')
-            const scoring = parseFrontmatterScoring(content)
+            const importance = signalsByPath.get(relativePath)?.importance ?? 50
 
             // Use abstract sibling for token budgeting only if it is known to exist
             // (checked via abstractsInDir set, avoiding ENOENT as control flow).
@@ -328,7 +349,7 @@ export class FileContextTreeManifestService implements IContextTreeManifestServi
             contexts.push({
               abstractPath: abstractTokens === undefined ? undefined : abstractRelPath,
               abstractTokens,
-              importance: scoring?.importance ?? 50,
+              importance,
               path: relativePath,
               tokens: abstractTokens ?? estimateTokens(content),
               type: 'context',

--- a/src/server/infra/context-tree/runtime-signal-store.ts
+++ b/src/server/infra/context-tree/runtime-signal-store.ts
@@ -54,10 +54,25 @@ export class RuntimeSignalStore implements IRuntimeSignalStore {
   }
 
   async getMany(relPaths: readonly string[]): Promise<Map<string, RuntimeSignals>> {
+    // Only include paths that have a stored record. Callers distinguish
+    // missing via `.has(path)`; ergonomic default-on-miss via
+    // `map.get(path) ?? createDefaultRuntimeSignals()`.
     const entries = await Promise.all(
-      relPaths.map(async (relPath) => [relPath, await this.get(relPath)] as const),
+      relPaths.map(async (relPath) => {
+        const raw = await this.keyStorage.get<unknown>(this.signalKey(relPath))
+        if (raw === undefined) return null
+        const parsed = RuntimeSignalsSchema.safeParse(raw)
+        if (parsed.success) {
+          return [relPath, parsed.data] as const
+        }
+
+        this.logger.warn(
+          `RuntimeSignalStore: discarding corrupt entry for ${relPath}: ${parsed.error.message}`,
+        )
+        return null
+      }),
     )
-    return new Map(entries)
+    return new Map(entries.filter((entry): entry is readonly [string, RuntimeSignals] => entry !== null))
   }
 
   async list(): Promise<Map<string, RuntimeSignals>> {

--- a/src/server/infra/context-tree/runtime-signal-store.ts
+++ b/src/server/infra/context-tree/runtime-signal-store.ts
@@ -21,13 +21,11 @@ import {
 
 const SIGNALS_PREFIX = 'signals'
 
-// TODO(runtime-signals): callers bumping `importance` must recompute
-// `maturity` via `determineTier` in the same updater — the store does not
-// enforce the hysteresis relationship. Audit call sites in commit 3.
-//
-// TODO(runtime-signals): orphan entries accumulate when markdown files are
-// deleted outside curate. Add `pruneOrphans(existingPaths)` when commit 6
-// lands, or expose via a `brv signals clean` admin command.
+// The store does not enforce the importance ↔ maturity hysteresis —
+// callers bumping importance must recompute maturity via `determineTier`
+// in the same updater. Invariant upheld at every write site; see
+// interface-level docs for the rationale. Orphan-entry cleanup is tracked
+// in features/runtime-signals/backlog.md (`pruneOrphans`).
 
 export class RuntimeSignalStore implements IRuntimeSignalStore {
   constructor(

--- a/src/server/infra/context-tree/runtime-signal-store.ts
+++ b/src/server/infra/context-tree/runtime-signal-store.ts
@@ -1,0 +1,137 @@
+/**
+ * IKeyStorage-backed implementation of {@link IRuntimeSignalStore}.
+ *
+ * Uses composite keys `["signals", ...pathSegments]`. Atomicity within a
+ * single process comes from `IKeyStorage.update`'s per-key RWLock; the
+ * interface docs cover the cross-process caveat.
+ */
+
+import type {IKeyStorage, StorageKey} from '../../../agent/core/interfaces/i-key-storage.js'
+import type {ILogger} from '../../../agent/core/interfaces/i-logger.js'
+import type {
+  IRuntimeSignalStore,
+  RuntimeSignalsUpdater,
+} from '../../core/interfaces/storage/i-runtime-signal-store.js'
+
+import {
+  createDefaultRuntimeSignals,
+  type RuntimeSignals,
+  RuntimeSignalsSchema,
+} from '../../core/domain/knowledge/runtime-signals-schema.js'
+
+const SIGNALS_PREFIX = 'signals'
+
+// TODO(runtime-signals): callers bumping `importance` must recompute
+// `maturity` via `determineTier` in the same updater — the store does not
+// enforce the hysteresis relationship. Audit call sites in commit 3.
+//
+// TODO(runtime-signals): orphan entries accumulate when markdown files are
+// deleted outside curate. Add `pruneOrphans(existingPaths)` when commit 6
+// lands, or expose via a `brv signals clean` admin command.
+
+export class RuntimeSignalStore implements IRuntimeSignalStore {
+  constructor(
+    private readonly keyStorage: IKeyStorage,
+    private readonly logger: ILogger,
+  ) {}
+
+  async batchUpdate(updates: Map<string, RuntimeSignalsUpdater>): Promise<void> {
+    // Different relPaths do not share a per-key lock, so parallel updates
+    // scale naturally. Each individual update remains atomic because
+    // IKeyStorage.update is atomic per key (within one process).
+    await Promise.all(
+      [...updates.entries()].map(([relPath, updater]) => this.update(relPath, updater)),
+    )
+  }
+
+  async delete(relPath: string): Promise<void> {
+    await this.keyStorage.delete(this.signalKey(relPath))
+  }
+
+  async get(relPath: string): Promise<RuntimeSignals> {
+    const raw = await this.keyStorage.get<unknown>(this.signalKey(relPath))
+    return this.validateOrDefault(raw, relPath)
+  }
+
+  async getMany(relPaths: readonly string[]): Promise<Map<string, RuntimeSignals>> {
+    const entries = await Promise.all(
+      relPaths.map(async (relPath) => [relPath, await this.get(relPath)] as const),
+    )
+    return new Map(entries)
+  }
+
+  async list(): Promise<Map<string, RuntimeSignals>> {
+    const entries = await this.keyStorage.listWithValues<unknown>([SIGNALS_PREFIX])
+    const result = new Map<string, RuntimeSignals>()
+
+    for (const entry of entries) {
+      const relPath = this.relPathFromKey(entry.key)
+      if (relPath === null) continue
+      result.set(relPath, this.validateOrDefault(entry.value, relPath))
+    }
+
+    return result
+  }
+
+  async set(relPath: string, signals: RuntimeSignals): Promise<void> {
+    const validated = RuntimeSignalsSchema.parse(signals)
+    await this.keyStorage.set(this.signalKey(relPath), validated)
+  }
+
+  async update(relPath: string, updater: RuntimeSignalsUpdater): Promise<RuntimeSignals> {
+    return this.keyStorage.update<RuntimeSignals>(this.signalKey(relPath), (current) => {
+      // `current` is typed as RuntimeSignals but the underlying value may be
+      // anything the disk held (missing, partial, corrupt). validateOrDefault
+      // coerces it into a valid record before the updater runs.
+      const base = this.validateOrDefault(current, relPath)
+      const merged = updater(base)
+      // Re-validate updater output so a buggy caller cannot land invalid
+      // data (e.g. importance out of range) on disk.
+      return RuntimeSignalsSchema.parse(merged)
+    })
+  }
+
+  /**
+   * Reconstruct the relative path from a `["signals", ...segments]` key.
+   * Returns null for keys that do not belong to this store (defensive against
+   * the remote chance of namespace collisions during listing).
+   */
+  private relPathFromKey(key: StorageKey): null | string {
+    if (key.length < 2 || key[0] !== SIGNALS_PREFIX) return null
+    return key.slice(1).join('/')
+  }
+
+  /**
+   * Encode a relative path into a composite storage key.
+   *
+   * FileKeyStorage rejects `/` inside segments, so each path component
+   * becomes its own segment. Empty components (from leading, trailing, or
+   * consecutive slashes) are dropped so the encoding is insensitive to
+   * path normalization variants.
+   */
+  private signalKey(relPath: string): StorageKey {
+    const segments = relPath.split('/').filter((s) => s.length > 0)
+    return [SIGNALS_PREFIX, ...segments]
+  }
+
+  /**
+   * Coerce an unknown stored value into a valid RuntimeSignals record.
+   *
+   * Missing (`undefined`) yields defaults silently — the common fresh-path
+   * case. Corrupt stored data logs a warning and also falls back to
+   * defaults so callers never have to handle read errors inline.
+   */
+  private validateOrDefault(raw: unknown, relPath: string): RuntimeSignals {
+    if (raw === undefined) {
+      return createDefaultRuntimeSignals()
+    }
+
+    const parsed = RuntimeSignalsSchema.safeParse(raw)
+    if (parsed.success) return parsed.data
+
+    this.logger.warn(
+      `RuntimeSignalStore: discarding corrupt entry for ${relPath}: ${parsed.error.message}`,
+    )
+    return createDefaultRuntimeSignals()
+  }
+}

--- a/src/server/infra/daemon/agent-process.ts
+++ b/src/server/infra/daemon/agent-process.ts
@@ -27,12 +27,14 @@ import {join} from 'node:path'
 import type {ISearchKnowledgeService} from '../../../agent/infra/sandbox/tools-sdk.js'
 import type {BrvConfig} from '../../core/domain/entities/brv-config.js'
 import type {ProviderConfigResponse, TaskExecute} from '../../core/domain/transport/schemas.js'
+import type {IRuntimeSignalStore} from '../../core/interfaces/storage/i-runtime-signal-store.js'
 
 import {SESSIONS_DIR} from '../../../agent/core/domain/session/session-metadata.js'
 import {CipherAgent} from '../../../agent/infra/agent/index.js'
 import {FileSystemService} from '../../../agent/infra/file-system/file-system-service.js'
 import {FolderPackService} from '../../../agent/infra/folder-pack/folder-pack-service.js'
 import {SessionMetadataStore} from '../../../agent/infra/session/session-metadata-store.js'
+import {FileKeyStorage} from '../../../agent/infra/storage/file-key-storage.js'
 import {createSearchKnowledgeService} from '../../../agent/infra/tools/implementations/search-knowledge-service.js'
 import {AuthEvents} from '../../../shared/transport/events/auth-events.js'
 import {decodeSearchContent} from '../../../shared/transport/search-content.js'
@@ -47,6 +49,7 @@ import {
   TransportTaskEventNames,
 } from '../../core/domain/transport/schemas.js'
 import {FileContextTreeArchiveService} from '../context-tree/file-context-tree-archive-service.js'
+import {RuntimeSignalStore} from '../context-tree/runtime-signal-store.js'
 import {DreamLockService} from '../dream/dream-lock-service.js'
 import {DreamLogStore} from '../dream/dream-log-store.js'
 import {DreamStateService} from '../dream/dream-state-service.js'
@@ -364,7 +367,27 @@ async function start(): Promise<void> {
     workingDirectory: projectPath,
   })
   await fileSystemService.initialize()
-  const searchService = createSearchKnowledgeService(fileSystemService, {baseDirectory: projectPath})
+
+  // Runtime-signal sidecar for this daemon. FileKeyStorage is file-backed
+  // under configResult.storagePath, so the daemon and any other process for
+  // the same project write to the same on-disk store. `brv search`, curate,
+  // and archive in this daemon all mirror scoring writes through it.
+  const daemonKeyStorage = new FileKeyStorage({
+    storageDir: configResult.storagePath,
+  })
+  await daemonKeyStorage.initialize()
+  const daemonLogger = {
+    debug: (msg: string): void => agentLog(msg),
+    error: (msg: string): void => agentLog(msg),
+    info: (msg: string): void => agentLog(msg),
+    warn: (msg: string): void => agentLog(msg),
+  }
+  const daemonRuntimeSignalStore = new RuntimeSignalStore(daemonKeyStorage, daemonLogger)
+
+  const searchService = createSearchKnowledgeService(fileSystemService, {
+    baseDirectory: projectPath,
+    runtimeSignalStore: daemonRuntimeSignalStore,
+  })
 
   // 7. Create executors and listen for task:execute from pool
   const curateExecutor = new CurateExecutor()
@@ -382,7 +405,16 @@ async function start(): Promise<void> {
   transport.on<TaskExecute>(TransportTaskEventNames.EXECUTE, (task) => {
     agentLog(`task:execute received taskId=${task.taskId} type=${task.type} activeTaskCount=${activeTaskCount + 1}`)
     // eslint-disable-next-line no-void
-    void executeTask(task, curateExecutor, folderPackExecutor, queryExecutor, searchExecutor, searchService, configResult.storagePath)
+    void executeTask(
+      task,
+      curateExecutor,
+      folderPackExecutor,
+      queryExecutor,
+      searchExecutor,
+      searchService,
+      configResult.storagePath,
+      daemonRuntimeSignalStore,
+    )
   })
 
   // 8. Register with transport server (for TransportHandlers tracking)
@@ -401,6 +433,7 @@ async function executeTask(
   searchExecutor: SearchExecutor,
   searchKnowledgeService: ISearchKnowledgeService,
   storagePath: string,
+  runtimeSignalStore: IRuntimeSignalStore,
 ): Promise<void> {
   const {clientCwd, clientId, content, files, folderPath, force, taskId, trigger, type, worktreeRoot} = task
   if (!transport || !agent) return
@@ -530,7 +563,7 @@ async function executeTask(
           }
 
           const dreamExecutor = new DreamExecutor({
-            archiveService: new FileContextTreeArchiveService(),
+            archiveService: new FileContextTreeArchiveService(runtimeSignalStore),
             curateLogStore: new FileCurateLogStore({baseDir: storagePath}),
             dreamLockService,
             dreamLogStore: new DreamLogStore({baseDir: brvDir}),

--- a/src/server/infra/daemon/agent-process.ts
+++ b/src/server/infra/daemon/agent-process.ts
@@ -569,6 +569,7 @@ async function executeTask(
             dreamLogStore: new DreamLogStore({baseDir: brvDir}),
             dreamStateService,
             reviewBackupStore: new FileReviewBackupStore(brvDir),
+            runtimeSignalStore,
             searchService: searchKnowledgeService,
           })
           const dreamResult = await dreamExecutor.executeWithAgent(agent, {

--- a/src/server/infra/dream/operations/consolidate.ts
+++ b/src/server/infra/dream/operations/consolidate.ts
@@ -21,7 +21,6 @@ import type {DreamOperation} from '../dream-log-schema.js'
 import type {ConsolidationAction} from '../dream-response-schemas.js'
 import type {DreamState, PendingMerge} from '../dream-state-schema.js'
 
-import {parseFrontmatterScoring} from '../../../core/domain/knowledge/markdown-writer.js'
 import {ConsolidateResponseSchema} from '../dream-response-schemas.js'
 import {parseDreamResponse} from '../parse-dream-response.js'
 
@@ -41,6 +40,15 @@ export type ConsolidateDeps = {
   }
   reviewBackupStore?: {
     save(relativePath: string, content: string): Promise<void>
+  }
+  /**
+   * Optional. When present, the CROSS_REFERENCE review-gate consults the
+   * sidecar to check whether any input file has `maturity === 'core'`. Absent
+   * store or missing entries mean no file qualifies as core — review is
+   * skipped, matching the pre-migration behaviour for paths without scoring.
+   */
+  runtimeSignalStore?: {
+    get(relPath: string): Promise<{maturity: 'core' | 'draft' | 'validated'}>
   }
   searchService: {
     search(query: string, options?: {limit?: number; scope?: string}): Promise<{results: Array<{path: string; score: number; title: string}>}>
@@ -197,7 +205,7 @@ async function processDomain(domain: string, files: string[], deps: ConsolidateD
     for (const action of parsed.actions) {
       try {
         // eslint-disable-next-line no-await-in-loop
-        const op = await executeAction(action, contextTreeDir, fileContents, deps.reviewBackupStore)
+        const op = await executeAction(action, contextTreeDir, fileContents, deps.runtimeSignalStore, deps.reviewBackupStore)
         if (op) results.push(op)
       } catch {
         // Skip failed action, continue with others
@@ -451,15 +459,16 @@ async function executeAction(
   action: ConsolidationAction,
   contextTreeDir: string,
   fileContents: Map<string, string>,
+  runtimeSignalStore: ConsolidateDeps['runtimeSignalStore'],
   reviewBackupStore?: ConsolidateDeps['reviewBackupStore'],
 ): Promise<DreamOperation | undefined> {
   switch (action.type) {
     case 'CROSS_REFERENCE': {
-      return executeCrossReference(action, contextTreeDir, fileContents, reviewBackupStore)
+      return executeCrossReference(action, contextTreeDir, fileContents, runtimeSignalStore, reviewBackupStore)
     }
 
     case 'MERGE': {
-      return executeMerge(action, contextTreeDir, fileContents, reviewBackupStore)
+      return executeMerge(action, contextTreeDir, fileContents, runtimeSignalStore, reviewBackupStore)
     }
 
     case 'SKIP': {
@@ -467,7 +476,7 @@ async function executeAction(
     }
 
     case 'TEMPORAL_UPDATE': {
-      return executeTemporalUpdate(action, contextTreeDir, fileContents, reviewBackupStore)
+      return executeTemporalUpdate(action, contextTreeDir, fileContents, runtimeSignalStore, reviewBackupStore)
     }
   }
 }
@@ -476,6 +485,7 @@ async function executeMerge(
   action: ConsolidationAction,
   contextTreeDir: string,
   fileContents: Map<string, string>,
+  runtimeSignalStore: ConsolidateDeps['runtimeSignalStore'],
   reviewBackupStore?: ConsolidateDeps['reviewBackupStore'],
 ): Promise<DreamOperation> {
   const outputFile = action.outputFile ?? action.files[0]
@@ -519,7 +529,7 @@ async function executeMerge(
   await Promise.all(toDelete.map((f) => unlink(join(contextTreeDir, f)).catch(() => {})))
 
   // Determine needsReview
-  const needsReview = determineNeedsReview('MERGE', action.files, fileContents)
+  const needsReview = await determineNeedsReview('MERGE', action.files, runtimeSignalStore)
 
   return {
     action: 'MERGE',
@@ -536,6 +546,7 @@ async function executeTemporalUpdate(
   action: ConsolidationAction,
   contextTreeDir: string,
   fileContents: Map<string, string>,
+  runtimeSignalStore: ConsolidateDeps['runtimeSignalStore'],
   reviewBackupStore?: ConsolidateDeps['reviewBackupStore'],
 ): Promise<DreamOperation> {
   const targetFile = action.files[0]
@@ -552,7 +563,7 @@ async function executeTemporalUpdate(
     previousTexts[targetFile] = original
   }
 
-  const needsReview = determineNeedsReview('TEMPORAL_UPDATE', action.files, fileContents, action.confidence)
+  const needsReview = await determineNeedsReview('TEMPORAL_UPDATE', action.files, runtimeSignalStore, action.confidence)
 
   // Create review backup only when the operation needs human review
   if (reviewBackupStore && original !== undefined && needsReview) {
@@ -582,6 +593,7 @@ async function executeCrossReference(
   action: ConsolidationAction,
   contextTreeDir: string,
   fileContents: Map<string, string>,
+  runtimeSignalStore: ConsolidateDeps['runtimeSignalStore'],
   reviewBackupStore?: ConsolidateDeps['reviewBackupStore'],
 ): Promise<DreamOperation> {
   const previousTexts: Record<string, string> = {}
@@ -592,7 +604,7 @@ async function executeCrossReference(
     }
   }
 
-  const needsReview = determineNeedsReview('CROSS_REFERENCE', action.files, fileContents)
+  const needsReview = await determineNeedsReview('CROSS_REFERENCE', action.files, runtimeSignalStore)
   if (needsReview && reviewBackupStore) {
     await Promise.all(
       Object.entries(previousTexts).map(([file, content]) =>
@@ -658,24 +670,29 @@ async function addRelatedLinks(filePath: string, relatedPaths: string[]): Promis
   await atomicWrite(filePath, `---\n${yaml}\n---\n${content}`)
 }
 
-function determineNeedsReview(
+async function determineNeedsReview(
   actionType: 'CROSS_REFERENCE' | 'MERGE' | 'TEMPORAL_UPDATE',
   files: string[],
-  fileContents: Map<string, string>,
+  runtimeSignalStore: ConsolidateDeps['runtimeSignalStore'],
   confidence?: number,
-): boolean {
+): Promise<boolean> {
   // MERGE always needs review
   if (actionType === 'MERGE') return true
 
   // TEMPORAL_UPDATE: needs review when confidence is low or absent
   if (actionType === 'TEMPORAL_UPDATE') return (confidence ?? 0) < 0.7
 
-  // CROSS_REFERENCE: only if any file has core maturity
+  // CROSS_REFERENCE: only if any file has core maturity in the sidecar.
+  // Without a store, no file can qualify as core — review is skipped, which
+  // matches the pre-migration default when no scoring was present.
+  if (!runtimeSignalStore) return false
   for (const file of files) {
-    const content = fileContents.get(file)
-    if (content) {
-      const scoring = parseFrontmatterScoring(content)
-      if (scoring?.maturity === 'core') return true
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const signals = await runtimeSignalStore.get(file)
+      if (signals.maturity === 'core') return true
+    } catch {
+      // Ignore per-file sidecar failures — continue checking remaining files.
     }
   }
 

--- a/src/server/infra/dream/operations/consolidate.ts
+++ b/src/server/infra/dream/operations/consolidate.ts
@@ -17,10 +17,12 @@ import {access, mkdir, readdir, readFile, rename, unlink, writeFile} from 'node:
 import {dirname, join} from 'node:path'
 
 import type {ICipherAgent} from '../../../../agent/core/interfaces/i-cipher-agent.js'
+import type {ILogger} from '../../../../agent/core/interfaces/i-logger.js'
 import type {DreamOperation} from '../dream-log-schema.js'
 import type {ConsolidationAction} from '../dream-response-schemas.js'
 import type {DreamState, PendingMerge} from '../dream-state-schema.js'
 
+import {warnSidecarFailure} from '../../../core/domain/knowledge/sidecar-logging.js'
 import {ConsolidateResponseSchema} from '../dream-response-schemas.js'
 import {parseDreamResponse} from '../parse-dream-response.js'
 
@@ -38,6 +40,11 @@ export type ConsolidateDeps = {
     update(updater: (state: DreamState) => DreamState): Promise<DreamState>
     write(state: DreamState): Promise<void>
   }
+  /**
+   * Optional logger. When provided, per-file sidecar failures during the
+   * CROSS_REFERENCE review gate emit a warn so silent swallows are visible.
+   */
+  logger?: ILogger
   reviewBackupStore?: {
     save(relativePath: string, content: string): Promise<void>
   }
@@ -205,7 +212,13 @@ async function processDomain(domain: string, files: string[], deps: ConsolidateD
     for (const action of parsed.actions) {
       try {
         // eslint-disable-next-line no-await-in-loop
-        const op = await executeAction(action, contextTreeDir, fileContents, deps.runtimeSignalStore, deps.reviewBackupStore)
+        const op = await executeAction(action, {
+          contextTreeDir,
+          fileContents,
+          logger: deps.logger,
+          reviewBackupStore: deps.reviewBackupStore,
+          runtimeSignalStore: deps.runtimeSignalStore,
+        })
         if (op) results.push(op)
       } catch {
         // Skip failed action, continue with others
@@ -455,20 +468,25 @@ function buildPrompt(
   return lines.join('\n')
 }
 
+type ActionContext = {
+  contextTreeDir: string
+  fileContents: Map<string, string>
+  logger?: ConsolidateDeps['logger']
+  reviewBackupStore?: ConsolidateDeps['reviewBackupStore']
+  runtimeSignalStore: ConsolidateDeps['runtimeSignalStore']
+}
+
 async function executeAction(
   action: ConsolidationAction,
-  contextTreeDir: string,
-  fileContents: Map<string, string>,
-  runtimeSignalStore: ConsolidateDeps['runtimeSignalStore'],
-  reviewBackupStore?: ConsolidateDeps['reviewBackupStore'],
+  ctx: ActionContext,
 ): Promise<DreamOperation | undefined> {
   switch (action.type) {
     case 'CROSS_REFERENCE': {
-      return executeCrossReference(action, contextTreeDir, fileContents, runtimeSignalStore, reviewBackupStore)
+      return executeCrossReference(action, ctx)
     }
 
     case 'MERGE': {
-      return executeMerge(action, contextTreeDir, fileContents, runtimeSignalStore, reviewBackupStore)
+      return executeMerge(action, ctx)
     }
 
     case 'SKIP': {
@@ -476,18 +494,13 @@ async function executeAction(
     }
 
     case 'TEMPORAL_UPDATE': {
-      return executeTemporalUpdate(action, contextTreeDir, fileContents, runtimeSignalStore, reviewBackupStore)
+      return executeTemporalUpdate(action, ctx)
     }
   }
 }
 
-async function executeMerge(
-  action: ConsolidationAction,
-  contextTreeDir: string,
-  fileContents: Map<string, string>,
-  runtimeSignalStore: ConsolidateDeps['runtimeSignalStore'],
-  reviewBackupStore?: ConsolidateDeps['reviewBackupStore'],
-): Promise<DreamOperation> {
+async function executeMerge(action: ConsolidationAction, ctx: ActionContext): Promise<DreamOperation> {
+  const {contextTreeDir, fileContents, reviewBackupStore, runtimeSignalStore} = ctx
   const outputFile = action.outputFile ?? action.files[0]
   if (!action.mergedContent) {
     throw new Error(`MERGE action missing mergedContent for ${outputFile}`)
@@ -529,7 +542,7 @@ async function executeMerge(
   await Promise.all(toDelete.map((f) => unlink(join(contextTreeDir, f)).catch(() => {})))
 
   // Determine needsReview
-  const needsReview = await determineNeedsReview('MERGE', action.files, runtimeSignalStore)
+  const needsReview = await determineNeedsReview('MERGE', action.files, {runtimeSignalStore})
 
   return {
     action: 'MERGE',
@@ -542,13 +555,8 @@ async function executeMerge(
   }
 }
 
-async function executeTemporalUpdate(
-  action: ConsolidationAction,
-  contextTreeDir: string,
-  fileContents: Map<string, string>,
-  runtimeSignalStore: ConsolidateDeps['runtimeSignalStore'],
-  reviewBackupStore?: ConsolidateDeps['reviewBackupStore'],
-): Promise<DreamOperation> {
+async function executeTemporalUpdate(action: ConsolidationAction, ctx: ActionContext): Promise<DreamOperation> {
+  const {contextTreeDir, fileContents, reviewBackupStore, runtimeSignalStore} = ctx
   const targetFile = action.files[0]
   if (!action.updatedContent) {
     throw new Error(`TEMPORAL_UPDATE action missing updatedContent for ${targetFile}`)
@@ -563,7 +571,10 @@ async function executeTemporalUpdate(
     previousTexts[targetFile] = original
   }
 
-  const needsReview = await determineNeedsReview('TEMPORAL_UPDATE', action.files, runtimeSignalStore, action.confidence)
+  const needsReview = await determineNeedsReview('TEMPORAL_UPDATE', action.files, {
+    confidence: action.confidence,
+    runtimeSignalStore,
+  })
 
   // Create review backup only when the operation needs human review
   if (reviewBackupStore && original !== undefined && needsReview) {
@@ -589,13 +600,8 @@ async function executeTemporalUpdate(
   }
 }
 
-async function executeCrossReference(
-  action: ConsolidationAction,
-  contextTreeDir: string,
-  fileContents: Map<string, string>,
-  runtimeSignalStore: ConsolidateDeps['runtimeSignalStore'],
-  reviewBackupStore?: ConsolidateDeps['reviewBackupStore'],
-): Promise<DreamOperation> {
+async function executeCrossReference(action: ConsolidationAction, ctx: ActionContext): Promise<DreamOperation> {
+  const {contextTreeDir, fileContents, logger, reviewBackupStore, runtimeSignalStore} = ctx
   const previousTexts: Record<string, string> = {}
   for (const file of action.files) {
     const content = fileContents.get(file)
@@ -604,7 +610,7 @@ async function executeCrossReference(
     }
   }
 
-  const needsReview = await determineNeedsReview('CROSS_REFERENCE', action.files, runtimeSignalStore)
+  const needsReview = await determineNeedsReview('CROSS_REFERENCE', action.files, {logger, runtimeSignalStore})
   if (needsReview && reviewBackupStore) {
     await Promise.all(
       Object.entries(previousTexts).map(([file, content]) =>
@@ -673,26 +679,31 @@ async function addRelatedLinks(filePath: string, relatedPaths: string[]): Promis
 async function determineNeedsReview(
   actionType: 'CROSS_REFERENCE' | 'MERGE' | 'TEMPORAL_UPDATE',
   files: string[],
-  runtimeSignalStore: ConsolidateDeps['runtimeSignalStore'],
-  confidence?: number,
+  opts: {
+    confidence?: number
+    logger?: ConsolidateDeps['logger']
+    runtimeSignalStore: ConsolidateDeps['runtimeSignalStore']
+  },
 ): Promise<boolean> {
   // MERGE always needs review
   if (actionType === 'MERGE') return true
 
   // TEMPORAL_UPDATE: needs review when confidence is low or absent
-  if (actionType === 'TEMPORAL_UPDATE') return (confidence ?? 0) < 0.7
+  if (actionType === 'TEMPORAL_UPDATE') return (opts.confidence ?? 0) < 0.7
 
   // CROSS_REFERENCE: only if any file has core maturity in the sidecar.
   // Without a store, no file can qualify as core — review is skipped, which
   // matches the pre-migration default when no scoring was present.
+  const {logger, runtimeSignalStore} = opts
   if (!runtimeSignalStore) return false
   for (const file of files) {
     try {
       // eslint-disable-next-line no-await-in-loop
       const signals = await runtimeSignalStore.get(file)
       if (signals.maturity === 'core') return true
-    } catch {
+    } catch (error) {
       // Ignore per-file sidecar failures — continue checking remaining files.
+      warnSidecarFailure(logger, 'consolidate', 'get', `${file} (CROSS_REFERENCE gate)`, error)
     }
   }
 

--- a/src/server/infra/dream/operations/prune.ts
+++ b/src/server/infra/dream/operations/prune.ts
@@ -20,6 +20,7 @@ import type {DreamOperation} from '../dream-log-schema.js'
 import type {PruneDecision} from '../dream-response-schemas.js'
 import type {DreamState} from '../dream-state-schema.js'
 
+import {DEFAULT_IMPORTANCE, DEFAULT_MATURITY} from '../../../core/domain/knowledge/runtime-signals-schema.js'
 import {isExcludedFromSync} from '../../context-tree/derived-artifact.js'
 import {toUnixPath} from '../../context-tree/path-utils.js'
 import {PruneResponseSchema} from '../dream-response-schemas.js'
@@ -41,6 +42,15 @@ export type PruneDeps = {
   projectRoot: string
   reviewBackupStore?: {
     save(relativePath: string, content: string): Promise<void>
+  }
+  /**
+   * Runtime-signal sidecar. Source of truth for `importance` and `maturity`
+   * used in prune's candidacy decisions. Absent store or missing-per-path
+   * entries are treated as defaults (importance 50, maturity 'draft') —
+   * matches the plan's "paths without entries use defaults" principle.
+   */
+  runtimeSignalStore?: {
+    list(): Promise<Map<string, {importance: number; maturity: 'core' | 'draft' | 'validated'}>>
   }
   signal?: AbortSignal
   taskId: string
@@ -88,11 +98,25 @@ async function findCandidates(deps: PruneDeps): Promise<CandidateInfo[]> {
   const candidateMap = new Map<string, CandidateInfo>()
   const now = Date.now()
 
+  // Source of truth for importance/maturity is the sidecar. Preload once per
+  // scan so per-path lookups are O(1) map reads instead of repeated regex
+  // passes over markdown content. On sidecar failure the map is empty and
+  // every path falls back to defaults (importance 50, maturity 'draft').
+  let signalsByPath: Map<string, {importance: number; maturity: 'core' | 'draft' | 'validated'}>
+  try {
+    signalsByPath = deps.runtimeSignalStore ? await deps.runtimeSignalStore.list() : new Map()
+  } catch {
+    signalsByPath = new Map()
+  }
+
   // Signal A: archive service importance decay
   try {
     const importancePaths = await deps.archiveService.findArchiveCandidates(deps.projectRoot)
     const infoResults = await Promise.all(
-      importancePaths.map(async (path) => ({info: await readCandidateInfo(deps.contextTreeDir, path, now), path})),
+      importancePaths.map(async (path) => ({
+        info: await readCandidateInfo(deps.contextTreeDir, path, now, signalsByPath),
+        path,
+      })),
     )
     for (const {info, path} of infoResults) {
       if (info && info.maturity !== 'core') {
@@ -105,7 +129,7 @@ async function findCandidates(deps: PruneDeps): Promise<CandidateInfo[]> {
 
   // Signal B: mtime staleness
   try {
-    const stalePaths = await findStaleFiles(deps.contextTreeDir, now)
+    const stalePaths = await findStaleFiles(deps.contextTreeDir, now, signalsByPath)
     for (const {info, path} of stalePaths) {
       if (candidateMap.has(path)) {
         // Already found by Signal A — mark as both
@@ -125,17 +149,22 @@ async function findCandidates(deps: PruneDeps): Promise<CandidateInfo[]> {
   return candidates.slice(0, MAX_CANDIDATES)
 }
 
-async function readCandidateInfo(contextTreeDir: string, relativePath: string, now: number): Promise<CandidateInfo | undefined> {
+async function readCandidateInfo(
+  contextTreeDir: string,
+  relativePath: string,
+  now: number,
+  signalsByPath: Map<string, {importance: number; maturity: 'core' | 'draft' | 'validated'}>,
+): Promise<CandidateInfo | undefined> {
   try {
     const fullPath = join(contextTreeDir, relativePath)
-    const content = await readFile(fullPath, 'utf8')
     const fileStat = await stat(fullPath)
     const daysSinceModified = (now - fileStat.mtimeMs) / MS_PER_DAY
+    const signals = signalsByPath.get(relativePath)
 
     return {
       daysSinceModified,
-      importance: extractImportance(content),
-      maturity: extractMaturity(content),
+      importance: signals?.importance ?? DEFAULT_IMPORTANCE,
+      maturity: signals?.maturity ?? DEFAULT_MATURITY,
       path: relativePath,
       signal: 'importance',
     }
@@ -144,15 +173,22 @@ async function readCandidateInfo(contextTreeDir: string, relativePath: string, n
   }
 }
 
-async function findStaleFiles(contextTreeDir: string, now: number): Promise<Array<{info: CandidateInfo; path: string}>> {
+async function findStaleFiles(
+  contextTreeDir: string,
+  now: number,
+  signalsByPath: Map<string, {importance: number; maturity: 'core' | 'draft' | 'validated'}>,
+): Promise<Array<{info: CandidateInfo; path: string}>> {
   const results: Array<{info: CandidateInfo; path: string}> = []
 
   await walkMdFiles(contextTreeDir, async (relativePath, fullPath) => {
     try {
-      const content = await readFile(fullPath, 'utf8')
-      const maturity = extractMaturity(content)
+      const signals = signalsByPath.get(relativePath)
+      const maturity = signals?.maturity ?? DEFAULT_MATURITY
 
-      // core files NEVER pruned
+      // core files NEVER pruned. Absent sidecar entry means maturity defaults
+      // to 'draft', so core protection depends on the sidecar being populated.
+      // That is intentional: post-migration, a file is only 'core' when the
+      // maturity tier has been earned via repeated access / curate updates.
       if (maturity === 'core') return
 
       const threshold = maturity === 'validated' ? VALIDATED_STALE_DAYS : DRAFT_STALE_DAYS
@@ -163,7 +199,7 @@ async function findStaleFiles(contextTreeDir: string, now: number): Promise<Arra
         results.push({
           info: {
             daysSinceModified,
-            importance: extractImportance(content),
+            importance: signals?.importance ?? DEFAULT_IMPORTANCE,
             maturity,
             path: relativePath,
             signal: 'mtime',
@@ -431,14 +467,3 @@ async function writePendingMerge(decision: PruneDecision, deps: PruneDeps): Prom
   })
 }
 
-// ── Frontmatter helpers ────────────────────────────────────────────────────
-
-function extractMaturity(content: string): string {
-  const match = /^maturity:\s*['"]?(core|draft|validated)['"]?/m.exec(content)
-  return match?.[1] ?? 'draft'
-}
-
-function extractImportance(content: string): number {
-  const match = /^importance:\s*(\d+(?:\.\d+)?)/m.exec(content)
-  return match ? Number.parseFloat(match[1]) : 50
-}

--- a/src/server/infra/dream/operations/prune.ts
+++ b/src/server/infra/dream/operations/prune.ts
@@ -16,11 +16,13 @@ import {readdir, readFile, stat, utimes} from 'node:fs/promises'
 import {join} from 'node:path'
 
 import type {ICipherAgent} from '../../../../agent/core/interfaces/i-cipher-agent.js'
+import type {ILogger} from '../../../../agent/core/interfaces/i-logger.js'
 import type {DreamOperation} from '../dream-log-schema.js'
 import type {PruneDecision} from '../dream-response-schemas.js'
 import type {DreamState} from '../dream-state-schema.js'
 
 import {DEFAULT_IMPORTANCE, DEFAULT_MATURITY} from '../../../core/domain/knowledge/runtime-signals-schema.js'
+import {warnSidecarFailure} from '../../../core/domain/knowledge/sidecar-logging.js'
 import {isExcludedFromSync} from '../../context-tree/derived-artifact.js'
 import {toUnixPath} from '../../context-tree/path-utils.js'
 import {PruneResponseSchema} from '../dream-response-schemas.js'
@@ -39,6 +41,11 @@ export type PruneDeps = {
     update(updater: (state: DreamState) => DreamState): Promise<DreamState>
     write(state: DreamState): Promise<void>
   }
+  /**
+   * Optional logger. When provided, sidecar failures in the candidate scan
+   * emit a warn so the fail-open degradation is visible.
+   */
+  logger?: ILogger
   projectRoot: string
   reviewBackupStore?: {
     save(relativePath: string, content: string): Promise<void>
@@ -105,7 +112,8 @@ async function findCandidates(deps: PruneDeps): Promise<CandidateInfo[]> {
   let signalsByPath: Map<string, {importance: number; maturity: 'core' | 'draft' | 'validated'}>
   try {
     signalsByPath = deps.runtimeSignalStore ? await deps.runtimeSignalStore.list() : new Map()
-  } catch {
+  } catch (error) {
+    warnSidecarFailure(deps.logger, 'prune', 'list', 'findCandidates', error)
     signalsByPath = new Map()
   }
 

--- a/src/server/infra/dream/operations/synthesize.ts
+++ b/src/server/infra/dream/operations/synthesize.ts
@@ -17,9 +17,12 @@ import {access, mkdir, readdir, readFile, rename, writeFile} from 'node:fs/promi
 import {dirname, join, resolve} from 'node:path'
 
 import type {ICipherAgent} from '../../../../agent/core/interfaces/i-cipher-agent.js'
+import type {IRuntimeSignalStore} from '../../../core/interfaces/storage/i-runtime-signal-store.js'
 import type {DreamOperation} from '../dream-log-schema.js'
 import type {SynthesisCandidate} from '../dream-response-schemas.js'
 
+import {createDefaultRuntimeSignals} from '../../../core/domain/knowledge/runtime-signals-schema.js'
+import {warnSidecarFailure} from '../../../core/domain/knowledge/sidecar-logging.js'
 import {isDescendantOf} from '../../../utils/path-utils.js'
 import {SynthesizeResponseSchema} from '../dream-response-schemas.js'
 import {parseDreamResponse} from '../parse-dream-response.js'
@@ -27,6 +30,12 @@ import {parseDreamResponse} from '../parse-dream-response.js'
 export type SynthesizeDeps = {
   agent: ICipherAgent
   contextTreeDir: string
+  /**
+   * Optional sidecar store for runtime ranking signals. When provided,
+   * newly created synthesis files are seeded with default signals so
+   * ranking data lives in the sidecar rather than in markdown frontmatter.
+   */
+  runtimeSignalStore?: IRuntimeSignalStore
   searchService: {
     search(query: string, options?: {limit?: number; scope?: string}): Promise<{results: Array<{path: string; score: number; title: string}>}>
   }
@@ -92,7 +101,7 @@ export async function synthesize(deps: SynthesizeDeps): Promise<DreamOperation[]
     for (const candidate of novel) {
       try {
         // eslint-disable-next-line no-await-in-loop
-        const op = await writeSynthesisFile(candidate, contextTreeDir)
+        const op = await writeSynthesisFile(candidate, contextTreeDir, deps.runtimeSignalStore)
         if (op) results.push(op)
       } catch {
         // Skip failed candidate — don't discard already-written results
@@ -221,6 +230,7 @@ async function isDuplicateCandidate(
 async function writeSynthesisFile(
   candidate: SynthesisCandidate,
   contextTreeDir: string,
+  runtimeSignalStore?: IRuntimeSignalStore,
 ): Promise<DreamOperation | undefined> {
   const slug = slugify(candidate.title)
   const relativePath = `${candidate.placement}/${slug}.md`
@@ -243,7 +253,6 @@ async function writeSynthesisFile(
   /* eslint-disable camelcase */
   const frontmatter = {
     confidence: candidate.confidence,
-    maturity: 'draft',
     sources,
     synthesized_at: new Date().toISOString(),
     type: 'synthesis',
@@ -263,6 +272,17 @@ async function writeSynthesisFile(
   const content = `---\n${yaml}\n---\n\n${body}`
 
   await atomicWrite(absPath, content)
+
+  // Seed the sidecar with default signals so ranking data lives in the
+  // sidecar rather than in markdown frontmatter. Best-effort — a sidecar
+  // failure must never prevent the synthesis file from being created.
+  if (runtimeSignalStore) {
+    try {
+      await runtimeSignalStore.set(relativePath, createDefaultRuntimeSignals())
+    } catch (error) {
+      warnSidecarFailure(undefined, 'synthesize', 'seed', relativePath, error)
+    }
+  }
 
   return {
     action: 'CREATE',

--- a/src/server/infra/dream/operations/synthesize.ts
+++ b/src/server/infra/dream/operations/synthesize.ts
@@ -17,6 +17,7 @@ import {access, mkdir, readdir, readFile, rename, writeFile} from 'node:fs/promi
 import {dirname, join, resolve} from 'node:path'
 
 import type {ICipherAgent} from '../../../../agent/core/interfaces/i-cipher-agent.js'
+import type {ILogger} from '../../../../agent/core/interfaces/i-logger.js'
 import type {IRuntimeSignalStore} from '../../../core/interfaces/storage/i-runtime-signal-store.js'
 import type {DreamOperation} from '../dream-log-schema.js'
 import type {SynthesisCandidate} from '../dream-response-schemas.js'
@@ -30,6 +31,11 @@ import {parseDreamResponse} from '../parse-dream-response.js'
 export type SynthesizeDeps = {
   agent: ICipherAgent
   contextTreeDir: string
+  /**
+   * Optional logger. When provided, sidecar seed failures emit a warn
+   * so the fail-open degradation is observable rather than silent.
+   */
+  logger?: ILogger
   /**
    * Optional sidecar store for runtime ranking signals. When provided,
    * newly created synthesis files are seeded with default signals so
@@ -101,7 +107,7 @@ export async function synthesize(deps: SynthesizeDeps): Promise<DreamOperation[]
     for (const candidate of novel) {
       try {
         // eslint-disable-next-line no-await-in-loop
-        const op = await writeSynthesisFile(candidate, contextTreeDir, deps.runtimeSignalStore)
+        const op = await writeSynthesisFile(candidate, contextTreeDir, deps.runtimeSignalStore, deps.logger)
         if (op) results.push(op)
       } catch {
         // Skip failed candidate — don't discard already-written results
@@ -231,6 +237,7 @@ async function writeSynthesisFile(
   candidate: SynthesisCandidate,
   contextTreeDir: string,
   runtimeSignalStore?: IRuntimeSignalStore,
+  logger?: ILogger,
 ): Promise<DreamOperation | undefined> {
   const slug = slugify(candidate.title)
   const relativePath = `${candidate.placement}/${slug}.md`
@@ -280,7 +287,7 @@ async function writeSynthesisFile(
     try {
       await runtimeSignalStore.set(relativePath, createDefaultRuntimeSignals())
     } catch (error) {
-      warnSidecarFailure(undefined, 'synthesize', 'seed', relativePath, error)
+      warnSidecarFailure(logger, 'synthesize', 'seed', relativePath, error)
     }
   }
 

--- a/src/server/infra/executor/dream-executor.ts
+++ b/src/server/infra/executor/dream-executor.ts
@@ -22,6 +22,7 @@ import type {ICipherAgent} from '../../../agent/core/interfaces/i-cipher-agent.j
 import type {FileState} from '../../core/domain/entities/context-tree-snapshot.js'
 import type {CurateLogEntry} from '../../core/domain/entities/curate-log-entry.js'
 import type {CurateLogStatus} from '../../core/interfaces/storage/i-curate-log-store.js'
+import type {IRuntimeSignalStore} from '../../core/interfaces/storage/i-runtime-signal-store.js'
 import type {DreamLogEntry, DreamLogSummary, DreamOperation} from '../dream/dream-log-schema.js'
 
 import {BRV_DIR, CONTEXT_TREE_DIR} from '../../constants.js'
@@ -62,10 +63,12 @@ export type DreamExecutorDeps = {
     save(relativePath: string, content: string): Promise<void>
   }
   /**
-   * Optional. Passed through to consolidate's CROSS_REFERENCE review gate so
-   * it reads maturity from the sidecar rather than markdown frontmatter.
+   * Optional. Passed through to consolidate's CROSS_REFERENCE review gate
+   * (reads `maturity` via `get`) and to prune's candidacy scan (reads
+   * `importance`/`maturity` via `list`). The full `IRuntimeSignalStore` is
+   * accepted so both code paths can consume what they need.
    */
-  runtimeSignalStore?: ConsolidateDeps['runtimeSignalStore']
+  runtimeSignalStore?: IRuntimeSignalStore
   searchService: ConsolidateDeps['searchService']
 }
 
@@ -301,6 +304,7 @@ export class DreamExecutor {
         dreamStateService: this.deps.dreamStateService,
         projectRoot,
         reviewBackupStore: this.deps.reviewBackupStore,
+        runtimeSignalStore: this.deps.runtimeSignalStore,
         signal,
         taskId,
       })),

--- a/src/server/infra/executor/dream-executor.ts
+++ b/src/server/infra/executor/dream-executor.ts
@@ -61,6 +61,11 @@ export type DreamExecutorDeps = {
   reviewBackupStore?: {
     save(relativePath: string, content: string): Promise<void>
   }
+  /**
+   * Optional. Passed through to consolidate's CROSS_REFERENCE review gate so
+   * it reads maturity from the sidecar rather than markdown frontmatter.
+   */
+  runtimeSignalStore?: ConsolidateDeps['runtimeSignalStore']
   searchService: ConsolidateDeps['searchService']
 }
 
@@ -268,6 +273,7 @@ export class DreamExecutor {
         contextTreeDir,
         dreamStateService: this.deps.dreamStateService,
         reviewBackupStore: this.deps.reviewBackupStore,
+        runtimeSignalStore: this.deps.runtimeSignalStore,
         searchService: this.deps.searchService,
         signal,
         taskId,

--- a/src/server/infra/executor/dream-executor.ts
+++ b/src/server/infra/executor/dream-executor.ts
@@ -288,6 +288,7 @@ export class DreamExecutor {
         ...(await synthesize({
           agent,
           contextTreeDir,
+          runtimeSignalStore: this.deps.runtimeSignalStore,
           searchService: this.deps.searchService,
           signal,
           taskId,

--- a/test/helpers/mock-factories.ts
+++ b/test/helpers/mock-factories.ts
@@ -381,9 +381,14 @@ export function createMockRuntimeSignalStore(): IRuntimeSignalStore {
     },
     get,
     async getMany(relPaths) {
-      const entries = await Promise.all(
-        relPaths.map(async (relPath) => [relPath, await get(relPath)] as const),
-      )
+      // Mirror the real store: only return entries for paths that have a
+      // stored record. Callers distinguish missing via `.has(path)`.
+      const entries: Array<readonly [string, ReturnType<typeof createDefaultRuntimeSignals>]> = []
+      for (const relPath of relPaths) {
+        const value = store.get(relPath)
+        if (value !== undefined) entries.push([relPath, value])
+      }
+
       return new Map(entries)
     },
     async list() {

--- a/test/helpers/mock-factories.ts
+++ b/test/helpers/mock-factories.ts
@@ -44,9 +44,11 @@ import type {IProviderConfigStore} from '../../src/server/core/interfaces/i-prov
 import type {IProviderKeychainStore} from '../../src/server/core/interfaces/i-provider-keychain-store.js'
 import type {IProviderOAuthTokenStore} from '../../src/server/core/interfaces/i-provider-oauth-token-store.js'
 import type {IAuthStateStore} from '../../src/server/core/interfaces/state/i-auth-state-store.js'
+import type {IRuntimeSignalStore} from '../../src/server/core/interfaces/storage/i-runtime-signal-store.js'
 import type {ITransportServer} from '../../src/server/core/interfaces/transport/i-transport-server.js'
 
 import {AuthToken} from '../../src/server/core/domain/entities/auth-token.js'
+import {createDefaultRuntimeSignals} from '../../src/server/core/domain/knowledge/runtime-signals-schema.js'
 
 /**
  * Type aliases for service mocks - balances type safety with readability.
@@ -353,6 +355,52 @@ export function createMockToolScheduler(
 }
 
 /**
+ * Creates an in-memory IRuntimeSignalStore backed by a Map.
+ *
+ * Behaviour mirrors RuntimeSignalStore: get returns defaults for unknown
+ * paths, update runs the updater against the current (or default) record.
+ * No atomicity guarantees are needed at the mock level — tests using this
+ * mock don't exercise concurrent writes.
+ */
+export function createMockRuntimeSignalStore(): IRuntimeSignalStore {
+  const store = new Map<string, ReturnType<typeof createDefaultRuntimeSignals>>()
+
+  const get = async (relPath: string) => store.get(relPath) ?? createDefaultRuntimeSignals()
+
+  return {
+    async batchUpdate(updates) {
+      await Promise.all(
+        [...updates.entries()].map(async ([relPath, updater]) => {
+          const current = await get(relPath)
+          store.set(relPath, updater(current))
+        }),
+      )
+    },
+    async delete(relPath) {
+      store.delete(relPath)
+    },
+    get,
+    async getMany(relPaths) {
+      const entries = await Promise.all(
+        relPaths.map(async (relPath) => [relPath, await get(relPath)] as const),
+      )
+      return new Map(entries)
+    },
+    async list() {
+      return new Map(store)
+    },
+    async set(relPath, signals) {
+      store.set(relPath, signals)
+    },
+    async update(relPath, updater) {
+      const next = updater(await get(relPath))
+      store.set(relPath, next)
+      return next
+    },
+  }
+}
+
+/**
  * Creates a properly-typed mock CipherAgentServices
  *
  * @param agentEventBus - Real or mock AgentEventBus instance
@@ -376,6 +424,7 @@ export function createMockCipherAgentServices(
     messageStorageService: {} as unknown as MessageStorageService,
     policyEngine: createMockPolicyEngine(sandbox),
     processService: createMockProcessService(sandbox),
+    runtimeSignalStore: createMockRuntimeSignalStore(),
     sandboxService: createMockSandboxService(sandbox),
     systemPromptManager: createMockSystemPromptManager(sandbox),
     toolManager: createMockToolManager(sandbox),

--- a/test/integration/runtime-signals/dual-write-pipeline.test.ts
+++ b/test/integration/runtime-signals/dual-write-pipeline.test.ts
@@ -1,0 +1,210 @@
+import {expect} from 'chai'
+import * as fs from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+
+import type {ICipherAgent} from '../../../src/agent/core/interfaces/i-cipher-agent.js'
+import type {IFileSystem} from '../../../src/agent/core/interfaces/i-file-system.js'
+import type {IRuntimeSignalStore} from '../../../src/server/core/interfaces/storage/i-runtime-signal-store.js'
+
+import {createCurateTool} from '../../../src/agent/infra/tools/implementations/curate-tool.js'
+import {SearchKnowledgeService} from '../../../src/agent/infra/tools/implementations/search-knowledge-service.js'
+import {BRV_DIR, CONTEXT_TREE_DIR} from '../../../src/server/constants.js'
+import {createDefaultRuntimeSignals} from '../../../src/server/core/domain/knowledge/runtime-signals-schema.js'
+import {FileContextTreeArchiveService} from '../../../src/server/infra/context-tree/file-context-tree-archive-service.js'
+import {createMockRuntimeSignalStore} from '../../helpers/mock-factories.js'
+
+interface PendingAccessHitsInternals {
+  pendingAccessHits: Map<string, number>
+}
+
+function createDiskFileSystem(): IFileSystem {
+  return {
+    async readFile(path: string) {
+      return {content: await fs.readFile(path, 'utf8')}
+    },
+    async writeFile(path: string, content: string) {
+      await fs.writeFile(path, content, 'utf8')
+    },
+  } as unknown as IFileSystem
+}
+
+function createMockAgent(): ICipherAgent {
+  return {
+    async cancel() {},
+    async createTaskSession() {
+      return 'mock-session'
+    },
+    async deleteSandboxVariable() {},
+    async deleteSandboxVariableOnSession() {},
+    async deleteSession() {},
+    async deleteTaskSession() {},
+    async execute() {
+      return 'ghost cue'
+    },
+    async executeOnSession() {
+      return 'ghost cue'
+    },
+    async generate() {
+      return 'ghost cue'
+    },
+    async getSessionMetadata() {},
+    getState() {
+      return 'idle'
+    },
+    async listPersistedSessions() {
+      return []
+    },
+    async reset() {},
+    async setSandboxVariable() {},
+    async setSandboxVariableOnSession() {},
+    async start() {},
+    async *stream() {
+      yield 'ghost cue'
+    },
+  } as unknown as ICipherAgent
+}
+
+/**
+ * End-to-end integration test for commit 3 (runtime-signals dual-write).
+ *
+ * Exercises the full sequence — curate ADD, curate UPDATE, flushAccessHits,
+ * curate MERGE, archive — on the same project tree, with a shared
+ * RuntimeSignalStore. Asserts the sidecar reflects the expected end state
+ * at each stage and stays consistent with markdown where observable.
+ */
+describe('Runtime-signals dual-write pipeline', () => {
+  let projectRoot: string
+  let contextTreeDir: string
+  let signalStore: IRuntimeSignalStore
+  let curateTool: {execute(input: unknown): Promise<unknown>}
+  let searchService: SearchKnowledgeService
+  let archiveService: FileContextTreeArchiveService
+  let agent: ICipherAgent
+
+  beforeEach(async () => {
+    projectRoot = join(tmpdir(), `rs-pipeline-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    contextTreeDir = join(projectRoot, BRV_DIR, CONTEXT_TREE_DIR)
+    await fs.mkdir(contextTreeDir, {recursive: true})
+
+    signalStore = createMockRuntimeSignalStore()
+    curateTool = createCurateTool(undefined, undefined, signalStore) as {execute(input: unknown): Promise<unknown>}
+    searchService = new SearchKnowledgeService(createDiskFileSystem(), {runtimeSignalStore: signalStore})
+    archiveService = new FileContextTreeArchiveService(signalStore)
+    agent = createMockAgent()
+  })
+
+  afterEach(async () => {
+    await fs.rm(projectRoot, {force: true, recursive: true})
+  })
+
+  it('ADD → UPDATE → flushAccessHits → MERGE → archive leaves the sidecar in the expected end state', async () => {
+    // Step 1: ADD two files.
+    await curateTool.execute({
+      basePath: contextTreeDir,
+      operations: [
+        {
+          confidence: 'high',
+          content: {snippets: ['source content'], tags: ['auth']},
+          impact: 'low',
+          path: 'auth/jwt',
+          reason: 'seed',
+          title: 'Refresh',
+          type: 'ADD',
+        },
+        {
+          confidence: 'high',
+          content: {snippets: ['target content'], tags: ['auth']},
+          impact: 'low',
+          path: 'auth/jwt',
+          reason: 'seed',
+          title: 'Rotation',
+          type: 'ADD',
+        },
+      ],
+    })
+
+    const srcRel = 'auth/jwt/refresh.md'
+    const tgtRel = 'auth/jwt/rotation.md'
+
+    // Both files have default signals.
+    expect(await signalStore.get(srcRel)).to.deep.equal(createDefaultRuntimeSignals())
+    expect(await signalStore.get(tgtRel)).to.deep.equal(createDefaultRuntimeSignals())
+
+    // Step 2: UPDATE the target — bumps importance +5, updateCount +1.
+    await curateTool.execute({
+      basePath: contextTreeDir,
+      operations: [
+        {
+          confidence: 'high',
+          content: {snippets: ['updated'], tags: ['auth']},
+          impact: 'low',
+          path: 'auth/jwt',
+          reason: 'refine',
+          title: 'Rotation',
+          type: 'UPDATE',
+        },
+      ],
+    })
+
+    const afterUpdate = await signalStore.get(tgtRel)
+    expect(afterUpdate.importance).to.equal(55)
+    expect(afterUpdate.updateCount).to.equal(1)
+    expect(afterUpdate.recency).to.equal(1)
+    expect(afterUpdate.maturity).to.equal('draft')
+
+    // Step 3: flushAccessHits on both files.
+    ;(searchService as unknown as PendingAccessHitsInternals).pendingAccessHits.set(srcRel, 3)
+    ;(searchService as unknown as PendingAccessHitsInternals).pendingAccessHits.set(tgtRel, 4)
+    await searchService.flushAccessHits(contextTreeDir)
+
+    const srcAfterFlush = await signalStore.get(srcRel)
+    // Source: default(50) + 3*3 = 59
+    expect(srcAfterFlush.importance).to.equal(59)
+    expect(srcAfterFlush.accessCount).to.equal(3)
+    expect(srcAfterFlush.maturity).to.equal('draft') // 59 < 65
+
+    const tgtAfterFlush = await signalStore.get(tgtRel)
+    // Target: 55 (from UPDATE) + 3*4 = 67 → crosses PROMOTE_TO_VALIDATED (65)
+    expect(tgtAfterFlush.importance).to.equal(67)
+    expect(tgtAfterFlush.accessCount).to.equal(4)
+    expect(tgtAfterFlush.maturity).to.equal('validated')
+
+    // Step 4: MERGE source into target. Merged signals land on target;
+    // source entry is dropped.
+    await curateTool.execute({
+      basePath: contextTreeDir,
+      operations: [
+        {
+          confidence: 'high',
+          impact: 'low',
+          mergeTarget: 'auth/jwt',
+          mergeTargetTitle: 'Rotation',
+          path: 'auth/jwt',
+          reason: 'consolidate',
+          title: 'Refresh',
+          type: 'MERGE',
+        },
+      ],
+    })
+
+    // Source sidecar entry gone.
+    expect((await signalStore.list()).has(srcRel)).to.equal(false)
+
+    // Target merged: max importance = max(59, 67) = 67; accessCount sum = 3+4 = 7;
+    // updateCount = 1 + 0 + 1 = 2; maturity re-derived at 67 = validated.
+    const afterMerge = await signalStore.get(tgtRel)
+    expect(afterMerge.importance).to.equal(67)
+    expect(afterMerge.accessCount).to.equal(7)
+    expect(afterMerge.updateCount).to.equal(2)
+    expect(afterMerge.maturity).to.equal('validated')
+
+    // Step 5: Archive the merged target.
+    await archiveService.archiveEntry(tgtRel, agent, projectRoot)
+
+    // Sidecar entry for the archived path is gone.
+    expect((await signalStore.list()).has(tgtRel)).to.equal(false)
+    // No orphans remain for either path.
+    expect((await signalStore.list()).size).to.equal(0)
+  })
+})

--- a/test/integration/runtime-signals/vc-clean-regression.test.ts
+++ b/test/integration/runtime-signals/vc-clean-regression.test.ts
@@ -1,0 +1,181 @@
+import {expect} from 'chai'
+import * as fs from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+
+import type {IFileSystem} from '../../../src/agent/core/interfaces/i-file-system.js'
+import type {IRuntimeSignalStore} from '../../../src/server/core/interfaces/storage/i-runtime-signal-store.js'
+
+import {SearchKnowledgeService} from '../../../src/agent/infra/tools/implementations/search-knowledge-service.js'
+import {BRV_DIR, CONTEXT_TREE_DIR} from '../../../src/server/constants.js'
+import {createMockRuntimeSignalStore} from '../../helpers/mock-factories.js'
+
+interface PendingAccessHitsInternals {
+  pendingAccessHits: Map<string, number>
+}
+
+function createDiskFileSystem(): IFileSystem {
+  return {
+    async readFile(path: string) {
+      return {content: await fs.readFile(path, 'utf8')}
+    },
+    async writeFile(path: string, content: string) {
+      await fs.writeFile(path, content, 'utf8')
+    },
+  } as unknown as IFileSystem
+}
+
+/**
+ * The user-facing acceptance test for commit 5:
+ * after N access-hit flushes on a populated context tree, every markdown
+ * file's on-disk content is byte-identical to its initial state.
+ *
+ * This is the test that defines "done" for the runtime-signals migration.
+ * If this fails, `brv vc status` shows noise for users after queries and
+ * the whole initiative has missed its goal.
+ */
+describe('Runtime-signals migration — VC-clean regression', () => {
+  let projectRoot: string
+  let contextTreeDir: string
+  let signalStore: IRuntimeSignalStore
+  let service: SearchKnowledgeService
+
+  beforeEach(async () => {
+    projectRoot = join(tmpdir(), `rs-vc-clean-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    contextTreeDir = join(projectRoot, BRV_DIR, CONTEXT_TREE_DIR)
+    await fs.mkdir(contextTreeDir, {recursive: true})
+    signalStore = createMockRuntimeSignalStore()
+    service = new SearchKnowledgeService(createDiskFileSystem(), {
+      baseDirectory: projectRoot,
+      runtimeSignalStore: signalStore,
+    })
+  })
+
+  afterEach(async () => {
+    await fs.rm(projectRoot, {force: true, recursive: true})
+  })
+
+  it('flushAccessHits never modifies markdown files, regardless of hit volume', async () => {
+    // Seed a context tree with 10 files that each have the post-commit-5
+    // frontmatter shape: only semantic fields + timestamps.
+    const relPaths: string[] = []
+    for (let i = 0; i < 10; i++) {
+      const domainDir = join(contextTreeDir, `domain_${i}`)
+      // eslint-disable-next-line no-await-in-loop
+      await fs.mkdir(domainDir, {recursive: true})
+
+      const relPath = `domain_${i}/entry_${i}.md`
+      const fullPath = join(contextTreeDir, relPath)
+      const content =
+        `---\n` +
+        `title: Entry ${i}\n` +
+        `tags: [test]\n` +
+        `keywords: [sample]\n` +
+        `createdAt: '2026-01-01T00:00:00.000Z'\n` +
+        `updatedAt: '2026-01-01T00:00:00.000Z'\n` +
+        `---\n\n# Entry ${i}\n\nSample content for regression test.\n`
+      // eslint-disable-next-line no-await-in-loop
+      await fs.writeFile(fullPath, content, 'utf8')
+      relPaths.push(relPath)
+    }
+
+    // Snapshot original content for every file.
+    const originals = new Map<string, string>()
+    for (const relPath of relPaths) {
+      // eslint-disable-next-line no-await-in-loop
+      originals.set(relPath, await fs.readFile(join(contextTreeDir, relPath), 'utf8'))
+    }
+
+    // Simulate 20 rounds of access-hit flushes, each touching every file.
+    const pendingMap = (service as unknown as PendingAccessHitsInternals).pendingAccessHits
+    for (let round = 0; round < 20; round++) {
+      pendingMap.clear()
+      for (const relPath of relPaths) {
+        pendingMap.set(relPath, 1)
+      }
+
+      // eslint-disable-next-line no-await-in-loop
+      const flushed = await service.flushAccessHits(contextTreeDir)
+      expect(flushed).to.equal(true)
+    }
+
+    // Every markdown file on disk is byte-identical to its initial state —
+    // no scoring fields were written, no timestamps touched, nothing.
+    for (const relPath of relPaths) {
+      // eslint-disable-next-line no-await-in-loop
+      const currentContent = await fs.readFile(join(contextTreeDir, relPath), 'utf8')
+      expect(currentContent, `file ${relPath} was modified after 20 flushes`).to.equal(originals.get(relPath))
+    }
+
+    // Meanwhile the sidecar has accumulated real signal state.
+    const signals = await signalStore.list()
+    expect(signals.size).to.equal(relPaths.length)
+    for (const relPath of relPaths) {
+      // 20 rounds × 1 hit × 3 importance bonus = 60 importance above default 50.
+      const entry = signals.get(relPath)
+      expect(entry?.importance).to.be.greaterThanOrEqual(60)
+      expect(entry?.accessCount).to.equal(20)
+    }
+  })
+
+  it('parseContent tolerates legacy files with full signal frontmatter', async () => {
+    const {MarkdownWriter} = await import('../../../src/server/core/domain/knowledge/markdown-writer.js')
+
+    // Pre-migration file: every runtime-signal field present in YAML.
+    const legacy =
+      `---\n` +
+      `title: Legacy Entry\n` +
+      `tags: [auth]\n` +
+      `keywords: [jwt]\n` +
+      `importance: 72\n` +
+      `recency: 0.8\n` +
+      `maturity: validated\n` +
+      `accessCount: 14\n` +
+      `updateCount: 3\n` +
+      `createdAt: '2026-01-01T00:00:00.000Z'\n` +
+      `updatedAt: '2026-01-15T00:00:00.000Z'\n` +
+      `---\n\n# Legacy Entry\n\nSome content.\n`
+
+    const parsed = MarkdownWriter.parseContent(legacy, 'Legacy Entry')
+
+    // Semantic fields round-trip.
+    expect(parsed.name).to.equal('Legacy Entry')
+    expect(parsed.tags).to.deep.equal(['auth'])
+    expect(parsed.keywords).to.deep.equal(['jwt'])
+    expect(parsed.timestamps?.createdAt).to.equal('2026-01-01T00:00:00.000Z')
+    expect(parsed.timestamps?.updatedAt).to.equal('2026-01-15T00:00:00.000Z')
+
+    // Legacy runtime-signal fields are silently ignored — not exposed on the
+    // semantic type (ContextData has no importance/recency/maturity fields).
+    const asRecord = parsed as unknown as Record<string, unknown>
+    expect(asRecord.importance).to.be.undefined
+    expect(asRecord.recency).to.be.undefined
+    expect(asRecord.maturity).to.be.undefined
+    expect(asRecord.accessCount).to.be.undefined
+    expect(asRecord.updateCount).to.be.undefined
+  })
+
+  it('generateFrontmatter never emits runtime-signal fields', async () => {
+    const {MarkdownWriter} = await import('../../../src/server/core/domain/knowledge/markdown-writer.js')
+
+    const output = MarkdownWriter.generateContext({
+      keywords: ['jwt'],
+      name: 'Fresh Entry',
+      snippets: [],
+      tags: ['auth'],
+      timestamps: {createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-15T00:00:00.000Z'},
+    })
+
+    expect(output).to.not.match(/^importance:/m)
+    expect(output).to.not.match(/^recency:/m)
+    expect(output).to.not.match(/^maturity:/m)
+    expect(output).to.not.match(/^accessCount:/m)
+    expect(output).to.not.match(/^updateCount:/m)
+
+    // Semantic fields and timestamps still emit.
+    expect(output).to.match(/^title: Fresh Entry/m)
+    expect(output).to.match(/^tags: \[auth\]/m)
+    expect(output).to.match(/^createdAt:/m)
+    expect(output).to.match(/^updatedAt:/m)
+  })
+})

--- a/test/unit/agent/agent/rebind-curate-tools-sidecar-wiring.test.ts
+++ b/test/unit/agent/agent/rebind-curate-tools-sidecar-wiring.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Regression guard: `rebindCurateTools` in cipher-agent.ts must thread
+ * `runtimeSignalStore` through to the sandbox `CurateService`.
+ *
+ * Root cause of the original bug: `createCurateService(workingDirectory,
+ * abstractQueue)` dropped the third optional arg, so agent-driven curate
+ * (the real user flow via the LLM sandbox) silently skipped sidecar
+ * seeds/bumps post-commit-5. The `tool-registry.ts` wiring at construction
+ * time was correct; the session-start rebind replaced it with a broken one.
+ *
+ * Testing `rebindCurateTools` end-to-end requires bootstrapping a full
+ * CipherAgent with an LLM config. We instead pin the wiring at the source
+ * level — cheapest reliable guard against a future refactor re-dropping the
+ * arg.
+ */
+
+import {expect} from 'chai'
+import * as fs from 'node:fs/promises'
+import {join} from 'node:path'
+
+describe('cipher-agent.ts — rebindCurateTools sidecar wiring regression', () => {
+  it('threads runtimeSignalStore into the sandbox CurateService at session start', async () => {
+    const sourcePath = join(process.cwd(), 'src/agent/infra/agent/cipher-agent.ts')
+    const source = await fs.readFile(sourcePath, 'utf8')
+
+    // Anchor on the exact call-site token — unique, load-bearing, and
+    // independent of surrounding comments. The 400-char window covers the
+    // multi-line arg list.
+    const anchor = source.indexOf('const newCurateService = createCurateService(')
+    expect(anchor, 'newCurateService call in rebindCurateTools missing').to.be.greaterThan(-1)
+    const window = source.slice(anchor, anchor + 400)
+
+    expect(window, 'createCurateService must receive runtimeSignalStore').to.match(
+      /createCurateService\([^)]*runtimeSignalStore/s,
+    )
+  })
+})

--- a/test/unit/agent/knowledge/markdown-writer.test.ts
+++ b/test/unit/agent/knowledge/markdown-writer.test.ts
@@ -475,5 +475,109 @@ Some old content`
       expect(parsed.relations).to.have.members(['domain/new/file.md', 'domain/old/file.md'])
       expect(parsed.tags).to.deep.equal(['newtag'])
     })
+
+    describe('timestamp merge', () => {
+      it('preserves the earliest createdAt from either input', () => {
+        const source = `---
+title: Source
+tags: []
+keywords: []
+createdAt: '2026-03-10T00:00:00.000Z'
+updatedAt: '2026-04-01T00:00:00.000Z'
+---
+Source body`
+
+        const target = `---
+title: Target
+tags: []
+keywords: []
+createdAt: '2026-01-15T00:00:00.000Z'
+updatedAt: '2026-02-20T00:00:00.000Z'
+---
+Target body`
+
+        const merged = MarkdownWriter.mergeContexts(source, target)
+        const parsed = MarkdownWriter.parseContent(merged)
+
+        // Earliest createdAt wins (target's 2026-01-15 is earlier than source's 2026-03-10).
+        expect(parsed.timestamps?.createdAt).to.equal('2026-01-15T00:00:00.000Z')
+      })
+
+      it('stamps a fresh updatedAt on merge', () => {
+        const source = `---
+title: Source
+tags: []
+keywords: []
+createdAt: '2026-01-01T00:00:00.000Z'
+updatedAt: '2026-01-01T00:00:00.000Z'
+---
+Source`
+
+        const target = `---
+title: Target
+tags: []
+keywords: []
+createdAt: '2026-01-01T00:00:00.000Z'
+updatedAt: '2026-01-01T00:00:00.000Z'
+---
+Target`
+
+        const before = Date.now()
+        const merged = MarkdownWriter.mergeContexts(source, target)
+        const after = Date.now()
+        const parsed = MarkdownWriter.parseContent(merged)
+
+        expect(parsed.timestamps?.updatedAt).to.exist
+        const updatedAtMs = new Date(parsed.timestamps!.updatedAt!).getTime()
+        expect(updatedAtMs).to.be.at.least(before)
+        expect(updatedAtMs).to.be.at.most(after)
+      })
+
+      it('falls back to the single available createdAt when only one input has it', () => {
+        const source = `---
+title: Source
+tags: []
+keywords: []
+createdAt: '2026-05-01T00:00:00.000Z'
+---
+Source`
+
+        const target = `---
+title: Target
+tags: []
+keywords: []
+---
+Target`
+
+        const merged = MarkdownWriter.mergeContexts(source, target)
+        const parsed = MarkdownWriter.parseContent(merged)
+
+        expect(parsed.timestamps?.createdAt).to.equal('2026-05-01T00:00:00.000Z')
+      })
+
+      it('omits createdAt entirely when neither input carries it', () => {
+        const source = `---
+title: Source
+tags: []
+keywords: []
+---
+Source`
+
+        const target = `---
+title: Target
+tags: []
+keywords: []
+---
+Target`
+
+        const merged = MarkdownWriter.mergeContexts(source, target)
+        const parsed = MarkdownWriter.parseContent(merged)
+
+        // Neither input had createdAt — merged output has no createdAt either.
+        expect(parsed.timestamps?.createdAt).to.be.undefined
+        // updatedAt is always stamped on merge since content changed.
+        expect(parsed.timestamps?.updatedAt).to.exist
+      })
+    })
   })
 })

--- a/test/unit/agent/knowledge/runtime-signal-store.test.ts
+++ b/test/unit/agent/knowledge/runtime-signal-store.test.ts
@@ -213,16 +213,21 @@ describe('RuntimeSignalStore', () => {
   })
 
   describe('getMany', () => {
-    it('returns a map with an entry for every requested path', async () => {
+    it('returns entries only for paths that have a stored record', async () => {
+      // Callers distinguish "no entry yet" from "entry with default values"
+      // via `.has(path)` — missing paths must be absent from the map so the
+      // distinction is expressible.
       await store.set('a.md', {...createDefaultRuntimeSignals(), importance: 91})
       await store.set('b.md', {...createDefaultRuntimeSignals(), importance: 92})
 
       const result = await store.getMany(['a.md', 'b.md', 'missing.md'])
 
-      expect(result.size).to.equal(3)
+      expect(result.size).to.equal(2)
+      expect(result.has('a.md')).to.equal(true)
       expect(result.get('a.md')?.importance).to.equal(91)
+      expect(result.has('b.md')).to.equal(true)
       expect(result.get('b.md')?.importance).to.equal(92)
-      expect(result.get('missing.md')).to.deep.equal(createDefaultRuntimeSignals())
+      expect(result.has('missing.md')).to.equal(false)
     })
 
     it('returns an empty map for an empty input', async () => {
@@ -236,6 +241,16 @@ describe('RuntimeSignalStore', () => {
       const result = await store.getMany(['wanted.md'])
       expect(result.size).to.equal(1)
       expect(result.has('ignored.md')).to.equal(false)
+    })
+
+    it('omits corrupt entries with a logged warning', async () => {
+      await keyStorage.set(['signals', 'good.md'], createDefaultRuntimeSignals())
+      await keyStorage.set(['signals', 'bad.md'], {importance: 'nope'})
+
+      const result = await store.getMany(['good.md', 'bad.md'])
+      expect(result.has('good.md')).to.equal(true)
+      expect(result.has('bad.md')).to.equal(false)
+      expect((logger.warn as sinon.SinonStub).calledOnce).to.equal(true)
     })
   })
 

--- a/test/unit/agent/knowledge/runtime-signal-store.test.ts
+++ b/test/unit/agent/knowledge/runtime-signal-store.test.ts
@@ -1,0 +1,308 @@
+import {expect} from 'chai'
+import sinon from 'sinon'
+
+import type {ILogger} from '../../../../src/agent/core/interfaces/i-logger.js'
+
+import {FileKeyStorage} from '../../../../src/agent/infra/storage/file-key-storage.js'
+import {
+  createDefaultRuntimeSignals,
+  DEFAULT_IMPORTANCE,
+  type RuntimeSignals,
+} from '../../../../src/server/core/domain/knowledge/runtime-signals-schema.js'
+import {RuntimeSignalStore} from '../../../../src/server/infra/context-tree/runtime-signal-store.js'
+
+function createMockLogger(): ILogger {
+  return {
+    debug: sinon.stub(),
+    error: sinon.stub(),
+    info: sinon.stub(),
+    warn: sinon.stub(),
+  }
+}
+
+async function expectRejected(promise: Promise<unknown>): Promise<void> {
+  let threw = false
+  try {
+    await promise
+  } catch {
+    threw = true
+  }
+
+  expect(threw).to.equal(true)
+}
+
+describe('RuntimeSignalStore', () => {
+  let keyStorage: FileKeyStorage
+  let logger: ILogger
+  let store: RuntimeSignalStore
+
+  beforeEach(async () => {
+    keyStorage = new FileKeyStorage({inMemory: true})
+    await keyStorage.initialize()
+    logger = createMockLogger()
+    store = new RuntimeSignalStore(keyStorage, logger)
+  })
+
+  afterEach(() => {
+    keyStorage.close()
+  })
+
+  describe('get', () => {
+    it('returns defaults for a path with no stored entry', async () => {
+      const result = await store.get('auth/jwt.md')
+      expect(result).to.deep.equal(createDefaultRuntimeSignals())
+    })
+
+    it('returns stored values for a path that was set', async () => {
+      await store.set('auth/jwt.md', {
+        accessCount: 7,
+        importance: 78,
+        maturity: 'validated',
+        recency: 0.6,
+        updateCount: 3,
+      })
+
+      expect(await store.get('auth/jwt.md')).to.deep.equal({
+        accessCount: 7,
+        importance: 78,
+        maturity: 'validated',
+        recency: 0.6,
+        updateCount: 3,
+      })
+    })
+
+    it('returns defaults and logs a warning when stored data is corrupt', async () => {
+      // Seed a corrupt record directly, bypassing the store's set() validation.
+      await keyStorage.set(['signals', 'corrupt.md'], {importance: 'not-a-number'})
+
+      expect(await store.get('corrupt.md')).to.deep.equal(createDefaultRuntimeSignals())
+      expect((logger.warn as sinon.SinonStub).calledOnce).to.equal(true)
+    })
+
+    it('fills missing fields with defaults when a partial record is stored (forward-compat)', async () => {
+      // If a future version adds a new field, existing records should still
+      // read successfully — the Zod schema's per-field defaults cover the gap.
+      await keyStorage.set(['signals', 'partial.md'], {importance: 80})
+
+      expect(await store.get('partial.md')).to.deep.equal({
+        ...createDefaultRuntimeSignals(),
+        importance: 80,
+      })
+    })
+
+    it('handles deeply-nested paths', async () => {
+      await store.set('a/b/c/d/leaf.md', {...createDefaultRuntimeSignals(), importance: 90})
+      expect((await store.get('a/b/c/d/leaf.md')).importance).to.equal(90)
+    })
+  })
+
+  describe('set', () => {
+    it('persists a full record round-trippable via get', async () => {
+      const signals: RuntimeSignals = {...createDefaultRuntimeSignals(), importance: 90, maturity: 'core'}
+      await store.set('auth/jwt.md', signals)
+      expect(await store.get('auth/jwt.md')).to.deep.equal(signals)
+    })
+
+    it('overwrites an existing record entirely', async () => {
+      await store.set('auth/jwt.md', {...createDefaultRuntimeSignals(), importance: 60})
+      await store.set('auth/jwt.md', {...createDefaultRuntimeSignals(), importance: 20})
+
+      expect((await store.get('auth/jwt.md')).importance).to.equal(20)
+    })
+
+    it('rejects invalid records at write time', async () => {
+      const invalid = {...createDefaultRuntimeSignals(), importance: 150}
+      await expectRejected(store.set('auth/jwt.md', invalid))
+    })
+  })
+
+  describe('update', () => {
+    it('seeds defaults when no record exists and applies the updater', async () => {
+      const next = await store.update('auth/jwt.md', (current) => ({
+        ...current,
+        importance: current.importance + 5,
+      }))
+
+      expect(next.importance).to.equal(DEFAULT_IMPORTANCE + 5)
+      expect(next.accessCount).to.equal(0)
+      expect((await store.get('auth/jwt.md')).importance).to.equal(DEFAULT_IMPORTANCE + 5)
+    })
+
+    it('reads the stored record and passes it to the updater', async () => {
+      await store.set('auth/jwt.md', {
+        accessCount: 2,
+        importance: 60,
+        maturity: 'draft',
+        recency: 0.8,
+        updateCount: 1,
+      })
+
+      await store.update('auth/jwt.md', (current) => ({
+        ...current,
+        accessCount: current.accessCount + 3,
+        importance: current.importance + 10,
+      }))
+
+      expect(await store.get('auth/jwt.md')).to.deep.equal({
+        accessCount: 5,
+        importance: 70,
+        maturity: 'draft',
+        recency: 0.8,
+        updateCount: 1,
+      })
+    })
+
+    it('rejects updater output that violates the schema', async () => {
+      await expectRejected(
+        store.update('auth/jwt.md', (current) => ({...current, importance: 150})),
+      )
+    })
+
+    it('serializes concurrent updates on the same path without losing bumps', async () => {
+      // Classic lost-update test: each update reads current and adds 1.
+      // With atomic read-modify-write, the final value reflects every iteration.
+      const iterations = 20
+      await Promise.all(
+        Array.from({length: iterations}, () =>
+          store.update('hot.md', (current) => ({
+            ...current,
+            importance: current.importance + 1,
+          })),
+        ),
+      )
+
+      expect((await store.get('hot.md')).importance).to.equal(DEFAULT_IMPORTANCE + iterations)
+    })
+  })
+
+  describe('batchUpdate', () => {
+    it('applies all updaters and persists the results', async () => {
+      const updates = new Map([
+        ['auth/jwt.md', (c: RuntimeSignals) => ({...c, importance: 70})],
+        ['auth/oauth.md', (c: RuntimeSignals) => ({...c, accessCount: 3, importance: 65})],
+        ['billing/invoices.md', (c: RuntimeSignals) => ({...c, maturity: 'validated' as const})],
+      ])
+
+      await store.batchUpdate(updates)
+
+      expect((await store.get('auth/jwt.md')).importance).to.equal(70)
+      const oauth = await store.get('auth/oauth.md')
+      expect(oauth.importance).to.equal(65)
+      expect(oauth.accessCount).to.equal(3)
+      expect((await store.get('billing/invoices.md')).maturity).to.equal('validated')
+    })
+
+    it('is a no-op for an empty map', async () => {
+      await store.batchUpdate(new Map())
+      expect((await store.list()).size).to.equal(0)
+    })
+
+    it('serializes concurrent bumps on the same path across batches', async () => {
+      // Two overlapping batch flushes target the same file — both must land.
+      const batchA = new Map([
+        ['shared.md', (c: RuntimeSignals) => ({...c, accessCount: c.accessCount + 5})],
+      ])
+      const batchB = new Map([
+        ['shared.md', (c: RuntimeSignals) => ({...c, accessCount: c.accessCount + 7})],
+      ])
+
+      await Promise.all([store.batchUpdate(batchA), store.batchUpdate(batchB)])
+
+      expect((await store.get('shared.md')).accessCount).to.equal(12)
+    })
+  })
+
+  describe('getMany', () => {
+    it('returns a map with an entry for every requested path', async () => {
+      await store.set('a.md', {...createDefaultRuntimeSignals(), importance: 91})
+      await store.set('b.md', {...createDefaultRuntimeSignals(), importance: 92})
+
+      const result = await store.getMany(['a.md', 'b.md', 'missing.md'])
+
+      expect(result.size).to.equal(3)
+      expect(result.get('a.md')?.importance).to.equal(91)
+      expect(result.get('b.md')?.importance).to.equal(92)
+      expect(result.get('missing.md')).to.deep.equal(createDefaultRuntimeSignals())
+    })
+
+    it('returns an empty map for an empty input', async () => {
+      expect((await store.getMany([])).size).to.equal(0)
+    })
+
+    it('does not read entries outside the requested set', async () => {
+      await store.set('wanted.md', {...createDefaultRuntimeSignals(), importance: 77})
+      await store.set('ignored.md', {...createDefaultRuntimeSignals(), importance: 42})
+
+      const result = await store.getMany(['wanted.md'])
+      expect(result.size).to.equal(1)
+      expect(result.has('ignored.md')).to.equal(false)
+    })
+  })
+
+  describe('path encoding edge cases', () => {
+    it('normalizes leading and trailing slashes', async () => {
+      await store.set('/leading.md', {...createDefaultRuntimeSignals(), importance: 61})
+      // Same logical path, different surface form — should hit the same entry.
+      expect((await store.get('leading.md')).importance).to.equal(61)
+
+      await store.set('trailing/', {...createDefaultRuntimeSignals(), importance: 62})
+      expect((await store.get('trailing')).importance).to.equal(62)
+    })
+
+    it('collapses consecutive slashes', async () => {
+      await store.set('a//b.md', {...createDefaultRuntimeSignals(), importance: 63})
+      expect((await store.get('a/b.md')).importance).to.equal(63)
+    })
+  })
+
+  describe('delete', () => {
+    it('removes an existing entry so subsequent get returns defaults', async () => {
+      await store.set('gone.md', {...createDefaultRuntimeSignals(), importance: 90})
+      await store.delete('gone.md')
+
+      expect(await store.get('gone.md')).to.deep.equal(createDefaultRuntimeSignals())
+    })
+
+    it('is a no-op for a missing path', async () => {
+      await store.delete('never-existed.md')
+      expect(await store.get('never-existed.md')).to.deep.equal(createDefaultRuntimeSignals())
+    })
+  })
+
+  describe('list', () => {
+    it('returns an empty map when nothing is stored', async () => {
+      expect((await store.list()).size).to.equal(0)
+    })
+
+    it('returns all stored entries keyed by relPath', async () => {
+      await store.set('a.md', {...createDefaultRuntimeSignals(), importance: 51})
+      await store.set('b/nested.md', {...createDefaultRuntimeSignals(), importance: 52})
+      await store.set('c/deeper/leaf.md', {...createDefaultRuntimeSignals(), importance: 53})
+
+      const all = await store.list()
+      expect(all.size).to.equal(3)
+      expect(all.get('a.md')?.importance).to.equal(51)
+      expect(all.get('b/nested.md')?.importance).to.equal(52)
+      expect(all.get('c/deeper/leaf.md')?.importance).to.equal(53)
+    })
+
+    it('falls back to defaults for corrupt entries instead of crashing', async () => {
+      await store.set('good.md', createDefaultRuntimeSignals())
+      await keyStorage.set(['signals', 'bad.md'], {importance: 'nope'})
+
+      const all = await store.list()
+      expect(all.has('good.md')).to.equal(true)
+      expect(all.get('bad.md')).to.deep.equal(createDefaultRuntimeSignals())
+    })
+
+    it('ignores keys outside the signals namespace', async () => {
+      // Another subsystem sharing the same keyStorage must not leak into list().
+      await store.set('a.md', createDefaultRuntimeSignals())
+      await keyStorage.set(['session', 'some-session-id'], {foo: 'bar'})
+
+      const all = await store.list()
+      expect(all.size).to.equal(1)
+      expect(all.has('a.md')).to.equal(true)
+    })
+  })
+})

--- a/test/unit/agent/knowledge/runtime-signals-schema.test.ts
+++ b/test/unit/agent/knowledge/runtime-signals-schema.test.ts
@@ -1,0 +1,108 @@
+import {expect} from 'chai'
+
+import {
+  createDefaultRuntimeSignals,
+  DEFAULT_ACCESS_COUNT,
+  DEFAULT_IMPORTANCE,
+  DEFAULT_MATURITY,
+  DEFAULT_RECENCY,
+  DEFAULT_UPDATE_COUNT,
+  RuntimeSignalsSchema,
+} from '../../../../src/server/core/domain/knowledge/runtime-signals-schema.js'
+
+describe('runtime-signals-schema', () => {
+  describe('RuntimeSignalsSchema', () => {
+    it('accepts a fully populated record', () => {
+      const result = RuntimeSignalsSchema.parse({
+        accessCount: 5,
+        importance: 72,
+        maturity: 'validated',
+        recency: 0.8,
+        updateCount: 2,
+      })
+
+      expect(result).to.deep.equal({
+        accessCount: 5,
+        importance: 72,
+        maturity: 'validated',
+        recency: 0.8,
+        updateCount: 2,
+      })
+    })
+
+    it('fills missing fields with defaults when parsing an empty object', () => {
+      const result = RuntimeSignalsSchema.parse({})
+
+      expect(result).to.deep.equal({
+        accessCount: DEFAULT_ACCESS_COUNT,
+        importance: DEFAULT_IMPORTANCE,
+        maturity: DEFAULT_MATURITY,
+        recency: DEFAULT_RECENCY,
+        updateCount: DEFAULT_UPDATE_COUNT,
+      })
+    })
+
+    it('rejects importance above 100', () => {
+      expect(() => RuntimeSignalsSchema.parse({importance: 101})).to.throw()
+    })
+
+    it('rejects importance below 0', () => {
+      expect(() => RuntimeSignalsSchema.parse({importance: -1})).to.throw()
+    })
+
+    it('rejects recency above 1', () => {
+      expect(() => RuntimeSignalsSchema.parse({recency: 1.5})).to.throw()
+    })
+
+    it('rejects recency below 0', () => {
+      expect(() => RuntimeSignalsSchema.parse({recency: -0.1})).to.throw()
+    })
+
+    it('rejects unknown maturity tier', () => {
+      expect(() => RuntimeSignalsSchema.parse({maturity: 'mature'})).to.throw()
+    })
+
+    it('rejects non-integer accessCount', () => {
+      expect(() => RuntimeSignalsSchema.parse({accessCount: 3.5})).to.throw()
+    })
+
+    it('rejects negative accessCount', () => {
+      expect(() => RuntimeSignalsSchema.parse({accessCount: -1})).to.throw()
+    })
+
+    it('rejects non-integer updateCount', () => {
+      expect(() => RuntimeSignalsSchema.parse({updateCount: 3.5})).to.throw()
+    })
+
+    it('rejects negative updateCount', () => {
+      expect(() => RuntimeSignalsSchema.parse({updateCount: -1})).to.throw()
+    })
+  })
+
+  describe('createDefaultRuntimeSignals', () => {
+    it('returns a record with default values for all fields', () => {
+      const defaults = createDefaultRuntimeSignals()
+
+      expect(defaults).to.deep.equal({
+        accessCount: DEFAULT_ACCESS_COUNT,
+        importance: DEFAULT_IMPORTANCE,
+        maturity: DEFAULT_MATURITY,
+        recency: DEFAULT_RECENCY,
+        updateCount: DEFAULT_UPDATE_COUNT,
+      })
+    })
+
+    it('returns a fresh object on each call (not a shared reference)', () => {
+      const a = createDefaultRuntimeSignals()
+      const b = createDefaultRuntimeSignals()
+
+      a.importance = 99
+      expect(b.importance).to.equal(DEFAULT_IMPORTANCE)
+    })
+
+    it('returns values that satisfy the schema', () => {
+      const defaults = createDefaultRuntimeSignals()
+      expect(() => RuntimeSignalsSchema.parse(defaults)).to.not.throw()
+    })
+  })
+})

--- a/test/unit/agent/tools/curate-tool-sidecar-dual-write.test.ts
+++ b/test/unit/agent/tools/curate-tool-sidecar-dual-write.test.ts
@@ -250,8 +250,8 @@ describe('Curate tool — runtime-signal sidecar dual-write', () => {
     })
   })
 
-  describe('markdown/sidecar consistency', () => {
-    it('ADD writes matching scoring to both markdown frontmatter and sidecar', async () => {
+  describe('markdown/sidecar separation', () => {
+    it('ADD writes scoring only to the sidecar — markdown carries no runtime-signal fields', async () => {
       await runCurate(basePath, signalStore, [
         {
           confidence: 'high',
@@ -269,17 +269,18 @@ describe('Curate tool — runtime-signal sidecar dual-write', () => {
       const markdown = await fs.readFile(markdownPath, 'utf8')
       const signals = await signalStore.get(relPath)
 
-      // Pull scoring fields out of the markdown frontmatter.
-      const importanceMatch = /^importance:\s*(\d+)/m.exec(markdown)
-      const maturityMatch = /^maturity:\s*(core|draft|validated)/m.exec(markdown)
-      const recencyMatch = /^recency:\s*([\d.]+)/m.exec(markdown)
+      // Sidecar carries the runtime signals (default values on ADD).
+      expect(signals).to.deep.equal(createDefaultRuntimeSignals())
 
-      expect(importanceMatch?.[1]).to.equal(String(signals.importance))
-      expect(maturityMatch?.[1]).to.equal(signals.maturity)
-      expect(recencyMatch?.[1]).to.equal(String(signals.recency))
+      // Markdown carries zero runtime-signal fields — not emitted any more.
+      expect(markdown).to.not.match(/^importance:/m)
+      expect(markdown).to.not.match(/^recency:/m)
+      expect(markdown).to.not.match(/^maturity:/m)
+      expect(markdown).to.not.match(/^accessCount:/m)
+      expect(markdown).to.not.match(/^updateCount:/m)
     })
 
-    it('UPDATE keeps markdown and sidecar in sync after a bump', async () => {
+    it('UPDATE bumps the sidecar while leaving markdown scoring-free', async () => {
       // Seed.
       await runCurate(basePath, signalStore, [
         {
@@ -309,13 +310,14 @@ describe('Curate tool — runtime-signal sidecar dual-write', () => {
       const markdown = await fs.readFile(join(basePath, relPath), 'utf8')
       const signals = await signalStore.get(relPath)
 
-      const importanceMatch = /^importance:\s*(\d+)/m.exec(markdown)
-      const maturityMatch = /^maturity:\s*(core|draft|validated)/m.exec(markdown)
-      const updateCountMatch = /^updateCount:\s*(\d+)/m.exec(markdown)
+      // Sidecar reflects the bump.
+      expect(signals.importance).to.equal(55) // 50 + UPDATE_IMPORTANCE_BONUS(5)
+      expect(signals.updateCount).to.equal(1)
 
-      expect(importanceMatch?.[1]).to.equal(String(signals.importance))
-      expect(maturityMatch?.[1]).to.equal(signals.maturity)
-      expect(updateCountMatch?.[1]).to.equal(String(signals.updateCount))
+      // Markdown still carries no runtime-signal fields.
+      expect(markdown).to.not.match(/^importance:/m)
+      expect(markdown).to.not.match(/^maturity:/m)
+      expect(markdown).to.not.match(/^updateCount:/m)
     })
   })
 

--- a/test/unit/agent/tools/curate-tool-sidecar-dual-write.test.ts
+++ b/test/unit/agent/tools/curate-tool-sidecar-dual-write.test.ts
@@ -189,6 +189,55 @@ describe('Curate tool — runtime-signal sidecar dual-write', () => {
       const after = await signalStore.get(relPath)
       expect(after).to.deep.equal(createDefaultRuntimeSignals())
     })
+
+    it('drops sidecar entries for every file inside a deleted folder', async () => {
+      // Seed two files under the same topic folder.
+      await runCurate(basePath, signalStore, [
+        {
+          confidence: 'high',
+          content: {snippets: ['a'], tags: ['t']},
+          impact: 'low',
+          path: 'domain/topic',
+          reason: 'seed one',
+          title: 'File One',
+          type: 'ADD',
+        },
+        {
+          confidence: 'high',
+          content: {snippets: ['b'], tags: ['t']},
+          impact: 'low',
+          path: 'domain/topic',
+          reason: 'seed two',
+          title: 'File Two',
+          type: 'ADD',
+        },
+      ])
+
+      const relOne = 'domain/topic/file_one.md'
+      const relTwo = 'domain/topic/file_two.md'
+
+      // Mark both sidecar entries with non-default values so we can prove removal.
+      await signalStore.set(relOne, {...createDefaultRuntimeSignals(), importance: 80})
+      await signalStore.set(relTwo, {...createDefaultRuntimeSignals(), importance: 90})
+
+      // Folder delete: omit `title` so executeDelete takes the folder branch.
+      const result = await runCurate(basePath, signalStore, [
+        {
+          confidence: 'low',
+          impact: 'low',
+          path: 'domain/topic',
+          reason: 'clean folder',
+          type: 'DELETE',
+        },
+      ])
+      expect(result.summary.deleted).to.equal(1)
+
+      // Both sidecar entries must be gone — get() returns defaults on miss.
+      const afterOne = await signalStore.get(relOne)
+      const afterTwo = await signalStore.get(relTwo)
+      expect(afterOne).to.deep.equal(createDefaultRuntimeSignals())
+      expect(afterTwo).to.deep.equal(createDefaultRuntimeSignals())
+    })
   })
 
   describe('MERGE', () => {

--- a/test/unit/agent/tools/curate-tool-sidecar-dual-write.test.ts
+++ b/test/unit/agent/tools/curate-tool-sidecar-dual-write.test.ts
@@ -1,0 +1,363 @@
+import {expect} from 'chai'
+import * as fs from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+
+import type {IRuntimeSignalStore} from '../../../../src/server/core/interfaces/storage/i-runtime-signal-store.js'
+
+import {createCurateTool} from '../../../../src/agent/infra/tools/implementations/curate-tool.js'
+import {createDefaultRuntimeSignals} from '../../../../src/server/core/domain/knowledge/runtime-signals-schema.js'
+import {createMockRuntimeSignalStore} from '../../../helpers/mock-factories.js'
+
+interface CurateOutput {
+  applied: Array<{
+    message?: string
+    path: string
+    status: 'failed' | 'success'
+    type: string
+  }>
+  summary: {
+    added: number
+    deleted: number
+    failed: number
+    merged: number
+    updated: number
+  }
+}
+
+interface CurateTool {
+  execute(input: unknown): Promise<CurateOutput>
+}
+
+async function runCurate(
+  basePath: string,
+  signalStore: IRuntimeSignalStore,
+  operations: Array<Record<string, unknown>>,
+): Promise<CurateOutput> {
+  const tool = createCurateTool(undefined, undefined, signalStore) as unknown as CurateTool
+  return tool.execute({basePath, operations})
+}
+
+describe('Curate tool — runtime-signal sidecar dual-write', () => {
+  let tmpDir: string
+  let basePath: string
+  let signalStore: IRuntimeSignalStore
+
+  beforeEach(async () => {
+    tmpDir = join(tmpdir(), `curate-dual-write-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    basePath = join(tmpDir, '.brv/context-tree')
+    await fs.mkdir(basePath, {recursive: true})
+    signalStore = createMockRuntimeSignalStore()
+  })
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, {force: true, recursive: true})
+  })
+
+  describe('ADD', () => {
+    it('seeds the sidecar with default signals for the new file', async () => {
+      const result = await runCurate(basePath, signalStore, [
+        {
+          confidence: 'high',
+          content: {snippets: ['const x = 1'], tags: ['test']},
+          impact: 'low',
+          path: 'tech_stack/typescript',
+          reason: 'init',
+          title: 'TypeScript Notes',
+          type: 'ADD',
+        },
+      ])
+
+      expect(result.summary.added).to.equal(1)
+      const relPath = 'tech_stack/typescript/typescript_notes.md'
+      const signals = await signalStore.get(relPath)
+      expect(signals).to.deep.equal(createDefaultRuntimeSignals())
+    })
+  })
+
+  describe('UPDATE', () => {
+    it('bumps importance/recency/updateCount and recomputes maturity in the sidecar', async () => {
+      // Seed via ADD so markdown + sidecar both start in sync.
+      await runCurate(basePath, signalStore, [
+        {
+          confidence: 'high',
+          content: {snippets: ['a'], tags: ['t']},
+          impact: 'low',
+          path: 'domain/topic',
+          reason: 'seed',
+          title: 'My Note',
+          type: 'ADD',
+        },
+      ])
+
+      const relPath = 'domain/topic/my_note.md'
+      const before = await signalStore.get(relPath)
+      expect(before.importance).to.equal(50)
+      expect(before.updateCount).to.equal(0)
+      expect(before.recency).to.equal(1)
+
+      // Simulate a "cold" sidecar by decaying recency so the update bump is visible.
+      await signalStore.update(relPath, (current) => ({...current, recency: 0.2}))
+
+      const updateResult = await runCurate(basePath, signalStore, [
+        {
+          confidence: 'high',
+          content: {snippets: ['a', 'b'], tags: ['t']},
+          impact: 'low',
+          path: 'domain/topic',
+          reason: 'update',
+          title: 'My Note',
+          type: 'UPDATE',
+        },
+      ])
+      expect(updateResult.summary.updated).to.equal(1)
+
+      const after = await signalStore.get(relPath)
+      expect(after.importance).to.equal(55) // 50 + UPDATE_IMPORTANCE_BONUS(5)
+      expect(after.recency).to.equal(1) // reset to 1 by recordCurateUpdate
+      expect(after.updateCount).to.equal(1)
+      expect(after.maturity).to.equal('draft') // 55 < PROMOTE_TO_VALIDATED(65)
+    })
+
+    it('maturity invariant: repeated updates promote draft -> validated when importance crosses 65', async () => {
+      // Seed, then apply 3 updates (+5 each = +15) on top of an already-elevated importance.
+      await runCurate(basePath, signalStore, [
+        {
+          confidence: 'high',
+          content: {snippets: ['a'], tags: ['t']},
+          impact: 'low',
+          path: 'd/t',
+          reason: 'seed',
+          title: 'N',
+          type: 'ADD',
+        },
+      ])
+      const relPath = 'd/t/n.md'
+
+      // Pre-set importance to 55 so the first UPDATE (+5=60) still stays draft,
+      // the second (+5=65) crosses the PROMOTE_TO_VALIDATED threshold.
+      await signalStore.set(relPath, {...createDefaultRuntimeSignals(), importance: 55})
+
+      const updateOp = {
+        confidence: 'high' as const,
+        content: {snippets: ['a'], tags: ['t']},
+        impact: 'low' as const,
+        path: 'd/t',
+        reason: 'u',
+        title: 'N',
+        type: 'UPDATE' as const,
+      }
+
+      await runCurate(basePath, signalStore, [updateOp])
+      expect((await signalStore.get(relPath)).maturity).to.equal('draft')
+
+      await runCurate(basePath, signalStore, [updateOp])
+      expect((await signalStore.get(relPath)).maturity).to.equal('validated')
+    })
+  })
+
+  describe('DELETE', () => {
+    it('drops the sidecar entry for the deleted file', async () => {
+      await runCurate(basePath, signalStore, [
+        {
+          confidence: 'high',
+          content: {snippets: ['a'], tags: ['t']},
+          impact: 'low',
+          path: 'x/y',
+          reason: 'seed',
+          title: 'Z',
+          type: 'ADD',
+        },
+      ])
+      const relPath = 'x/y/z.md'
+      // Mark the sidecar entry with a non-default value so we can verify removal.
+      await signalStore.set(relPath, {...createDefaultRuntimeSignals(), importance: 87})
+
+      const delResult = await runCurate(basePath, signalStore, [
+        {
+          confidence: 'low',
+          impact: 'low',
+          path: 'x/y',
+          reason: 'clean',
+          title: 'Z',
+          type: 'DELETE',
+        },
+      ])
+      expect(delResult.summary.deleted).to.equal(1)
+
+      // After delete, sidecar get() should return defaults (entry gone).
+      const after = await signalStore.get(relPath)
+      expect(after).to.deep.equal(createDefaultRuntimeSignals())
+    })
+  })
+
+  describe('MERGE', () => {
+    it('merges source+target signals into the target and drops the source entry', async () => {
+      // Seed two files.
+      await runCurate(basePath, signalStore, [
+        {
+          confidence: 'high',
+          content: {snippets: ['a'], tags: ['t']},
+          impact: 'low',
+          path: 'auth/jwt',
+          reason: 'seed src',
+          title: 'Refresh',
+          type: 'ADD',
+        },
+        {
+          confidence: 'high',
+          content: {snippets: ['b'], tags: ['t']},
+          impact: 'low',
+          path: 'auth/jwt',
+          reason: 'seed tgt',
+          title: 'Rotation',
+          type: 'ADD',
+        },
+      ])
+
+      const srcRel = 'auth/jwt/refresh.md'
+      const tgtRel = 'auth/jwt/rotation.md'
+
+      // Give source and target distinct signal profiles.
+      await signalStore.set(srcRel, {accessCount: 3, importance: 70, maturity: 'validated', recency: 0.6, updateCount: 2})
+      await signalStore.set(tgtRel, {accessCount: 5, importance: 50, maturity: 'draft', recency: 1, updateCount: 0})
+
+      const mergeResult = await runCurate(basePath, signalStore, [
+        {
+          confidence: 'high',
+          impact: 'low',
+          mergeTarget: 'auth/jwt',
+          mergeTargetTitle: 'Rotation',
+          path: 'auth/jwt',
+          reason: 'consolidate',
+          title: 'Refresh',
+          type: 'MERGE',
+        },
+      ])
+      expect(mergeResult.summary.merged).to.equal(1)
+
+      // Source entry dropped.
+      expect(await signalStore.get(srcRel)).to.deep.equal(createDefaultRuntimeSignals())
+
+      // Target entry merged: max importance, max recency, sum counts, updateCount+1,
+      // tier re-derived from merged importance (70 -> validated by hysteresis).
+      const merged = await signalStore.get(tgtRel)
+      expect(merged.accessCount).to.equal(8)
+      expect(merged.importance).to.equal(70)
+      expect(merged.recency).to.equal(1)
+      expect(merged.updateCount).to.equal(3) // 2 + 0 + 1
+      expect(merged.maturity).to.equal('validated')
+    })
+  })
+
+  describe('markdown/sidecar consistency', () => {
+    it('ADD writes matching scoring to both markdown frontmatter and sidecar', async () => {
+      await runCurate(basePath, signalStore, [
+        {
+          confidence: 'high',
+          content: {snippets: ['code'], tags: ['t']},
+          impact: 'low',
+          path: 'd/t',
+          reason: 'seed',
+          title: 'Consistency',
+          type: 'ADD',
+        },
+      ])
+
+      const relPath = 'd/t/consistency.md'
+      const markdownPath = join(basePath, relPath)
+      const markdown = await fs.readFile(markdownPath, 'utf8')
+      const signals = await signalStore.get(relPath)
+
+      // Pull scoring fields out of the markdown frontmatter.
+      const importanceMatch = /^importance:\s*(\d+)/m.exec(markdown)
+      const maturityMatch = /^maturity:\s*(core|draft|validated)/m.exec(markdown)
+      const recencyMatch = /^recency:\s*([\d.]+)/m.exec(markdown)
+
+      expect(importanceMatch?.[1]).to.equal(String(signals.importance))
+      expect(maturityMatch?.[1]).to.equal(signals.maturity)
+      expect(recencyMatch?.[1]).to.equal(String(signals.recency))
+    })
+
+    it('UPDATE keeps markdown and sidecar in sync after a bump', async () => {
+      // Seed.
+      await runCurate(basePath, signalStore, [
+        {
+          confidence: 'high',
+          content: {snippets: ['a'], tags: ['t']},
+          impact: 'low',
+          path: 'd/t',
+          reason: 'seed',
+          title: 'Sync',
+          type: 'ADD',
+        },
+      ])
+      // Bump.
+      await runCurate(basePath, signalStore, [
+        {
+          confidence: 'high',
+          content: {snippets: ['a', 'b'], tags: ['t']},
+          impact: 'low',
+          path: 'd/t',
+          reason: 'bump',
+          title: 'Sync',
+          type: 'UPDATE',
+        },
+      ])
+
+      const relPath = 'd/t/sync.md'
+      const markdown = await fs.readFile(join(basePath, relPath), 'utf8')
+      const signals = await signalStore.get(relPath)
+
+      const importanceMatch = /^importance:\s*(\d+)/m.exec(markdown)
+      const maturityMatch = /^maturity:\s*(core|draft|validated)/m.exec(markdown)
+      const updateCountMatch = /^updateCount:\s*(\d+)/m.exec(markdown)
+
+      expect(importanceMatch?.[1]).to.equal(String(signals.importance))
+      expect(maturityMatch?.[1]).to.equal(signals.maturity)
+      expect(updateCountMatch?.[1]).to.equal(String(signals.updateCount))
+    })
+  })
+
+  describe('sidecar failure isolation', () => {
+    it('does not abort a curate ADD when the sidecar throws', async () => {
+      const throwing: IRuntimeSignalStore = {
+        async batchUpdate() {},
+        async delete() {
+          throw new Error('sidecar down')
+        },
+        async get() {
+          return createDefaultRuntimeSignals()
+        },
+        async getMany() {
+          return new Map()
+        },
+        async list() {
+          return new Map()
+        },
+        async set() {
+          throw new Error('sidecar down')
+        },
+        async update() {
+          throw new Error('sidecar down')
+        },
+      }
+
+      const result = await runCurate(basePath, throwing, [
+        {
+          confidence: 'high',
+          content: {snippets: ['a'], tags: ['t']},
+          impact: 'low',
+          path: 'd/t',
+          reason: 'test',
+          title: 'N',
+          type: 'ADD',
+        },
+      ])
+
+      // ADD completed — markdown write succeeded despite sidecar failure.
+      expect(result.summary.added).to.equal(1)
+      expect(result.summary.failed).to.equal(0)
+    })
+  })
+})

--- a/test/unit/agent/tools/memory-symbol-tree.test.ts
+++ b/test/unit/agent/tools/memory-symbol-tree.test.ts
@@ -99,11 +99,14 @@ describe('Memory Symbol Tree & Path Matcher', () => {
       expect(refresh?.parent?.parent?.parent).to.be.undefined
     })
 
-    it('should absorb context.md files into parent folder metadata', () => {
+    it('should absorb context.md files into parent folder node (structural only)', () => {
+      // Post-commit-5: the symbol tree no longer carries per-node scoring
+      // (importance / maturity) — ranking reads those from the sidecar.
+      // Metadata collapses to structural defaults at tree-build time.
       const auth = tree.symbolMap.get('auth')
-      // context.md had importance=75, maturity='validated'
-      expect(auth?.metadata.importance).to.equal(75)
-      expect(auth?.metadata.maturity).to.equal('validated')
+      expect(auth).to.exist
+      expect(auth?.metadata.importance).to.equal(50)
+      expect(auth?.metadata.maturity).to.equal('draft')
     })
 
     it('should not create Context nodes for context.md files', () => {

--- a/test/unit/agent/tools/search-knowledge-flush-sidecar.test.ts
+++ b/test/unit/agent/tools/search-knowledge-flush-sidecar.test.ts
@@ -110,7 +110,7 @@ describe('SearchKnowledgeService — flushAccessHits dual-write', () => {
     expect((await signalStore.list()).size).to.equal(0)
   })
 
-  it('completes the markdown flush even if the sidecar batchUpdate throws', async () => {
+  it('reports completion even when the sidecar batchUpdate throws and leaves markdown untouched', async () => {
     const throwing: IRuntimeSignalStore = {
       async batchUpdate() {
         throw new Error('sidecar down')
@@ -135,14 +135,17 @@ describe('SearchKnowledgeService — flushAccessHits dual-write', () => {
     const relPath = 'x.md'
     const filePath = join(contextTreeDir, relPath)
     await fs.writeFile(filePath, MARKDOWN_WITH_SCORING, 'utf8')
+    const before = await fs.readFile(filePath, 'utf8')
     primePendingHits(isolated, {[relPath]: 1})
 
+    // Flush must not throw despite the sidecar failure — commit 5 no longer
+    // writes to markdown so `flushed` simply indicates that pending hits
+    // were processed.
     const flushed = await isolated.flushAccessHits(contextTreeDir)
     expect(flushed).to.equal(true)
 
-    // Markdown was written despite sidecar failure — read it back and verify
-    // importance bumped (50 + 3 = 53).
-    const rewritten = await fs.readFile(filePath, 'utf8')
-    expect(rewritten).to.include('importance: 53')
+    // Markdown is byte-identical — flush never touches it post-commit-5.
+    const after = await fs.readFile(filePath, 'utf8')
+    expect(after).to.equal(before)
   })
 })

--- a/test/unit/agent/tools/search-knowledge-flush-sidecar.test.ts
+++ b/test/unit/agent/tools/search-knowledge-flush-sidecar.test.ts
@@ -1,0 +1,148 @@
+import {expect} from 'chai'
+import * as fs from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+
+import type {IFileSystem} from '../../../../src/agent/core/interfaces/i-file-system.js'
+import type {IRuntimeSignalStore} from '../../../../src/server/core/interfaces/storage/i-runtime-signal-store.js'
+
+import {SearchKnowledgeService} from '../../../../src/agent/infra/tools/implementations/search-knowledge-service.js'
+import {createDefaultRuntimeSignals} from '../../../../src/server/core/domain/knowledge/runtime-signals-schema.js'
+import {createMockRuntimeSignalStore} from '../../../helpers/mock-factories.js'
+
+// Minimal IFileSystem shim backed by real disk.
+function createDiskFileSystem(): IFileSystem {
+  return {
+    async readFile(path: string) {
+      return {content: await fs.readFile(path, 'utf8')}
+    },
+    async writeFile(path: string, content: string) {
+      await fs.writeFile(path, content, 'utf8')
+    },
+  } as unknown as IFileSystem
+}
+
+interface PendingAccessHitsInternals {
+  pendingAccessHits: Map<string, number>
+}
+
+// Narrow unsafe-cast helper: SearchKnowledgeService accumulates access hits
+// via private `pendingAccessHits`. The flush pipeline is the unit under test,
+// so we prime the map directly rather than going through the indexing path.
+function primePendingHits(service: SearchKnowledgeService, hits: Record<string, number>): void {
+  const bag = (service as unknown as PendingAccessHitsInternals).pendingAccessHits
+  bag.clear()
+  for (const [path, count] of Object.entries(hits)) {
+    bag.set(path, count)
+  }
+}
+
+const MARKDOWN_WITH_SCORING = `---
+title: Test
+importance: 50
+recency: 1
+maturity: draft
+accessCount: 0
+updateCount: 0
+---
+
+Body.
+`
+
+describe('SearchKnowledgeService — flushAccessHits dual-write', () => {
+  let tmpDir: string
+  let contextTreeDir: string
+  let signalStore: IRuntimeSignalStore
+  let service: SearchKnowledgeService
+
+  beforeEach(async () => {
+    tmpDir = join(tmpdir(), `sks-flush-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    contextTreeDir = join(tmpDir, 'ctx')
+    await fs.mkdir(contextTreeDir, {recursive: true})
+    signalStore = createMockRuntimeSignalStore()
+    service = new SearchKnowledgeService(createDiskFileSystem(), {runtimeSignalStore: signalStore})
+  })
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, {force: true, recursive: true})
+  })
+
+  it('mirrors accumulated hits into the sidecar with bumped importance and accessCount', async () => {
+    const relPath = 'auth/jwt.md'
+    const filePath = join(contextTreeDir, relPath)
+    await fs.mkdir(join(contextTreeDir, 'auth'), {recursive: true})
+    await fs.writeFile(filePath, MARKDOWN_WITH_SCORING, 'utf8')
+
+    primePendingHits(service, {[relPath]: 4})
+
+    const flushed = await service.flushAccessHits(contextTreeDir)
+    expect(flushed).to.equal(true)
+
+    const signals = await signalStore.get(relPath)
+    // importance: 50 + 3 * 4 = 62
+    expect(signals.importance).to.equal(62)
+    expect(signals.accessCount).to.equal(4)
+    // 62 < 65 -> stays draft under hysteresis
+    expect(signals.maturity).to.equal('draft')
+  })
+
+  it('promotes maturity from draft to validated once importance crosses 65', async () => {
+    const relPath = 'domain/topic.md'
+    const filePath = join(contextTreeDir, relPath)
+    await fs.mkdir(join(contextTreeDir, 'domain'), {recursive: true})
+    await fs.writeFile(filePath, MARKDOWN_WITH_SCORING, 'utf8')
+
+    // Prime the sidecar at importance 60 so 3 hits (+9) crosses the threshold.
+    await signalStore.set(relPath, {...createDefaultRuntimeSignals(), importance: 60})
+    primePendingHits(service, {[relPath]: 3})
+
+    await service.flushAccessHits(contextTreeDir)
+
+    const signals = await signalStore.get(relPath)
+    expect(signals.importance).to.equal(69)
+    expect(signals.maturity).to.equal('validated')
+  })
+
+  it('returns false and does not touch the sidecar when there are no pending hits', async () => {
+    const flushed = await service.flushAccessHits(contextTreeDir)
+    expect(flushed).to.equal(false)
+    // No side effects — signal store is empty.
+    expect((await signalStore.list()).size).to.equal(0)
+  })
+
+  it('completes the markdown flush even if the sidecar batchUpdate throws', async () => {
+    const throwing: IRuntimeSignalStore = {
+      async batchUpdate() {
+        throw new Error('sidecar down')
+      },
+      async delete() {},
+      async get() {
+        return createDefaultRuntimeSignals()
+      },
+      async getMany() {
+        return new Map()
+      },
+      async list() {
+        return new Map()
+      },
+      async set() {},
+      async update() {
+        return createDefaultRuntimeSignals()
+      },
+    }
+    const isolated = new SearchKnowledgeService(createDiskFileSystem(), {runtimeSignalStore: throwing})
+
+    const relPath = 'x.md'
+    const filePath = join(contextTreeDir, relPath)
+    await fs.writeFile(filePath, MARKDOWN_WITH_SCORING, 'utf8')
+    primePendingHits(isolated, {[relPath]: 1})
+
+    const flushed = await isolated.flushAccessHits(contextTreeDir)
+    expect(flushed).to.equal(true)
+
+    // Markdown was written despite sidecar failure — read it back and verify
+    // importance bumped (50 + 3 = 53).
+    const rewritten = await fs.readFile(filePath, 'utf8')
+    expect(rewritten).to.include('importance: 53')
+  })
+})

--- a/test/unit/agent/tools/search-knowledge-tool.test.ts
+++ b/test/unit/agent/tools/search-knowledge-tool.test.ts
@@ -1160,7 +1160,25 @@ describe('Search Knowledge Tool', () => {
         })
       })
 
-      const tool = createSearchKnowledgeTool(fileSystemMock, {baseDirectory: '/test', cacheTtlMs: 0})
+      // Post-migration: ranking reads scoring from the sidecar, not markdown.
+      // Seed the sidecar to match the intent of the markdown fixtures — both
+      // the summary _index.md entries (for propagation boost) and the leaves
+      // (so main-ranking scoreFloor is computed from the same signal state).
+      const {createMockRuntimeSignalStore} = await import('../../../helpers/mock-factories.js')
+      const runtimeSignalStore = createMockRuntimeSignalStore()
+      await runtimeSignalStore.set('auth/_index.md', {
+        accessCount: 0, importance: 90, maturity: 'core', recency: 0.9, updateCount: 0,
+      })
+      await runtimeSignalStore.set('api/_index.md', {
+        accessCount: 0, importance: 20, maturity: 'draft', recency: 0.2, updateCount: 0,
+      })
+      // Leaves have identical signals to isolate the summary-scoring
+      // differential — mirrors the old test's equal-BM25 intent.
+      const leafSignals = {accessCount: 0, importance: 50, maturity: 'draft' as const, recency: 1, updateCount: 0}
+      await runtimeSignalStore.set('auth/jwt.md', leafSignals)
+      await runtimeSignalStore.set('api/design.md', leafSignals)
+
+      const tool = createSearchKnowledgeTool(fileSystemMock, {baseDirectory: '/test', cacheTtlMs: 0, runtimeSignalStore})
       const result = (await tool.execute({query: 'security token'})) as {
         message: string
         results: Array<{excerpt: string; path: string; score: number; symbolKind?: string; title: string}>
@@ -1260,7 +1278,20 @@ describe('Search Knowledge Tool', () => {
         })
       })
 
-      const tool = createSearchKnowledgeTool(fileSystemMock, {baseDirectory: '/test', cacheTtlMs: 0})
+      // Post-migration: ranking reads scoring from the sidecar, so both the
+      // summary and the leaf need entries that mirror the markdown fixtures.
+      // Without a leaf entry, jwt would fall back to default scoring and
+      // scoreFloor would drop low enough for the weak summary to survive.
+      const {createMockRuntimeSignalStore} = await import('../../../helpers/mock-factories.js')
+      const runtimeSignalStore = createMockRuntimeSignalStore()
+      await runtimeSignalStore.set('auth/_index.md', {
+        accessCount: 0, importance: 5, maturity: 'draft', recency: 0.1, updateCount: 0,
+      })
+      await runtimeSignalStore.set('auth/jwt.md', {
+        accessCount: 0, importance: 95, maturity: 'core', recency: 1, updateCount: 0,
+      })
+
+      const tool = createSearchKnowledgeTool(fileSystemMock, {baseDirectory: '/test', cacheTtlMs: 0, runtimeSignalStore})
       const result = (await tool.execute({query: 'security token'})) as {
         results: Array<{path: string; symbolKind?: string}>
       }

--- a/test/unit/agent/tools/search-knowledge-tool.test.ts
+++ b/test/unit/agent/tools/search-knowledge-tool.test.ts
@@ -619,29 +619,27 @@ describe('Search Knowledge Tool', () => {
       expect(secondListDirCount).to.equal(firstListDirCount)
     })
 
-    it('flushes pending access hits even when the cached file mtimes are unchanged', async () => {
+    it('does not write to markdown on flush — access hits only touch the sidecar', async () => {
+      // Post-commit-5 flushAccessHits never writes to markdown. This test
+      // guards the invariant by asserting writeFile is never invoked across
+      // repeated searches, regardless of pending hits.
       const tool = createSearchKnowledgeTool(fileSystemMock, {baseDirectory: '/test', cacheTtlMs: 0})
 
       readFileStub.resolves({
         content:
-          '---\nimportance: 50\nrecency: 1\nmaturity: draft\naccessCount: 0\nupdateCount: 0\ncreatedAt: \'2026-03-27T00:00:00.000Z\'\nupdatedAt: \'2026-03-27T00:00:00.000Z\'\n---\n# Test File\n\nTest content for caching.',
+          '---\ncreatedAt: \'2026-03-27T00:00:00.000Z\'\nupdatedAt: \'2026-03-27T00:00:00.000Z\'\n---\n# Test File\n\nTest content for caching.',
         encoding: 'utf8',
-        lines: 10,
-        size: 220,
-        totalLines: 10,
+        lines: 5,
+        size: 140,
+        totalLines: 5,
         truncated: false,
       })
-      writeFileStub.resolves({bytesWritten: 240, path: '/test/.brv/context-tree/test/file.md', success: true})
+      writeFileStub.resolves({bytesWritten: 0, path: '/test/.brv/context-tree/test/file.md', success: true})
 
       await tool.execute({query: 'test'})
+      await tool.execute({query: 'test'})
+
       expect(writeFileStub.called).to.equal(false)
-
-      await tool.execute({query: 'test'})
-
-      expect(writeFileStub.calledOnce).to.equal(true)
-      expect(writeFileStub.firstCall.args[0]).to.equal('/test/.brv/context-tree/test/file.md')
-      expect(writeFileStub.firstCall.args[1]).to.include('importance: 53')
-      expect(writeFileStub.firstCall.args[1]).to.include('accessCount: 1')
     })
   })
 
@@ -906,8 +904,10 @@ describe('Search Knowledge Tool', () => {
       expect((secondBatch[0] as SearchKnowledgeOutput).results).to.be.an('array')
       expect((secondBatch[1] as SearchKnowledgeOutput).results).to.be.an('array')
 
-      // Second batch triggers one more build (not two) + one readFile from access-hit flush = 3 total
-      expect(readFileStub.callCount).to.equal(3)
+      // Second batch triggers one more build (not two). Post-commit-5 the
+      // access-hit flush no longer reads the file for a markdown rewrite,
+      // so the total readFile count is 2 (one per batch build), not 3.
+      expect(readFileStub.callCount).to.equal(2)
     })
 
     it('should not deadlock when multiple tools execute concurrently', async () => {
@@ -1233,7 +1233,20 @@ describe('Search Knowledge Tool', () => {
         })
       })
 
-      const tool = createSearchKnowledgeTool(fileSystemMock, {baseDirectory: '/test', cacheTtlMs: 0})
+      // Post-commit-5: the symbol-tree fallback for minMaturity is gone.
+      // Seed the sidecar to match the intent of the markdown fixtures: leaf
+      // is core, summary is draft, so with minMaturity='core' only the leaf
+      // survives.
+      const {createMockRuntimeSignalStore} = await import('../../../helpers/mock-factories.js')
+      const runtimeSignalStore = createMockRuntimeSignalStore()
+      await runtimeSignalStore.set('auth/jwt.md', {
+        accessCount: 0, importance: 90, maturity: 'core', recency: 1, updateCount: 0,
+      })
+      await runtimeSignalStore.set('auth/_index.md', {
+        accessCount: 0, importance: 70, maturity: 'draft', recency: 0.9, updateCount: 0,
+      })
+
+      const tool = createSearchKnowledgeTool(fileSystemMock, {baseDirectory: '/test', cacheTtlMs: 0, runtimeSignalStore})
       const result = (await tool.execute({minMaturity: 'core', query: 'security token'})) as {
         results: Array<{path: string; symbolKind?: string}>
       }

--- a/test/unit/infra/context-tree/archive-service-sidecar-dual-write.test.ts
+++ b/test/unit/infra/context-tree/archive-service-sidecar-dual-write.test.ts
@@ -1,0 +1,180 @@
+import {expect} from 'chai'
+import {mkdir, rm, writeFile} from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+
+import type {ICipherAgent} from '../../../../src/agent/core/interfaces/i-cipher-agent.js'
+import type {IRuntimeSignalStore} from '../../../../src/server/core/interfaces/storage/i-runtime-signal-store.js'
+
+import {BRV_DIR, CONTEXT_TREE_DIR} from '../../../../src/server/constants.js'
+import {createDefaultRuntimeSignals} from '../../../../src/server/core/domain/knowledge/runtime-signals-schema.js'
+import {FileContextTreeArchiveService} from '../../../../src/server/infra/context-tree/file-context-tree-archive-service.js'
+import {createMockRuntimeSignalStore} from '../../../helpers/mock-factories.js'
+
+function createMockAgent(ghostCue = 'ghost cue'): ICipherAgent {
+  return {
+    async cancel() {},
+    async createTaskSession() {
+      return 'mock-session-id'
+    },
+    async deleteSandboxVariable() {},
+    async deleteSandboxVariableOnSession() {},
+    async deleteSession() {},
+    async deleteTaskSession() {},
+    async execute() {
+      return ghostCue
+    },
+    async executeOnSession() {
+      return ghostCue
+    },
+    async generate() {
+      return ghostCue
+    },
+    async getSessionMetadata() {},
+    getState() {
+      return 'idle'
+    },
+    async listPersistedSessions() {
+      return []
+    },
+    async reset() {},
+    async setSandboxVariable() {},
+    async setSandboxVariableOnSession() {},
+    async start() {},
+    async *stream() {
+      yield ghostCue
+    },
+  } as unknown as ICipherAgent
+}
+
+const MARKDOWN_WITH_SCORING = `---
+title: Tokens
+importance: 45
+maturity: draft
+---
+
+# Tokens
+Content.
+`
+
+describe('FileContextTreeArchiveService — sidecar dual-write', () => {
+  let testDir: string
+  let contextTreeDir: string
+  let signalStore: IRuntimeSignalStore
+  let service: FileContextTreeArchiveService
+  let agent: ICipherAgent
+
+  beforeEach(async () => {
+    testDir = join(tmpdir(), `archive-dual-write-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    contextTreeDir = join(testDir, BRV_DIR, CONTEXT_TREE_DIR)
+    await mkdir(contextTreeDir, {recursive: true})
+    signalStore = createMockRuntimeSignalStore()
+    service = new FileContextTreeArchiveService(signalStore)
+    agent = createMockAgent()
+  })
+
+  afterEach(async () => {
+    await rm(testDir, {force: true, recursive: true})
+  })
+
+  describe('archiveEntry', () => {
+    it('drops the sidecar entry for the archived path', async () => {
+      const relPath = 'auth/tokens.md'
+      await mkdir(join(contextTreeDir, 'auth'), {recursive: true})
+      await writeFile(join(contextTreeDir, relPath), MARKDOWN_WITH_SCORING, 'utf8')
+
+      // Seed the sidecar with a non-default value so we can observe the delete.
+      await signalStore.set(relPath, {...createDefaultRuntimeSignals(), importance: 42})
+
+      await service.archiveEntry(relPath, agent, testDir)
+
+      // After archive, get() returns defaults — entry was deleted.
+      const after = await signalStore.get(relPath)
+      expect(after).to.deep.equal(createDefaultRuntimeSignals())
+      // And the map does not contain this key.
+      expect((await signalStore.list()).has(relPath)).to.equal(false)
+    })
+
+    it('succeeds even if the sidecar delete throws', async () => {
+      const throwing: IRuntimeSignalStore = {
+        async batchUpdate() {},
+        async delete() {
+          throw new Error('sidecar down')
+        },
+        async get() {
+          return createDefaultRuntimeSignals()
+        },
+        async getMany() {
+          return new Map()
+        },
+        async list() {
+          return new Map()
+        },
+        async set() {},
+        async update() {
+          return createDefaultRuntimeSignals()
+        },
+      }
+      const isolated = new FileContextTreeArchiveService(throwing)
+
+      const relPath = 'x.md'
+      await writeFile(join(contextTreeDir, relPath), MARKDOWN_WITH_SCORING, 'utf8')
+
+      // Must not throw — markdown archive completes even though sidecar fails.
+      const result = await isolated.archiveEntry(relPath, agent, testDir)
+      expect(result.originalPath).to.equal(relPath)
+      expect(result.stubPath).to.include('_archived/x.stub.md')
+    })
+  })
+
+  describe('restoreEntry', () => {
+    it('seeds default signals for the restored path', async () => {
+      const relPath = 'auth/tokens.md'
+      await mkdir(join(contextTreeDir, 'auth'), {recursive: true})
+      await writeFile(join(contextTreeDir, relPath), MARKDOWN_WITH_SCORING, 'utf8')
+
+      // Archive first so there is something to restore.
+      const archiveResult = await service.archiveEntry(relPath, agent, testDir)
+      // Sidecar is empty at this point (archive deleted any entry and there was none).
+      expect((await signalStore.list()).size).to.equal(0)
+
+      await service.restoreEntry(archiveResult.stubPath, testDir)
+
+      // Sidecar now has a default entry for the restored path.
+      const after = await signalStore.get(relPath)
+      expect(after).to.deep.equal(createDefaultRuntimeSignals())
+      expect((await signalStore.list()).has(relPath)).to.equal(true)
+    })
+
+    it('succeeds even if the sidecar set throws on restore', async () => {
+      const throwing: IRuntimeSignalStore = {
+        async batchUpdate() {},
+        async delete() {},
+        async get() {
+          return createDefaultRuntimeSignals()
+        },
+        async getMany() {
+          return new Map()
+        },
+        async list() {
+          return new Map()
+        },
+        async set() {
+          throw new Error('sidecar down')
+        },
+        async update() {
+          return createDefaultRuntimeSignals()
+        },
+      }
+      const isolated = new FileContextTreeArchiveService(throwing)
+
+      const relPath = 'y.md'
+      await writeFile(join(contextTreeDir, relPath), MARKDOWN_WITH_SCORING, 'utf8')
+      const archiveResult = await isolated.archiveEntry(relPath, agent, testDir)
+
+      // Restore must not throw even though sidecar.set rejects.
+      const restored = await isolated.restoreEntry(archiveResult.stubPath, testDir)
+      expect(restored).to.equal(relPath)
+    })
+  })
+})

--- a/test/unit/infra/context-tree/file-context-tree-archive-service.test.ts
+++ b/test/unit/infra/context-tree/file-context-tree-archive-service.test.ts
@@ -108,12 +108,26 @@ describe('FileContextTreeArchiveService', () => {
       expect(await fileExists(join(contextTreeDir, ARCHIVE_DIR, 'api', 'endpoints', 'legacy-v1.stub.md'))).to.be.true
     })
 
-    it('should extract importance from frontmatter', async () => {
+    it('captures importance from the runtime-signal sidecar in the archive stub', async () => {
+      // Post-migration: evicted_importance is read from the sidecar, not
+      // markdown. Seed the sidecar with a known value, then assert the stub
+      // preserves it.
+      const {createMockRuntimeSignalStore} = await import('../../../helpers/mock-factories.js')
+      const signalStore = createMockRuntimeSignalStore()
+      await signalStore.set('auth/tokens.md', {
+        accessCount: 0,
+        importance: 25,
+        maturity: 'draft',
+        recency: 1,
+        updateCount: 0,
+      })
+      const scopedService = new FileContextTreeArchiveService(signalStore)
+
       const domainDir = join(contextTreeDir, 'auth')
       await mkdir(domainDir, {recursive: true})
-      await writeFile(join(domainDir, 'tokens.md'), '---\nimportance: 25\nmaturity: draft\n---\n# Tokens')
+      await writeFile(join(domainDir, 'tokens.md'), '# Tokens')
 
-      await service.archiveEntry('auth/tokens.md', mockAgent, testDir)
+      await scopedService.archiveEntry('auth/tokens.md', mockAgent, testDir)
 
       const stubContent = await readFile(join(contextTreeDir, ARCHIVE_DIR, 'auth', 'tokens.stub.md'), 'utf8')
       const fm = parseArchiveStubFrontmatter(stubContent)

--- a/test/unit/infra/dream/operations/consolidate.test.ts
+++ b/test/unit/infra/dream/operations/consolidate.test.ts
@@ -298,10 +298,19 @@ describe('consolidate', () => {
 
   it('sets needsReview=true when file has core maturity', async () => {
     await createMdFile(ctxDir, 'auth/core-auth.md', '# Core Auth', {
-      keywords: [], maturity: 'core', related: [], tags: [], title: 'Core Auth',
+      keywords: [], related: [], tags: [], title: 'Core Auth',
     })
     await createMdFile(ctxDir, 'auth/helper.md', '# Helper')
     const reviewBackupStore = {save: stub().resolves()}
+
+    // Post-migration: maturity is read from the sidecar, not markdown.
+    // Seed the sidecar with `maturity: 'core'` for the file that should
+    // trigger the review gate.
+    const runtimeSignalStore = {
+      get: stub().callsFake(async (path: string) => ({
+        maturity: path === 'auth/core-auth.md' ? 'core' : 'draft',
+      })),
+    }
 
     agent.executeOnSession.resolves(llmResponse([{
       files: ['auth/core-auth.md', 'auth/helper.md'],
@@ -309,12 +318,15 @@ describe('consolidate', () => {
       type: 'CROSS_REFERENCE',
     }]))
 
-    const results = await consolidate(['auth/core-auth.md', 'auth/helper.md'], {...deps, reviewBackupStore})
+    const results = await consolidate(
+      ['auth/core-auth.md', 'auth/helper.md'],
+      {...deps, reviewBackupStore, runtimeSignalStore},
+    )
 
     // CROSS_REFERENCE is normally needsReview=false, but core maturity overrides
     expect(results[0].needsReview).to.be.true
     expect(asConsolidate(results[0]).previousTexts).to.deep.equal({
-      'auth/core-auth.md': '---\nkeywords: []\nmaturity: core\nrelated: []\ntags: []\ntitle: Core Auth\n---\n# Core Auth',
+      'auth/core-auth.md': '---\nkeywords: []\nrelated: []\ntags: []\ntitle: Core Auth\n---\n# Core Auth',
       'auth/helper.md': '# Helper',
     })
     expect(reviewBackupStore.save.calledTwice).to.be.true

--- a/test/unit/infra/dream/operations/prune.test.ts
+++ b/test/unit/infra/dream/operations/prune.test.ts
@@ -165,23 +165,46 @@ describe('prune', () => {
   })
 
   it('finds stale validated files via mtime (threshold 120 days)', async () => {
-    await createMdFile(ctxDir, 'api/old-validated.md', '# Validated doc', {maturity: 'validated'})
+    // Post-commit-5: maturity is read from the sidecar, not markdown.
+    await createMdFile(ctxDir, 'api/old-validated.md', '# Validated doc')
     await setMtimeDaysAgo(ctxDir, 'api/old-validated.md', 121)
+
+    const runtimeSignalStore = {
+      async list() {
+        return new Map([
+          ['api/old-validated.md', {importance: 50, maturity: 'validated' as const}],
+        ])
+      },
+    }
 
     agent.executeOnSession.resolves(llmResponse([
       {decision: 'KEEP', file: 'api/old-validated.md', reason: 'Still relevant'},
     ]))
 
-    const results = await prune(deps)
+    const results = await prune({...deps, runtimeSignalStore})
     expect(results).to.have.lengthOf(1)
+    expect(agent.createTaskSession.called).to.be.true
   })
 
   it('does NOT flag validated files under 120 days old', async () => {
-    await createMdFile(ctxDir, 'api/recent-validated.md', '# Validated doc', {maturity: 'validated'})
+    // Post-commit-5: maturity is read from the sidecar, not markdown.
+    // Without a sidecar entry reporting 'validated' the file would default
+    // to 'draft' (60-day threshold) and 119 days would cross it — so we
+    // must prime the sidecar to genuinely exercise the 120-day threshold.
+    await createMdFile(ctxDir, 'api/recent-validated.md', '# Validated doc')
     await setMtimeDaysAgo(ctxDir, 'api/recent-validated.md', 119)
 
-    const results = await prune(deps)
+    const runtimeSignalStore = {
+      async list() {
+        return new Map([
+          ['api/recent-validated.md', {importance: 50, maturity: 'validated' as const}],
+        ])
+      },
+    }
+
+    const results = await prune({...deps, runtimeSignalStore})
     expect(results).to.deep.equal([])
+    expect(agent.createTaskSession.called).to.be.false
   })
 
   it('NEVER flags core files regardless of age', async () => {

--- a/test/unit/infra/dream/operations/prune.test.ts
+++ b/test/unit/infra/dream/operations/prune.test.ts
@@ -185,10 +185,21 @@ describe('prune', () => {
   })
 
   it('NEVER flags core files regardless of age', async () => {
-    await createMdFile(ctxDir, 'auth/core-doc.md', '# Core knowledge', {maturity: 'core'})
+    // Post-commit-5: core protection comes from the sidecar, not markdown.
+    // Seed a runtimeSignalStore that reports maturity='core' for this path
+    // so the prune candidacy scan excludes it.
+    await createMdFile(ctxDir, 'auth/core-doc.md', '# Core knowledge')
     await setMtimeDaysAgo(ctxDir, 'auth/core-doc.md', 365)
 
-    const results = await prune(deps)
+    const runtimeSignalStore = {
+      async list() {
+        return new Map([
+          ['auth/core-doc.md', {importance: 80, maturity: 'core' as const}],
+        ])
+      },
+    }
+
+    const results = await prune({...deps, runtimeSignalStore})
     expect(results).to.deep.equal([])
     expect(agent.createTaskSession.called).to.be.false
   })

--- a/test/unit/infra/dream/operations/synthesize.test.ts
+++ b/test/unit/infra/dream/operations/synthesize.test.ts
@@ -5,9 +5,11 @@ import {join} from 'node:path'
 import {restore, type SinonStub, stub} from 'sinon'
 
 import type {ICipherAgent} from '../../../../../src/agent/core/interfaces/i-cipher-agent.js'
+import type {IRuntimeSignalStore} from '../../../../../src/server/core/interfaces/storage/i-runtime-signal-store.js'
 import type {DreamOperation} from '../../../../../src/server/infra/dream/dream-log-schema.js'
 
 import {synthesize, type SynthesizeDeps} from '../../../../../src/server/infra/dream/operations/synthesize.js'
+import {createMockRuntimeSignalStore} from '../../../../helpers/mock-factories.js'
 
 /** Helper: create a markdown file with optional frontmatter */
 async function createMdFile(dir: string, relativePath: string, body: string, frontmatter?: Record<string, unknown>): Promise<void> {
@@ -159,7 +161,7 @@ describe('synthesize', () => {
 
     const content = await readFile(join(ctxDir, 'auth/shared-token-validation.md'), 'utf8')
     expect(content).to.include('type: synthesis')
-    expect(content).to.include('maturity: draft')
+    expect(content).to.not.include('maturity:')
     expect(content).to.include('Shared Token Validation')
     expect(content).to.include('Both auth and API share token validation logic.')
   })
@@ -477,5 +479,107 @@ describe('synthesize', () => {
     expect(agent.executeOnSession.calledOnce).to.be.true
     const options = agent.executeOnSession.firstCall.args[2]
     expect(options).to.have.property('signal', controller.signal)
+  })
+
+  // ── Runtime-signal sidecar ──────────────────────────────────────────────
+
+  describe('runtime-signal sidecar', () => {
+    let signalStore: IRuntimeSignalStore
+
+    beforeEach(() => {
+      signalStore = createMockRuntimeSignalStore()
+    })
+
+    it('does not write maturity to markdown frontmatter', async () => {
+      await createMdFile(ctxDir, 'auth/_index.md', '# Auth', {type: 'summary'})
+      await createMdFile(ctxDir, 'api/_index.md', '# API', {type: 'summary'})
+
+      agent.executeOnSession.resolves(llmResponse([{
+        claim: 'Cross-domain pattern.',
+        confidence: 0.9,
+        evidence: [{domain: 'auth', fact: 'A'}, {domain: 'api', fact: 'B'}],
+        placement: 'auth',
+        title: 'Sidecar Test',
+      }]))
+
+      await synthesize({...deps, runtimeSignalStore: signalStore})
+
+      const content = await readFile(join(ctxDir, 'auth/sidecar-test.md'), 'utf8')
+      expect(content).to.not.include('maturity:')
+      expect(content).to.not.include('importance:')
+      expect(content).to.not.include('recency:')
+      expect(content).to.not.include('accessCount:')
+      expect(content).to.not.include('updateCount:')
+    })
+
+    it('seeds sidecar with default signals after writing synthesis file', async () => {
+      await createMdFile(ctxDir, 'auth/_index.md', '# Auth', {type: 'summary'})
+      await createMdFile(ctxDir, 'api/_index.md', '# API', {type: 'summary'})
+
+      agent.executeOnSession.resolves(llmResponse([{
+        claim: 'Pattern.',
+        confidence: 0.85,
+        evidence: [{domain: 'auth', fact: 'A'}, {domain: 'api', fact: 'B'}],
+        placement: 'auth',
+        title: 'Seeded Pattern',
+      }]))
+
+      await synthesize({...deps, runtimeSignalStore: signalStore})
+
+      const signals = await signalStore.get('auth/seeded-pattern.md')
+      expect(signals.importance).to.equal(50)
+      expect(signals.maturity).to.equal('draft')
+      expect(signals.accessCount).to.equal(0)
+      expect(signals.updateCount).to.equal(0)
+    })
+
+    it('seeds sidecar for each created file in multi-candidate run', async () => {
+      await createMdFile(ctxDir, 'auth/_index.md', '# Auth', {type: 'summary'})
+      await createMdFile(ctxDir, 'api/_index.md', '# API', {type: 'summary'})
+
+      agent.executeOnSession.resolves(llmResponse([
+        {
+          claim: 'First.',
+          confidence: 0.9,
+          evidence: [{domain: 'auth', fact: 'A'}, {domain: 'api', fact: 'B'}],
+          placement: 'auth',
+          title: 'Multi One',
+        },
+        {
+          claim: 'Second.',
+          confidence: 0.8,
+          evidence: [{domain: 'auth', fact: 'C'}, {domain: 'api', fact: 'D'}],
+          placement: 'api',
+          title: 'Multi Two',
+        },
+      ]))
+
+      await synthesize({...deps, runtimeSignalStore: signalStore})
+
+      const sig1 = await signalStore.get('auth/multi-one.md')
+      const sig2 = await signalStore.get('api/multi-two.md')
+      expect(sig1.importance).to.equal(50)
+      expect(sig2.importance).to.equal(50)
+    })
+
+    it('succeeds even when sidecar store is not provided', async () => {
+      await createMdFile(ctxDir, 'auth/_index.md', '# Auth', {type: 'summary'})
+      await createMdFile(ctxDir, 'api/_index.md', '# API', {type: 'summary'})
+
+      agent.executeOnSession.resolves(llmResponse([{
+        claim: 'No store.',
+        confidence: 0.9,
+        evidence: [{domain: 'auth', fact: 'A'}, {domain: 'api', fact: 'B'}],
+        placement: 'auth',
+        title: 'No Store Pattern',
+      }]))
+
+      // No runtimeSignalStore in deps — should still create the file
+      const results = await synthesize(deps)
+      expect(results).to.have.lengthOf(1)
+
+      const content = await readFile(join(ctxDir, 'auth/no-store-pattern.md'), 'utf8')
+      expect(content).to.include('type: synthesis')
+    })
   })
 })

--- a/test/unit/infra/dream/operations/synthesize.test.ts
+++ b/test/unit/infra/dream/operations/synthesize.test.ts
@@ -524,8 +524,12 @@ describe('synthesize', () => {
         title: 'Seeded Pattern',
       }]))
 
+      const setSpy = stub(signalStore, 'set').callThrough()
+
       await synthesize({...deps, runtimeSignalStore: signalStore})
 
+      expect(setSpy.calledOnce).to.be.true
+      expect(setSpy.firstCall.args[0]).to.equal('auth/seeded-pattern.md')
       const signals = await signalStore.get('auth/seeded-pattern.md')
       expect(signals.importance).to.equal(50)
       expect(signals.maturity).to.equal('draft')
@@ -554,12 +558,35 @@ describe('synthesize', () => {
         },
       ]))
 
+      const setSpy = stub(signalStore, 'set').callThrough()
+
       await synthesize({...deps, runtimeSignalStore: signalStore})
 
-      const sig1 = await signalStore.get('auth/multi-one.md')
-      const sig2 = await signalStore.get('api/multi-two.md')
-      expect(sig1.importance).to.equal(50)
-      expect(sig2.importance).to.equal(50)
+      expect(setSpy.calledTwice).to.be.true
+      expect(setSpy.firstCall.args[0]).to.equal('auth/multi-one.md')
+      expect(setSpy.secondCall.args[0]).to.equal('api/multi-two.md')
+    })
+
+    it('creates file even when sidecar store.set throws (fail-open)', async () => {
+      const brokenStore = createMockRuntimeSignalStore()
+      stub(brokenStore, 'set').rejects(new Error('disk full'))
+
+      await createMdFile(ctxDir, 'auth/_index.md', '# Auth', {type: 'summary'})
+      await createMdFile(ctxDir, 'api/_index.md', '# API', {type: 'summary'})
+
+      agent.executeOnSession.resolves(llmResponse([{
+        claim: 'Fail open.',
+        confidence: 0.9,
+        evidence: [{domain: 'auth', fact: 'A'}, {domain: 'api', fact: 'B'}],
+        placement: 'auth',
+        title: 'Fail Open Pattern',
+      }]))
+
+      const results = await synthesize({...deps, runtimeSignalStore: brokenStore})
+      expect(results).to.have.lengthOf(1)
+
+      const content = await readFile(join(ctxDir, 'auth/fail-open-pattern.md'), 'utf8')
+      expect(content).to.include('type: synthesis')
     })
 
     it('succeeds even when sidecar store is not provided', async () => {

--- a/test/unit/infra/runtime-signals/sidecar-failure-logging.test.ts
+++ b/test/unit/infra/runtime-signals/sidecar-failure-logging.test.ts
@@ -1,0 +1,548 @@
+/**
+ * Commit 6 — runtime-signals sidecar-failure logging.
+ *
+ * Post-commit-5 the sidecar is the canonical source for ranking signals.
+ * Operational failures (disk error, permission denied, backend outage) on
+ * sidecar writes continue to be swallowed at every mutation site — they are
+ * documented as best-effort and the next bump self-heals. But swallow-only
+ * leaves operators blind to outages in production. This suite proves that
+ * each of the 11 sidecar-swallow sites now emits exactly one `warn` log
+ * with the operation name and the affected path when the store throws.
+ */
+
+import {expect} from 'chai'
+import * as fs from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+import {restore, type SinonStub, stub} from 'sinon'
+
+import type {ICipherAgent} from '../../../../src/agent/core/interfaces/i-cipher-agent.js'
+import type {ILogger} from '../../../../src/agent/core/interfaces/i-logger.js'
+import type {IRuntimeSignalStore} from '../../../../src/server/core/interfaces/storage/i-runtime-signal-store.js'
+
+import {createCurateTool} from '../../../../src/agent/infra/tools/implementations/curate-tool.js'
+import {createDefaultRuntimeSignals} from '../../../../src/server/core/domain/knowledge/runtime-signals-schema.js'
+import {FileContextTreeArchiveService} from '../../../../src/server/infra/context-tree/file-context-tree-archive-service.js'
+import {FileContextTreeManifestService} from '../../../../src/server/infra/context-tree/file-context-tree-manifest-service.js'
+import {EMPTY_DREAM_STATE} from '../../../../src/server/infra/dream/dream-state-schema.js'
+import {consolidate} from '../../../../src/server/infra/dream/operations/consolidate.js'
+import {prune} from '../../../../src/server/infra/dream/operations/prune.js'
+import {createMockRuntimeSignalStore} from '../../../helpers/mock-factories.js'
+
+interface CurateOutput {
+  applied: Array<{message?: string; path: string; status: 'failed' | 'success'; type: string}>
+  summary: {added: number; deleted: number; failed: number; merged: number; updated: number}
+}
+
+interface CurateTool {
+  execute(input: unknown): Promise<CurateOutput>
+}
+
+function createCapturingLogger(): {logger: ILogger; warnings: string[]} {
+  const warnings: string[] = []
+  const logger: ILogger = {
+    debug() {},
+    error() {},
+    info() {},
+    warn(message) {
+      warnings.push(message)
+    },
+  }
+  return {logger, warnings}
+}
+
+/**
+ * Build a throwing-on-one-method wrapper around a healthy store. Lets us
+ * target exactly the failure path a site exercises without replacing the
+ * entire store (the healthy calls in other paths still succeed).
+ */
+function wrapThrowingMethod(
+  store: IRuntimeSignalStore,
+  method: keyof IRuntimeSignalStore,
+  error = new Error('sidecar down'),
+): IRuntimeSignalStore {
+  return new Proxy(store, {
+    get(target, prop, receiver) {
+      if (prop === method) {
+        return async () => {
+          throw error
+        }
+      }
+
+      return Reflect.get(target, prop, receiver)
+    },
+  })
+}
+
+async function runCurateWithFailingStore(
+  tmpRoot: string,
+  failingMethod: keyof IRuntimeSignalStore,
+  operations: Array<Record<string, unknown>>,
+): Promise<{warnings: string[]}> {
+  const basePath = join(tmpRoot, '.brv/context-tree')
+  await fs.mkdir(basePath, {recursive: true})
+  const healthy = createMockRuntimeSignalStore()
+  const failing = wrapThrowingMethod(healthy, failingMethod)
+  const {logger, warnings} = createCapturingLogger()
+  const tool = createCurateTool(undefined, undefined, failing, logger) as unknown as CurateTool
+  await tool.execute({basePath, operations})
+  return {warnings}
+}
+
+describe('Runtime-signals — sidecar-failure logging at swallow sites', () => {
+  let tmpDir: string
+
+  beforeEach(async () => {
+    tmpDir = join(tmpdir(), `sidecar-log-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    await fs.mkdir(tmpDir, {recursive: true})
+  })
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, {force: true, recursive: true})
+    restore()
+  })
+
+  describe('curate-tool helpers', () => {
+    it('seedSidecarDefaults — warns with operation name and path on set() failure', async () => {
+      const {warnings} = await runCurateWithFailingStore(tmpDir, 'set', [
+        {
+          confidence: 'high',
+          content: {snippets: ['x'], tags: ['t']},
+          impact: 'low',
+          path: 'domain/topic',
+          reason: 'seed',
+          title: 'My Note',
+          type: 'ADD',
+        },
+      ])
+      expect(warnings).to.have.lengthOf(1)
+      expect(warnings[0]).to.include('sidecar seed failed')
+      expect(warnings[0]).to.include('domain/topic/my_note.md')
+    })
+
+    it('mirrorCurateUpdate — warns on update() failure during UPDATE', async () => {
+      const basePath = join(tmpDir, '.brv/context-tree')
+      await fs.mkdir(basePath, {recursive: true})
+      const healthy = createMockRuntimeSignalStore()
+      const {logger, warnings} = createCapturingLogger()
+      // Seed through a healthy store first so the file exists on disk.
+      let tool = createCurateTool(undefined, undefined, healthy, logger) as unknown as CurateTool
+      await tool.execute({
+        basePath,
+        operations: [
+          {
+            confidence: 'high',
+            content: {snippets: ['x'], tags: ['t']},
+            impact: 'low',
+            path: 'domain/topic',
+            reason: 'seed',
+            title: 'My Note',
+            type: 'ADD',
+          },
+        ],
+      })
+      warnings.length = 0
+
+      const failing = wrapThrowingMethod(healthy, 'update')
+      tool = createCurateTool(undefined, undefined, failing, logger) as unknown as CurateTool
+      await tool.execute({
+        basePath,
+        operations: [
+          {
+            confidence: 'high',
+            content: {snippets: ['y'], tags: ['t']},
+            impact: 'low',
+            path: 'domain/topic',
+            reason: 'bump',
+            title: 'My Note',
+            type: 'UPDATE',
+          },
+        ],
+      })
+      expect(warnings).to.have.lengthOf(1)
+      expect(warnings[0]).to.include('sidecar update failed')
+      expect(warnings[0]).to.include('domain/topic/my_note.md')
+    })
+
+    it('dropSidecar — warns on delete() failure during DELETE', async () => {
+      const basePath = join(tmpDir, '.brv/context-tree')
+      await fs.mkdir(basePath, {recursive: true})
+      const healthy = createMockRuntimeSignalStore()
+      const {logger, warnings} = createCapturingLogger()
+      let tool = createCurateTool(undefined, undefined, healthy, logger) as unknown as CurateTool
+      await tool.execute({
+        basePath,
+        operations: [
+          {
+            confidence: 'high',
+            content: {snippets: ['x'], tags: ['t']},
+            impact: 'low',
+            path: 'domain/topic',
+            reason: 'seed',
+            title: 'My Note',
+            type: 'ADD',
+          },
+        ],
+      })
+      warnings.length = 0
+
+      const failing = wrapThrowingMethod(healthy, 'delete')
+      tool = createCurateTool(undefined, undefined, failing, logger) as unknown as CurateTool
+      await tool.execute({
+        basePath,
+        operations: [
+          {
+            confidence: 'low',
+            impact: 'low',
+            path: 'domain/topic',
+            reason: 'clean',
+            title: 'My Note',
+            type: 'DELETE',
+          },
+        ],
+      })
+      expect(warnings).to.have.lengthOf(1)
+      expect(warnings[0]).to.include('sidecar drop failed')
+      expect(warnings[0]).to.include('domain/topic/my_note.md')
+    })
+
+    it('executeMerge sidecar block — warns on update() failure during MERGE', async () => {
+      const basePath = join(tmpDir, '.brv/context-tree')
+      await fs.mkdir(basePath, {recursive: true})
+      const healthy = createMockRuntimeSignalStore()
+      const {logger, warnings} = createCapturingLogger()
+      let tool = createCurateTool(undefined, undefined, healthy, logger) as unknown as CurateTool
+      // Seed source + target.
+      await tool.execute({
+        basePath,
+        operations: [
+          {
+            confidence: 'high',
+            content: {snippets: ['a'], tags: ['t']},
+            impact: 'low',
+            path: 'auth/jwt',
+            reason: 's1',
+            title: 'Refresh',
+            type: 'ADD',
+          },
+          {
+            confidence: 'high',
+            content: {snippets: ['b'], tags: ['t']},
+            impact: 'low',
+            path: 'auth/jwt',
+            reason: 's2',
+            title: 'Rotation',
+            type: 'ADD',
+          },
+        ],
+      })
+      warnings.length = 0
+
+      const failing = wrapThrowingMethod(healthy, 'update')
+      tool = createCurateTool(undefined, undefined, failing, logger) as unknown as CurateTool
+      await tool.execute({
+        basePath,
+        operations: [
+          {
+            confidence: 'high',
+            impact: 'low',
+            mergeTarget: 'auth/jwt',
+            mergeTargetTitle: 'Rotation',
+            path: 'auth/jwt',
+            reason: 'dedupe',
+            title: 'Refresh',
+            type: 'MERGE',
+          },
+        ],
+      })
+      expect(warnings).to.have.lengthOf(1)
+      expect(warnings[0]).to.include('sidecar merge failed')
+      expect(warnings[0]).to.include('auth/jwt/refresh.md')
+      expect(warnings[0]).to.include('auth/jwt/rotation.md')
+    })
+  })
+
+  describe('FileContextTreeArchiveService', () => {
+    it('archiveEntry — warns on delete() failure after markdown archive succeeds', async () => {
+      const contextTreeDir = join(tmpDir, '.brv/context-tree')
+      await fs.mkdir(join(contextTreeDir, 'auth'), {recursive: true})
+      const relPath = 'auth/token.md'
+      await fs.writeFile(join(contextTreeDir, relPath), '# Token\n', 'utf8')
+
+      const healthy = createMockRuntimeSignalStore()
+      const failing = wrapThrowingMethod(healthy, 'delete')
+      const {logger, warnings} = createCapturingLogger()
+      const svc = new FileContextTreeArchiveService(failing, logger)
+
+      const fakeAgent = {
+        createTaskSession: async () => 'sess',
+        async deleteTaskSession() {},
+        executeOnSession: async () => '```json\n{"title":"Ghost","summary":"g","tags":[]}\n```',
+        async setSandboxVariableOnSession() {},
+      } as unknown as ICipherAgent
+
+      await svc.archiveEntry(relPath, fakeAgent, tmpDir)
+
+      const match = warnings.find((w) => w.includes('archive-service: sidecar delete failed'))
+      expect(match, `expected warn for archive delete, got: ${warnings.join(' | ')}`).to.not.be.undefined
+      expect(match).to.include(relPath)
+    })
+
+    it('restoreEntry — warns on set() failure after markdown restore succeeds', async () => {
+      const contextTreeDir = join(tmpDir, '.brv/context-tree')
+      const archivedDir = join(contextTreeDir, '_archived/auth')
+      await fs.mkdir(archivedDir, {recursive: true})
+      const stubRel = '_archived/auth/token.stub.md'
+      const fullRel = '_archived/auth/token.full.md'
+      const stubContent = [
+        '---',
+        'type: archive_stub',
+        'original_path: auth/token.md',
+        'original_token_count: 10',
+        'evicted_at: 2026-04-19T00:00:00.000Z',
+        'evicted_importance: 20',
+        'points_to: _archived/auth/token.full.md',
+        '---',
+        '# Ghost\n',
+      ].join('\n')
+      await fs.writeFile(join(contextTreeDir, stubRel), stubContent, 'utf8')
+      await fs.writeFile(join(contextTreeDir, fullRel), '# Full\n', 'utf8')
+
+      const healthy = createMockRuntimeSignalStore()
+      const failing = wrapThrowingMethod(healthy, 'set')
+      const {logger, warnings} = createCapturingLogger()
+      const svc = new FileContextTreeArchiveService(failing, logger)
+
+      await svc.restoreEntry(stubRel, tmpDir)
+
+      const match = warnings.find((w) => w.includes('archive-service: sidecar seed failed'))
+      expect(match, `expected warn for archive seed, got: ${warnings.join(' | ')}`).to.not.be.undefined
+      expect(match).to.include('auth/token.md')
+    })
+
+    it('findArchiveCandidates — warns on list() failure during candidate scan', async () => {
+      const contextTreeDir = join(tmpDir, '.brv/context-tree')
+      await fs.mkdir(contextTreeDir, {recursive: true})
+
+      const healthy = createMockRuntimeSignalStore()
+      const failing = wrapThrowingMethod(healthy, 'list')
+      const {logger, warnings} = createCapturingLogger()
+      const svc = new FileContextTreeArchiveService(failing, logger)
+
+      await svc.findArchiveCandidates(tmpDir)
+
+      const match = warnings.find((w) => w.includes('archive-service: sidecar list failed'))
+      expect(match, `expected warn for archive list, got: ${warnings.join(' | ')}`).to.not.be.undefined
+    })
+
+    it('readImportanceForArchiveMetadata — warns on get() failure during archive flow', async () => {
+      const contextTreeDir = join(tmpDir, '.brv/context-tree')
+      await fs.mkdir(join(contextTreeDir, 'auth'), {recursive: true})
+      const relPath = 'auth/token.md'
+      await fs.writeFile(join(contextTreeDir, relPath), '# Token\n', 'utf8')
+
+      const healthy = createMockRuntimeSignalStore()
+      // `archiveEntry` calls `readImportanceForArchiveMetadata` (get) and
+      // later `delete`. Fail only `get` to isolate this site from the
+      // archiveEntry-delete site already covered above.
+      const failing = wrapThrowingMethod(healthy, 'get')
+      const {logger, warnings} = createCapturingLogger()
+      const svc = new FileContextTreeArchiveService(failing, logger)
+
+      const fakeAgent = {
+        async createTaskSession() {
+          return 'sess'
+        },
+        async deleteTaskSession() {},
+        async executeOnSession() {
+          return '```json\n{"title":"Ghost","summary":"g","tags":[]}\n```'
+        },
+        async setSandboxVariableOnSession() {},
+      } as unknown as ICipherAgent
+
+      await svc.archiveEntry(relPath, fakeAgent, tmpDir)
+
+      const match = warnings.find((w) =>
+        w.includes('archive-service: sidecar get failed') && w.includes('archive metadata read'),
+      )
+      expect(match, `expected warn for archive get, got: ${warnings.join(' | ')}`).to.not.be.undefined
+      expect(match).to.include(relPath)
+    })
+  })
+
+  describe('dream operations', () => {
+    it('consolidate.determineNeedsReview — warns on per-file get() failure during CROSS_REFERENCE gate', async () => {
+      const contextTreeDir = join(tmpDir, '.brv/context-tree')
+      await fs.mkdir(join(contextTreeDir, 'auth'), {recursive: true})
+      await fs.writeFile(join(contextTreeDir, 'auth/a.md'), '# A\nBody.', 'utf8')
+      await fs.writeFile(join(contextTreeDir, 'auth/b.md'), '# B\nBody.', 'utf8')
+
+      const failingGet: {get: (path: string) => Promise<{maturity: 'core' | 'draft' | 'validated'}>} = {
+        async get() {
+          throw new Error('sidecar down')
+        },
+      }
+
+      const {logger, warnings} = createCapturingLogger()
+
+      const agent = {
+        createTaskSession: stub().resolves('sess'),
+        deleteTaskSession: stub().resolves(),
+        executeOnSession: stub().resolves(
+          '```json\n' +
+            JSON.stringify({
+              actions: [
+                {
+                  files: ['auth/a.md', 'auth/b.md'],
+                  reason: 'related',
+                  type: 'CROSS_REFERENCE',
+                },
+              ],
+            }) +
+            '\n```',
+        ),
+        setSandboxVariableOnSession: stub(),
+      }
+
+      await consolidate(['auth/a.md', 'auth/b.md'], {
+        agent: agent as unknown as ICipherAgent,
+        contextTreeDir,
+        logger,
+        runtimeSignalStore: failingGet,
+        searchService: {search: async () => ({results: []})},
+        taskId: 't1',
+      })
+
+      const match = warnings.find((w) => w.includes('consolidate: sidecar get failed'))
+      expect(match, `expected warn for consolidate get, got: ${warnings.join(' | ')}`).to.not.be.undefined
+      expect(match).to.satisfy((m: string) => m.includes('auth/a.md') || m.includes('auth/b.md'))
+    })
+
+    it('prune.findCandidates — warns on list() failure (fail-open to defaults)', async () => {
+      const contextTreeDir = join(tmpDir, '.brv/context-tree')
+      await fs.mkdir(contextTreeDir, {recursive: true})
+
+      const failingList: {list: () => Promise<Map<string, never>>} = {
+        async list() {
+          throw new Error('list broken')
+        },
+      }
+
+      const {logger, warnings} = createCapturingLogger()
+
+      const updateStub: SinonStub = stub().callsFake(
+        async (updater: (s: typeof EMPTY_DREAM_STATE) => typeof EMPTY_DREAM_STATE) => updater({...EMPTY_DREAM_STATE}),
+      )
+
+      await prune({
+        agent: {
+          createTaskSession: stub().resolves('s'),
+          deleteTaskSession: stub().resolves(),
+          executeOnSession: stub().resolves('```json\n{"decisions":[]}\n```'),
+          setSandboxVariableOnSession: stub(),
+        } as unknown as ICipherAgent,
+        archiveService: {
+          archiveEntry: stub(),
+          findArchiveCandidates: stub().resolves([]),
+        },
+        contextTreeDir,
+        dreamLogId: 'd1',
+        dreamStateService: {
+          read: stub().resolves({...EMPTY_DREAM_STATE}),
+          update: updateStub,
+          write: stub().resolves(),
+        },
+        logger,
+        projectRoot: contextTreeDir,
+        runtimeSignalStore: failingList,
+        signal: undefined,
+        taskId: 't1',
+      })
+
+      const match = warnings.find((w) => w.includes('prune: sidecar list failed'))
+      expect(match, `expected warn for prune list, got: ${warnings.join(' | ')}`).to.not.be.undefined
+    })
+  })
+
+  describe('FileContextTreeManifestService', () => {
+    it('buildManifest — warns on list() failure (fail-open to defaults)', async () => {
+      const baseDirectory = tmpDir
+      await fs.mkdir(join(baseDirectory, '.brv/context-tree'), {recursive: true})
+
+      const failingList = {
+        async batchUpdate() {},
+        async delete() {},
+        async get() {
+          return createDefaultRuntimeSignals()
+        },
+        async getMany() {
+          return new Map()
+        },
+        async list() {
+          throw new Error('list broken')
+        },
+        async set() {},
+        async update() {
+          return createDefaultRuntimeSignals()
+        },
+      }
+
+      const {logger, warnings} = createCapturingLogger()
+
+      const svc = new FileContextTreeManifestService({
+        baseDirectory,
+        logger,
+        runtimeSignalStore: failingList,
+      })
+
+      await svc.buildManifest()
+
+      const match = warnings.find((w) => w.includes('manifest-service: sidecar list failed'))
+      expect(match, `expected warn for manifest list, got: ${warnings.join(' | ')}`).to.not.be.undefined
+    })
+  })
+
+  describe('commit 6 wiring', () => {
+    it('buildUndoDeps (CLI dream-undo) threads the runtime-signal sidecar into archive + manifest services', async () => {
+      const {buildUndoDeps} = await import('../../../../src/oclif/commands/dream.js')
+      const root = await fs.mkdtemp(join(tmpdir(), 'undo-wiring-'))
+
+      try {
+        const deps = await buildUndoDeps(root)
+
+        // The archive service receives the sidecar as its first (and only)
+        // constructor arg. We assert on the instance shape via a private-field
+        // cast because the public surface deliberately hides implementation.
+        const archiveService = deps.archiveService as unknown as {runtimeSignalStore?: unknown}
+        expect(archiveService.runtimeSignalStore, 'archiveService sidecar wiring').to.not.be.undefined
+
+        // The manifest service takes its config via constructor; we inspect
+        // the `config` field (the only property the implementation keeps).
+        const manifestService = deps.manifestService as unknown as {config: {runtimeSignalStore?: unknown}}
+        expect(manifestService.config.runtimeSignalStore, 'manifestService sidecar wiring').to.not.be.undefined
+      } finally {
+        await fs.rm(root, {force: true, recursive: true})
+      }
+    })
+
+    it('service-initializer threads runtimeSignalStore into the swarm SearchKnowledgeService (source regression)', async () => {
+      const sourcePath = join(
+        process.cwd(),
+        'src/agent/infra/agent/service-initializer.ts',
+      )
+      const source = await fs.readFile(sourcePath, 'utf8')
+
+      // Locate the buildProvidersFromConfig block and slice the next few lines
+      // so the assertion fails loudly if a refactor drops the store — without
+      // mocking the entire agent bootstrap.
+      const anchor = source.indexOf('buildProvidersFromConfig(swarmConfig')
+      expect(anchor, 'buildProvidersFromConfig block missing').to.be.greaterThan(-1)
+      const window = source.slice(anchor, anchor + 400)
+
+      expect(window, 'swarm search service must receive runtimeSignalStore').to.match(/runtimeSignalStore/)
+      expect(window, 'swarm search service call must use config object form').to.match(
+        /createSearchKnowledgeService\(\s*fileSystemService\s*,/,
+      )
+    })
+  })
+})

--- a/test/unit/infra/runtime-signals/sidecar-failure-logging.test.ts
+++ b/test/unit/infra/runtime-signals/sidecar-failure-logging.test.ts
@@ -255,10 +255,73 @@ describe('Runtime-signals — sidecar-failure logging at swallow sites', () => {
           },
         ],
       })
+      // Forcing `update` to throw triggers the merge-update warn and
+      // short-circuits before the delete (targetUpdated stays false) so
+      // exactly one warning fires.
       expect(warnings).to.have.lengthOf(1)
-      expect(warnings[0]).to.include('sidecar merge failed')
+      expect(warnings[0]).to.include('sidecar merge-update failed')
       expect(warnings[0]).to.include('auth/jwt/refresh.md')
       expect(warnings[0]).to.include('auth/jwt/rotation.md')
+    })
+
+    it('executeMerge sidecar block — warns on delete() failure after successful update (orphan path)', async () => {
+      const basePath = join(tmpDir, '.brv/context-tree')
+      await fs.mkdir(basePath, {recursive: true})
+      const healthy = createMockRuntimeSignalStore()
+      const {logger, warnings} = createCapturingLogger()
+      let tool = createCurateTool(undefined, undefined, healthy, logger) as unknown as CurateTool
+      // Seed source + target — both sidecar entries exist.
+      await tool.execute({
+        basePath,
+        operations: [
+          {
+            confidence: 'high',
+            content: {snippets: ['a'], tags: ['t']},
+            impact: 'low',
+            path: 'auth/jwt',
+            reason: 's1',
+            title: 'Refresh',
+            type: 'ADD',
+          },
+          {
+            confidence: 'high',
+            content: {snippets: ['b'], tags: ['t']},
+            impact: 'low',
+            path: 'auth/jwt',
+            reason: 's2',
+            title: 'Rotation',
+            type: 'ADD',
+          },
+        ],
+      })
+      warnings.length = 0
+
+      // `update` stays healthy so the merge-target sidecar is written;
+      // `delete` throws so the source sidecar becomes a permanent orphan
+      // (markdown is already removed upstream). Exactly one `merge-delete`
+      // warn should fire, and no `merge-update` warn should appear.
+      const failing = wrapThrowingMethod(healthy, 'delete')
+      tool = createCurateTool(undefined, undefined, failing, logger) as unknown as CurateTool
+      await tool.execute({
+        basePath,
+        operations: [
+          {
+            confidence: 'high',
+            impact: 'low',
+            mergeTarget: 'auth/jwt',
+            mergeTargetTitle: 'Rotation',
+            path: 'auth/jwt',
+            reason: 'dedupe',
+            title: 'Refresh',
+            type: 'MERGE',
+          },
+        ],
+      })
+
+      expect(warnings).to.have.lengthOf(1)
+      expect(warnings[0]).to.include('sidecar merge-delete failed')
+      expect(warnings[0]).to.include('auth/jwt/refresh.md')
+      expect(warnings[0]).to.not.include('merge-update')
     })
   })
 
@@ -499,6 +562,65 @@ describe('Runtime-signals — sidecar-failure logging at swallow sites', () => {
 
       const match = warnings.find((w) => w.includes('manifest-service: sidecar list failed'))
       expect(match, `expected warn for manifest list, got: ${warnings.join(' | ')}`).to.not.be.undefined
+    })
+  })
+
+  describe('SearchKnowledgeService.mirrorHitsToSignalStore', () => {
+    it('warns on batchUpdate() failure during access-hit flush', async () => {
+      const {createSearchKnowledgeService} = await import(
+        '../../../../src/agent/infra/tools/implementations/search-knowledge-service.js'
+      )
+      const {FileSystemService} = await import(
+        '../../../../src/agent/infra/file-system/file-system-service.js'
+      )
+
+      const contextTreeDir = join(tmpDir, '.brv/context-tree/auth')
+      await fs.mkdir(contextTreeDir, {recursive: true})
+      await fs.writeFile(join(contextTreeDir, 'a.md'), '# A\nBody.', 'utf8')
+
+      const throwingStore = {
+        async batchUpdate() {
+          throw new Error('batchUpdate failed')
+        },
+        async delete() {},
+        async get() {
+          return createDefaultRuntimeSignals()
+        },
+        async getMany() {
+          return new Map()
+        },
+        async list() {
+          return new Map()
+        },
+        async set() {},
+        async update() {
+          return createDefaultRuntimeSignals()
+        },
+      }
+      const {logger, warnings} = createCapturingLogger()
+      const fsService = new FileSystemService({
+        allowedPaths: [tmpDir],
+        workingDirectory: tmpDir,
+      })
+      await fsService.initialize()
+      const svc = createSearchKnowledgeService(fsService, {
+        baseDirectory: tmpDir,
+        logger,
+        runtimeSignalStore: throwingStore,
+      })
+
+      // Prime pendingAccessHits so the flush has work to do. The ISearchKnowledgeService
+      // surface doesn't expose flushAccessHits — cast to the concrete class.
+      const concrete = svc as unknown as {
+        flushAccessHits(path: string): Promise<boolean>
+        pendingAccessHits: Map<string, number>
+      }
+      concrete.pendingAccessHits.set('auth/a.md', 3)
+
+      const flushed = await concrete.flushAccessHits(contextTreeDir)
+      expect(flushed).to.equal(true)
+      const match = warnings.find((w) => w.includes('search-knowledge-flush: sidecar batchUpdate failed'))
+      expect(match, `expected warn for flush batchUpdate, got: ${warnings.join(' | ')}`).to.not.be.undefined
     })
   })
 


### PR DESCRIPTION
## Summary

- Problem: `brv query` was mutating markdown frontmatter with ranking-signal bumps (`importance`, `recency`, `maturity`, `accessCount`, `updateCount`) on every access-hit flush. This dirtied `.brv/context-tree/` on every query, making `brv vc status` useless for detecting real user edits and creating spurious merge conflicts across teammates.
- Why it matters: version-controlled knowledge is the core of ByteRover's team-context promise. A dirty `vc status` after a read-only operation broke the mental model users had of the context tree as their authored artifact. Per-machine ranking noise was polluting shared source of truth.
- What changed: the five ranking fields are moved out of markdown and into a per-machine sidecar keyed by file path. Sidecar lives under `$XDG/keystore/signals/<path>.json`, populated by an `IKeyStorage`-backed `RuntimeSignalStore`. Markdown keeps only semantic fields (`title`, `summary`, `tags`, `keywords`, `related`, `createdAt`, `updatedAt`).
- What did NOT change (scope boundary):
  - **No migration of pre-existing markdown.** Legacy files keep their inert `importance`/`maturity` fields. `parseContent` silently ignores them. Signals self-heal on next curate/search.
  - **Cloud sync is not touched.** Architecturally N/A — `IKeyStorage` lives outside `.brv/context-tree` and was never enumerated by push.
  - **No change to ranking math.** Same BM25 + compound-scoring formulas; only the storage backend moved.
  - **No change to user-visible CLI surface.** Same commands, same outputs.

## Type of change

- [x] Bug fix (shared-state churn on reads — the user-facing regression)
- [x] New feature (`RuntimeSignalStore` + sidecar storage layer)
- [x] Refactor (storage boundary move, type split `FrontmatterScoring` → `RuntimeSignals` + `SemanticFrontmatter`)
- [ ] Documentation
- [x] Test (new unit + integration + VC-clean regression)
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [x] Agent / Tools  — curate-tool, search-knowledge-service, memory-symbol-tree, cipher-agent session rebind
- [x] Server / Daemon  — archive, manifest, consolidate, prune, service-initializer
- [x] Shared (constants, types, transport events)  — `RuntimeSignals` schema, `SemanticFrontmatter` type
- [x] CLI Commands (oclif)  — `brv dream --undo` wiring
- [ ] TUI / REPL
- [ ] LLM Providers
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- ENG-2133 (1/6): add RuntimeSignals Zod schema and types
- ENG-2157 (2/6): add RuntimeSignalStore with atomic update primitive
- ENG-2158 (3/6): dual-write runtime signals to sidecar
- ENG-2159 (4/6): switch all ranking read paths to sidecar
- ENG-2160 (5/6): stop writing runtime signals to markdown
- ENG-2162 (6/6): close series loose ends — CLI/swarm wiring + sidecar observability
- Fix: thread runtimeSignalStore through `rebindCurateTools` (caught during end-to-end verification)

## Root cause (bug fixes only)

The original dirty-`vc status` issue was architectural, not a bug: ranking mutations were interleaved with authored content in the same file. The migration moves to a clean separation rather than "fixing" the intertwining.

The one in-flight bug fix (`rebindCurateTools` wiring) was a signature-evolution gap: commit 3 added `runtimeSignalStore?` as an optional third param to `createCurateService`, but the `cipher-agent.ts:rebindCurateTools` call site was missed — it remained a two-arg call. TypeScript didn't flag the omission because the new param is optional. Invisible pre-commit-5 (markdown fallback held); materialised as a silent regression post-commit-5. Fixed on this branch.

## Test plan

- Coverage added:
  - [x] Unit test (11 new sidecar swallow-logging sites + 2 wiring regressions + store-level CRUD + schema validation + merge semantics)
  - [x] Integration test (`search-knowledge-flush-sidecar.test.ts` — 20-round flush against real disk, byte-identical markdown)
  - [x] Manual verification (local-auto-test/runtime-signals sandbox — see Evidence)
- Primary test files:
  - `test/unit/agent/knowledge/runtime-signals-schema.test.ts` — schema boundaries
  - `test/unit/infra/context-tree/runtime-signal-store.test.ts` — CRUD + atomicity
  - `test/integration/runtime-signals/vc-clean-regression.test.ts` — `brv vc status` stays clean
  - `test/unit/infra/runtime-signals/sidecar-failure-logging.test.ts` — 13 cases (11 logging + 2 wiring)
  - `test/unit/agent/tools/curate-tool-sidecar-dual-write.test.ts` — ADD/UPDATE/MERGE/DELETE mirror into sidecar
  - `test/unit/agent/agent/rebind-curate-tools-sidecar-wiring.test.ts` — source regression for the fix
- Key scenarios:
  - 20 rounds of access-hit flush produce byte-identical markdown files
  - `parseContent` on legacy pre-migration markdown parses cleanly, legacy fields silently dropped
  - Curate ADD seeds defaults, UPDATE bumps importance + recency + updateCount, MERGE merges two sidecars into one + drops source, DELETE removes sidecar entry
  - Search access-hit flush bumps importance + accessCount, promotes maturity at threshold (65)
  - Every sidecar swallow site logs `warn` with op-name + path on store failure (observability for operators post-commit-5)

## User-visible changes

- `brv query` no longer dirties markdown. Running `brv vc status` after a session of queries returns a clean tree (the user-facing promise of this initiative).
- Sidecar JSON appears under `$XDG/keystore/signals/` after first curate/search. Users inspecting it will see `{importance, recency, maturity, accessCount, updateCount}` — this is expected and intentional.
- Legacy markdown files keep their old `importance:`/`maturity:` frontmatter fields until they are next rewritten by a curate UPDATE. Inert — silently ignored by readers.

## Evidence

**VC-clean regression test** — the user-facing promise:


**End-to-end sandbox** (in the companion `local-auto-test/runtime-signals` repo) — real `brv curate` + `brv query` produces the expected XDG sidecar progression:

| Step | accessCount | importance | maturity |
|---|---:|---:|---|
| After `brv curate` | 0 | 50 | draft |
| After `brv query #1` | 0 | 50 | draft (hits pending — flush runs at start of next search) |
| After `brv query #2` | 4 | 62 | draft |
| After `brv query #3` | 8 | 74 | **validated** (hysteresis threshold crossed at 65) |

Deltas reflect that each query touches the main doc + its parent `context.md` + `_index.md` chain (~4 files), not just the hit.

**Grep audit** — zero remaining silent sidecar swallows (every swallow site logs via `warnSidecarFailure`):


**Full suite**: `6499 passing / 0 failing`. Lint: 0 errors. Build: clean.

## Checklist

- [x] Tests added or updated and passing (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow Conventional Commits format
- [ ] Documentation updated — user docs still accurate; no CHANGELOG update (internal storage change)
- [x] No breaking changes (legacy tolerance is permanent)
- [x] Branch is up to date with `main`

## Risks and mitigations

- **Risk: Pre-migration `maturity: 'core'` files silently lose protection.** Users who pinned files as `core` via old curate UPDATE calls have that stored in markdown, which is now ignored. Until a fresh curate UPDATE or enough access hits bump importance past the 85 threshold, those files default to `draft` in the sidecar-sourced view. Prune's "core never pruned" gate, symbol-tree boost, and ranking priority all silently degrade until the signal self-heals.
  - Mitigation: tracked in backlog with trigger "first user report of core-file ranking degradation." Fix is a one-shot hydrator that reads legacy markdown and seeds the sidecar. Deferred per plan's "no migration, signals self-heal" decision; can ship as a follow-up if a user surfaces it.

- **Risk: Cross-process lost-update window on concurrent sidecar writes.** Daemon and CLI processes have independent in-process RWLocks, so a race between `daemon.flushAccessHits` and `CLI.brv curate` on the same path can lose one bump.
  - Mitigation: explicitly documented in the `IRuntimeSignalStore` interface. For ranking signals this is acceptable — one lost bump is a tiny drift, not a correctness issue. Upgrade to file-level advisory locking deferred with trigger "observed drift in production."

- **Risk: Source-level regression guards (swarm + rebind wiring) are tied to specific anchor tokens.** A refactor that renames the anchored identifier would silently bypass the guard.
  - Mitigation: anchors chosen to be load-bearing code identifiers (not comments) — `buildProvidersFromConfig(swarmConfig` and `const newCurateService = createCurateService(` — both fail loudly with a clear message if the structure breaks. A rename refactor would also touch the assertion block, making it obvious to the author.

- **Risk: Observability gap post-commit-5.** Sidecar is now canonical for ranking; silent swallow of write failures would hide operational outages.
  - Mitigation: 11 swallow sites now emit `warn` with operation name + path via a shared `warnSidecarFailure` helper. Unit tests pin the behavior.

## Deployment notes

- **No schema migration required.** Sidecar files are created lazily on first curate/search in each project. Fresh deployments start empty and populate organically.
- **No flag-gated rollout needed.** The fix is architectural; there is no "old behavior" worth preserving via a kill switch. Revert is clean — commits 1-3 are strictly additive and reverting commits 4-6 restores markdown-based ranking (existing legacy fields still present in files).
- **Docs**: internal storage change, no user-facing doc update needed.