### PR TITLE
feat: surface local↔remote linkage and tighten side-sheet chrome

### DIFF
--- a/src/webui/features/onboarding/components/tour-bar.tsx
+++ b/src/webui/features/onboarding/components/tour-bar.tsx
@@ -77,13 +77,20 @@ export function TourBar() {
 
   const idx = TOUR_STEPS.indexOf(tourStep)
 
-  // When a right sheet is open, dock just to its left so the bar lives next
-  // to the user's focus. Otherwise, center horizontally (more visible on wide
-  // screens than a corner anchor).
+  // Steps 2 (curate) + 3 (query) open a right-side sheet that fills full height,
+  // so the bar moves to the top to stay visually clear of it. Steps 1 (provider)
+  // and 4 (connector) use centered dialogs — bottom is the natural rest spot.
+  const dockTop = tourStep === 'curate' || tourStep === 'query'
+  const verticalAnchor = dockTop ? 'top-4' : 'bottom-4'
+
+  // When a right sheet is open, anchor by the right edge so the bar sits next
+  // to the sheet's left edge instead of being hidden under it.
   const sheetOpen = sheetWidth > 0
-  const wrapperClass = sheetOpen
-    ? 'pointer-events-none fixed bottom-4 z-100 flex'
-    : 'pointer-events-none fixed inset-x-0 bottom-4 z-100 flex justify-center px-4'
+  const wrapperClass = cn(
+    'pointer-events-none fixed z-100 flex',
+    verticalAnchor,
+    sheetOpen ? '' : 'inset-x-0 justify-center px-4',
+  )
   const wrapperStyle = sheetOpen ? {right: `${sheetWidth + 16}px`} : undefined
 
   return (

--- a/src/webui/features/project/api/get-project-config.ts
+++ b/src/webui/features/project/api/get-project-config.ts
@@ -14,6 +14,12 @@ interface GetProjectConfigRequest {
   projectPath: string
 }
 
+/**
+ * Mirrors the daemon's wire shape (see brv-server.ts:487-491). Top-level
+ * `spaceId` / `teamId` are the agent-process contract — the webui only reads
+ * `brvConfig.teamName` / `brvConfig.spaceName`, but we keep the duplicates so
+ * this type stays a faithful response decoder.
+ */
 interface GetProjectConfigResponse {
   brvConfig?: BrvConfigDTO
   spaceId: string
@@ -41,9 +47,4 @@ type UseGetProjectConfigOptions = {
 }
 
 export const useGetProjectConfig = ({projectPath, queryConfig}: UseGetProjectConfigOptions) =>
-  useQuery({
-    // .brv/config.json only changes via brv link / re-onboard within a session.
-    staleTime: 5 * 60 * 1000,
-    ...getProjectConfigQueryOptions(projectPath),
-    ...queryConfig,
-  })
+  useQuery({...queryConfig, ...getProjectConfigQueryOptions(projectPath)})

--- a/src/webui/features/project/api/get-project-config.ts
+++ b/src/webui/features/project/api/get-project-config.ts
@@ -1,0 +1,49 @@
+import {queryOptions, useQuery} from '@tanstack/react-query'
+
+import type {QueryConfig} from '../../../lib/react-query'
+
+import {type BrvConfigDTO} from '../../../../shared/transport/events'
+import {useTransportStore} from '../../../stores/transport-store'
+
+// Daemon's existing endpoint used by agent child processes on startup
+// (src/server/infra/daemon/brv-server.ts:474). Re-used so the webui can read
+// team/space linkage per-project without adding a new transport event.
+const GET_PROJECT_CONFIG_EVENT = 'state:getProjectConfig'
+
+interface GetProjectConfigRequest {
+  projectPath: string
+}
+
+interface GetProjectConfigResponse {
+  brvConfig?: BrvConfigDTO
+  spaceId: string
+  storagePath: string
+  teamId: string
+}
+
+export const getProjectConfig = (projectPath: string): Promise<GetProjectConfigResponse> => {
+  const {apiClient} = useTransportStore.getState()
+  if (!apiClient) return Promise.reject(new Error('Not connected'))
+
+  return apiClient.request<GetProjectConfigResponse, GetProjectConfigRequest>(GET_PROJECT_CONFIG_EVENT, {projectPath})
+}
+
+export const getProjectConfigQueryOptions = (projectPath: string) =>
+  queryOptions({
+    enabled: projectPath.length > 0,
+    queryFn: () => getProjectConfig(projectPath),
+    queryKey: ['project-config', projectPath],
+  })
+
+type UseGetProjectConfigOptions = {
+  projectPath: string
+  queryConfig?: QueryConfig<typeof getProjectConfigQueryOptions>
+}
+
+export const useGetProjectConfig = ({projectPath, queryConfig}: UseGetProjectConfigOptions) =>
+  useQuery({
+    // .brv/config.json only changes via brv link / re-onboard within a session.
+    staleTime: 5 * 60 * 1000,
+    ...getProjectConfigQueryOptions(projectPath),
+    ...queryConfig,
+  })

--- a/src/webui/features/project/components/project-dropdown.tsx
+++ b/src/webui/features/project/components/project-dropdown.tsx
@@ -49,7 +49,7 @@ function ProjectItem({onSelect, project, showRemote = false}: ProjectItemProps) 
   })
   const teamName = projectConfig?.brvConfig?.teamName
   const spaceName = projectConfig?.brvConfig?.spaceName
-  const remoteLabel = teamName && spaceName ? `${teamName}/${spaceName}` : undefined
+  const remoteLabel = teamName && spaceName ? `${teamName} / ${spaceName}` : undefined
 
   return (
     <DropdownMenuItem className="gap-2 rounded-md" onClick={onSelect}>

--- a/src/webui/features/project/components/project-dropdown.tsx
+++ b/src/webui/features/project/components/project-dropdown.tsx
@@ -17,11 +17,12 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@campfirein/byterover-packages/components/dropdown-menu'
-import {ChevronDown, FolderOpen} from 'lucide-react'
+import {ChevronDown, FolderOpen, Link2} from 'lucide-react'
 import {useMemo, useState} from 'react'
 
 import {ProjectLocationDTO} from '../../../../shared/transport/events'
 import {useTransportStore} from '../../../stores/transport-store'
+import {useGetProjectConfig} from '../api/get-project-config'
 import {useGetProjectList} from '../api/get-project-list'
 import {displayPath} from '../utils/display-path'
 import {getProjectName} from '../utils/project-name'
@@ -33,10 +34,22 @@ const RECENT_LIMIT = 5
 type ProjectItemProps = {
   onSelect: () => void
   project: ProjectLocationDTO
+  /**
+   * Fetch + show "Linked to <team> / <space>" — only worth doing for open
+   * projects since the daemon won't have warm config caches for unopened ones.
+   */
+  showRemote?: boolean
 }
 
-function ProjectItem({onSelect, project}: ProjectItemProps) {
+function ProjectItem({onSelect, project, showRemote = false}: ProjectItemProps) {
   const name = getProjectName(project.projectPath)
+  const {data: projectConfig} = useGetProjectConfig({
+    projectPath: project.projectPath,
+    queryConfig: {enabled: showRemote},
+  })
+  const teamName = projectConfig?.brvConfig?.teamName
+  const spaceName = projectConfig?.brvConfig?.spaceName
+  const remoteLabel = teamName && spaceName ? `${teamName}/${spaceName}` : undefined
 
   return (
     <DropdownMenuItem className="gap-2 rounded-md" onClick={onSelect}>
@@ -44,6 +57,15 @@ function ProjectItem({onSelect, project}: ProjectItemProps) {
       <div className="flex min-w-0 flex-1 flex-col">
         <span className="truncate text-sm font-medium leading-5 text-card-foreground!">{name}</span>
         <span className="truncate text-xs leading-4 text-muted-foreground!">{displayPath(project.projectPath)}</span>
+        {remoteLabel && (
+          <span className="text-muted-foreground! mono flex items-start gap-1 text-[10px] leading-4">
+            <Link2 className="mt-0.5 size-2.5 shrink-0" />
+            <span className="min-w-0 wrap-break-word">
+              <span>Remote space: </span>
+              <span className="text-primary-foreground! font-medium">{remoteLabel}</span>
+            </span>
+          </span>
+        )}
       </div>
     </DropdownMenuItem>
   )
@@ -102,7 +124,7 @@ export function ProjectDropdown() {
             <DropdownMenuGroup>
               <DropdownMenuLabel>Open Projects</DropdownMenuLabel>
               {openProjects.map((p) => (
-                <ProjectItem key={p.projectPath} onSelect={() => handleSelect(p)} project={p} />
+                <ProjectItem key={p.projectPath} onSelect={() => handleSelect(p)} project={p} showRemote />
               ))}
 
               <DropdownMenuSeparator />

--- a/src/webui/features/tasks/components/task-composer.tsx
+++ b/src/webui/features/tasks/components/task-composer.tsx
@@ -1,5 +1,6 @@
 import {Sheet, SheetContent} from '@campfirein/byterover-packages/components/sheet'
 import {Textarea} from '@campfirein/byterover-packages/components/textarea'
+import {cn} from '@campfirein/byterover-packages/lib/utils'
 import {type ComponentRef, type KeyboardEvent, useEffect, useRef, useState} from 'react'
 
 import {useTransportStore} from '../../../stores/transport-store'
@@ -32,10 +33,17 @@ export function TaskComposerSheet({
   prefillNotice,
   tourStepLabel,
 }: TaskComposerSheetProps) {
+  // Tour mode keeps the dim/blur backdrop because the composer is the focal
+  // point of the step. Outside the tour, drop the overlay so the rest of the
+  // app stays sharp behind the side sheet.
+  const inTour = Boolean(tourStepLabel)
   return (
     <Sheet onOpenChange={(next) => !next && onClose()} open={open}>
       <SheetContent
-        className="data-[side=right]:w-full data-[side=right]:max-w-xl p-0 shadow-[inset_1px_0_0_rgba(96,165,250,0.18)]"
+        className={cn(
+          'data-[side=right]:w-full data-[side=right]:max-w-xl p-0 shadow-[inset_1px_0_0_rgba(96,165,250,0.18)]',
+          !inTour && 'sheet-no-overlay',
+        )}
         side="right"
       >
         {open && (
@@ -72,7 +80,7 @@ function ComposerForm({
   const {data: activeProviderConfig} = useGetActiveProviderConfig()
   const [type, setType] = useState<ComposerType>(initialType ?? 'curate')
   const [content, setContent] = useState(initialContent ?? '')
-  const [openDetailAfter, setOpenDetailAfter] = useState(false)
+  const [openDetailAfter, setOpenDetailAfter] = useState(true)
   const [providerDialogOpen, setProviderDialogOpen] = useState(false)
   const [hadPrefill, setHadPrefill] = useState(Boolean(initialContent))
   const textareaRef = useRef<ComponentRef<typeof Textarea>>(null)

--- a/src/webui/features/tasks/components/task-list-view.tsx
+++ b/src/webui/features/tasks/components/task-list-view.tsx
@@ -6,12 +6,7 @@ import {useSearchParams} from 'react-router-dom'
 import {useTransportStore} from '../../../stores/transport-store'
 import {useGetTasks} from '../api/get-tasks'
 import {useTickingNow} from '../hooks/use-ticking-now'
-import {
-  statusMatchesFilter,
-  taskMatchesQuery,
-  useStatusBreakdown,
-  useTaskStore,
-} from '../stores/task-store'
+import {statusMatchesFilter, taskMatchesQuery, useStatusBreakdown, useTaskStore} from '../stores/task-store'
 import {isTerminalStatus} from '../utils/task-status'
 import {TaskComposerSheet} from './task-composer'
 import {TaskDetailView} from './task-detail-view'
@@ -180,16 +175,15 @@ export function TaskListView() {
       )}
 
       <Sheet onOpenChange={(open) => !open && closeTask()} open={Boolean(selectedTaskId)}>
-        <SheetContent className="data-[side=right]:w-full data-[side=right]:max-w-3xl p-0 shadow-[inset_1px_0_0_rgba(96,165,250,0.18)]" side="right">
+        <SheetContent
+          className="data-[side=right]:w-full data-[side=right]:max-w-3xl p-0 shadow-[inset_1px_0_0_rgba(96,165,250,0.18)]"
+          side="right"
+        >
           {selectedTaskId && <TaskDetailView taskId={selectedTaskId} />}
         </SheetContent>
       </Sheet>
 
-      <TaskComposerSheet
-        onClose={closeComposer}
-        onSubmitted={onComposerSubmitted}
-        open={composer.open}
-      />
+      <TaskComposerSheet onClose={closeComposer} onSubmitted={onComposerSubmitted} open={composer.open} />
     </div>
   )
 }

--- a/src/webui/layouts/header.tsx
+++ b/src/webui/layouts/header.tsx
@@ -37,15 +37,20 @@ export function Header() {
 
         <BranchDropdown />
 
-        <Badge
-          aria-label="Running against the local daemon"
-          className="border-primary-foreground/40 bg-primary-foreground/15 text-primary-foreground mono gap-1 px-1.5 text-[9px] leading-none font-semibold tracking-[0.16em] uppercase"
-          title="You're viewing the local web UI, served from the daemon on your machine."
-          variant="outline"
-        >
-          <span aria-hidden className="bg-primary-foreground size-1 shrink-0 rounded-full" />
-          <span className="leading-none">Local</span>
-        </Badge>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Badge
+                className="border-primary-foreground/40 bg-primary-foreground/15 text-primary-foreground mono gap-1 px-1.5 text-[9px] leading-none font-semibold tracking-[0.16em] uppercase"
+                variant="outline"
+              />
+            }
+          >
+            <span aria-hidden className="bg-primary-foreground size-1 shrink-0 rounded-full" />
+            <span className="leading-none">Local</span>
+          </TooltipTrigger>
+          <TooltipContent>You're viewing the local web UI, served from the daemon on your machine.</TooltipContent>
+        </Tooltip>
       </div>
 
       {/* Spacer */}

--- a/src/webui/layouts/header.tsx
+++ b/src/webui/layouts/header.tsx
@@ -1,3 +1,4 @@
+import {Badge} from '@campfirein/byterover-packages/components/badge'
 import {Button} from '@campfirein/byterover-packages/components/button'
 import {Tooltip, TooltipContent, TooltipTrigger} from '@campfirein/byterover-packages/components/tooltip'
 import {useState} from 'react'
@@ -35,6 +36,16 @@ export function Header() {
         <ProjectDropdown />
 
         <BranchDropdown />
+
+        <Badge
+          aria-label="Running against the local daemon"
+          className="border-primary-foreground/40 bg-primary-foreground/15 text-primary-foreground mono gap-1 px-1.5 text-[9px] leading-none font-semibold tracking-[0.16em] uppercase"
+          title="You're viewing the local web UI, served from the daemon on your machine."
+          variant="outline"
+        >
+          <span aria-hidden className="bg-primary-foreground size-1 shrink-0 rounded-full" />
+          <span className="leading-none">Local</span>
+        </Badge>
       </div>
 
       {/* Spacer */}
@@ -43,17 +54,11 @@ export function Header() {
       {/* Right: provider/model + docs + login */}
       <div className="flex items-center gap-2">
         <Tooltip>
-          <TooltipTrigger render={
-            <Button onClick={() => setProviderDialogOpen(true)} size="sm" variant="ghost" />
-          }>
+          <TooltipTrigger render={<Button onClick={() => setProviderDialogOpen(true)} size="sm" variant="ghost" />}>
             {providerLabel}
             {!activeProvider && <span className="size-1.5 shrink-0 rounded-full bg-amber-500" />}
           </TooltipTrigger>
-          {!activeProvider && (
-            <TooltipContent>
-              Configure to use curate/query feature
-            </TooltipContent>
-          )}
+          {!activeProvider && <TooltipContent>Configure to use curate/query feature</TooltipContent>}
         </Tooltip>
         <ProviderFlowDialog onOpenChange={setProviderDialogOpen} open={providerDialogOpen} />
 

--- a/src/webui/styles/index.css
+++ b/src/webui/styles/index.css
@@ -187,3 +187,13 @@
   background-size: 24px 24px;
 }
 
+/*
+ * Opt-out of the sheet's default backdrop dim + blur.
+ * Apply `sheet-no-overlay` to a SheetContent and the overlay sibling in the
+ * same portal becomes transparent, keeping the page behind the sheet sharp.
+ */
+[data-slot="sheet-portal"]:has(.sheet-no-overlay) [data-slot="sheet-overlay"] {
+  background: transparent;
+  backdrop-filter: none;
+}
+


### PR DESCRIPTION
Header
- Add a LOCAL badge in the right cluster of the header so users always know they're on the local web UI vs byterover.dev.

Project dropdown
- Each Open Project row now shows 'Remote space: <team> / <space>' underneath the path, so users can see which projects are linked to which remote at a glance. Team/space identifier is brand green to visually tie back to the LOCAL badge.
- New useGetProjectConfig hook calls the existing daemon-internal state:getProjectConfig event with an explicit projectPath, so each ProjectItem can fetch its own config in parallel (React Query dedups on the projectPath query key). Recent/unopened projects don't fire the request — only the open ones, since the daemon won't have warm config caches for unopened paths.

Sheets
- New  opt-in CSS class drops the dim+blur backdrop on the underlying byterover-packages Sheet via :has() targeting. Applied to the task detail sheet (always sharp behind) and to the task composer sheet only when the user is NOT in the onboarding tour — tour mode keeps the backdrop because the composer is the step's focal point.

Tour bar
- Anchor vertically per step: provider/connector at bottom (centered dialogs), curate/query at top (full-height side sheets) so the bar never overlaps the active surface.

Update: 
- Wrap the LOCAL badge in the design-system <Tooltip> instead of thnative title attribute, matching the model-selector pattern in the same header. Drops aria-label since base-ui wires aria-describedby from trigger to TooltipContent.
- Document on GetProjectConfigResponse that top-level spaceId/teamId duplicate brvConfig fields intentionally — the type mirrors the daemon's wire shape (brv-server.ts:487-491) so it stays a faithful decoder, even though the webui only reads brvConfig.teamName / spaceName.
- Tighten "Remote space:" label spacing — render as "team / space" (with surrounding spaces around the slash) instead of "team/space", matching the dropdown's other identifier rows.
- Flip TaskComposerSheet's `openDetailAfter` default from false to true. Submitting a task and immediately landing on its detail is the path users overwhelmingly want; opting in by checkbox per submit was friction.