### PR TITLE
feat: [ENG-2224] AutoHarness V2 heuristic helper

### DIFF
--- a/src/agent/core/domain/harness/heuristic.ts
+++ b/src/agent/core/domain/harness/heuristic.ts
@@ -1,0 +1,105 @@
+/**
+ * AutoHarness V2 — heuristic H.
+ *
+ * Pure function that turns a list of `CodeExecOutcome` records into the
+ * scalar H consumed by the mode selector (Phase 5) and the refinement
+ * evaluator (Phase 6).
+ *
+ * H = 0.2·successRate + 0.3·(1 − errorRate) + 0.5·realHarnessRate
+ *
+ * where each rate is a recency-weighted fraction over the most recent
+ * `WINDOW_SIZE` outcomes, and weight(o) = exp(−ageDays(o) / DECAY_HALF_LIFE_DAYS).
+ *
+ * `realHarnessRate` carries the highest weight so the pass-through cap
+ * works: a window of `delegated:true` outcomes (LLM doing all the work
+ * through the harness sandbox) yields H ≤ 0.55 regardless of success,
+ * preventing Option C templates from graduating to Mode B/C without real
+ * refinement generating `!delegated` outcomes. See
+ * `features/autoharness-v2/analysis/v1-design-decisions.md §2.1`.
+ *
+ * Pure function — `now` is passed in, not read from `Date`. Mirrors the
+ * pattern used by `src/server/core/domain/knowledge/memory-scoring.ts`.
+ */
+
+import type {CodeExecOutcome} from './types.js'
+
+/** Weight applied to successRate in H. */
+const W_SUCCESS = 0.2
+
+/** Weight applied to (1 − errorRate) in H. */
+const W_ERROR = 0.3
+
+/** Weight applied to realHarnessRate in H. */
+const W_REAL_HARNESS = 0.5
+
+/** Cap the window at the most-recent N outcomes before computing H. */
+const WINDOW_SIZE = 50
+
+/** Below this many outcomes, H is not computable — caller treats as "unknown". */
+const MIN_SAMPLE_FLOOR = 10
+
+/** Recency half-life in days. 30 → 30-day-old outcomes contribute ~50% weight. */
+const DECAY_HALF_LIFE_DAYS = 30
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+/**
+ * Compute the heuristic H from a list of outcomes.
+ *
+ * Returns `null` when the input cannot support a meaningful H:
+ *   - fewer than `MIN_SAMPLE_FLOOR` outcomes (caller should treat as
+ *     "not computed yet", NOT as H=0), OR
+ *   - the sum of recency weights rounds to 0 (defensive — unreachable
+ *     with finite valid outcomes at realistic timestamps, but guards
+ *     against bugs upstream).
+ *
+ * `errorRate` reads `stderr` only; non-empty stderr signals tool/code
+ * friction even on eventual success. The schema has no `error` field.
+ *
+ * The final H is clamped to `[0, 1]`. Clamp is defensive: future-dated
+ * outcomes produce weights > 1 (`ageDays < 0` ⇒ `exp(positive) > 1`),
+ * which doesn't break the weighted-average math but can push the raw
+ * sum slightly out of range.
+ */
+export function computeHeuristic(
+  outcomes: readonly CodeExecOutcome[],
+  now: number,
+): null | number {
+  if (outcomes.length < MIN_SAMPLE_FLOOR) return null
+
+  const window = [...outcomes]
+    .sort((a, b) => b.timestamp - a.timestamp)
+    .slice(0, WINDOW_SIZE)
+
+  let sumWeight = 0
+  let sumSuccess = 0
+  let sumError = 0
+  let sumRealHarness = 0
+
+  for (const o of window) {
+    const ageDays = (now - o.timestamp) / MS_PER_DAY
+    const weight = Math.exp(-ageDays / DECAY_HALF_LIFE_DAYS)
+
+    sumWeight += weight
+    if (o.success) sumSuccess += weight
+    if (o.stderr && o.stderr.length > 0) sumError += weight
+    // `=== false` (not `!o.delegated`) so an outcome with `delegated`
+    // omitted is NOT silently counted as real harness work. Missing
+    // means "the recorder didn't say" — we require an affirmative
+    // `delegated: false` before crediting realHarnessRate.
+    if (o.usedHarness && o.delegated === false) sumRealHarness += weight
+  }
+
+  if (sumWeight === 0) return null
+
+  const successRate = sumSuccess / sumWeight
+  const errorRate = sumError / sumWeight
+  const realHarnessRate = sumRealHarness / sumWeight
+
+  const h =
+    W_SUCCESS * successRate +
+    W_ERROR * (1 - errorRate) +
+    W_REAL_HARNESS * realHarnessRate
+
+  return Math.max(0, Math.min(1, h))
+}

