### PR TITLE
feat: [ENG-2229] HarnessOutcomeRecorder core

### DIFF
--- a/src/agent/infra/harness/harness-outcome-recorder.ts
+++ b/src/agent/infra/harness/harness-outcome-recorder.ts
@@ -42,7 +42,8 @@ export interface RecordParams {
 // Usage-detection regexes (§C1)
 // ---------------------------------------------------------------------------
 
-// Capabilities from HarnessCapabilitySchema (core/domain/harness/types.ts) + meta pseudo-method.
+// Capabilities from HarnessCapabilitySchema (core/domain/harness/types.ts) + meta pseudo-method
+// + query (commandType-level harness method, not yet formalized in the capability enum).
 // If a new capability is added to the schema, update this regex to match.
 const HARNESS_CALL_RE =
   /\bharness\.(curate|query|search|extract|gather|answer|buildOps|discover|meta)\b/
@@ -164,7 +165,11 @@ export class HarnessOutcomeRecorder {
       this.commandTypesBySession.set(params.sessionId, new Set<string>([params.commandType]))
     }
 
-    // 5. Rate limit check — counter increments BEFORE write
+    // 5. Rate limit check — counter increments BEFORE write intentionally.
+    // Moving it after the write opens a concurrency window: N parallel calls
+    // all read count < 50, all pass, all write — defeating the cap.
+    // Tradeoff: transient store failures burn slots. Acceptable for v1.0;
+    // the 50-slot budget is generous for human-paced sessions.
     const count = this.sessionCount.get(params.sessionId) ?? 0
     this.sessionCount.set(params.sessionId, count + 1)
     if (count >= MAX_OUTCOMES_PER_SESSION) {

--- a/src/agent/infra/harness/harness-outcome-recorder.ts
+++ b/src/agent/infra/harness/harness-outcome-recorder.ts
@@ -1,0 +1,192 @@
+/**
+ * AutoHarness V2 — Outcome recorder.
+ *
+ * Fire-and-forget: `SandboxService` calls `recorder.record(...)` without
+ * `await`ing. The recorder is responsible for backpressure (semaphore
+ * with 5 permits), per-session rate limiting (50 outcomes), session
+ * state tracking, and event emission.
+ *
+ * Implements contracts §C1, §C3, §C5, §C6, §C7 from
+ * `features/autoharness-v2/tasks/phase_1_2_handoff.md`.
+ */
+
+import {randomUUID} from 'node:crypto'
+
+import type {CodeExecOutcome, ProjectType} from '../../core/domain/harness/types.js'
+import type {REPLResult} from '../../core/domain/sandbox/types.js'
+import type {IHarnessStore} from '../../core/interfaces/i-harness-store.js'
+import type {ILogger} from '../../core/interfaces/i-logger.js'
+import type {ValidatedHarnessConfig} from '../agent/agent-schemas.js'
+import type {SessionEventBus} from '../events/event-emitter.js'
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface RecordParams {
+  code: string
+  commandType: 'chat' | 'curate' | 'query'
+  conversationTurn?: number
+  executionTimeMs: number
+  harnessVersionId?: string
+  projectId: string
+  projectType: ProjectType
+  result: REPLResult
+  sessionId: string
+  taskDescription?: string
+}
+
+// ---------------------------------------------------------------------------
+// Usage-detection regexes (§C1)
+// ---------------------------------------------------------------------------
+
+const HARNESS_CALL_RE =
+  /\bharness\.(curate|query|search|extract|gather|answer|buildOps|discover|meta)\b/
+
+// ---------------------------------------------------------------------------
+// Semaphore — bounded concurrency for store writes
+// ---------------------------------------------------------------------------
+
+class Semaphore {
+  private permits: number
+  private readonly waiting: Array<() => void> = []
+
+  constructor(permits: number) {
+    this.permits = permits
+  }
+
+  async acquire(): Promise<void> {
+    if (this.permits > 0) {
+      this.permits--
+      return
+    }
+
+    return new Promise<void>((resolve) => {
+      this.waiting.push(resolve)
+    })
+  }
+
+  release(): void {
+    const next = this.waiting.shift()
+    if (next) {
+      next()
+    } else {
+      this.permits++
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Recorder
+// ---------------------------------------------------------------------------
+
+const MAX_OUTCOMES_PER_SESSION = 50
+const SEMAPHORE_PERMITS = 5
+
+export class HarnessOutcomeRecorder {
+  private readonly commandTypesBySession = new Map<string, Set<string>>()
+  private readonly config: ValidatedHarnessConfig
+  private readonly logger: ILogger
+  private readonly semaphore = new Semaphore(SEMAPHORE_PERMITS)
+  private readonly sessionCount = new Map<string, number>()
+  private readonly sessionEventBus: SessionEventBus
+  private readonly store: IHarnessStore
+
+  constructor(
+    store: IHarnessStore,
+    sessionEventBus: SessionEventBus,
+    logger: ILogger,
+    config: ValidatedHarnessConfig,
+  ) {
+    this.store = store
+    this.sessionEventBus = sessionEventBus
+    this.logger = logger
+    this.config = config
+  }
+
+  /**
+   * Returns the set of command types seen for a session. Phase 6 uses
+   * this to trigger refinement only for command types the session touched.
+   */
+  getCommandTypesForSession(sessionId: string): ReadonlySet<string> {
+    return this.commandTypesBySession.get(sessionId) ?? new Set<string>()
+  }
+
+  /**
+   * Record a code_exec outcome. Fire-and-forget from the caller's
+   * perspective — errors are logged, never propagated.
+   */
+  async record(params: RecordParams): Promise<void> {
+    // 1. Early return if disabled
+    if (!this.config.enabled) return
+
+    // 2. Usage detection
+    let usedHarness = HARNESS_CALL_RE.test(params.code)
+    if (usedHarness && !params.harnessVersionId) {
+      this.logger.warn('usedHarness detected but harnessVersionId missing — downgrading', {
+        commandType: params.commandType,
+        projectId: params.projectId,
+        sessionId: params.sessionId,
+      })
+      usedHarness = false
+    }
+
+    // 3. Build outcome
+    const outcome: CodeExecOutcome = {
+      code: params.code,
+      commandType: params.commandType,
+      curateResult: params.result.curateResults,
+      delegated: undefined, // placeholder — real detection lives in §C1
+      executionTimeMs: params.executionTimeMs,
+      harnessVersionId: usedHarness ? params.harnessVersionId : undefined,
+      id: randomUUID(),
+      projectId: params.projectId,
+      projectType: params.projectType,
+      sessionId: params.sessionId,
+      stderr: params.result.stderr || undefined,
+      stdout: params.result.stdout || undefined,
+      success: !params.result.stderr,
+      timestamp: Date.now(),
+      usedHarness,
+    }
+
+    // 4. Session state update — BEFORE rate limit check
+    if (!this.commandTypesBySession.has(params.sessionId)) {
+      this.commandTypesBySession.set(params.sessionId, new Set())
+    }
+
+    this.commandTypesBySession.get(params.sessionId)!.add(params.commandType)
+
+    // 5. Rate limit check — counter increments BEFORE write
+    const count = this.sessionCount.get(params.sessionId) ?? 0
+    this.sessionCount.set(params.sessionId, count + 1)
+    if (count >= MAX_OUTCOMES_PER_SESSION) {
+      this.logger.debug('Rate limit reached for session', {sessionId: params.sessionId})
+      return
+    }
+
+    // 6. Bounded concurrency — acquire semaphore permit
+    await this.semaphore.acquire()
+    try {
+      await this.store.saveOutcome(outcome)
+
+      // 7. Event emission — only after successful write
+      this.sessionEventBus.emit('harness:outcome-recorded', {
+        commandType: outcome.commandType,
+        outcomeId: outcome.id,
+        projectId: outcome.projectId,
+        success: outcome.success,
+      })
+    } catch (error) {
+      // 8. Error handling — log and swallow
+      this.logger.warn('saveOutcome failed', {
+        commandType: outcome.commandType,
+        error,
+        outcomeId: outcome.id,
+        projectId: outcome.projectId,
+      })
+    } finally {
+      this.semaphore.release()
+    }
+  }
+}

--- a/src/agent/infra/harness/harness-outcome-recorder.ts
+++ b/src/agent/infra/harness/harness-outcome-recorder.ts
@@ -26,6 +26,7 @@ import type {SessionEventBus} from '../events/event-emitter.js'
 export interface RecordParams {
   code: string
   commandType: 'chat' | 'curate' | 'query'
+  /** Reserved for Task 2.4 — threaded from AgentLLMService conversation loop. */
   conversationTurn?: number
   executionTimeMs: number
   harnessVersionId?: string
@@ -33,6 +34,7 @@ export interface RecordParams {
   projectType: ProjectType
   result: REPLResult
   sessionId: string
+  /** Reserved for Task 2.4 — threaded from AgentLLMService conversation loop. */
   taskDescription?: string
 }
 
@@ -40,6 +42,8 @@ export interface RecordParams {
 // Usage-detection regexes (§C1)
 // ---------------------------------------------------------------------------
 
+// Capabilities from HarnessCapabilitySchema (core/domain/harness/types.ts) + meta pseudo-method.
+// If a new capability is added to the schema, update this regex to match.
 const HARNESS_CALL_RE =
   /\bharness\.(curate|query|search|extract|gather|answer|buildOps|discover|meta)\b/
 
@@ -145,17 +149,20 @@ export class HarnessOutcomeRecorder {
       sessionId: params.sessionId,
       stderr: params.result.stderr || undefined,
       stdout: params.result.stdout || undefined,
-      success: !params.result.stderr,
+      // Approximation: any stderr = failure. Task 2.3 replaces with an
+      // explicit boolean from the sandbox runner to avoid false positives
+      // from deprecation warnings, console.warn, etc.
+      success: params.result.stderr.length === 0,
       timestamp: Date.now(),
       usedHarness,
     }
 
     // 4. Session state update — BEFORE rate limit check
-    if (!this.commandTypesBySession.has(params.sessionId)) {
-      this.commandTypesBySession.set(params.sessionId, new Set())
+    if (this.commandTypesBySession.has(params.sessionId)) {
+      this.commandTypesBySession.get(params.sessionId)?.add(params.commandType)
+    } else {
+      this.commandTypesBySession.set(params.sessionId, new Set<string>([params.commandType]))
     }
-
-    this.commandTypesBySession.get(params.sessionId)!.add(params.commandType)
 
     // 5. Rate limit check — counter increments BEFORE write
     const count = this.sessionCount.get(params.sessionId) ?? 0

--- a/src/agent/infra/harness/harness-outcome-recorder.ts
+++ b/src/agent/infra/harness/harness-outcome-recorder.ts
@@ -148,8 +148,8 @@ export class HarnessOutcomeRecorder {
       projectId: params.projectId,
       projectType: params.projectType,
       sessionId: params.sessionId,
-      stderr: params.result.stderr || undefined,
-      stdout: params.result.stdout || undefined,
+      stderr: params.result.stderr.length > 0 ? params.result.stderr : undefined,
+      stdout: params.result.stdout.length > 0 ? params.result.stdout : undefined,
       // Approximation: any stderr = failure. Task 2.3 replaces with an
       // explicit boolean from the sandbox runner to avoid false positives
       // from deprecation warnings, console.warn, etc.

--- a/test/unit/agent/harness/harness-outcome-recorder.test.ts
+++ b/test/unit/agent/harness/harness-outcome-recorder.test.ts
@@ -114,6 +114,26 @@ describe('HarnessOutcomeRecorder', () => {
     })
   })
 
+  // ── Success determination ──────────────────────────────────────────────────
+
+  describe('success determination', () => {
+    it('sets success: false when stderr is non-empty', async () => {
+      const recorder = new HarnessOutcomeRecorder(store, bus, logger, makeConfig())
+      await recorder.record(makeParams({result: makeResult({stderr: 'uncaught error'})}))
+
+      const outcomes = await store.listOutcomes('proj-1', 'curate')
+      expect(outcomes[0].success).to.equal(false)
+    })
+
+    it('sets success: true when stderr is empty', async () => {
+      const recorder = new HarnessOutcomeRecorder(store, bus, logger, makeConfig())
+      await recorder.record(makeParams({result: makeResult({stderr: '', stdout: 'ok'})}))
+
+      const outcomes = await store.listOutcomes('proj-1', 'curate')
+      expect(outcomes[0].success).to.equal(true)
+    })
+  })
+
   // ── Usage detection ───────────────────────────────────────────────────────
 
   describe('usage detection', () => {

--- a/test/unit/agent/harness/harness-outcome-recorder.test.ts
+++ b/test/unit/agent/harness/harness-outcome-recorder.test.ts
@@ -1,0 +1,331 @@
+import {expect} from 'chai'
+import sinon from 'sinon'
+
+import type {CodeExecOutcome} from '../../../../src/agent/core/domain/harness/types.js'
+import type {REPLResult} from '../../../../src/agent/core/domain/sandbox/types.js'
+import type {ILogger} from '../../../../src/agent/core/interfaces/i-logger.js'
+import type {ValidatedHarnessConfig} from '../../../../src/agent/infra/agent/agent-schemas.js'
+import type {RecordParams} from '../../../../src/agent/infra/harness/harness-outcome-recorder.js'
+
+import {SessionEventBus} from '../../../../src/agent/infra/events/event-emitter.js'
+import {HarnessOutcomeRecorder} from '../../../../src/agent/infra/harness/harness-outcome-recorder.js'
+import {InMemoryHarnessStore} from '../../../helpers/in-memory-harness-store.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeConfig(overrides: Partial<ValidatedHarnessConfig> = {}): ValidatedHarnessConfig {
+  return {
+    autoLearn: true,
+    enabled: true,
+    language: 'auto',
+    maxVersions: 20,
+    ...overrides,
+  }
+}
+
+function makeLogger(): ILogger & {calls: Record<string, Array<{context?: Record<string, unknown>; message: string}>>} {
+  const calls: Record<string, Array<{context?: Record<string, unknown>; message: string}>> = {
+    debug: [],
+    error: [],
+    info: [],
+    warn: [],
+  }
+  return {
+    calls,
+    debug(message: string, context?: Record<string, unknown>) {
+      calls.debug.push({context, message})
+    },
+    error(message: string, context?: Record<string, unknown>) {
+      calls.error.push({context, message})
+    },
+    info(message: string, context?: Record<string, unknown>) {
+      calls.info.push({context, message})
+    },
+    warn(message: string, context?: Record<string, unknown>) {
+      calls.warn.push({context, message})
+    },
+  }
+}
+
+function makeResult(overrides: Partial<REPLResult> = {}): REPLResult {
+  return {
+    executionTime: 42,
+    locals: {},
+    stderr: '',
+    stdout: 'ok',
+    ...overrides,
+  }
+}
+
+function makeParams(overrides: Partial<RecordParams> = {}): RecordParams {
+  return {
+    code: 'tools.search("x")',
+    commandType: 'curate',
+    executionTimeMs: 42,
+    projectId: 'proj-1',
+    projectType: 'typescript',
+    result: makeResult(),
+    sessionId: 'sess-1',
+    ...overrides,
+  }
+}
+
+async function recordN(recorder: HarnessOutcomeRecorder, n: number, overrides: Partial<RecordParams> = {}): Promise<void> {
+  const promises = Array.from({length: n}, () => recorder.record(makeParams(overrides)))
+  await Promise.all(promises)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('HarnessOutcomeRecorder', () => {
+  let store: InMemoryHarnessStore
+  let bus: SessionEventBus
+  let logger: ReturnType<typeof makeLogger>
+
+  beforeEach(() => {
+    store = new InMemoryHarnessStore()
+    bus = new SessionEventBus()
+    logger = makeLogger()
+  })
+
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  // ── Config-gated ──────────────────────────────────────────────────────────
+
+  describe('config.enabled: false', () => {
+    it('does not call store.saveOutcome and does not emit events', async () => {
+      const recorder = new HarnessOutcomeRecorder(store, bus, logger, makeConfig({enabled: false}))
+      const spy = sinon.spy(store, 'saveOutcome')
+      let emitted = false
+      bus.on('harness:outcome-recorded', () => {
+        emitted = true
+      })
+
+      await recorder.record(makeParams())
+
+      expect(spy.callCount).to.equal(0)
+      expect(emitted).to.equal(false)
+    })
+  })
+
+  // ── Usage detection ───────────────────────────────────────────────────────
+
+  describe('usage detection', () => {
+    it('detects usedHarness: true when code contains harness.curate', async () => {
+      const recorder = new HarnessOutcomeRecorder(store, bus, logger, makeConfig())
+      await recorder.record(makeParams({
+        code: 'const r = harness.curate(input)',
+        harnessVersionId: 'hv-1',
+      }))
+
+      const outcomes = await store.listOutcomes('proj-1', 'curate')
+      expect(outcomes).to.have.length(1)
+      expect(outcomes[0].usedHarness).to.equal(true)
+    })
+
+    it('detects usedHarness: false when code uses only tools.*', async () => {
+      const recorder = new HarnessOutcomeRecorder(store, bus, logger, makeConfig())
+      await recorder.record(makeParams({code: 'tools.search("x")'}))
+
+      const outcomes = await store.listOutcomes('proj-1', 'curate')
+      expect(outcomes).to.have.length(1)
+      expect(outcomes[0].usedHarness).to.equal(false)
+    })
+
+    it('logs warn and downgrades usedHarness when harnessVersionId missing', async () => {
+      const recorder = new HarnessOutcomeRecorder(store, bus, logger, makeConfig())
+      await recorder.record(makeParams({
+        code: 'harness.curate(input)',
+        harnessVersionId: undefined,
+      }))
+
+      const outcomes = await store.listOutcomes('proj-1', 'curate')
+      expect(outcomes).to.have.length(1)
+      expect(outcomes[0].usedHarness).to.equal(false)
+      expect(logger.calls.warn.length).to.be.greaterThanOrEqual(1)
+      expect(logger.calls.warn.some((c) => c.message.includes('harnessVersionId'))).to.equal(true)
+    })
+
+    it('persists usedHarness: true with harnessVersionId present', async () => {
+      const recorder = new HarnessOutcomeRecorder(store, bus, logger, makeConfig())
+      await recorder.record(makeParams({
+        code: 'harness.query(q)',
+        harnessVersionId: 'hv-1',
+      }))
+
+      const outcomes = await store.listOutcomes('proj-1', 'curate')
+      expect(outcomes).to.have.length(1)
+      expect(outcomes[0].usedHarness).to.equal(true)
+      expect(outcomes[0].harnessVersionId).to.equal('hv-1')
+    })
+  })
+
+  // ── Rate limit ────────────────────────────────────────────────────────────
+
+  describe('rate limit', () => {
+    it('persists all 50 outcomes for the same sessionId', async () => {
+      const recorder = new HarnessOutcomeRecorder(store, bus, logger, makeConfig())
+      await recordN(recorder, 50, {sessionId: 's1'})
+
+      const outcomes = await store.listOutcomes('proj-1', 'curate', 100)
+      expect(outcomes).to.have.length(50)
+    })
+
+    it('does not persist the 51st call for the same sessionId', async () => {
+      const recorder = new HarnessOutcomeRecorder(store, bus, logger, makeConfig())
+      await recordN(recorder, 51, {sessionId: 's1'})
+
+      const outcomes = await store.listOutcomes('proj-1', 'curate', 100)
+      expect(outcomes).to.have.length(50)
+    })
+
+    it('rate-limited call still updates commandType set', async () => {
+      const recorder = new HarnessOutcomeRecorder(store, bus, logger, makeConfig())
+      await recordN(recorder, 50, {commandType: 'curate', sessionId: 's1'})
+
+      // 51st call with a different commandType — should still track it
+      await recorder.record(makeParams({commandType: 'query', sessionId: 's1'}))
+
+      const types = recorder.getCommandTypesForSession('s1')
+      expect(types.has('curate')).to.equal(true)
+      expect(types.has('query')).to.equal(true)
+    })
+
+    it('rate limit is per-session: s2 persists after s1 is capped', async () => {
+      const recorder = new HarnessOutcomeRecorder(store, bus, logger, makeConfig())
+      await recordN(recorder, 50, {sessionId: 's1'})
+      await recorder.record(makeParams({sessionId: 's2'}))
+
+      const outcomes = await store.listOutcomes('proj-1', 'curate', 100)
+      // 50 from s1, 1 from s2
+      expect(outcomes).to.have.length(51)
+    })
+  })
+
+  // ── Concurrency ───────────────────────────────────────────────────────────
+
+  describe('bounded concurrency', () => {
+    it('all 10 parallel record calls eventually persist', async () => {
+      const recorder = new HarnessOutcomeRecorder(store, bus, logger, makeConfig())
+      const promises = Array.from({length: 10}, (_, i) =>
+        recorder.record(makeParams({sessionId: `s-${i}`})),
+      )
+
+      await Promise.all(promises)
+
+      const outcomes = await store.listOutcomes('proj-1', 'curate', 100)
+      expect(outcomes).to.have.length(10)
+    })
+
+    it('at most 5 store.saveOutcome calls are in-flight at any moment', async () => {
+      let inFlight = 0
+      let highWater = 0
+      const originalSave = store.saveOutcome.bind(store)
+
+      sinon.stub(store, 'saveOutcome').callsFake(async (outcome: CodeExecOutcome) => {
+        inFlight++
+        if (inFlight > highWater) highWater = inFlight
+        // Simulate a slow write
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 10)
+        })
+        const result = await originalSave(outcome)
+        inFlight--
+        return result
+      })
+
+      const recorder = new HarnessOutcomeRecorder(store, bus, logger, makeConfig())
+      const promises = Array.from({length: 10}, (_, i) =>
+        recorder.record(makeParams({sessionId: `s-${i}`})),
+      )
+
+      await Promise.all(promises)
+
+      expect(highWater).to.be.at.most(5)
+      const outcomes = await store.listOutcomes('proj-1', 'curate', 100)
+      expect(outcomes).to.have.length(10)
+    })
+  })
+
+  // ── Event emission ────────────────────────────────────────────────────────
+
+  describe('event emission', () => {
+    it('emits harness:outcome-recorded after successful write', async () => {
+      const recorder = new HarnessOutcomeRecorder(store, bus, logger, makeConfig())
+      const events: Array<{commandType: string; outcomeId: string; projectId: string; success: boolean}> = []
+      bus.on('harness:outcome-recorded', (payload) => {
+        events.push(payload)
+      })
+
+      await recorder.record(makeParams({commandType: 'curate', projectId: 'proj-1'}))
+
+      expect(events).to.have.length(1)
+      expect(events[0].commandType).to.equal('curate')
+      expect(events[0].projectId).to.equal('proj-1')
+      expect(events[0].success).to.equal(true)
+      expect(events[0].outcomeId).to.be.a('string').and.not.empty
+    })
+
+    it('does NOT emit when store.saveOutcome fails', async () => {
+      sinon.stub(store, 'saveOutcome').rejects(new Error('storage down'))
+      const recorder = new HarnessOutcomeRecorder(store, bus, logger, makeConfig())
+      const events: unknown[] = []
+      bus.on('harness:outcome-recorded', (payload) => {
+        events.push(payload)
+      })
+
+      await recorder.record(makeParams())
+
+      expect(events).to.have.length(0)
+    })
+  })
+
+  // ── Error handling ────────────────────────────────────────────────────────
+
+  describe('error handling', () => {
+    it('logs warn and resolves when store.saveOutcome rejects', async () => {
+      sinon.stub(store, 'saveOutcome').rejects(new Error('storage down'))
+      const recorder = new HarnessOutcomeRecorder(store, bus, logger, makeConfig())
+
+      // Should not throw
+      await recorder.record(makeParams())
+
+      expect(logger.calls.warn.length).to.be.greaterThanOrEqual(1)
+    })
+
+    it('logs warn and resolves when store.saveOutcome throws synchronously', async () => {
+      sinon.stub(store, 'saveOutcome').throws(new Error('sync boom'))
+      const recorder = new HarnessOutcomeRecorder(store, bus, logger, makeConfig())
+
+      await recorder.record(makeParams())
+
+      expect(logger.calls.warn.length).to.be.greaterThanOrEqual(1)
+    })
+  })
+
+  // ── Session state ─────────────────────────────────────────────────────────
+
+  describe('session state (getCommandTypesForSession)', () => {
+    it('tracks commandTypes across multiple record calls', async () => {
+      const recorder = new HarnessOutcomeRecorder(store, bus, logger, makeConfig())
+      await recorder.record(makeParams({commandType: 'curate', sessionId: 's1'}))
+      await recorder.record(makeParams({commandType: 'query', sessionId: 's1'}))
+
+      const types = recorder.getCommandTypesForSession('s1')
+      expect(types.has('curate')).to.equal(true)
+      expect(types.has('query')).to.equal(true)
+    })
+
+    it('returns empty set for unknown sessionId', () => {
+      const recorder = new HarnessOutcomeRecorder(store, bus, logger, makeConfig())
+      const types = recorder.getCommandTypesForSession('unknown')
+      expect(types.size).to.equal(0)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Problem: Phase 2 of AutoHarness V2 needs a recorder that captures every `code_exec` outcome in the background without blocking the sandbox's user-visible latency.
- Why it matters: Outcome data feeds the heuristic H (Phase 5) and the refinement loop (Phase 6). Without it, the harness cannot learn.
- What changed: New `HarnessOutcomeRecorder` class with fire-and-forget writes, bounded concurrency (5-permit semaphore), per-session rate limiting (50 outcomes), regex-based usage detection, session state tracking, and event emission.
- What did NOT change (scope boundary): No wiring into `SandboxService` (Task 2.3), no `attachFeedback` (Task 2.2), no `AgentLLMService` threading (Task 2.4), no integration test (Task 2.5).

## Type of change

- [x] New feature

## Scope (select all touched areas)

- [x] Agent / Tools

## Linked issues

- Closes ENG-2229
- Related ENG-2225 (Phase 1.1 — in-memory test double, merged)

## Root cause (bug fixes only, otherwise write `N/A`)

N/A

## Test plan

- Coverage added:
  - [x] Unit test
- Test file(s): `test/unit/agent/harness/harness-outcome-recorder.test.ts`
- Key scenario(s) covered:
  - Config-gated: `enabled: false` → zero writes, zero events
  - Usage detection: `harness.curate(...)` → `usedHarness: true`; `tools.search(...)` → `false`; missing `harnessVersionId` → warn + downgrade
  - Rate limit: 50 calls persist, 51st skipped, commandType set still updates, per-session not global
  - Bounded concurrency: 10 parallel calls → all persist, max 5 in-flight at any moment (high-water counter spy)
  - Event emission: emitted after successful write, NOT emitted on failure
  - Error handling: `saveOutcome` reject/throw → warn logged, no propagation
  - Session state: `getCommandTypesForSession` tracks across calls including rate-limited ones

## User-visible changes

None. `harness.enabled = false` by default. This is internal data collection infrastructure.

## Evidence

- [x] Failing test/log before + passing after

```
17 passing (30ms)

  HarnessOutcomeRecorder
    config.enabled: false
      ✔ does not call store.saveOutcome and does not emit events
    usage detection
      ✔ detects usedHarness: true when code contains harness.curate
      ✔ detects usedHarness: false when code uses only tools.*
      ✔ logs warn and downgrades usedHarness when harnessVersionId missing
      ✔ persists usedHarness: true with harnessVersionId present
    rate limit
      ✔ persists all 50 outcomes for the same sessionId
      ✔ does not persist the 51st call for the same sessionId
      ✔ rate-limited call still updates commandType set
      ✔ rate limit is per-session: s2 persists after s1 is capped
    bounded concurrency
      ✔ all 10 parallel record calls eventually persist
      ✔ at most 5 store.saveOutcome calls are in-flight at any moment
    event emission
      ✔ emits harness:outcome-recorded after successful write
      ✔ does NOT emit when store.saveOutcome fails
    error handling
      ✔ logs warn and resolves when store.saveOutcome rejects
      ✔ logs warn and resolves when store.saveOutcome throws synchronously
    session state (getCommandTypesForSession)
      ✔ tracks commandTypes across multiple record calls
      ✔ returns empty set for unknown sessionId
```

Full suite: 6603 passing, 0 failing.

## Checklist

- [x] Tests added or updated and passing (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented above)
- [x] Branch is up to date with `proj/autoharness-v2`

## Risks and mitigations

- Risk: `delegated` field is a placeholder (`undefined` always) — real detection deferred per §C1 hand-off.
  - Mitigation: Documented in code comment. Phase 3 module builder will make the signal precise by instrumenting the sandbox VM. Regex is sufficient for v1.0 per the execution plan.
- Risk: Semaphore is a custom ~25-line implementation rather than a shared utility.
  - Mitigation: `AsyncMutex` in the repo is 1-permit only, not configurable. Task spec says "implement ~20 lines if not found." Extraction to `src/shared/` is a candidate post-Phase 2 cleanup.
- Risk: Rate-limit counter leaks per session if cleanup is never triggered.
  - Mitigation: Documented in ENG-2229 reviewer notes. Either tie to `session:ended` or cap with LRU — implementer's choice, doesn't affect the contract.