### PR TITLE
feat: [ENG-2226] AutoHarness V2 HarnessStore — version CRUD

### DIFF
--- a/src/agent/infra/harness/harness-store.ts
+++ b/src/agent/infra/harness/harness-store.ts
@@ -1,0 +1,245 @@
+/**
+ * AutoHarness V2 storage — `IKeyStorage`-backed implementation.
+ *
+ * Facade over `IKeyStorage` that partitions harness versions, outcomes,
+ * and scenarios under composite key prefixes. This file ships the
+ * version CRUD (Phase 1 Task 1.2); outcome and scenario CRUD land in
+ * Task 1.3 — those methods are `throw 'not implemented yet'` stubs
+ * here so the class satisfies the interface and stays compile-valid
+ * mid-phase.
+ *
+ * Key-space layout (see `tasks/phase_1_2_handoff.md §C4`):
+ *   ["harness", "version",  projectId, commandType, versionId]
+ *   ["harness", "outcome",  projectType, projectId, commandType, outcomeId]   (Task 1.3)
+ *   ["harness", "scenario", projectType, projectId, commandType, scenarioId]  (Task 1.3)
+ *
+ * `HarnessVersion` bodies are inlined in the key record — typical
+ * harness code is <10KB. If that ceiling moves, swap the code field to
+ * an `IBlobStorage` reference; consumers see no interface change.
+ *
+ * Atomicity per-key comes from `IKeyStorage.update`'s RWLock within a
+ * process; cross-key writes are not atomic. Single-writer flows
+ * (bootstrap v1, refinement serialized per (projectId, commandType))
+ * make that sufficient for v1.0 — see the `IHarnessStore` module header.
+ */
+
+import type {
+  CodeExecOutcome,
+  EvaluationScenario,
+  HarnessVersion,
+} from '../../core/domain/harness/types.js'
+import type {IHarnessStore} from '../../core/interfaces/i-harness-store.js'
+import type {BatchOperation, IKeyStorage, StorageKey} from '../../core/interfaces/i-key-storage.js'
+import type {ILogger} from '../../core/interfaces/i-logger.js'
+
+import {HarnessStoreError} from '../../core/domain/errors/harness-store-error.js'
+import {HarnessVersionSchema} from '../../core/domain/harness/types.js'
+
+const HARNESS_PREFIX = 'harness'
+const VERSION_PREFIX = 'version'
+
+const TASK_1_3_PENDING =
+  'Not implemented — HarnessStore: outcome/scenario CRUD lands in Phase 1 Task 1.3'
+
+export class HarnessStore implements IHarnessStore {
+  constructor(
+    private readonly keyStorage: IKeyStorage,
+    private readonly logger: ILogger,
+  ) {}
+
+  // ── outcomes (Task 1.3 stubs) ──────────────────────────────────────────────
+
+  async deleteOutcomes(_projectId: string, _commandType: string): Promise<number> {
+    throw new Error(TASK_1_3_PENDING)
+  }
+
+  // ── versions ───────────────────────────────────────────────────────────────
+
+  async getLatest(projectId: string, commandType: string): Promise<HarnessVersion | undefined> {
+    // Delegate to `listVersions` rather than re-deriving the "max version"
+    // comparator — a future change to the sort key can't silently break
+    // `getLatest`. The O(n log n) sort is negligible at v1.0 scale
+    // (`maxVersions` default 20).
+    const sorted = await this.listVersions(projectId, commandType)
+    return sorted[0]
+  }
+
+  async getVersion(
+    projectId: string,
+    commandType: string,
+    versionId: string,
+  ): Promise<HarnessVersion | undefined> {
+    return this.keyStorage.get<HarnessVersion>(this.versionKey(projectId, commandType, versionId))
+  }
+
+  async listOutcomes(
+    _projectId: string,
+    _commandType: string,
+    _limit?: number,
+  ): Promise<CodeExecOutcome[]> {
+    throw new Error(TASK_1_3_PENDING)
+  }
+
+  async listScenarios(_projectId: string, _commandType: string): Promise<EvaluationScenario[]> {
+    throw new Error(TASK_1_3_PENDING)
+  }
+
+  async listVersions(projectId: string, commandType: string): Promise<HarnessVersion[]> {
+    const versions = await this.listVersionsForPair(projectId, commandType)
+    return [...versions].sort((a, b) => b.version - a.version)
+  }
+
+  /**
+   * Preservation policy:
+   *   1. Latest (highest `version`) is always kept.
+   *   2. Best-heuristic version AND its parent chain (up to the root) are
+   *      kept, so refinement history stays traceable.
+   *   3. Remaining versions are dropped oldest-first until at most `keep`
+   *      versions remain — OR until only preserved versions remain,
+   *      whichever hits first. If preservation demands more than `keep`,
+   *      the preserved set wins (matches the Phase 1 Task 1.2 test doc's
+   *      test #12 semantics).
+   */
+  async pruneOldVersions(
+    projectId: string,
+    commandType: string,
+    keep: number,
+  ): Promise<number> {
+    // Precondition: `keep` is a non-negative integer. Defensive validation
+    // at this interface boundary catches caller bugs (e.g. a future CLI
+    // passing `--keep -1`) with an immediate, clear error rather than a
+    // silent "all non-preserved candidates deleted" behavior.
+    if (!Number.isInteger(keep) || keep < 0) {
+      throw new RangeError(`pruneOldVersions: keep must be a non-negative integer, got ${keep}`)
+    }
+
+    const versions = await this.listVersionsForPair(projectId, commandType)
+    if (versions.length <= keep) return 0
+
+    const preserved = new Set<string>()
+    const byId = new Map(versions.map((v) => [v.id, v]))
+
+    let latest = versions[0]
+    let bestH = versions[0]
+    for (const v of versions) {
+      if (v.version > latest.version) latest = v
+      if (v.heuristic > bestH.heuristic) bestH = v
+    }
+
+    preserved.add(latest.id)
+    preserved.add(bestH.id)
+
+    // Walk parent chain of best-H. Break on missing parent (dangling)
+    // OR on an already-preserved id (defensive cycle guard).
+    let cursor: HarnessVersion | undefined = bestH
+    while (cursor?.parentId !== undefined) {
+      const parent = byId.get(cursor.parentId)
+      if (!parent) break
+      if (preserved.has(parent.id)) break
+      preserved.add(parent.id)
+      cursor = parent
+    }
+
+    const candidates = versions
+      .filter((v) => !preserved.has(v.id))
+      .sort((a, b) => a.version - b.version)
+
+    const deleteCount = Math.min(candidates.length, versions.length - keep)
+    if (deleteCount <= 0) return 0
+
+    const toDelete = candidates.slice(0, deleteCount)
+    const operations: BatchOperation[] = toDelete.map((v) => ({
+      key: this.versionKey(v.projectId, v.commandType, v.id),
+      type: 'delete' as const,
+    }))
+
+    await this.keyStorage.batch(operations)
+    this.logger.debug('HarnessStore.pruneOldVersions deleted entries', {
+      commandType,
+      deleted: toDelete.length,
+      projectId,
+    })
+
+    return toDelete.length
+  }
+
+  async recordFeedback(
+    _projectId: string,
+    _commandType: string,
+    _outcomeId: string,
+    _verdict: 'bad' | 'good' | null,
+  ): Promise<void> {
+    throw new Error(TASK_1_3_PENDING)
+  }
+
+  async saveOutcome(_outcome: CodeExecOutcome): Promise<void> {
+    throw new Error(TASK_1_3_PENDING)
+  }
+
+  async saveScenario(_scenario: EvaluationScenario): Promise<void> {
+    throw new Error(TASK_1_3_PENDING)
+  }
+
+  async saveVersion(version: HarnessVersion): Promise<void> {
+    const parsed = HarnessVersionSchema.parse(version)
+    const key = this.versionKey(parsed.projectId, parsed.commandType, parsed.id)
+
+    // NOTE: this sibling-version-number check is racy across concurrent
+    // `saveVersion` calls with the SAME `(projectId, commandType, version)`
+    // tuple but DIFFERENT ids — closing that window would require a
+    // cross-key lock. Accepted for v1.0 because Phase 6's refinement
+    // queue serializes writes per `(projectId, commandType)`; if that
+    // assumption breaks, introduce a per-pair mutex.
+    const siblings = await this.listVersionsForPair(parsed.projectId, parsed.commandType)
+    const clash = siblings.find((v) => v.version === parsed.version)
+    if (clash !== undefined) {
+      throw HarnessStoreError.versionConflict(parsed.projectId, parsed.commandType, {
+        version: parsed.version,
+      })
+    }
+
+    // Id-uniqueness check is closed atomically via `update` — the read,
+    // updater evaluation, and write all happen under the same per-key
+    // RWLock, so concurrent saves with the same id can't both succeed.
+    //
+    // `FileKeyStorage.update` rewraps thrown errors as plain `Error`,
+    // discarding the typed `HarnessStoreError` class. To preserve the
+    // caller-facing error type, we signal the conflict via a closure
+    // flag instead — the updater returns the existing value unchanged
+    // (effective no-op write), and we throw the typed error once
+    // `update` resolves normally.
+    let idConflict = false
+    await this.keyStorage.update<HarnessVersion | undefined>(key, (existing) => {
+      if (existing !== undefined) {
+        idConflict = true
+        return existing
+      }
+
+      return parsed
+    })
+    if (idConflict) {
+      throw HarnessStoreError.versionConflict(parsed.projectId, parsed.commandType, {
+        id: parsed.id,
+      })
+    }
+  }
+
+  // ── internals ──────────────────────────────────────────────────────────────
+
+  private async listVersionsForPair(
+    projectId: string,
+    commandType: string,
+  ): Promise<HarnessVersion[]> {
+    const entries = await this.keyStorage.listWithValues<HarnessVersion>([
+      HARNESS_PREFIX,
+      VERSION_PREFIX,
+      projectId,
+      commandType,
+    ])
+    return entries.map((e) => e.value)
+  }
+
+  private versionKey(projectId: string, commandType: string, versionId: string): StorageKey {
+    return [HARNESS_PREFIX, VERSION_PREFIX, projectId, commandType, versionId]
+  }
+}