--- a/test/unit/agent/harness/heuristic.test.ts
+++ b/test/unit/agent/harness/heuristic.test.ts
@@ -1,0 +1,198 @@
+import {expect} from 'chai'
+
+import type {CodeExecOutcome} from '../../../../src/agent/core/domain/harness/types.js'
+
+import {computeHeuristic} from '../../../../src/agent/core/domain/harness/heuristic.js'
+
+const NOW = 1_700_000_000_000
+const DAY_MS = 24 * 60 * 60 * 1000
+
+function outcome(overrides: Partial<CodeExecOutcome> = {}): CodeExecOutcome {
+  return {
+    code: 'tools.search("x")',
+    commandType: 'curate',
+    executionTimeMs: 10,
+    id: `o-${Math.random().toString(36).slice(2)}`,
+    projectId: 'p',
+    projectType: 'typescript',
+    sessionId: 's',
+    success: true,
+    timestamp: NOW,
+    usedHarness: false,
+    ...overrides,
+  }
+}
+
+describe('computeHeuristic', () => {
+  // ── Min-sample floor ──────────────────────────────────────────────────────
+
+  it('returns null for empty input', () => {
+    expect(computeHeuristic([], NOW)).to.equal(null)
+  })
+
+  it('returns null for 9 outcomes (below floor)', () => {
+    const outcomes = Array.from({length: 9}, () => outcome({success: true, usedHarness: true}))
+    expect(computeHeuristic(outcomes, NOW)).to.equal(null)
+  })
+
+  // ── At min-sample ─────────────────────────────────────────────────────────
+
+  it('returns a real number in (0, 1] at n=10 with all-success, all-real-harness', () => {
+    const outcomes = Array.from({length: 10}, () =>
+      outcome({delegated: false, success: true, usedHarness: true}),
+    )
+    const h = computeHeuristic(outcomes, NOW)
+    expect(h).to.be.a('number')
+    // success=1, errorRate=0, realHarness=1 → 0.2 + 0.3 + 0.5 = 1.0
+    expect(h).to.equal(1)
+  })
+
+  // ── Window cap ────────────────────────────────────────────────────────────
+
+  it('uses only the most recent 50 outcomes when 100 are supplied', () => {
+    // 50 recent: delegated, success=false, usedHarness=true, stderr empty
+    //   → successRate=0, errorRate=0, realHarness=0 → 0.2·0 + 0.3·1 + 0 = 0.3
+    // 50 older: real harness, success=true, no stderr
+    //   → would give H near 1 if included
+    // With the recent 50 dominating, H should land at 0.3, not ≈1.
+    const recent: CodeExecOutcome[] = Array.from({length: 50}, (_, i) =>
+      outcome({
+        delegated: true,
+        success: false,
+        timestamp: NOW - i, // distinct, most recent
+        usedHarness: true,
+      }),
+    )
+    const older: CodeExecOutcome[] = Array.from({length: 50}, (_, i) =>
+      outcome({
+        delegated: false,
+        success: true,
+        timestamp: NOW - (1000 + i), // older than every `recent`
+        usedHarness: true,
+      }),
+    )
+
+    const h = computeHeuristic([...recent, ...older], NOW)
+    expect(h).to.be.closeTo(0.3, 1e-9)
+  })
+
+  // ── Decay ─────────────────────────────────────────────────────────────────
+
+  it('weights recent outcomes more heavily than 60-day-old ones', () => {
+    // 10 fresh all-zero outcomes: success=false, stderr='err', delegated
+    //   fresh contribution to rates: successRate=0, errorRate=1, realHarness=0 → H ≈ 0.2·0 + 0.3·0 + 0 = 0
+    // 10 @ 60d all-one outcomes: success=true, no stderr, real harness
+    //   @60d contribution to rates: successRate=1, errorRate=0, realHarness=1 → H ≈ 1
+    // weight ratio fresh:old = 1 : exp(-60/30) = 1 : e^-2 ≈ 1 : 0.1353
+    // Fresh dominates — H should be well under 0.5, not well over.
+    const fresh: CodeExecOutcome[] = Array.from({length: 10}, () =>
+      outcome({
+        delegated: true,
+        stderr: 'err',
+        success: false,
+        timestamp: NOW,
+        usedHarness: true,
+      }),
+    )
+    const old: CodeExecOutcome[] = Array.from({length: 10}, () =>
+      outcome({
+        delegated: false,
+        success: true,
+        timestamp: NOW - 60 * DAY_MS,
+        usedHarness: true,
+      }),
+    )
+
+    const h = computeHeuristic([...fresh, ...old], NOW)
+    expect(h).to.be.a('number')
+    // If no decay, H would be the unweighted average → 0.5. With e^-2
+    // decay on the old outcomes, H should lean heavily toward the fresh
+    // (0-ish) side.
+    expect(h).to.be.lessThan(0.2)
+  })
+
+  // ── Pass-through cap (Tier 1 A2) ──────────────────────────────────────────
+  //
+  // The invariant: any window where every outcome has `delegated: true`
+  // caps at H ≤ 0.5 (well inside the ≤ 0.55 budget the design doc
+  // requires). With `realHarnessRate = 0`, the formula reduces to
+  // `H = 0.2·successRate + 0.3·(1 − errorRate)`, both rates ∈ [0, 1].
+  // Four deterministic corner cases pin the four extremes of the
+  // (successRate, errorRate) plane — any implementation drift in the
+  // weights or in the `realHarnessRate` condition shifts at least one
+  // of these four to a wrong exact value.
+
+  it('pass-through cap: all-delegated + all-success + no stderr → H = 0.5 (max)', () => {
+    const outcomes = Array.from({length: 10}, (_, i) =>
+      outcome({
+        delegated: true,
+        success: true,
+        timestamp: NOW - i,
+        usedHarness: true,
+      }),
+    )
+    const h = computeHeuristic(outcomes, NOW)
+    expect(h).to.be.closeTo(0.5, 1e-9)
+  })
+
+  it('pass-through cap: all-delegated + all-success + all stderr → H = 0.2', () => {
+    const outcomes = Array.from({length: 10}, (_, i) =>
+      outcome({
+        delegated: true,
+        stderr: 'warning',
+        success: true,
+        timestamp: NOW - i,
+        usedHarness: true,
+      }),
+    )
+    const h = computeHeuristic(outcomes, NOW)
+    expect(h).to.be.closeTo(0.2, 1e-9)
+  })
+
+  it('pass-through cap: all-delegated + all-fail + no stderr → H = 0.3', () => {
+    const outcomes = Array.from({length: 10}, (_, i) =>
+      outcome({
+        delegated: true,
+        success: false,
+        timestamp: NOW - i,
+        usedHarness: true,
+      }),
+    )
+    const h = computeHeuristic(outcomes, NOW)
+    expect(h).to.be.closeTo(0.3, 1e-9)
+  })
+
+  it('pass-through cap: all-delegated + all-fail + all stderr → H = 0 (min)', () => {
+    const outcomes = Array.from({length: 10}, (_, i) =>
+      outcome({
+        delegated: true,
+        stderr: 'error',
+        success: false,
+        timestamp: NOW - i,
+        usedHarness: true,
+      }),
+    )
+    const h = computeHeuristic(outcomes, NOW)
+    expect(h).to.be.closeTo(0, 1e-9)
+  })
+
+  // ── Defensive clamp against future timestamps ─────────────────────────────
+
+  it('clamps H to [0, 1] when future timestamps produce weights > 1', () => {
+    // timestamp = NOW + 1_000_000 ms ⇒ ageDays ≈ −0.0116 ⇒ weight ≈ 1.0004.
+    // The weighted-average math still normalizes, so H naturally stays
+    // in [0, 1]. The clamp is a belt-and-braces guard; this test asserts
+    // the invariant rather than exercising an out-of-range code path.
+    const outcomes = Array.from({length: 10}, () =>
+      outcome({
+        delegated: false,
+        success: true,
+        timestamp: NOW + 1_000_000,
+        usedHarness: true,
+      }),
+    )
+    const h = computeHeuristic(outcomes, NOW)
+    expect(h).to.be.a('number')
+    expect(h).to.be.within(0, 1)
+  })
+})


