### PR TITLE
feat: [ENG-2154] Add OS system/temp files to CONTEXT_TREE_GITIGNORE_P…

### DIFF
--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -120,14 +120,37 @@ export const MANIFEST_FILE = '_manifest.json'
 export const ARCHIVE_IMPORTANCE_THRESHOLD = 35
 export const DEFAULT_GHOST_CUE_MAX_TOKENS = 220
 
-/** Patterns the context-tree .gitignore must contain (derived artifacts only). */
+/** Patterns the context-tree .gitignore must contain. */
 export const CONTEXT_TREE_GITIGNORE_PATTERNS = [
+  // Derived artifacts
   '.gitignore',
   '.snapshot.json',
   '_manifest.json',
   '_index.md',
   '*.abstract.md',
   '*.overview.md',
+
+  // macOS
+  '.DS_Store',
+  '._*',
+
+  // Windows
+  'Thumbs.db',
+  'ehthumbs.db',
+  'Desktop.ini',
+
+  // Linux
+  '.directory',
+  '.fuse_hidden*',
+  '.nfs*',
+
+  // Editor swap / backup / temp
+  '*.swp',
+  '*.swo',
+  '*~',
+  '.#*',
+  '*.bak',
+  '*.tmp',
 ]
 
 export const CONTEXT_TREE_GITIGNORE_HEADER = '# Derived artifacts — do not track'

--- a/test/unit/server/constants.test.ts
+++ b/test/unit/server/constants.test.ts
@@ -17,4 +17,38 @@ describe('CONTEXT_TREE_GITIGNORE_PATTERNS', () => {
     expect(CONTEXT_TREE_GITIGNORE_PATTERNS).to.include('_manifest.json')
     expect(CONTEXT_TREE_GITIGNORE_PATTERNS).to.include('_index.md')
   })
+
+  describe('OS-generated junk files', () => {
+    it('should exclude macOS junk (Finder metadata + AppleDouble forks)', () => {
+      expect(CONTEXT_TREE_GITIGNORE_PATTERNS).to.include('.DS_Store')
+      expect(CONTEXT_TREE_GITIGNORE_PATTERNS).to.include('._*')
+    })
+
+    it('should exclude Windows junk (thumbnail cache + folder config)', () => {
+      expect(CONTEXT_TREE_GITIGNORE_PATTERNS).to.include('Thumbs.db')
+      expect(CONTEXT_TREE_GITIGNORE_PATTERNS).to.include('ehthumbs.db')
+      expect(CONTEXT_TREE_GITIGNORE_PATTERNS).to.include('Desktop.ini')
+    })
+
+    it('should exclude Linux junk (KDE metadata + FUSE/NFS hidden files)', () => {
+      expect(CONTEXT_TREE_GITIGNORE_PATTERNS).to.include('.directory')
+      expect(CONTEXT_TREE_GITIGNORE_PATTERNS).to.include('.fuse_hidden*')
+      expect(CONTEXT_TREE_GITIGNORE_PATTERNS).to.include('.nfs*')
+    })
+
+    it('should exclude editor swap / backup / temp files', () => {
+      expect(CONTEXT_TREE_GITIGNORE_PATTERNS).to.include('*.swp')
+      expect(CONTEXT_TREE_GITIGNORE_PATTERNS).to.include('*.swo')
+      expect(CONTEXT_TREE_GITIGNORE_PATTERNS).to.include('*~')
+      expect(CONTEXT_TREE_GITIGNORE_PATTERNS).to.include('.#*')
+      expect(CONTEXT_TREE_GITIGNORE_PATTERNS).to.include('*.bak')
+      expect(CONTEXT_TREE_GITIGNORE_PATTERNS).to.include('*.tmp')
+    })
+
+    it('should deliberately NOT include trash folders (out of scope per ENG-2154)', () => {
+      expect(CONTEXT_TREE_GITIGNORE_PATTERNS).to.not.include('.Trashes')
+      expect(CONTEXT_TREE_GITIGNORE_PATTERNS).to.not.include('.Trash-*')
+      expect(CONTEXT_TREE_GITIGNORE_PATTERNS).to.not.include('$RECYCLE.BIN/')
+    })
+  })
 })