--- a/test/unit/agent/harness/harness-store-versions.test.ts
+++ b/test/unit/agent/harness/harness-store-versions.test.ts
@@ -1,0 +1,276 @@
+import {expect} from 'chai'
+import {ZodError} from 'zod'
+
+import type {HarnessVersion} from '../../../../src/agent/core/domain/harness/types.js'
+
+import {
+  HarnessStoreError,
+  HarnessStoreErrorCode,
+} from '../../../../src/agent/core/domain/errors/harness-store-error.js'
+import {NoOpLogger} from '../../../../src/agent/core/interfaces/i-logger.js'
+import {HarnessStore} from '../../../../src/agent/infra/harness/harness-store.js'
+import {FileKeyStorage} from '../../../../src/agent/infra/storage/file-key-storage.js'
+
+function makeVersion(overrides: Partial<HarnessVersion> = {}): HarnessVersion {
+  return {
+    code: 'function meta(){return {}}',
+    commandType: 'curate',
+    createdAt: 1_700_000_000_000,
+    heuristic: 0.5,
+    id: 'v-default',
+    metadata: {
+      capabilities: ['curate'],
+      commandType: 'curate',
+      projectPatterns: [],
+      version: 1,
+    },
+    projectId: 'p',
+    projectType: 'typescript',
+    version: 1,
+    ...overrides,
+  }
+}
+
+async function newStore(): Promise<HarnessStore> {
+  const keyStorage = new FileKeyStorage({inMemory: true})
+  await keyStorage.initialize()
+  return new HarnessStore(keyStorage, new NoOpLogger())
+}
+
+describe('HarnessStore — version CRUD', () => {
+  // ── Round-trip ────────────────────────────────────────────────────────────
+
+  it('saveVersion + getVersion round-trips an entry', async () => {
+    const store = await newStore()
+    const v = makeVersion({id: 'v1', version: 1})
+    await store.saveVersion(v)
+
+    const fetched = await store.getVersion('p', 'curate', 'v1')
+    expect(fetched).to.deep.equal(v)
+  })
+
+  it('saveVersion + getLatest returns the just-saved entry when it is the only one', async () => {
+    const store = await newStore()
+    const v = makeVersion({id: 'v1', version: 1})
+    await store.saveVersion(v)
+
+    const latest = await store.getLatest('p', 'curate')
+    expect(latest).to.deep.equal(v)
+  })
+
+  it('getLatest returns the entry with the highest version number among multiple entries', async () => {
+    const store = await newStore()
+    await store.saveVersion(makeVersion({id: 'v1', version: 1}))
+    await store.saveVersion(makeVersion({id: 'v2', version: 2}))
+    await store.saveVersion(makeVersion({id: 'v3', version: 3}))
+
+    const latest = await store.getLatest('p', 'curate')
+    expect(latest?.version).to.equal(3)
+    expect(latest?.id).to.equal('v3')
+  })
+
+  it('listVersions returns newest-first on three entries with different version numbers', async () => {
+    const store = await newStore()
+    await store.saveVersion(makeVersion({id: 'v1', version: 1}))
+    await store.saveVersion(makeVersion({id: 'v2', version: 2}))
+    await store.saveVersion(makeVersion({id: 'v3', version: 3}))
+
+    const list = await store.listVersions('p', 'curate')
+    expect(list.map((v) => v.version)).to.deep.equal([3, 2, 1])
+  })
+
+  // ── Conflict detection ────────────────────────────────────────────────────
+
+  it('saveVersion twice with the same id throws VERSION_CONFLICT with details.id', async () => {
+    const store = await newStore()
+    await store.saveVersion(makeVersion({id: 'v1', version: 1}))
+
+    try {
+      await store.saveVersion(makeVersion({id: 'v1', version: 2}))
+      expect.fail('expected throw')
+    } catch (error) {
+      expect(HarnessStoreError.isCode(error, HarnessStoreErrorCode.VERSION_CONFLICT)).to.equal(true)
+      if (!HarnessStoreError.isHarnessStoreError(error)) expect.fail('not a HarnessStoreError')
+      expect(error.details?.id).to.equal('v1')
+    }
+  })
+
+  it('saveVersion twice with the same (projectId, commandType, version) throws with details.version', async () => {
+    const store = await newStore()
+    await store.saveVersion(makeVersion({id: 'v1', version: 1}))
+
+    try {
+      await store.saveVersion(makeVersion({id: 'v2', version: 1}))
+      expect.fail('expected throw')
+    } catch (error) {
+      expect(HarnessStoreError.isCode(error, HarnessStoreErrorCode.VERSION_CONFLICT)).to.equal(true)
+      if (!HarnessStoreError.isHarnessStoreError(error)) expect.fail('not a HarnessStoreError')
+      expect(error.details?.version).to.equal(1)
+    }
+  })
+
+  // ── Validation ────────────────────────────────────────────────────────────
+
+  it('saveVersion with malformed input (empty code) throws ZodError', async () => {
+    const store = await newStore()
+    try {
+      await store.saveVersion(makeVersion({code: '', id: 'v1'}))
+      expect.fail('expected throw')
+    } catch (error) {
+      expect(error).to.be.instanceOf(ZodError)
+    }
+  })
+
+  it('saveVersion with malformed input (heuristic > 1) throws ZodError', async () => {
+    const store = await newStore()
+    try {
+      await store.saveVersion(makeVersion({heuristic: 1.5, id: 'v1'}))
+      expect.fail('expected throw')
+    } catch (error) {
+      expect(error).to.be.instanceOf(ZodError)
+    }
+  })
+
+  // ── Empty-store semantics ─────────────────────────────────────────────────
+
+  it('getVersion on a missing id returns undefined', async () => {
+    const store = await newStore()
+    expect(await store.getVersion('p', 'curate', 'does-not-exist')).to.equal(undefined)
+  })
+
+  it('getLatest on an empty store returns undefined', async () => {
+    const store = await newStore()
+    expect(await store.getLatest('p', 'curate')).to.equal(undefined)
+  })
+
+  it('listVersions on an empty store returns an empty array', async () => {
+    const store = await newStore()
+    expect(await store.listVersions('p', 'curate')).to.deep.equal([])
+  })
+
+  // ── Pruning ───────────────────────────────────────────────────────────────
+
+  it('pruneOldVersions(..., 2) on 5 versions keeps latest + best-H and returns 3', async () => {
+    const store = await newStore()
+    // v1..v5 with heuristics: v1=0.1, v2=0.2, v3=0.9 (best), v4=0.4, v5=0.5
+    // Latest is v5 (version 5). Best-H is v3.
+    // Preserved: {v5, v3}. Candidates oldest-first: [v1, v2, v4]. Delete 3.
+    await store.saveVersion(makeVersion({heuristic: 0.1, id: 'v1', version: 1}))
+    await store.saveVersion(makeVersion({heuristic: 0.2, id: 'v2', version: 2}))
+    await store.saveVersion(makeVersion({heuristic: 0.9, id: 'v3', version: 3}))
+    await store.saveVersion(makeVersion({heuristic: 0.4, id: 'v4', version: 4}))
+    await store.saveVersion(makeVersion({heuristic: 0.5, id: 'v5', version: 5}))
+
+    const deleted = await store.pruneOldVersions('p', 'curate', 2)
+    expect(deleted).to.equal(3)
+
+    const remaining = await store.listVersions('p', 'curate')
+    expect(remaining.map((v) => v.id).sort()).to.deep.equal(['v3', 'v5'])
+  })
+
+  it('pruneOldVersions preserves the parent chain of the best-H version', async () => {
+    const store = await newStore()
+    // v1 (root), v2 parent=v1, v3 parent=v2 (best-H, 0.9), v4 (no chain), v5 (latest).
+    // Preserved: {v5 (latest), v3 (best-H), v2 (v3's parent), v1 (v2's parent)} = 4 items.
+    // keep = 3 → want 3, but preservation demands 4 → preservation wins.
+    // Candidates not in preserved: [v4]. Delete 1.
+    await store.saveVersion(makeVersion({heuristic: 0.1, id: 'v1', version: 1}))
+    await store.saveVersion(makeVersion({heuristic: 0.2, id: 'v2', parentId: 'v1', version: 2}))
+    await store.saveVersion(makeVersion({heuristic: 0.9, id: 'v3', parentId: 'v2', version: 3}))
+    await store.saveVersion(makeVersion({heuristic: 0.3, id: 'v4', version: 4}))
+    await store.saveVersion(makeVersion({heuristic: 0.5, id: 'v5', version: 5}))
+
+    const deleted = await store.pruneOldVersions('p', 'curate', 3)
+    expect(deleted).to.equal(1)
+
+    const remaining = await store.listVersions('p', 'curate')
+    expect(remaining.map((v) => v.id).sort()).to.deep.equal(['v1', 'v2', 'v3', 'v5'])
+  })
+
+  it('pruneOldVersions with keep >= count returns 0', async () => {
+    const store = await newStore()
+    await store.saveVersion(makeVersion({id: 'v1', version: 1}))
+    await store.saveVersion(makeVersion({id: 'v2', version: 2}))
+
+    expect(await store.pruneOldVersions('p', 'curate', 5)).to.equal(0)
+    expect(await store.pruneOldVersions('p', 'curate', 2)).to.equal(0)
+  })
+
+  it('pruneOldVersions with keep=0 still preserves latest and best-H (preservation wins over keep)', async () => {
+    const store = await newStore()
+    await store.saveVersion(makeVersion({id: 'v1', version: 1}))
+
+    // Single version is both latest and best-H; preservation set has
+    // size 1, which exceeds keep=0. Preservation wins → 0 deletions.
+    expect(await store.pruneOldVersions('p', 'curate', 0)).to.equal(0)
+    expect(await store.listVersions('p', 'curate')).to.have.lengthOf(1)
+  })
+
+  it('pruneOldVersions with negative keep throws RangeError', async () => {
+    const store = await newStore()
+    await store.saveVersion(makeVersion({id: 'v1', version: 1}))
+
+    try {
+      await store.pruneOldVersions('p', 'curate', -1)
+      expect.fail('expected throw')
+    } catch (error) {
+      expect(error).to.be.instanceOf(RangeError)
+    }
+  })
+
+  it('pruneOldVersions with non-integer keep throws RangeError', async () => {
+    const store = await newStore()
+    await store.saveVersion(makeVersion({id: 'v1', version: 1}))
+
+    try {
+      await store.pruneOldVersions('p', 'curate', 2.5)
+      expect.fail('expected throw')
+    } catch (error) {
+      expect(error).to.be.instanceOf(RangeError)
+    }
+  })
+
+  // ── Concurrency ───────────────────────────────────────────────────────────
+
+  it('100 parallel saveVersion calls on distinct (id, version) tuples all persist', async () => {
+    const store = await newStore()
+    const saves = Array.from({length: 100}, (_, i) =>
+      store.saveVersion(makeVersion({id: `v${i}`, version: i + 1})),
+    )
+    await Promise.all(saves)
+
+    const list = await store.listVersions('p', 'curate')
+    expect(list).to.have.lengthOf(100)
+  })
+
+  it('seeded version + 100 parallels (99 unique, 1 clash on seed id) yields exactly one throw', async () => {
+    const store = await newStore()
+    // Seed with v-seed so the conflicting call below has something to clash against.
+    await store.saveVersion(makeVersion({id: 'v-seed', version: 1000}))
+
+    const attempts = Array.from({length: 100}, (_, i) => {
+      if (i === 0) {
+        // The one intentional clash — same id as the seed.
+        return store.saveVersion(makeVersion({id: 'v-seed', version: 2000}))
+      }
+
+      return store.saveVersion(makeVersion({id: `v-${i}`, version: i}))
+    })
+
+    const results = await Promise.allSettled(attempts)
+    const rejected = results.filter((r) => r.status === 'rejected')
+    const fulfilled = results.filter((r) => r.status === 'fulfilled')
+
+    expect(rejected).to.have.lengthOf(1)
+    expect(fulfilled).to.have.lengthOf(99)
+    expect(
+      HarnessStoreError.isCode(
+        (rejected[0] as PromiseRejectedResult).reason,
+        HarnessStoreErrorCode.VERSION_CONFLICT,
+      ),
+    ).to.equal(true)
+
+    const list = await store.listVersions('p', 'curate')
+    expect(list).to.have.lengthOf(100) // seed + 99 unique
+  })
+})


