### PR TITLE
feat: [ENG-2217] AutoHarness V2 types and Zod schemas

### DIFF
--- a/src/agent/infra/harness/types.ts
+++ b/src/agent/infra/harness/types.ts
@@ -1,0 +1,164 @@
+/**
+ * AutoHarness V2 — core types and Zod schemas.
+ *
+ * Models the per-project learned harness functions, their outcomes
+ * from sandbox `code_exec` calls, and the evaluation scenarios used
+ * by the refinement loop.
+ */
+
+import {z} from 'zod'
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+/**
+ * Harness operating mode, selected from the per-(projectId, commandType)
+ * heuristic H.
+ *
+ *  - `assisted`: LLM orchestrates, harness is a helper
+ *  - `filter`:   LLM reviews proposals from the harness
+ *  - `policy`:   harness runs autonomously (safety caps required)
+ */
+export const HarnessModeSchema = z.enum(['assisted', 'filter', 'policy'])
+export type HarnessMode = z.output<typeof HarnessModeSchema>
+
+/**
+ * Capability tags a harness declares in its meta block. Drives which
+ * code paths can call which harness functions.
+ */
+export const HarnessCapabilitySchema = z.enum([
+  'discover',
+  'extract',
+  'buildOps',
+  'search',
+  'gather',
+  'curate',
+  'answer',
+])
+export type HarnessCapability = z.output<typeof HarnessCapabilitySchema>
+
+/**
+ * Project-type namespace. Partitions outcomes and scenarios so
+ * cross-project harness aggregation is a query change, not a
+ * migration.
+ */
+export const ProjectTypeSchema = z.enum(['typescript', 'python', 'generic'])
+export type ProjectType = z.output<typeof ProjectTypeSchema>
+
+// ---------------------------------------------------------------------------
+// Record schemas
+// ---------------------------------------------------------------------------
+
+/**
+ * Metadata block embedded in every `HarnessVersion`. Describes what the
+ * harness can do and which project patterns it was trained against.
+ *
+ * Invariant (enforced at the storage layer, not the schema): the `version`
+ * field here must equal the enclosing `HarnessVersion.version`. They are
+ * modelled separately because `meta` reflects what the harness code declares
+ * about itself, while `HarnessVersion.version` is the store-assigned
+ * monotonic counter. Consolidation is a candidate cleanup once Phase 1 wires
+ * the store and the invariant becomes concrete.
+ */
+export const HarnessMetaSchema = z
+  .object({
+    capabilities: z.array(HarnessCapabilitySchema),
+    commandType: z.string().min(1),
+    projectPatterns: z.array(z.string()),
+    version: z.number().int().positive(),
+  })
+  .strict()
+export type HarnessMeta = z.input<typeof HarnessMetaSchema>
+export type ValidatedHarnessMeta = z.output<typeof HarnessMetaSchema>
+
+/**
+ * One immutable version of a harness. Templates are written as v1;
+ * refinements produce v2, v3, … each pointing to its parent. The store
+ * prunes old versions per `config.harness.maxVersions`.
+ */
+export const HarnessVersionSchema = z
+  .object({
+    code: z.string().min(1),
+    commandType: z.string().min(1),
+    createdAt: z.number().int().nonnegative(),
+    heuristic: z.number().min(0).max(1),
+    id: z.string().min(1),
+    metadata: HarnessMetaSchema,
+    parentId: z.string().min(1).optional(),
+    projectId: z.string().min(1),
+    projectType: ProjectTypeSchema,
+    version: z.number().int().positive(),
+  })
+  .strict()
+export type HarnessVersion = z.input<typeof HarnessVersionSchema>
+export type ValidatedHarnessVersion = z.output<typeof HarnessVersionSchema>
+
+/**
+ * One recorded sandbox `code_exec` outcome. Drives the heuristic H,
+ * feeds the refinement evaluator, and carries the user-feedback flag.
+ *
+ * `harnessVersionId` attributes the outcome to a specific harness version
+ * when one was injected. The invariant `usedHarness === true ⇒
+ * harnessVersionId is set` is enforced at the recorder (Phase 2), not the
+ * schema, because an LLM-driven outcome with `usedHarness === false` has
+ * no version to link.
+ *
+ * `userFeedback` distinguishes four states:
+ *   - `undefined` — never flagged by the user
+ *   - `null`      — user explicitly cleared a prior flag
+ *   - `'good'`    — user flagged as good
+ *   - `'bad'`     — user flagged as bad
+ * The weighting policy lives upstream in the outcome-recorder, which
+ * inserts synthetic outcomes per verdict.
+ *
+ * `executionTimeMs` is fractional (from `performance.now()`) and must not
+ * be constrained to integer.
+ */
+export const CodeExecOutcomeSchema = z
+  .object({
+    code: z.string(),
+    commandType: z.string().min(1),
+    curateResult: z.unknown().optional(),
+    delegated: z.boolean().optional(),
+    executionTimeMs: z.number().nonnegative(),
+    harnessVersionId: z.string().min(1).optional(),
+    id: z.string().min(1),
+    projectId: z.string().min(1),
+    projectType: ProjectTypeSchema,
+    queryResult: z.unknown().optional(),
+    sessionId: z.string().min(1),
+    stderr: z.string().optional(),
+    stdout: z.string().optional(),
+    success: z.boolean(),
+    timestamp: z.number().int().nonnegative(),
+    usedHarness: z.boolean(),
+    userFeedback: z.enum(['good', 'bad']).nullable().optional(),
+  })
+  .strict()
+export type CodeExecOutcome = z.input<typeof CodeExecOutcomeSchema>
+export type ValidatedCodeExecOutcome = z.output<typeof CodeExecOutcomeSchema>
+
+/**
+ * A captured test scenario used to evaluate candidate harness versions.
+ * Scenarios come from both successful AND failed sessions — negative
+ * scenarios prevent the refiner from "improving" into a harness that
+ * succeeds by damaging data.
+ */
+export const EvaluationScenarioSchema = z
+  .object({
+    code: z.string().min(1),
+    commandType: z.string().min(1),
+    expectedBehavior: z.string().min(1),
+    id: z.string().min(1),
+    projectId: z.string().min(1),
+    projectType: ProjectTypeSchema,
+    taskDescription: z.string().min(1),
+  })
+  .strict()
+export type EvaluationScenario = z.input<typeof EvaluationScenarioSchema>
+export type ValidatedEvaluationScenario = z.output<typeof EvaluationScenarioSchema>
+
+// `HarnessConfig` is a re-export of the inferred type from
+// `agent-schemas.ts`. It is added in a follow-up change — defining it
+// here now would create a circular import with the config schema.