### PR DESCRIPTION
## Summary

Phase 0, Task 0.6 of the AutoHarness V2 rollout — the pure heuristic
function that every mode-selection and refinement-accept decision
will consume. Lives at `src/agent/core/domain/harness/heuristic.ts`
next to `types.ts`.

- `computeHeuristic(outcomes: readonly CodeExecOutcome[], now: number): number | null`
- Returns `null` below the 10-outcome floor (caller treats as
  "not computed yet", not `0`).
- Slides a 50-outcome window, newest first.
- Each outcome weighted by `exp(−ageDays / 30)` (30-day half-life).
- `H = 0.2·successRate + 0.3·(1 − errorRate) + 0.5·realHarnessRate`.
- Clamps the final H to `[0, 1]` as a belt-and-braces guard against
  future-dated outcomes producing weights > 1.

## Why these weights (and not the earlier draft)

The earlier design draft had weights `[0.5, 0.3, 0.2]`. That version
makes the advertised pass-through cap unreachable:

- All-delegated + all-success + no stderr → `0.5·1 + 0.3·1 + 0.2·0 = 0.8`
- Mode thresholds say H ≥ 0.85 → Mode C (fully autonomous harness)
- After 10 successful LLM-delivered-via-delegation calls, an
  un-refined Option C pass-through template would graduate to Mode C.
  Users would see "autonomous harness" when reality is "LLM in a
  trench coat."

