### PR TITLE
feat: jump from open projects to their remote space

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@ai-sdk/xai": "^2.0.57",
         "@anthropic-ai/sdk": "^0.70.1",
         "@campfirein/brv-transport-client": "github:campfirein/brv-transport-client#1.0.0",
-        "@campfirein/byterover-packages": "github:campfirein/byterover-packages#main",
+        "@campfirein/byterover-packages": "github:campfirein/byterover-packages#1.0.0",
         "@google/genai": "^1.29.0",
         "@inkjs/ui": "^2.0.0",
         "@inquirer/prompts": "^7.9.0",
@@ -3335,7 +3335,7 @@
     },
     "node_modules/@campfirein/byterover-packages": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/campfirein/byterover-packages.git#3d52e818611784f6ccad4f683153cccfb1ce0519",
+      "resolved": "git+ssh://git@github.com/campfirein/byterover-packages.git#32a38ed107bd38e1e5dff4a9dc29a95935191c3e",
       "inBundle": true,
       "dependencies": {
         "@base-ui/react": "^1.3.0",
@@ -5889,7 +5889,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5910,7 +5909,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5931,7 +5929,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5952,7 +5949,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5973,7 +5969,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5994,7 +5989,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6015,7 +6009,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6036,7 +6029,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6057,7 +6049,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6078,7 +6069,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6099,7 +6089,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@ai-sdk/xai": "^2.0.57",
     "@anthropic-ai/sdk": "^0.70.1",
     "@campfirein/brv-transport-client": "github:campfirein/brv-transport-client#1.0.0",
-    "@campfirein/byterover-packages": "github:campfirein/byterover-packages#main",
+    "@campfirein/byterover-packages": "github:campfirein/byterover-packages#1.0.0",
     "@google/genai": "^1.29.0",
     "@inkjs/ui": "^2.0.0",
     "@inquirer/prompts": "^7.9.0",

--- a/src/webui/features/config/api/get-environment-config.ts
+++ b/src/webui/features/config/api/get-environment-config.ts
@@ -1,0 +1,27 @@
+import {queryOptions, useQuery} from '@tanstack/react-query'
+
+import type {QueryConfig} from '../../../lib/react-query'
+
+import {ConfigEvents, type ConfigGetEnvironmentResponse} from '../../../../shared/transport/events'
+import {useTransportStore} from '../../../stores/transport-store'
+
+export const getEnvironmentConfig = (): Promise<ConfigGetEnvironmentResponse> => {
+  const {apiClient} = useTransportStore.getState()
+  if (!apiClient) return Promise.reject(new Error('Not connected'))
+
+  return apiClient.request(ConfigEvents.GET_ENVIRONMENT)
+}
+
+export const getEnvironmentConfigQueryOptions = () =>
+  queryOptions({
+    queryFn: getEnvironmentConfig,
+    queryKey: ['config', 'environment'],
+    staleTime: Infinity,
+  })
+
+type UseGetEnvironmentConfigOptions = {
+  queryConfig?: QueryConfig<typeof getEnvironmentConfigQueryOptions>
+}
+
+export const useGetEnvironmentConfig = ({queryConfig}: UseGetEnvironmentConfigOptions = {}) =>
+  useQuery({...getEnvironmentConfigQueryOptions(), ...queryConfig})

--- a/src/webui/features/project/components/project-dropdown.tsx
+++ b/src/webui/features/project/components/project-dropdown.tsx
@@ -15,15 +15,20 @@ import {
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '@campfirein/byterover-packages/components/dropdown-menu'
-import {ChevronDown, FolderOpen, Link2} from 'lucide-react'
+import {ArrowRightLeft, ChevronDown, FolderOpen, SquareArrowOutUpRight} from 'lucide-react'
 import {useMemo, useState} from 'react'
 
 import {ProjectLocationDTO} from '../../../../shared/transport/events'
 import {useTransportStore} from '../../../stores/transport-store'
+import {useGetEnvironmentConfig} from '../../config/api/get-environment-config'
 import {useGetProjectConfig} from '../api/get-project-config'
 import {useGetProjectList} from '../api/get-project-list'
+import {buildRemoteSpaceUrl} from '../utils/build-remote-space-url'
 import {displayPath} from '../utils/display-path'
 import {getProjectName} from '../utils/project-name'
 import {AllProjectsDialog} from './all-projects-dialog'
@@ -41,6 +46,32 @@ type ProjectItemProps = {
   showRemote?: boolean
 }
 
+type ProjectItemRowProps = {
+  name: string
+  project: ProjectLocationDTO
+  remoteLabel?: string
+}
+
+function ProjectItemRow({name, project, remoteLabel}: ProjectItemRowProps) {
+  return (
+    <>
+      <ProjectAvatar name={name} seed={project.projectPath} />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <span className="truncate text-sm font-medium leading-5 text-card-foreground!">{name}</span>
+        <span className="truncate text-xs leading-4 text-muted-foreground!">{displayPath(project.projectPath)}</span>
+        {remoteLabel && (
+          <span className="text-muted-foreground! mono flex items-start gap-1 text-[10px] leading-4">
+            <span className="min-w-0 wrap-break-word">
+              <span>Remote space: </span>
+              <span className="text-primary-foreground! font-medium">{remoteLabel}</span>
+            </span>
+          </span>
+        )}
+      </div>
+    </>
+  )
+}
+
 function ProjectItem({onSelect, project, showRemote = false}: ProjectItemProps) {
   const name = getProjectName(project.projectPath)
   const {data: projectConfig} = useGetProjectConfig({
@@ -53,21 +84,47 @@ function ProjectItem({onSelect, project, showRemote = false}: ProjectItemProps) 
 
   return (
     <DropdownMenuItem className="gap-2 rounded-md" onClick={onSelect}>
-      <ProjectAvatar name={name} seed={project.projectPath} />
-      <div className="flex min-w-0 flex-1 flex-col">
-        <span className="truncate text-sm font-medium leading-5 text-card-foreground!">{name}</span>
-        <span className="truncate text-xs leading-4 text-muted-foreground!">{displayPath(project.projectPath)}</span>
-        {remoteLabel && (
-          <span className="text-muted-foreground! mono flex items-start gap-1 text-[10px] leading-4">
-            <Link2 className="mt-0.5 size-2.5 shrink-0" />
-            <span className="min-w-0 wrap-break-word">
-              <span>Remote space: </span>
-              <span className="text-primary-foreground! font-medium">{remoteLabel}</span>
-            </span>
-          </span>
-        )}
-      </div>
+      <ProjectItemRow name={name} project={project} remoteLabel={remoteLabel} />
     </DropdownMenuItem>
+  )
+}
+
+type OpenProjectItemProps = {
+  isSelected: boolean
+  onSelect: () => void
+  project: ProjectLocationDTO
+}
+
+function OpenProjectItem({isSelected, onSelect, project}: OpenProjectItemProps) {
+  const name = getProjectName(project.projectPath)
+  const {data: projectConfig} = useGetProjectConfig({projectPath: project.projectPath})
+  const {data: envConfig} = useGetEnvironmentConfig()
+  const teamName = projectConfig?.brvConfig?.teamName
+  const spaceName = projectConfig?.brvConfig?.spaceName
+  const remoteLabel = teamName && spaceName ? `${teamName} / ${spaceName}` : undefined
+  const remoteSpaceUrl = buildRemoteSpaceUrl({spaceName, teamName, webAppUrl: envConfig?.webAppUrl})
+
+  return (
+    <DropdownMenuSub>
+      <DropdownMenuSubTrigger className="gap-2 rounded-md">
+        <ProjectItemRow name={name} project={project} remoteLabel={remoteLabel} />
+      </DropdownMenuSubTrigger>
+      <DropdownMenuSubContent className="min-w-56">
+        <DropdownMenuItem disabled={isSelected} onClick={onSelect}>
+          <ArrowRightLeft className="size-4" />
+          <span className="text-sm">{isSelected ? 'Current project' : 'Switch to this project'}</span>
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          disabled={!remoteSpaceUrl}
+          onClick={() => {
+            if (remoteSpaceUrl) window.open(remoteSpaceUrl, '_blank', 'noopener,noreferrer')
+          }}
+        >
+          <SquareArrowOutUpRight className="size-4" />
+          <span className="text-sm">Open Remote space</span>
+        </DropdownMenuItem>
+      </DropdownMenuSubContent>
+    </DropdownMenuSub>
   )
 }
 
@@ -124,7 +181,12 @@ export function ProjectDropdown() {
             <DropdownMenuGroup>
               <DropdownMenuLabel>Open Projects</DropdownMenuLabel>
               {openProjects.map((p) => (
-                <ProjectItem key={p.projectPath} onSelect={() => handleSelect(p)} project={p} showRemote />
+                <OpenProjectItem
+                  isSelected={p.projectPath === selectedProject}
+                  key={p.projectPath}
+                  onSelect={() => handleSelect(p)}
+                  project={p}
+                />
               ))}
 
               <DropdownMenuSeparator />

--- a/src/webui/features/project/components/project-dropdown.tsx
+++ b/src/webui/features/project/components/project-dropdown.tsx
@@ -93,16 +93,16 @@ type OpenProjectItemProps = {
   isSelected: boolean
   onSelect: () => void
   project: ProjectLocationDTO
+  webAppUrl: string | undefined
 }
 
-function OpenProjectItem({isSelected, onSelect, project}: OpenProjectItemProps) {
+function OpenProjectItem({isSelected, onSelect, project, webAppUrl}: OpenProjectItemProps) {
   const name = getProjectName(project.projectPath)
   const {data: projectConfig} = useGetProjectConfig({projectPath: project.projectPath})
-  const {data: envConfig} = useGetEnvironmentConfig()
   const teamName = projectConfig?.brvConfig?.teamName
   const spaceName = projectConfig?.brvConfig?.spaceName
   const remoteLabel = teamName && spaceName ? `${teamName} / ${spaceName}` : undefined
-  const remoteSpaceUrl = buildRemoteSpaceUrl({spaceName, teamName, webAppUrl: envConfig?.webAppUrl})
+  const remoteSpaceUrl = buildRemoteSpaceUrl({spaceName, teamName, webAppUrl})
 
   return (
     <DropdownMenuSub>
@@ -138,6 +138,7 @@ export function ProjectDropdown() {
       staleTime: 30 * 1000,
     },
   })
+  const {data: envConfig} = useGetEnvironmentConfig()
 
   const projects = useMemo(() => projResp?.locations ?? [], [projResp])
   const {openProjects, recentProjects} = useMemo(() => {
@@ -186,6 +187,7 @@ export function ProjectDropdown() {
                   key={p.projectPath}
                   onSelect={() => handleSelect(p)}
                   project={p}
+                  webAppUrl={envConfig?.webAppUrl}
                 />
               ))}
 

--- a/src/webui/features/project/utils/build-remote-space-url.ts
+++ b/src/webui/features/project/utils/build-remote-space-url.ts
@@ -1,0 +1,11 @@
+type BuildRemoteSpaceUrlInput = {
+  spaceName: string | undefined
+  teamName: string | undefined
+  webAppUrl: string | undefined
+}
+
+export function buildRemoteSpaceUrl({spaceName, teamName, webAppUrl}: BuildRemoteSpaceUrlInput): string | undefined {
+  if (!teamName || !spaceName || !webAppUrl) return undefined
+  const base = webAppUrl.replace(/\/+$/, '')
+  return `${base}/${encodeURIComponent(teamName)}/${encodeURIComponent(spaceName)}`
+}

--- a/test/unit/webui/features/project/utils/build-remote-space-url.test.ts
+++ b/test/unit/webui/features/project/utils/build-remote-space-url.test.ts
@@ -1,0 +1,49 @@
+import {expect} from 'chai'
+
+import {buildRemoteSpaceUrl} from '../../../../../../src/webui/features/project/utils/build-remote-space-url'
+
+describe('buildRemoteSpaceUrl', () => {
+  it('returns the webApp URL for a linked team and space', () => {
+    expect(
+      buildRemoteSpaceUrl({spaceName: 'payments', teamName: 'acme', webAppUrl: 'https://app.byterover.dev'}),
+    ).to.equal('https://app.byterover.dev/acme/payments')
+  })
+
+  it('strips a trailing slash from the base URL', () => {
+    expect(
+      buildRemoteSpaceUrl({spaceName: 'payments', teamName: 'acme', webAppUrl: 'https://app.byterover.dev/'}),
+    ).to.equal('https://app.byterover.dev/acme/payments')
+  })
+
+  it('returns undefined when the base URL is missing', () => {
+    expect(buildRemoteSpaceUrl({spaceName: 'payments', teamName: 'acme', webAppUrl: undefined})).to.equal(undefined)
+    expect(buildRemoteSpaceUrl({spaceName: 'payments', teamName: 'acme', webAppUrl: ''})).to.equal(undefined)
+  })
+
+  it('returns undefined when the team name is missing', () => {
+    expect(
+      buildRemoteSpaceUrl({spaceName: 'payments', teamName: undefined, webAppUrl: 'https://app.byterover.dev'}),
+    ).to.equal(undefined)
+  })
+
+  it('returns undefined when the space name is missing', () => {
+    expect(
+      buildRemoteSpaceUrl({spaceName: undefined, teamName: 'acme', webAppUrl: 'https://app.byterover.dev'}),
+    ).to.equal(undefined)
+  })
+
+  it('returns undefined when either name is an empty string', () => {
+    expect(buildRemoteSpaceUrl({spaceName: '', teamName: 'acme', webAppUrl: 'https://app.byterover.dev'})).to.equal(
+      undefined,
+    )
+    expect(buildRemoteSpaceUrl({spaceName: 'payments', teamName: '', webAppUrl: 'https://app.byterover.dev'})).to.equal(
+      undefined,
+    )
+  })
+
+  it('percent-encodes names that contain reserved URL characters', () => {
+    expect(
+      buildRemoteSpaceUrl({spaceName: 'my space', teamName: 'acme/ops', webAppUrl: 'https://app.byterover.dev'}),
+    ).to.equal('https://app.byterover.dev/acme%2Fops/my%20space')
+  })
+})


### PR DESCRIPTION
Open Projects items now reveal a submenu with 'Switch to this project' and 'Open Remote space'. The remote link is built from BRV_WEB_APP_URL (surfaced to the webui through config:getEnvironment) so dev, beta, and prod all point at the right host.