### PR DESCRIPTION
## Summary

- Problem: AutoHarness V2 needs a concrete `IHarnessStore` before any downstream phase (Phase 2 outcome recorder, Phase 3 module builder, Phase 5 mode selector, Phase 7 `brv harness *`) can persist learned versions to disk. ENG-2222 shipped the interface; this PR ships the first half of the implementation.
- Why it matters: Phase 1 is on the critical path for the eventual Internal-Dogfood ship. Phase 2 Task 2.5 (integration test) can only go green once Phase 1 is fully merged to `proj/autoharness-v2`.
- What changed: New `HarnessStore` class under `src/agent/infra/harness/` — implements the 5 version methods on `IHarnessStore` (`saveVersion`, `getVersion`, `getLatest`, `listVersions`, `pruneOldVersions`). New unit-test suite with 15 scenarios. No production wiring yet.
- What did NOT change (scope boundary): The 6 outcome/scenario methods (`saveOutcome`, `listOutcomes`, `deleteOutcomes`, `recordFeedback`, `saveScenario`, `listScenarios`) ship as `throw new Error('...Task 1.3')` stubs. `service-initializer.ts` is NOT modified (Task 1.4). No consumer imports this class yet. `main` is not touched.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [x] Agent / Tools
- [ ] LLM Providers
- [ ] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes ENG-2226
- Related ENG-2225 (Phase 1 Task 1.1 — in-memory test double, merged)
- Related ENG-2222 (Phase 0 Task 0.4 — `IHarnessStore` interface, merged)

## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause: N/A
- Why this was not caught earlier: N/A

## Test plan

- Coverage added:
  - [x] Unit test
  - [ ] Integration test
  - [ ] Manual verification only
- Test file(s): `test/unit/agent/harness/harness-store-versions.test.ts`
- Key scenario(s) covered:
  - Round-trip: `saveVersion` + `getVersion` / `getLatest` / `listVersions`, newest-first ordering on 3 entries
  - Conflict: duplicate `id` → `VERSION_CONFLICT` with `details.id`; duplicate `(projectId, commandType, version)` → `VERSION_CONFLICT` with `details.version`
  - Validation: empty `code` → `ZodError`; `heuristic > 1` → `ZodError`
  - Empty-store: `getVersion` / `getLatest` return `undefined`; `listVersions` returns `[]`
  - Prune simple: 5 versions with best-H at v3, `keep=2` → preserves {v5, v3}, deletes 3
  - Prune parent chain: v1 ← v2 ← v3 (best-H) + v4 + v5 (latest), `keep=3` → preserves 4 records (v5, v3, v2, v1), deletes 1 (preservation wins over keep)
  - Prune no-op: `keep >= count` → returns 0
  - Concurrency: 100 parallel `saveVersion` on distinct `(id, version)` tuples → all 100 persist
  - Concurrency with seeded conflict: pre-seeded `v-seed` + 100 parallels (99 distinct + 1 clash on `v-seed`) → exactly 1 rejects with `VERSION_CONFLICT`, 99 persist