Swapping to `[0.2, 0.3, 0.5]` makes the cap structural — the
`realHarnessRate` term (which is 0 under pass-through) is the
dominant weight, so:

- All-delegated + all-success + no stderr → `0.2·1 + 0.3·1 + 0.5·0 = 0.5`
- Pass-through windows land in Mode A (Assisted) until refinement
  produces real `!delegated` outcomes. That's the system enforcing
  its own contract: **mode promotion requires evidence the harness
  code actually did work**, not just evidence the LLM eventually
  succeeded.

The rationale column in `v1-design-decisions.md §2.1` already said
"real-harness weighed highest among differentiators" — the weights
row was the inconsistency. This PR fixes the weights row to match
the stated intent.

## Why deterministic tests, not `fast-check`

An earlier Task 0.6 draft planned a property-based test for the
pass-through cap. When revisiting it:

- The invariant reduces to closed-form arithmetic. With all outcomes
  `delegated: true`, the formula collapses to
  `0.2·successRate + 0.3·(1 − errorRate)`, both rates ∈ [0, 1].
- Four deterministic corner cases pin every extreme of the
  `(successRate, errorRate)` plane:

  | successRate | errorRate | Expected H |
  |---|---|---|
  | 1 (all succeed) | 0 (no stderr) | **0.5** (max of the cap) |
  | 1 | 1 (all stderr) | **0.2** |
  | 0 (all fail) | 0 | **0.3** |
  | 0 | 1 | **0** (min) |

- Each case uses `closeTo(exact, 1e-9)` — any drift in the weights,
  the `realHarnessRate` condition, or the arithmetic shifts one of
  the four to a wrong exact value and fails with a readable diff.
  That's tighter coverage than random exploration could produce.
- `fast-check` is a ~200KB transitive surface for no net gain. Given
  the active focus on supply-chain security, the call was to keep
  the dep tree narrow.

## Verification

- `npm run typecheck` — exit=0
- `npm run lint` — 0 errors, 206 pre-existing warnings
- `npm run build` — exit=0
- `npm test -- --grep "computeHeuristic"` — 10/10 passing
- `npm test` (full suite) — 6576 passing, 0 failing (up from 6566
  pre-branch; +10 heuristic tests)
- `git diff package.json` — 0 lines (no new dependency)

## Acceptance criteria

- [x] `src/agent/core/domain/harness/heuristic.ts` exports
      `computeHeuristic(outcomes, now): number | null`
- [x] Function is pure — no `Date`, `process.hrtime`, no time
      dependency beyond the passed `now`
- [x] `test/unit/agent/harness/heuristic.test.ts` covers every case
      enumerated in the task doc — min-sample floor (n=0, n=9),
      at-floor sanity, window cap, decay, four pass-through corners,
      future-timestamp clamp
- [x] No new runtime or devDependency
- [x] typecheck / lint / test / build all clean

## Notes for reviewers

- **The formula is load-bearing.** Every mode transition and every
  refinement accept/reject decision flows through this function.
  Review the math carefully — the four pass-through corner tests are
  the regression guard.
- **Design-doc update.** `features/autoharness-v2/analysis/v1-design-decisions.md §2.1`
  formula row now matches the shipped weights. If any downstream
  planning doc cached the old `[0.5, 0.3, 0.2]` weights, the fix
  hasn't rippled there yet.
- **Task doc updated** to record why `fast-check` was considered and
  rejected, so future contributors don't re-propose it without
  reading the trade-off.

## Related

- Task doc: `features/autoharness-v2/tasks/phase_0/task_06-heuristic-helper.md`
- Execution plan: `features/autoharness-v2/execution-plan.md § Phase 0 Task 0.6`
- Numeric parameters: `features/autoharness-v2/analysis/v1-design-decisions.md §2.1`
- Brutal-review items closed: A1 (time dimension), A2 (pass-through cap)
- Consumers: Phase 5 (mode selector), Phase 6 (evaluator)
- Reference pattern: `src/server/core/domain/knowledge/memory-scoring.ts`
- Previous: ENG-2223 (Phase 0 Task 0.5 — pre-flight wiring)
- Next: Phase 1 — `HarnessStore` implementation
