### PR TITLE
fix: resume provider setup after successful ByteRover OAuth login

### DIFF
--- a/src/tui/features/provider/components/provider-flow.tsx
+++ b/src/tui/features/provider/components/provider-flow.tsx
@@ -26,6 +26,7 @@ import {useDisconnectProvider} from '../api/disconnect-provider.js'
 import {useGetProviders} from '../api/get-providers.js'
 import {useSetActiveProvider} from '../api/set-active-provider.js'
 import {useValidateApiKey} from '../api/validate-api-key.js'
+import {derivePostLoginAction} from '../utils/derive-post-login-action.js'
 import {ApiKeyDialog} from './api-key-dialog.js'
 import {AuthMethodDialog} from './auth-method-dialog.js'
 import {BaseUrlDialog} from './base-url-dialog.js'
@@ -281,14 +282,34 @@ export const ProviderFlow: React.FC<ProviderFlowProps> = ({
     }
   }, [disconnectMutation, isAuthorized, onComplete, selectedProvider, setActiveMutation])
 
-  const handleLoginComplete = useCallback((message: string) => {
+  const handleLoginComplete = useCallback(async (message: string) => {
     const nowAuthorized = useAuthStore.getState().isAuthorized
-    if (!nowAuthorized) {
-      setError(message)
+    const action = derivePostLoginAction({
+      errorMessage: message,
+      isAuthorized: nowAuthorized,
+      selectedProviderId: selectedProvider?.id,
+    })
+
+    if (action.type === 'connect-byterover' && selectedProvider) {
+      setStep('connecting')
+      try {
+        await connectMutation.mutateAsync({providerId: selectedProvider.id})
+        await setActiveMutation.mutateAsync({providerId: selectedProvider.id})
+        onComplete(`Connected to ${selectedProvider.name}`)
+      } catch (error_) {
+        setError(formatTransportError(error_))
+        setStep('select')
+      }
+
+      return
+    }
+
+    if (action.type === 'return-to-select-with-error') {
+      setError(action.message)
     }
 
     setStep('select')
-  }, [])
+  }, [connectMutation, onComplete, selectedProvider, setActiveMutation])
 
   const handleBaseUrlSubmit = useCallback((url: string) => {
     setBaseUrl(url)

--- a/src/tui/features/provider/utils/derive-post-login-action.ts
+++ b/src/tui/features/provider/utils/derive-post-login-action.ts
@@ -1,0 +1,44 @@
+/**
+ * Post-Login Action Selector
+ *
+ * Pure decision logic for what the provider flow should do after the OAuth
+ * login flow completes. Extracted from ProviderFlow.handleLoginComplete for
+ * testability — mirrors the deriveAppViewMode pattern in the onboarding feature.
+ */
+
+/**
+ * Discriminated union of transitions the provider flow can take after login.
+ */
+export type PostLoginAction =
+  | {message: string; type: 'return-to-select-with-error'}
+  | {type: 'connect-byterover'}
+  | {type: 'return-to-select'}
+
+/**
+ * Parameters for the pure post-login action derivation function.
+ */
+export type DerivePostLoginActionParams = {
+  errorMessage: string
+  isAuthorized: boolean
+  selectedProviderId?: string
+}
+
+/**
+ * Decides which transition the provider flow should perform after LoginFlow completes.
+ *
+ * Decision tree:
+ * 1. Not authorized → show the login error and return to provider selection
+ * 2. Authorized + ByteRover was selected → resume by connecting/activating ByteRover
+ * 3. Otherwise → return to provider selection (defensive — only ByteRover triggers login today)
+ */
+export function derivePostLoginAction(params: DerivePostLoginActionParams): PostLoginAction {
+  if (!params.isAuthorized) {
+    return {message: params.errorMessage, type: 'return-to-select-with-error'}
+  }
+
+  if (params.selectedProviderId === 'byterover') {
+    return {type: 'connect-byterover'}
+  }
+
+  return {type: 'return-to-select'}
+}

--- a/test/unit/tui/features/provider/derive-post-login-action.test.ts
+++ b/test/unit/tui/features/provider/derive-post-login-action.test.ts
@@ -1,0 +1,59 @@
+import {expect} from 'chai'
+
+import {derivePostLoginAction} from '../../../../../src/tui/features/provider/utils/derive-post-login-action.js'
+
+describe('derivePostLoginAction', () => {
+  it('returns return-to-select-with-error when not authorized and ByteRover was selected', () => {
+    const result = derivePostLoginAction({
+      errorMessage: 'Authentication failed',
+      isAuthorized: false,
+      selectedProviderId: 'byterover',
+    })
+
+    expect(result).to.deep.equal({
+      message: 'Authentication failed',
+      type: 'return-to-select-with-error',
+    })
+  })
+
+  it('returns return-to-select-with-error when not authorized and no provider was selected', () => {
+    const result = derivePostLoginAction({
+      errorMessage: 'Token exchange failed',
+      isAuthorized: false,
+    })
+
+    expect(result).to.deep.equal({
+      message: 'Token exchange failed',
+      type: 'return-to-select-with-error',
+    })
+  })
+
+  it('returns connect-byterover when authorized and ByteRover was selected', () => {
+    const result = derivePostLoginAction({
+      errorMessage: '',
+      isAuthorized: true,
+      selectedProviderId: 'byterover',
+    })
+
+    expect(result).to.deep.equal({type: 'connect-byterover'})
+  })
+
+  it('returns return-to-select when authorized but no provider was selected', () => {
+    const result = derivePostLoginAction({
+      errorMessage: '',
+      isAuthorized: true,
+    })
+
+    expect(result).to.deep.equal({type: 'return-to-select'})
+  })
+
+  it('returns return-to-select when authorized and a non-ByteRover provider was selected', () => {
+    const result = derivePostLoginAction({
+      errorMessage: '',
+      isAuthorized: true,
+      selectedProviderId: 'openrouter',
+    })
+
+    expect(result).to.deep.equal({type: 'return-to-select'})
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #464.

After a successful ByteRover OAuth login, the provider flow always returned the user to the provider selection list, instead of resuming the in-progress ByteRover setup. The OAuth callback succeeded and `isAuthorized` flipped to `true`, but the post-login state transition discarded the previously selected provider — so the user had to re-select ByteRover from the list to actually finish setup.

This PR makes the CLI auto-continue with the connect/activate flow once login succeeds, matching the standard pattern in `gh auth login`, `vercel login`, `supabase login`, etc.

## Approach

- **New pure helper** `derivePostLoginAction` (`src/tui/features/provider/utils/derive-post-login-action.ts`) — discriminated-union return type encoding the three transitions (connect ByteRover, return to selection with error, return to selection). Mirrors the existing `deriveAppViewMode` pattern in the onboarding feature.
- **5 new unit tests** for the helper using the same chai/mocha style as `derive-app-view-mode.test.ts`.
- **`provider-flow.tsx`** — `handleLoginComplete` now delegates to the helper and runs the same `connect → setActive → onComplete` sequence used in `handleSelect` for fresh ByteRover connections.

The duplicated connect/activate sequence between `handleSelect` and `handleLoginComplete` is intentional in this PR — kept the diff narrow. Happy to extract a shared helper if you'd prefer.

## Test plan

- [x] `npm run lint` — 0 errors (1 pre-existing warning on `provider-flow.tsx` complexity, unchanged by this diff)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 6424 passing, 0 failing (incl. 5 new tests for `derivePostLoginAction`)
- [ ] Manual verification on macOS ARM64: select ByteRover during onboarding → browser login → CLI auto-continues to "Connected to ByteRover" without showing the provider list again

Closes #464