## User-visible changes

None. No consumer imports `HarnessStore` yet; Task 1.4 wires it into `service-initializer.ts`. `harness.enabled = false` remains the public default.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording

All 15 new tests pass; full suite is 6601 passing / 0 failing (+15 from this branch). Before this PR, `src/agent/infra/harness/harness-store.ts` did not exist, so the class under test didn't exist — the "passing after" is demonstrated by the suite; there's no meaningful "failing before" for net-new files.

## Summary

- Problem: AutoHarness V2 needs a concrete `IHarnessStore` before any downstream phase (Phase 2 outcome recorder, Phase 3 module builder, Phase 5 mode selector, Phase 7 `brv harness *`) can persist learned versions to disk. ENG-2222 shipped the interface; this PR ships the first half of the implementation.
- Why it matters: Phase 1 is on the critical path for the eventual Internal-Dogfood ship. Phase 2 Task 2.5 (integration test) can only go green once Phase 1 is fully merged to `proj/autoharness-v2`.
- What changed: New `HarnessStore` class under `src/agent/infra/harness/` — implements the 5 version methods on `IHarnessStore` (`saveVersion`, `getVersion`, `getLatest`, `listVersions`, `pruneOldVersions`). New unit-test suite with 15 scenarios. No production wiring yet.
- What did NOT change (scope boundary): The 6 outcome/scenario methods (`saveOutcome`, `listOutcomes`, `deleteOutcomes`, `recordFeedback`, `saveScenario`, `listScenarios`) ship as `throw new Error('...Task 1.3')` stubs. `service-initializer.ts` is NOT modified (Task 1.4). No consumer imports this class yet. `main` is not touched.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [x] Agent / Tools
- [ ] LLM Providers
- [ ] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes ENG-2226
- Related ENG-2225 (Phase 1 Task 1.1 — in-memory test double, merged)
- Related ENG-2222 (Phase 0 Task 0.4 — `IHarnessStore` interface, merged)

## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause: N/A
- Why this was not caught earlier: N/A

## Test plan

- Coverage added:
  - [x] Unit test
  - [ ] Integration test
  - [ ] Manual verification only
- Test file(s): `test/unit/agent/harness/harness-store-versions.test.ts`
- Key scenario(s) covered:
  - Round-trip: `saveVersion` + `getVersion` / `getLatest` / `listVersions`, newest-first ordering on 3 entries
  - Conflict: duplicate `id` → `VERSION_CONFLICT` with `details.id`; duplicate `(projectId, commandType, version)` → `VERSION_CONFLICT` with `details.version`
  - Validation: empty `code` → `ZodError`; `heuristic > 1` → `ZodError`
  - Empty-store: `getVersion` / `getLatest` return `undefined`; `listVersions` returns `[]`
  - Prune simple: 5 versions with best-H at v3, `keep=2` → preserves {v5, v3}, deletes 3
  - Prune parent chain: v1 ← v2 ← v3 (best-H) + v4 + v5 (latest), `keep=3` → preserves 4 records (v5, v3, v2, v1), deletes 1 (preservation wins over keep)
  - Prune no-op: `keep >= count` → returns 0
  - Concurrency: 100 parallel `saveVersion` on distinct `(id, version)` tuples → all 100 persist
  - Concurrency with seeded conflict: pre-seeded `v-seed` + 100 parallels (99 distinct + 1 clash on `v-seed`) → exactly 1 rejects with `VERSION_CONFLICT`, 99 persist

## User-visible changes

None. No consumer imports `HarnessStore` yet; Task 1.4 wires it into `service-initializer.ts`. `harness.enabled = false` remains the public default.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording

All 15 new tests pass; full suite is 6601 passing / 0 failing (+15 from this branch). Before this PR, `src/agent/infra/harness/harness-store.ts` did not exist, so the class under test didn't exist — the "passing after" is demonstrated by the suite; there's no meaningful "failing before" for net-new files.

