### PR TITLE
feat: [ENG-2219] AutoHarness V2 config schema

### DIFF
--- a/src/agent/infra/agent/agent-schemas.ts
+++ b/src/agent/infra/agent/agent-schemas.ts
@@ -1,5 +1,7 @@
 import {z} from 'zod'
 
+import {HarnessLanguageSchema, HarnessModeSchema} from '../harness/types.js'
+
 /**
  * LLM configuration schema with validation and defaults.
  */
@@ -60,6 +62,29 @@ export type BlobStorageConfig = z.input<typeof BlobStorageConfigSchema>
 export type ValidatedBlobStorageConfig = z.output<typeof BlobStorageConfigSchema>
 
 /**
+ * AutoHarness V2 configuration schema.
+ *
+ * Off by default. When enabled, the sandbox injects per-(projectId,
+ * commandType) learned harness functions at `harness.*`. Mode selection
+ * (assisted / filter / policy) derives from the heuristic H at each
+ * session; `modeOverride` pins a specific mode. `language` picks the
+ * bootstrap template and defaults to runtime auto-detection.
+ */
+export const HarnessConfigSchema = z
+  .object({
+    autoLearn: z.boolean().default(true).describe('Run the refinement loop post-session when enabled'),
+    enabled: z.boolean().default(false).describe('Master switch for the AutoHarness feature'),
+    language: HarnessLanguageSchema.default('auto').describe('Template language — auto-detects unless overridden'),
+    maxVersions: z.number().int().positive().default(20).describe('Versions retained per (projectId, commandType)'),
+    modeOverride: HarnessModeSchema.optional().describe('Force a specific mode, bypassing heuristic gating'),
+    refinementModel: z.string().min(1).optional().describe('Model id for the refiner; defaults to the runtime model'),
+  })
+  .strict()
+
+export type HarnessConfig = z.input<typeof HarnessConfigSchema>
+export type ValidatedHarnessConfig = z.output<typeof HarnessConfigSchema>
+
+/**
  * Main agent configuration schema.
  * Combines all sub-schemas with validation and defaults.
  *
@@ -71,6 +96,7 @@ export const AgentConfigSchema = z
     apiBaseUrl: z.string().url().describe('ByteRover API base URL'),
     blobStorage: BlobStorageConfigSchema.optional().describe('Blob storage configuration'),
     fileSystem: FileSystemConfigSchema.optional().describe('File system configuration'),
+    harness: HarnessConfigSchema.default({}).describe('AutoHarness V2 configuration (off by default)'),
     httpReferer: z.string().optional().describe('HTTP Referer for OpenRouter rankings'),
     llm: LLMConfigSchema.default({}).describe('LLM configuration'),
     maxInputTokens: z.number().positive().optional().describe('Context window size from provider API'),

--- a/src/agent/infra/harness/types.ts
+++ b/src/agent/infra/harness/types.ts
@@ -46,6 +46,17 @@ export type HarnessCapability = z.output<typeof HarnessCapabilitySchema>
 export const ProjectTypeSchema = z.enum(['typescript', 'python', 'generic'])
 export type ProjectType = z.output<typeof ProjectTypeSchema>
 
+/**
+ * Template language for harness bootstrap. Superset of `ProjectType`:
+ * derives its members from `ProjectTypeSchema.options` and adds `'auto'`
+ * for runtime detection. A detected project pins to one of the
+ * `ProjectType` members; `'auto'` is only valid as a user-facing config
+ * value. Deriving (rather than listing) keeps the two enums in sync if
+ * a new project type is ever added.
+ */
+export const HarnessLanguageSchema = z.enum([...ProjectTypeSchema.options, 'auto'] as const)
+export type HarnessLanguage = z.output<typeof HarnessLanguageSchema>
+
 // ---------------------------------------------------------------------------
 // Record schemas
 // ---------------------------------------------------------------------------
@@ -159,6 +170,11 @@ export const EvaluationScenarioSchema = z
 export type EvaluationScenario = z.input<typeof EvaluationScenarioSchema>
 export type ValidatedEvaluationScenario = z.output<typeof EvaluationScenarioSchema>
 
-// `HarnessConfig` is a re-export of the inferred type from
-// `agent-schemas.ts`. It is added in a follow-up change — defining it
-// here now would create a circular import with the config schema.
+// ---------------------------------------------------------------------------
+// Config re-export
+// ---------------------------------------------------------------------------
+
+// Callers in the harness module import `HarnessConfig` from here rather
+// than reaching into `agent-schemas.ts`. `type`-only re-export keeps the
+// runtime-module graph acyclic.
+export type {HarnessConfig, ValidatedHarnessConfig} from '../agent/agent-schemas.js'