--- a/test/unit/agent/harness/types.test.ts
+++ b/test/unit/agent/harness/types.test.ts
@@ -1,0 +1,298 @@
+import {expect} from 'chai'
+
+import {
+  CodeExecOutcomeSchema,
+  EvaluationScenarioSchema,
+  HarnessCapabilitySchema,
+  HarnessMetaSchema,
+  HarnessModeSchema,
+  HarnessVersionSchema,
+  ProjectTypeSchema,
+} from '../../../../src/agent/infra/harness/types.js'
+
+describe('autoharness-v2 types and schemas', () => {
+  // ─── Enums ────────────────────────────────────────────────────────────────
+
+  describe('enum schemas', () => {
+    it('HarnessModeSchema accepts assisted / filter / policy', () => {
+      expect(HarnessModeSchema.parse('assisted')).to.equal('assisted')
+      expect(HarnessModeSchema.parse('filter')).to.equal('filter')
+      expect(HarnessModeSchema.parse('policy')).to.equal('policy')
+    })
+
+    it('HarnessModeSchema rejects unknown values', () => {
+      expect(() => HarnessModeSchema.parse('autonomous')).to.throw()
+    })
+
+    it('HarnessCapabilitySchema accepts the seven capabilities', () => {
+      for (const c of ['discover', 'extract', 'buildOps', 'search', 'gather', 'curate', 'answer']) {
+        expect(HarnessCapabilitySchema.parse(c)).to.equal(c)
+      }
+    })
+
+    it('HarnessCapabilitySchema rejects unknown capabilities', () => {
+      expect(() => HarnessCapabilitySchema.parse('mutate')).to.throw()
+    })
+
+    it('ProjectTypeSchema accepts typescript / python / generic', () => {
+      expect(ProjectTypeSchema.parse('typescript')).to.equal('typescript')
+      expect(ProjectTypeSchema.parse('python')).to.equal('python')
+      expect(ProjectTypeSchema.parse('generic')).to.equal('generic')
+    })
+
+    it('ProjectTypeSchema rejects non-canonical shorthand', () => {
+      expect(() => ProjectTypeSchema.parse('ts')).to.throw()
+      expect(() => ProjectTypeSchema.parse('Typescript')).to.throw()
+      expect(() => ProjectTypeSchema.parse('rust')).to.throw()
+    })
+  })
+
+  // ─── HarnessMeta ──────────────────────────────────────────────────────────
+
+  describe('HarnessMetaSchema', () => {
+    const valid = {
+      capabilities: ['discover', 'curate'] as const,
+      commandType: 'curate',
+      projectPatterns: ['src/**/*.ts'],
+      version: 1,
+    }
+
+    it('round-trips a valid record via JSON', () => {
+      const parsed = HarnessMetaSchema.parse(valid)
+      const reparsed = HarnessMetaSchema.parse(structuredClone(parsed))
+      expect(reparsed).to.deep.equal(parsed)
+    })
+
+    it('rejects an empty commandType', () => {
+      expect(() => HarnessMetaSchema.parse({...valid, commandType: ''})).to.throw()
+    })
+
+    it('rejects non-positive version', () => {
+      expect(() => HarnessMetaSchema.parse({...valid, version: 0})).to.throw()
+      expect(() => HarnessMetaSchema.parse({...valid, version: -1})).to.throw()
+    })
+
+    it('rejects an unknown capability in the array', () => {
+      expect(() =>
+        HarnessMetaSchema.parse({...valid, capabilities: ['discover', 'mutate']}),
+      ).to.throw()
+    })
+
+    it('rejects unknown extra keys (strict)', () => {
+      expect(() => HarnessMetaSchema.parse({...valid, extra: 'nope'})).to.throw()
+    })
+  })
+
+  // ─── HarnessVersion ───────────────────────────────────────────────────────
+
+  describe('HarnessVersionSchema', () => {
+    const valid = {
+      code: 'export async function curate() {}',
+      commandType: 'curate',
+      createdAt: 1_700_000_000_000,
+      heuristic: 0.42,
+      id: 'harness-ver-p1-curate-v1',
+      metadata: {
+        capabilities: ['curate'] as const,
+        commandType: 'curate',
+        projectPatterns: ['src/**/*.ts'],
+        version: 1,
+      },
+      projectId: 'proj-1',
+      projectType: 'typescript' as const,
+      version: 1,
+    }
+
+    it('round-trips a valid record via JSON', () => {
+      const parsed = HarnessVersionSchema.parse(valid)
+      const reparsed = HarnessVersionSchema.parse(structuredClone(parsed))
+      expect(reparsed).to.deep.equal(parsed)
+    })
+
+    it('accepts an optional parentId', () => {
+      const withParent = HarnessVersionSchema.parse({...valid, parentId: 'harness-ver-p1-curate-v0'})
+      expect(withParent.parentId).to.equal('harness-ver-p1-curate-v0')
+    })
+
+    it('rejects heuristic above 1', () => {
+      expect(() => HarnessVersionSchema.parse({...valid, heuristic: 1.5})).to.throw()
+    })
+
+    it('rejects heuristic below 0', () => {
+      expect(() => HarnessVersionSchema.parse({...valid, heuristic: -0.1})).to.throw()
+    })
+
+    it('rejects non-positive version', () => {
+      expect(() => HarnessVersionSchema.parse({...valid, version: 0})).to.throw()
+    })
+
+    it('rejects non-integer version', () => {
+      expect(() => HarnessVersionSchema.parse({...valid, version: 1.5})).to.throw()
+    })
+
+    it('rejects unknown projectType', () => {
+      expect(() => HarnessVersionSchema.parse({...valid, projectType: 'rust'})).to.throw()
+    })
+
+    it('rejects empty id / projectId / commandType', () => {
+      expect(() => HarnessVersionSchema.parse({...valid, id: ''})).to.throw()
+      expect(() => HarnessVersionSchema.parse({...valid, projectId: ''})).to.throw()
+      expect(() => HarnessVersionSchema.parse({...valid, commandType: ''})).to.throw()
+    })
+
+    it('rejects empty code', () => {
+      expect(() => HarnessVersionSchema.parse({...valid, code: ''})).to.throw()
+    })
+
+    it('rejects unknown extra keys (strict)', () => {
+      expect(() => HarnessVersionSchema.parse({...valid, extra: 'nope'})).to.throw()
+    })
+  })
+
+  // ─── CodeExecOutcome ──────────────────────────────────────────────────────
+
+  describe('CodeExecOutcomeSchema', () => {
+    const valid = {
+      code: 'await tools.curate([])',
+      commandType: 'curate',
+      executionTimeMs: 128,
+      id: 'out-1',
+      projectId: 'proj-1',
+      projectType: 'typescript' as const,
+      sessionId: 'sess-1',
+      success: true,
+      timestamp: 1_700_000_000_000,
+      usedHarness: false,
+    }
+
+    it('round-trips a minimal valid record via JSON', () => {
+      const parsed = CodeExecOutcomeSchema.parse(valid)
+      const reparsed = CodeExecOutcomeSchema.parse(structuredClone(parsed))
+      expect(reparsed).to.deep.equal(parsed)
+    })
+
+    it('round-trips with all optional fields populated', () => {
+      const full = {
+        ...valid,
+        curateResult: {ops: 5},
+        delegated: true,
+        queryResult: {answer: 'yes'},
+        stderr: '',
+        stdout: 'ok',
+        userFeedback: 'good' as const,
+      }
+      const parsed = CodeExecOutcomeSchema.parse(full)
+      const reparsed = CodeExecOutcomeSchema.parse(structuredClone(parsed))
+      expect(reparsed).to.deep.equal(parsed)
+    })
+
+    it('userFeedback distinguishes all four states', () => {
+      // undefined — never flagged (omit field)
+      const undef = CodeExecOutcomeSchema.parse(valid)
+      expect(undef.userFeedback).to.equal(undefined)
+
+      // null — explicitly cleared
+      const cleared = CodeExecOutcomeSchema.parse({...valid, userFeedback: null})
+      expect(cleared.userFeedback).to.equal(null)
+
+      // 'good'
+      const good = CodeExecOutcomeSchema.parse({...valid, userFeedback: 'good'})
+      expect(good.userFeedback).to.equal('good')
+
+      // 'bad'
+      const bad = CodeExecOutcomeSchema.parse({...valid, userFeedback: 'bad'})
+      expect(bad.userFeedback).to.equal('bad')
+    })
+
+    it('userFeedback rejects unknown values', () => {
+      expect(() => CodeExecOutcomeSchema.parse({...valid, userFeedback: 'meh'})).to.throw()
+      expect(() => CodeExecOutcomeSchema.parse({...valid, userFeedback: 1})).to.throw()
+    })
+
+    it('rejects negative executionTimeMs', () => {
+      expect(() => CodeExecOutcomeSchema.parse({...valid, executionTimeMs: -1})).to.throw()
+    })
+
+    it('rejects negative timestamp', () => {
+      expect(() => CodeExecOutcomeSchema.parse({...valid, timestamp: -1})).to.throw()
+    })
+
+    it('rejects non-integer timestamp', () => {
+      expect(() => CodeExecOutcomeSchema.parse({...valid, timestamp: 1.5})).to.throw()
+    })
+
+    it('rejects unknown projectType', () => {
+      expect(() => CodeExecOutcomeSchema.parse({...valid, projectType: 'rust'})).to.throw()
+    })
+
+    it('rejects empty id / sessionId / projectId / commandType', () => {
+      expect(() => CodeExecOutcomeSchema.parse({...valid, id: ''})).to.throw()
+      expect(() => CodeExecOutcomeSchema.parse({...valid, sessionId: ''})).to.throw()
+      expect(() => CodeExecOutcomeSchema.parse({...valid, projectId: ''})).to.throw()
+      expect(() => CodeExecOutcomeSchema.parse({...valid, commandType: ''})).to.throw()
+    })
+
+    it('rejects empty harnessVersionId when provided', () => {
+      expect(() => CodeExecOutcomeSchema.parse({...valid, harnessVersionId: ''})).to.throw()
+    })
+
+    it('round-trips with harnessVersionId populated', () => {
+      const parsed = CodeExecOutcomeSchema.parse({
+        ...valid,
+        harnessVersionId: 'harness-ver-proj-1-curate-v3',
+        usedHarness: true,
+      })
+      expect(parsed.harnessVersionId).to.equal('harness-ver-proj-1-curate-v3')
+    })
+
+    it('accepts fractional executionTimeMs (from performance.now)', () => {
+      // executionTime = performance.now() - startTime is not guaranteed integer.
+      // Schema deliberately omits .int() on this field.
+      expect(() => CodeExecOutcomeSchema.parse({...valid, executionTimeMs: 12.345})).to.not.throw()
+    })
+
+    it('rejects unknown extra keys (strict)', () => {
+      expect(() => CodeExecOutcomeSchema.parse({...valid, extra: 'nope'})).to.throw()
+    })
+  })
+
+  // ─── EvaluationScenario ───────────────────────────────────────────────────
+
+  describe('EvaluationScenarioSchema', () => {
+    const valid = {
+      code: 'await tools.curate([])',
+      commandType: 'curate',
+      expectedBehavior: 'Produces 5 curate operations',
+      id: 'scen-1',
+      projectId: 'proj-1',
+      projectType: 'typescript' as const,
+      taskDescription: 'Save this JWT pattern',
+    }
+
+    it('round-trips a valid record via JSON', () => {
+      const parsed = EvaluationScenarioSchema.parse(valid)
+      const reparsed = EvaluationScenarioSchema.parse(structuredClone(parsed))
+      expect(reparsed).to.deep.equal(parsed)
+    })
+
+    it('rejects unknown projectType', () => {
+      expect(() => EvaluationScenarioSchema.parse({...valid, projectType: 'rust'})).to.throw()
+    })
+
+    it('rejects empty id / projectId / commandType', () => {
+      expect(() => EvaluationScenarioSchema.parse({...valid, id: ''})).to.throw()
+      expect(() => EvaluationScenarioSchema.parse({...valid, projectId: ''})).to.throw()
+      expect(() => EvaluationScenarioSchema.parse({...valid, commandType: ''})).to.throw()
+    })
+
+    it('rejects empty code / taskDescription / expectedBehavior', () => {
+      expect(() => EvaluationScenarioSchema.parse({...valid, code: ''})).to.throw()
+      expect(() => EvaluationScenarioSchema.parse({...valid, taskDescription: ''})).to.throw()
+      expect(() => EvaluationScenarioSchema.parse({...valid, expectedBehavior: ''})).to.throw()
+    })
+
+    it('rejects unknown extra keys (strict)', () => {
+      expect(() => EvaluationScenarioSchema.parse({...valid, extra: 'nope'})).to.throw()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Problem: AutoHarness V2 needs a shared type vocabulary before any later phase can build on it. Without it, Phases 1-7 would each invent their own shape for `HarnessVersion`, `CodeExecOutcome`, etc., and drift immediately.
- Why it matters: foundation for the 6-task Phase 0 scaffolding of the AutoHarness V2 migration. Every downstream phase (store, outcome recorder, module builder, templates, mode selector, synthesizer, CLI) imports from this module. Nail the shapes here or pay compounding refactor costs later.
- What changed:
  - New module `src/agent/infra/harness/types.ts` — 3 enum schemas (`HarnessModeSchema`, `HarnessCapabilitySchema`, `ProjectTypeSchema`), 4 record schemas (`HarnessMetaSchema`, `HarnessVersionSchema`, `CodeExecOutcomeSchema`, `EvaluationScenarioSchema`), each paired with a `z.infer`-derived type export.
  - New tests `test/unit/agent/harness/types.test.ts` — 30 tests: enum round-trips, reject-invalid per enum and per record, round-trip via `structuredClone`, dedicated assertion that `userFeedback` distinguishes all 4 states (`undefined` / `null` / `'good'` / `'bad'`).
- What did NOT change (scope boundary):
  - No runtime code consumes these types yet — later tasks in Phase 0 wire them in
  - `HarnessConfig` type deliberately NOT declared here — it's a re-export from `AgentConfigSchema` that lands in Phase 0 Task 0.2 (avoids a module-load cycle)
  - No `IHarnessStore` interface — Phase 0 Task 0.4
  - No feature flag — `harness.enabled` config block lands in Task 0.2

## Type of change

- [ ] Bug fix
- [x] New feature (foundational types for AutoHarness V2)
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [x] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [x] Agent / Tools  — `src/agent/infra/harness/` (new module)
- [ ] TUI / REPL
- [ ] LLM Providers
- [ ] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- ENG-2217 — AutoHarness V2, Phase 0 Task 0.1: Types and Zod schemas

## Root cause (bug fixes only)

N/A — foundational feature commit.

## Test plan

- Coverage added:
  - [x] Unit test
  - [ ] Integration test
  - [ ] Manual verification only
- Test file(s): `test/unit/agent/harness/types.test.ts`
- Key scenarios covered:
  - Each of 3 enum schemas: accept the canonical values, reject unknowns (e.g. `'ts'`, `'Typescript'`, `'rust'` for `ProjectType`)
  - Each of 4 record schemas: round-trip a valid fixture via `structuredClone`, reject empty required strings, reject out-of-range numerics
  - `HarnessVersion`: `heuristic` clamped to `[0, 1]`, `version` int-positive, optional `parentId`
  - `CodeExecOutcome`: `executionTimeMs` / `timestamp` non-negative + integer, `userFeedback` round-trips across all 4 states and rejects unknown verdicts, all optional fields round-trip when populated
  - `EvaluationScenario`: required strings non-empty, `projectType` must match enum

## User-visible changes

None. No runtime code consumes these types yet. Feature remains gated off by default until the `harness.enabled` config flag is added in Task 0.2.

## Evidence


## Checklist

- [x] Tests added or updated and passing (`npm test`)
- [x] Lint passes (`npm run lint`) — 0 errors
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow Conventional Commits format
- [ ] Documentation updated — N/A (internal types, no user-facing doc changes)
- [x] No breaking changes (strictly additive new module)
- [x] Branch is up to date with `main`

## Risks and mitigations

- **Risk: type shape drift in later phases.** If Phase 1's `HarnessStore` implementation finds a missing field (e.g. needs `projectPath` on `HarnessVersion`), the schema has to be amended and every test updated.
  - Mitigation: the task breakdown for Phase 0 cross-checks signatures against Phase 1's planned consumer surface. If drift happens, it's a one-line schema change — additive fields are backward-compatible, breaking changes would need a version bump (handled via `HarnessVersion.version` increment).

- **Risk: `userFeedback` 4-state modeling is subtle (`undefined` vs `null`).** A reviewer or future contributor could conflate the two.
  - Mitigation: the dedicated test "userFeedback distinguishes all four states" locks the contract in code. Docstring on the field explicitly enumerates the four states.

- **Risk: `HarnessConfig` omitted here is a surprise.** Readers may expect it colocated.
  - Mitigation: bottom-of-file comment explains the deferred re-export and why (module-load cycle with `agent-schemas.ts`). Follow-up PR (Task 0.2) adds it.
