### PR TITLE
feat: [ENG-2220] AutoHarness V2 agent events

### DIFF
--- a/src/agent/core/domain/agent-events/types.ts
+++ b/src/agent/core/domain/agent-events/types.ts
@@ -1,3 +1,5 @@
+import type {HarnessMode} from '../../../infra/harness/types.js'
+
 /**
  * Agent-level event names for CipherAgent.
  * These events are emitted at the agent level and include sessionId in payloads.
@@ -10,6 +12,7 @@ export const AGENT_EVENT_NAMES = [
   'cipher:stateChanged',
   'cipher:stateReset',
   'cipher:ui',
+  'harness:refinement-completed',
 ] as const
 
 /**
@@ -17,6 +20,9 @@ export const AGENT_EVENT_NAMES = [
  * These events are emitted at the session level and do not include sessionId in payloads.
  */
 export const SESSION_EVENT_NAMES = [
+  'harness:loaded',
+  'harness:mode-selected',
+  'harness:outcome-recorded',
   'llmservice:chunk',
   'llmservice:contextCompressed',
   'llmservice:contextOverflow',
@@ -112,7 +118,16 @@ export type AgentExecutionStateType = 'ABORTED' | 'COMPLETE' | 'ERROR' | 'EXECUT
 
 /**
  * Agent-level event payloads.
- * All agent events include sessionId for tracking which session triggered the event.
+ *
+ * Session-scoped events (every `cipher:*` event, every forwarded session
+ * event) carry `sessionId` — required for events tied to a live session,
+ * optional for global state changes (`cipher:stateChanged`,
+ * `cipher:stateReset`).
+ *
+ * Post-session events — currently only `harness:refinement-completed`,
+ * which fires from the async refinement flow after a session has
+ * ended — intentionally omit `sessionId`. They are scoped to a
+ * `(projectId, commandType)` pair rather than to a specific session.
  */
 export interface AgentEventMap {
   /**
@@ -209,6 +224,88 @@ export interface AgentEventMap {
     sessionId?: string
     type: UIEventType
   }
+
+  /**
+   * Emitted when a harness version is loaded into a sandbox for a session.
+   * @property {string} commandType - Command type the harness is scoped to
+   * @property {HarnessMode} mode - Mode selected for this session ('assisted' initially, replaced in Phase 5)
+   * @property {string} projectId - Project ID the harness belongs to
+   * @property {string} sessionId - ID of the session into which the harness was loaded
+   * @property {number} version - Harness version number
+   */
+  'harness:loaded': {
+    commandType: string
+    mode: HarnessMode
+    projectId: string
+    sessionId: string
+    version: number
+  }
+
+  /**
+   * Emitted when the harness mode is selected (Phase 5). Follows `harness:loaded`
+   * once per session for harness-enabled sessions.
+   * @property {string} commandType - Command type the harness is scoped to
+   * @property {number} heuristic - H value that drove the mode choice
+   * @property {HarnessMode} mode - Selected mode
+   * @property {string} projectId - Project ID the harness belongs to
+   * @property {string} sessionId - ID of the session
+   * @property {number} version - Harness version number
+   */
+  'harness:mode-selected': {
+    commandType: string
+    heuristic: number
+    mode: HarnessMode
+    projectId: string
+    sessionId: string
+    version: number
+  }
+
+  /**
+   * Emitted every time a `code_exec` outcome is persisted to the store.
+   * Payload carries only identifiers + the success bit; full outcome lives
+   * in storage and is looked up via `IHarnessStore.listOutcomes`.
+   * @property {string} commandType - Command type the outcome belongs to
+   * @property {string} outcomeId - Unique id of the persisted outcome record
+   * @property {string} projectId - Project id the outcome belongs to
+   * @property {string} sessionId - ID of the session the outcome came from
+   * @property {boolean} success - Whether the code_exec succeeded
+   */
+  'harness:outcome-recorded': {
+    commandType: string
+    outcomeId: string
+    projectId: string
+    sessionId: string
+    success: boolean
+  }
+
+  /**
+   * Emitted by the synthesizer (Phase 6) after a refinement attempt finishes,
+   * regardless of outcome. Fires once per `(projectId, commandType)` post-session
+   * trigger. Not scoped to a specific session.
+   *
+   * Discriminated by `accepted`:
+   *   - `accepted: true`  → `toVersion: number` (the newly-promoted version id)
+   *   - `accepted: false` → `reason: string`    (why the candidate was rejected)
+   *
+   * TypeScript enforces the invariant — Phase 6's emitter cannot produce
+   * `{accepted: true}` without `toVersion`, nor `{accepted: false}` without
+   * `reason`.
+   */
+  'harness:refinement-completed':
+    | {
+        accepted: false
+        commandType: string
+        fromVersion: number
+        projectId: string
+        reason: string
+      }
+    | {
+        accepted: true
+        commandType: string
+        fromVersion: number
+        projectId: string
+        toVersion: number
+      }
 
   /**
    * Session events forwarded to agent bus with sessionId added.
@@ -578,6 +675,50 @@ export interface AgentEventMap {
  * These are scoped to a specific session and do not include sessionId.
  */
 export interface SessionEventMap {
+  /**
+   * Emitted when a harness version is loaded into the sandbox.
+   * @property {string} commandType - Command type the harness is scoped to
+   * @property {HarnessMode} mode - Mode selected for this session
+   * @property {string} projectId - Project ID the harness belongs to
+   * @property {number} version - Harness version number
+   */
+  'harness:loaded': {
+    commandType: string
+    mode: HarnessMode
+    projectId: string
+    version: number
+  }
+
+  /**
+   * Emitted when the harness mode is selected. Follows `harness:loaded`.
+   * @property {string} commandType - Command type the harness is scoped to
+   * @property {number} heuristic - H value that drove the mode choice
+   * @property {HarnessMode} mode - Selected mode
+   * @property {string} projectId - Project ID the harness belongs to
+   * @property {number} version - Harness version number
+   */
+  'harness:mode-selected': {
+    commandType: string
+    heuristic: number
+    mode: HarnessMode
+    projectId: string
+    version: number
+  }
+
+  /**
+   * Emitted every time a `code_exec` outcome is persisted.
+   * @property {string} commandType - Command type the outcome belongs to
+   * @property {string} outcomeId - Unique id of the persisted outcome record
+   * @property {string} projectId - Project id the outcome belongs to
+   * @property {boolean} success - Whether the code_exec succeeded
+   */
+  'harness:outcome-recorded': {
+    commandType: string
+    outcomeId: string
+    projectId: string
+    success: boolean
+  }
+
   /**
    * Emitted when a chunk of content is received (streaming).
    * @property {string} content - Content of the chunk

--- a/test/unit/agent/types/agent-events/types.test.ts
+++ b/test/unit/agent/types/agent-events/types.test.ts
@@ -9,6 +9,7 @@ import type {
   SessionEventName,
   TokenUsage,
 } from '../../../../../src/agent/core/domain/agent-events/index.js'
+import type {HarnessMode} from '../../../../../src/agent/infra/harness/types.js'
 
 import {
   AGENT_EVENT_NAMES,
@@ -35,11 +36,15 @@ describe('cipher/agent-events', () => {
         'cipher:stateChanged',
         'cipher:stateReset',
         'cipher:ui',
+        'harness:refinement-completed',
       ])
     })
 
     it('should have correct SESSION_EVENT_NAMES array', () => {
       expect(SESSION_EVENT_NAMES).to.deep.equal([
+        'harness:loaded',
+        'harness:mode-selected',
+        'harness:outcome-recorded',
         'llmservice:chunk',
         'llmservice:contextCompressed',
         'llmservice:contextOverflow',
@@ -73,6 +78,10 @@ describe('cipher/agent-events', () => {
         'cipher:stateChanged',
         'cipher:stateReset',
         'cipher:ui',
+        'harness:refinement-completed',
+        'harness:loaded',
+        'harness:mode-selected',
+        'harness:outcome-recorded',
         'llmservice:chunk',
         'llmservice:contextCompressed',
         'llmservice:contextOverflow',
@@ -377,6 +386,117 @@ describe('cipher/agent-events', () => {
       expectTypeOf<string>(payload.sessionId)
       expectTypeOf<string | undefined>(payload.model)
       expectTypeOf<string | undefined>(payload.provider)
+    })
+  })
+
+  describe('Type Safety - Harness events', () => {
+    it('harness:loaded (SessionEventMap) omits sessionId; (AgentEventMap) requires it', () => {
+      const sessionPayload: SessionEventMap['harness:loaded'] = {
+        commandType: 'curate',
+        mode: 'assisted',
+        projectId: 'proj-1',
+        version: 1,
+      }
+      expectTypeOf<HarnessMode>(sessionPayload.mode)
+      expectTypeOf<number>(sessionPayload.version)
+
+      // SessionEventMap form does NOT expose sessionId
+      type SessionHasSessionId = SessionEventMap['harness:loaded'] extends {sessionId: unknown} ? true : false
+      expectTypeOf<SessionHasSessionId>().toEqualTypeOf<false>()
+
+      const agentPayload: AgentEventMap['harness:loaded'] = {
+        commandType: 'curate',
+        mode: 'assisted',
+        projectId: 'proj-1',
+        sessionId: 'session-123',
+        version: 1,
+      }
+      expectTypeOf<string>(agentPayload.sessionId)
+    })
+
+    it('harness:mode-selected carries heuristic + mode in both maps', () => {
+      const sessionPayload: SessionEventMap['harness:mode-selected'] = {
+        commandType: 'curate',
+        heuristic: 0.42,
+        mode: 'filter',
+        projectId: 'proj-1',
+        version: 3,
+      }
+      expectTypeOf<number>(sessionPayload.heuristic)
+      expectTypeOf<HarnessMode>(sessionPayload.mode)
+
+      const agentPayload: AgentEventMap['harness:mode-selected'] = {
+        ...sessionPayload,
+        sessionId: 'session-123',
+      }
+      expectTypeOf<string>(agentPayload.sessionId)
+    })
+
+    it('harness:outcome-recorded carries identifiers only (no full outcome)', () => {
+      const sessionPayload: SessionEventMap['harness:outcome-recorded'] = {
+        commandType: 'curate',
+        outcomeId: 'out-1',
+        projectId: 'proj-1',
+        success: true,
+      }
+      expectTypeOf<string>(sessionPayload.outcomeId)
+      expectTypeOf<boolean>(sessionPayload.success)
+
+      // Intentionally not on SessionEventMap payload — full outcome is
+      // retrieved via IHarnessStore.listOutcomes, not shipped on the bus.
+      type HasCode = SessionEventMap['harness:outcome-recorded'] extends {code: unknown} ? true : false
+      expectTypeOf<HasCode>().toEqualTypeOf<false>()
+    })
+
+    it('harness:refinement-completed is agent-only and discriminates on `accepted`', () => {
+      // Accepted branch: toVersion required, reason absent.
+      const accepted: AgentEventMap['harness:refinement-completed'] = {
+        accepted: true,
+        commandType: 'curate',
+        fromVersion: 2,
+        projectId: 'proj-1',
+        toVersion: 3,
+      }
+      if (accepted.accepted) {
+        // Narrowing proves the invariant: toVersion is `number`, not `number | undefined`.
+        expectTypeOf<number>(accepted.toVersion)
+      }
+
+      // Rejected branch: reason required, toVersion absent.
+      const rejected: AgentEventMap['harness:refinement-completed'] = {
+        accepted: false,
+        commandType: 'curate',
+        fromVersion: 2,
+        projectId: 'proj-1',
+        reason: 'delta-H below 0.05 threshold',
+      }
+      if (!rejected.accepted) {
+        expectTypeOf<string>(rejected.reason)
+      }
+
+      // Compile-time: omitting toVersion on an accepted payload is a type error.
+      // @ts-expect-error — accepted without toVersion violates the discriminated union.
+      const bogusAccepted: AgentEventMap['harness:refinement-completed'] = {
+        accepted: true,
+        commandType: 'curate',
+        fromVersion: 2,
+        projectId: 'proj-1',
+      }
+      expect(bogusAccepted).to.exist // runtime presence suppresses unused-var lint
+
+      // Compile-time: omitting reason on a rejected payload is a type error.
+      // @ts-expect-error — rejected without reason violates the discriminated union.
+      const bogusRejected: AgentEventMap['harness:refinement-completed'] = {
+        accepted: false,
+        commandType: 'curate',
+        fromVersion: 2,
+        projectId: 'proj-1',
+      }
+      expect(bogusRejected).to.exist
+
+      // Deliberately NOT in SessionEventMap — refinement is post-session.
+      type InSessionMap = 'harness:refinement-completed' extends keyof SessionEventMap ? true : false
+      expectTypeOf<InSessionMap>().toEqualTypeOf<false>()
     })
   })
 })


### PR DESCRIPTION
## Summary

- Problem: AutoHarness V2 needs typed event channels before any emitter in Phases 2, 3, 5, or 6 can fire. Declaring names + payloads in one place upfront means each later phase adds an emitter without touching the central event-types file — no drift, no merge conflicts at the declaration level.
- Why it matters: third of six foundational tasks in Phase 0. The event surface is the contract between producers (sandbox, synthesizer) and any future consumer (telemetry, CLI status, UI banners). Locking it here means Phase 5's mode selector and Phase 6's synthesizer can emit without re-negotiating the payload.
- What changed:
  - 4 new event names declared in `src/agent/core/domain/agent-events/types.ts`:
    - `harness:loaded` — session event, emitted when a harness is injected into a sandbox
    - `harness:mode-selected` — session event, emitted after mode gating (Phase 5)
    - `harness:outcome-recorded` — session event, emitted per `code_exec` outcome persisted
    - `harness:refinement-completed` — agent event, emitted post-session by the synthesizer (Phase 6)
  - Payloads added to both `SessionEventMap` (no `sessionId`) and `AgentEventMap` (with `sessionId`, forwarded form) for the 3 session events. `harness:refinement-completed` is agent-only — it fires in an async background flow with no live session context.
  - `import type {HarnessMode} from '../../../infra/harness/types.js'` — type-only import, no runtime cycle.
  - Updated test `test/unit/agent/types/agent-events/types.test.ts`:
    - 3 exact-array assertions (`AGENT_EVENT_NAMES`, `SESSION_EVENT_NAMES`, `EVENT_NAMES`) updated to reflect the new members
    - 4 new type-safety tests documenting harness payload shapes + intentional omissions
- What did NOT change (scope boundary):
  - No emitter produces these events yet — each later phase wires its emitter
  - No event bus plumbing — the existing bus consumes whatever's in the maps
  - No CLI / UI consumer of harness events — that's Phase 7
  - No metrics / telemetry wiring — observability counters in §4.5 of the execution plan ship per-phase

## Type of change

- [ ] Bug fix
- [x] New feature (event surface for AutoHarness V2)
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [x] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [x] Agent / Tools  — `src/agent/core/domain/agent-events/types.ts`
- [ ] TUI / REPL
- [ ] LLM Providers
- [ ] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- ENG-2220 — AutoHarness V2, Phase 0 Task 0.3: Harness agent events
- Builds on Task 0.1 (`HarnessMode`) and Task 0.2 (schema scaffold)

## Root cause (bug fixes only)

N/A — foundational feature commit.

## Test plan

- Coverage added:
  - [x] Unit test (type-safety + runtime array shape)
  - [ ] Integration test
  - [ ] Manual verification only
- Test file(s): `test/unit/agent/types/agent-events/types.test.ts`
- Key scenarios covered:
  - 3 existing `deep.equal` array assertions updated to include the new event names in their sorted positions
  - `harness:loaded`: SessionEventMap form omits `sessionId`; AgentEventMap form requires it — encoded via `type HasSessionId = ... extends {sessionId: unknown} ? true : false; expectTypeOf<HasSessionId>().toEqualTypeOf<false>()`
  - `harness:mode-selected`: `heuristic: number` and `mode: HarnessMode` appear in both maps
  - `harness:outcome-recorded`: payload carries identifiers + success bit only — a type-level assertion proves the full outcome code/stdout/etc. are NOT on the payload (consumers look up via `IHarnessStore.listOutcomes`)
  - `harness:refinement-completed`: accepted and rejected cases (`toVersion` present iff accepted, `reason` present iff rejected); type-level assertion proves the event is NOT in `SessionEventMap`

## User-visible changes

None. Pure type-surface declaration — nothing emits or consumes these events yet.

## Evidence


## Checklist

- [x] Tests added or updated and passing (`npm test`)
- [x] Lint passes (`npm run lint`) — 0 errors
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow Conventional Commits format
- [ ] Documentation updated — N/A (internal event surface, no user-facing docs affected)
- [x] No breaking changes (additive event names + payloads)
- [x] Branch is up to date with `main`

## Risks and mitigations

- **Risk: `harness:refinement-completed` deviates from the "AgentEventMap always has sessionId" docstring convention.** Refinement runs post-session in a background flow with no live session context; the task-doc payload doesn't include `sessionId`. Some subscribers that filter by sessionId would miss this event.
  - Mitigation: documented explicitly in the payload's doc comment ("Fires once per `(projectId, commandType)` post-session trigger. Not scoped to a specific session."). Existing `cipher:stateChanged` / `cipher:stateReset` have precedent for optional `sessionId`. If a future subscriber needs session attribution, adding `sessionId?: string` later is a purely additive change.

- **Risk: adding to the `EVENT_NAMES` / `AGENT_EVENT_NAMES` / `SESSION_EVENT_NAMES` arrays could break any consumer asserting exact array length or exact contents.**
  - Mitigation: one test file (`types.test.ts`) held three such assertions and was updated in this PR. No other exact-content assertions on these arrays exist in the repo — verified via grep (`rg "AGENT_EVENT_NAMES\|SESSION_EVENT_NAMES\|EVENT_NAMES" src/ test/`).

- **Risk: payloads are underspecified vs. what Phase 6 may actually need to emit.** E.g. `harness:refinement-completed` currently omits the specific Δ-heuristic value and the evaluation-run count; Phase 6 observability might want them.
  - Mitigation: payloads are additive. Phase 6 can extend the payload with optional fields (`deltaHeuristic?: number`, `evalRuns?: number`) without breaking existing subscribers. Intentionally minimal surface now; grow by evidence when emitters ship.