--- a/test/unit/agent/agent-state-manager.test.ts
+++ b/test/unit/agent/agent-state-manager.test.ts
@@ -13,6 +13,12 @@ import {AgentEventBus} from '../../../src/agent/infra/events/event-emitter.js'
 function createTestConfig(overrides?: Partial<ValidatedAgentConfig>): ValidatedAgentConfig {
   return {
     apiBaseUrl: 'https://api.test.com',
+    harness: {
+      autoLearn: true,
+      enabled: false,
+      language: 'auto',
+      maxVersions: 20,
+    },
     llm: {
       maxIterations: 50,
       maxTokens: 8192,

--- a/test/unit/agent/agent/agent-schemas.test.ts
+++ b/test/unit/agent/agent/agent-schemas.test.ts
@@ -1,0 +1,108 @@
+import {expect} from 'chai'
+
+import {
+  AgentConfigSchema,
+  HarnessConfigSchema,
+} from '../../../../src/agent/infra/agent/agent-schemas.js'
+
+describe('agent-schemas — harness config block', () => {
+  // Minimal valid AgentConfig fixture (covers the required fields).
+  const baseConfig = {
+    apiBaseUrl: 'https://example.invalid',
+    model: 'test-model',
+    projectId: 'proj-1',
+    storagePath: '/tmp/brv',
+  }
+
+  describe('HarnessConfigSchema', () => {
+    it('fills missing fields with defaults when parsing an empty object', () => {
+      const parsed = HarnessConfigSchema.parse({})
+      expect(parsed).to.deep.equal({
+        autoLearn: true,
+        enabled: false,
+        language: 'auto',
+        maxVersions: 20,
+      })
+      expect(parsed.modeOverride).to.equal(undefined)
+      expect(parsed.refinementModel).to.equal(undefined)
+    })
+
+    it('accepts fully populated config', () => {
+      const parsed = HarnessConfigSchema.parse({
+        autoLearn: false,
+        enabled: true,
+        language: 'typescript',
+        maxVersions: 50,
+        modeOverride: 'filter',
+        refinementModel: 'claude-sonnet-4-6',
+      })
+      expect(parsed).to.deep.equal({
+        autoLearn: false,
+        enabled: true,
+        language: 'typescript',
+        maxVersions: 50,
+        modeOverride: 'filter',
+        refinementModel: 'claude-sonnet-4-6',
+      })
+    })
+
+    it('rejects unknown modeOverride values', () => {
+      expect(() => HarnessConfigSchema.parse({modeOverride: 'supercharged'})).to.throw()
+    })
+
+    it('rejects unknown language values', () => {
+      expect(() => HarnessConfigSchema.parse({language: 'rust'})).to.throw()
+      // 'Typescript' capitalised is not the canonical value
+      expect(() => HarnessConfigSchema.parse({language: 'Typescript'})).to.throw()
+    })
+
+    it('rejects non-positive maxVersions', () => {
+      expect(() => HarnessConfigSchema.parse({maxVersions: 0})).to.throw()
+      expect(() => HarnessConfigSchema.parse({maxVersions: -1})).to.throw()
+    })
+
+    it('rejects non-integer maxVersions', () => {
+      expect(() => HarnessConfigSchema.parse({maxVersions: 1.5})).to.throw()
+    })
+
+    it('rejects empty-string refinementModel', () => {
+      // Fail-fast — an empty model id would otherwise surface as a confusing
+      // provider-SDK error at refinement time.
+      expect(() => HarnessConfigSchema.parse({refinementModel: ''})).to.throw()
+    })
+
+    it('rejects unknown extra keys (strict)', () => {
+      expect(() => HarnessConfigSchema.parse({extra: 'nope'})).to.throw()
+    })
+  })
+
+  describe('AgentConfigSchema integration', () => {
+    it('parses a config without a harness block and defaults to disabled', () => {
+      const parsed = AgentConfigSchema.parse(baseConfig)
+      expect(parsed.harness).to.deep.equal({
+        autoLearn: true,
+        enabled: false,
+        language: 'auto',
+        maxVersions: 20,
+      })
+    })
+
+    it('parses a config with an explicit harness.enabled = true', () => {
+      const parsed = AgentConfigSchema.parse({
+        ...baseConfig,
+        harness: {enabled: true, language: 'python'},
+      })
+      expect(parsed.harness.enabled).to.equal(true)
+      expect(parsed.harness.language).to.equal('python')
+      // Other fields keep their defaults.
+      expect(parsed.harness.autoLearn).to.equal(true)
+      expect(parsed.harness.maxVersions).to.equal(20)
+    })
+
+    it('rejects unknown extra keys inside harness (strict)', () => {
+      expect(() =>
+        AgentConfigSchema.parse({...baseConfig, harness: {enabled: true, surprise: 'field'}}),
+      ).to.throw()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Problem: AutoHarness V2 needs a user-facing config block before any later phase can read runtime settings. Without it, Phases 2-7 would plumb flags through ad-hoc constructor args, and enabling/disabling the feature per-project wouldn't have a config path.
- Why it matters: second of six foundational tasks in Phase 0. Establishes the feature's kill-switch (`harness.enabled`, default `false`) and the knobs the later phases need — auto-learn trigger, version pruning window, mode override, refinement model override, and template language. Everything ships off by default — this PR is invisible to every existing user.
- What changed:
  - New `HarnessConfigSchema` sub-schema in `src/agent/infra/agent/agent-schemas.ts` with 6 fields (`enabled`, `autoLearn`, `refinementModel`, `maxVersions`, `modeOverride`, `language`) plus sensible defaults. Composed into `AgentConfigSchema` as `harness: HarnessConfigSchema.default({})`.
  - New `HarnessLanguageSchema` enum (`typescript | python | generic | auto`) added to `src/agent/infra/harness/types.ts` and reused in the config. Single source of truth for Phase 4's template detector to import without rediscovery.
  - `modeOverride` reuses the existing `HarnessModeSchema` from Task 0.1 — one place declares the 3 modes.
  - `HarnessConfig` / `ValidatedHarnessConfig` type pair exported from `agent-schemas.ts` following the `LLMConfig` / `ValidatedLLMConfig` pattern; type-only re-exported from `harness/types.ts` so harness-module consumers have a single import path.
  - 10 new tests in `test/unit/agent/agent/agent-schemas.test.ts`.
- What did NOT change (scope boundary):
  - No runtime code reads `config.harness` yet — `SandboxService.setHarnessConfig(config.harness)` wiring lands in Task 0.5
  - No template detection logic — Phase 4 consumes `HarnessLanguageSchema`
  - No refinement-model policy — Phase 6 reads `refinementModel`
  - `HarnessConfig` is NOT re-exported via `NonNullable<AgentConfig['harness']>` as the task doc originally sketched; direct sub-schema type-pair export (consistent with `LLMConfig` et al) is equivalent and cleaner

## Type of change

- [ ] Bug fix
- [x] New feature (AutoHarness V2 config surface)
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [x] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [x] Agent / Tools  — `agent-schemas.ts`, `harness/types.ts`
- [ ] TUI / REPL
- [ ] LLM Providers
- [ ] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- ENG-2217 — AutoHarness V2, Phase 0 Task 0.2: Config schema extension
- Builds on Task 0.1 (`HarnessModeSchema` import + `HarnessLanguageSchema` addition)

## Root cause (bug fixes only)

N/A — foundational feature commit.

## Test plan

- Coverage added:
  - [x] Unit test
  - [ ] Integration test
  - [ ] Manual verification only
- Test file(s): `test/unit/agent/agent/agent-schemas.test.ts` (new)
- Key scenarios covered:
  - Empty input → `HarnessConfigSchema.parse({})` yields all defaults (`enabled: false`, `autoLearn: true`, `language: 'auto'`, `maxVersions: 20`, `modeOverride`/`refinementModel` undefined)
  - Fully-populated input round-trips identically
  - `modeOverride` rejects unknown values (e.g. `'supercharged'`)
  - `language` rejects unknown values (`'rust'`) and non-canonical casing (`'Typescript'`)
  - `maxVersions`: rejects 0, -1, and fractional (1.5)
  - `.strict()`: rejects unknown extra keys at both the `HarnessConfigSchema` level and inside the nested `harness` block on `AgentConfigSchema`
  - `AgentConfigSchema` integration: config without a harness block parses cleanly with defaults; explicit partial override merges correctly

## User-visible changes

None. `harness.enabled` defaults to `false`, so every existing config continues to behave identically. The feature remains dark until Phase 4 template-bootstrap lands and a user explicitly opts in.

## Evidence


## Checklist

- [x] Tests added or updated and passing (`npm test`)
- [x] Lint passes (`npm run lint`) — 0 errors
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow Conventional Commits format
- [ ] Documentation updated — N/A (internal config surface, no user-facing docs affected)
- [x] No breaking changes (schema extension is additive; `harness.enabled = false` keeps behavior identical)
- [x] Branch is up to date with `main`

## Risks and mitigations

- **Risk: `ValidatedAgentConfig.harness` is now a required post-parse field.** Any code constructing a `ValidatedAgentConfig` literal (as opposed to `AgentConfigSchema.parse(...)`) needs to supply a `harness` block or TypeScript rejects the literal.
  - Mitigation: typecheck surfaces every such site. One existing fixture in `test/unit/agent/agent-state-manager.test.ts` needed an `harness` field addition with default values — fixed in this PR. Grep for future-written literal fixtures: `grep -rn "ValidatedAgentConfig" src/ test/` returns 7 files, all consume the type via destructuring/property access, not literal construction.

- **Risk: `HarnessLanguageSchema` has a superset relationship with `ProjectTypeSchema` (adds `'auto'`).** A consumer expecting the two to be interchangeable could mix them up.
  - Mitigation: `'auto'` is only valid as a user-facing config value; Phase 4's detector narrows from `HarnessLanguage` to `ProjectType` after auto-detection. Docstring on `HarnessLanguageSchema` spells out the contract.

- **Risk: Two places to reach `HarnessConfig`** — direct from `agent-schemas.ts`, or re-exported through `harness/types.ts`.
  - Mitigation: by convention, harness-module code imports from `harness/types.ts`; everything outside the harness module (e.g. `service-initializer.ts`) imports from `agent-schemas.ts` alongside `AgentConfig`. This mirrors how `LLMConfig` et al are reached only from `agent-schemas.ts` — no one re-exports those. Zero consumer yet, so drift risk is low.