--- a/test/unit/utils/gitignore.test.ts
+++ b/test/unit/utils/gitignore.test.ts
@@ -348,14 +348,10 @@ _index.md
     })
 
     it('should handle lines with leading/trailing whitespace', async () => {
-      const withSpaces = `# Derived artifacts — do not track
-  .gitignore
-  .snapshot.json
-_manifest.json
-_index.md
-  *.abstract.md
-*.overview.md
-`
+      const withSpaces = FULL_GITIGNORE
+        .replace(/^\.gitignore$/m, '  .gitignore')
+        .replace(/^\.snapshot\.json$/m, '  .snapshot.json')
+        .replace(/^\*\.abstract\.md$/m, '  *.abstract.md')
       writeFileSync(path.join(testDir, '.gitignore'), withSpaces)
 
       await ensureContextTreeGitignore(testDir)
@@ -365,14 +361,7 @@ _index.md
     })
 
     it('should skip pattern when a variant already covers it — /_manifest.json contains _manifest.json', async () => {
-      const withSlash = `# Derived artifacts — do not track
-.gitignore
-.snapshot.json
-/_manifest.json
-_index.md
-*.abstract.md
-*.overview.md
-`
+      const withSlash = FULL_GITIGNORE.replace(/^_manifest\.json$/m, '/_manifest.json')
       writeFileSync(path.join(testDir, '.gitignore'), withSlash)
 
       await ensureContextTreeGitignore(testDir)


### PR DESCRIPTION
## Summary

- Problem: `.brv/context-tree/` accumulates OS- and editor-generated junk (`.DS_Store`, `Thumbs.db`, `*.swp`, AppleDouble `._*`, etc.) when users sync the tree across machines or open editors directly inside it. These leak into commits and pollute the BM25 index.
- Why it matters: A polluted context tree degrades retrieval quality (BM25 indexes junk tokens) and creates noisy diffs when users commit their context tree to their project repo via `brv vc`.
- What changed: Extended `CONTEXT_TREE_GITIGNORE_PATTERNS` in [src/server/constants.ts](src/server/constants.ts#L120-L156) with grouped, commented sections for macOS / Windows / Linux / editor swap-backup-temp. Refactored the two variance tests in `test/unit/utils/gitignore.test.ts` to derive their fixtures from the shared `FULL_GITIGNORE` constant so they stay in sync with the array.
- What did NOT change (scope boundary): The writer [`ensureContextTreeGitignore`](src/server/utils/gitignore.ts#L50) is untouched — its idempotent / negation-respecting / comment-respecting behavior already handles in-place upgrades for existing users. No trash folder patterns (`.Trashes`, `.Trash-*`, `$RECYCLE.BIN/`), no language caches (`__pycache__`, `.cache/`), no `_archived/`.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [ ] Agent / Tools
- [ ] LLM Providers
- [x] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes ENG-2154
- Related #

## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause: N/A
- Why this was not caught earlier: N/A

## Test plan

- Coverage added:
  - [x] Unit test
  - [ ] Integration test
  - [ ] Manual verification only
- Test file(s):
  - `test/unit/server/constants.test.ts` — new `describe('OS-generated junk files')` block with 5 assertions
  - `test/unit/utils/gitignore.test.ts` — refactored two fixtures to derive from `FULL_GITIGNORE` so future additions to the constant do not silently drop test coverage
- Key scenario(s) covered:
  - macOS patterns present (`.DS_Store`, `._*`)
  - Windows patterns present (`Thumbs.db`, `ehthumbs.db`, `Desktop.ini`)
  - Linux patterns present (`.directory`, `.fuse_hidden*`, `.nfs*`)
  - Editor swap / backup / temp patterns present (`*.swp`, `*.swo`, `*~`, `.#*`, `*.bak`, `*.tmp`)
  - Negative assertion: trash folders (`.Trashes`, `.Trash-*`, `$RECYCLE.BIN/`) are deliberately NOT included (out of scope per ENG-2154)
  - Existing `ensureContextTreeGitignore` behavior tests (idempotency, negation `!pattern`, comment `# pattern`, whitespace handling, `/pattern` variant suppression) remain green against the enlarged pattern set

## User-visible changes

- Newly-created `.brv/context-tree/.gitignore` files include 14 additional ignore patterns covering common OS- and editor-generated junk.
- Existing `.brv/context-tree/.gitignore` files will be upgraded in place on next daemon write — the writer appends only missing patterns, preserves user edits (including `!negations` and `# comments`), and never rewrites the file when all patterns are already covered.
- No CLI flag, config key, or command-output changes.

## Evidence

- [x] Failing test/log before + passing after

```bash
# Before constant update — new OS/junk assertions fail
$ npx mocha --forbid-only "test/unit/server/constants.test.ts"
  CONTEXT_TREE_GITIGNORE_PATTERNS
    ✓ should include derived artifact patterns
    OS-generated junk files
      1) should exclude macOS junk (Finder metadata + AppleDouble forks)
      2) should exclude Windows junk (thumbnail cache + folder config)
      3) should exclude Linux junk (KDE metadata + FUSE/NFS hidden files)
      4) should exclude editor swap / backup / temp files
      ✓ should deliberately NOT include trash folders (out of scope per ENG-2154)

# After constant update — all green
$ npx mocha --forbid-only "test/unit/server/constants.test.ts"
  6 passing

$ npx mocha --forbid-only "test/unit/utils/gitignore.test.ts"
  (all behavioral tests pass against the enlarged pattern set)