### PR TITLE
feat: [ENG-2232] wire HarnessOutcomeRecorder into SandboxService

### DIFF
--- a/src/agent/core/interfaces/cipher-services.ts
+++ b/src/agent/core/interfaces/cipher-services.ts
@@ -1,6 +1,7 @@
 import type {IRuntimeSignalStore} from '../../../server/core/interfaces/storage/i-runtime-signal-store.js'
 import type {AgentEventBus, SessionEventBus} from '../../infra/events/event-emitter.js'
 import type {FileSystemService} from '../../infra/file-system/file-system-service.js'
+import type {HarnessOutcomeRecorder} from '../../infra/harness/harness-outcome-recorder.js'
 import type {CompactionService} from '../../infra/llm/context/compaction/compaction-service.js'
 import type {AbstractGenerationQueue} from '../../infra/map/abstract-queue.js'
 import type {MemoryManager} from '../../infra/memory/memory-manager.js'
@@ -45,6 +46,13 @@ export interface CipherAgentServices {
    */
   compactionService: CompactionService
   fileSystemService: FileSystemService
+  /**
+   * AutoHarness V2 outcome recorder. Currently `undefined` — construction
+   * in `service-initializer.ts` is blocked by Phase 1.4 (ENG-2228) which
+   * adds `HarnessStore`. Declared now so the type is ready when wiring
+   * lands; first consumer is Phase 7's `brv query --feedback`.
+   */
+  harnessOutcomeRecorder?: HarnessOutcomeRecorder
   historyStorage: IHistoryStorage
   memoryManager: MemoryManager
   /**

--- a/src/agent/core/interfaces/i-sandbox-service.ts
+++ b/src/agent/core/interfaces/i-sandbox-service.ts
@@ -1,3 +1,5 @@
+import type { ValidatedHarnessConfig } from '../../infra/agent/agent-schemas.js'
+import type { HarnessOutcomeRecorder } from '../../infra/harness/harness-outcome-recorder.js'
 import type { ISearchKnowledgeService } from '../../infra/sandbox/tools-sdk.js'
 import type { SessionManager } from '../../infra/session/session-manager.js'
 import type { EnvironmentContext } from '../domain/environment/types.js'
@@ -5,6 +7,7 @@ import type { REPLResult, SandboxConfig } from '../domain/sandbox/types.js'
 import type { IContentGenerator } from './i-content-generator.js'
 import type { ICurateService } from './i-curate-service.js'
 import type { IFileSystem } from './i-file-system.js'
+import type { ILogger } from './i-logger.js'
 import type { ISwarmCoordinator } from './i-swarm-coordinator.js'
 
 /**
@@ -74,6 +77,22 @@ export interface ISandboxService {
    * @param fileSystem - File system service instance
    */
   setFileSystem?(fileSystem: IFileSystem): void
+
+  /**
+   * Wire in the AutoHarness V2 config block.
+   *
+   * @param config - Harness config block from `AgentConfig.harness`
+   */
+  setHarnessConfig?(config: ValidatedHarnessConfig): void
+
+  /**
+   * Wire in the AutoHarness V2 outcome recorder for fire-and-forget
+   * recording on every `executeCode` call.
+   *
+   * @param recorder - Outcome recorder instance
+   * @param logger - Logger for defensive .catch on fire-and-forget calls
+   */
+  setHarnessOutcomeRecorder?(recorder: HarnessOutcomeRecorder, logger?: ILogger): void
 
   /**
    * Set a variable in a session's sandbox.

--- a/src/agent/infra/agent/service-initializer.ts
+++ b/src/agent/infra/agent/service-initializer.ts
@@ -175,6 +175,15 @@ export async function createCipherAgentServices(
   const sandboxService = new SandboxService()
   sandboxService.setHarnessConfig(config.harness)
 
+  // 5b-1. AutoHarness V2 outcome recorder (depends on HarnessStore from Phase 1.4)
+  // TODO(ENG-2228): When Phase 1.4 adds `harnessStore` construction above,
+  // construct the recorder here:
+  //   const harnessOutcomeRecorder = new HarnessOutcomeRecorder(
+  //     harnessStore, sessionEventBus,
+  //     logger.withSource('HarnessOutcomeRecorder'), config.harness,
+  //   )
+  //   sandboxService.setHarnessOutcomeRecorder(harnessOutcomeRecorder, logger)
+
   // 5c. Build environment context for sandbox injection
   const environmentBuilder = new EnvironmentContextBuilder()
   const environmentContext = await environmentBuilder.build({

--- a/src/agent/infra/agent/service-initializer.ts
+++ b/src/agent/infra/agent/service-initializer.ts
@@ -177,9 +177,11 @@ export async function createCipherAgentServices(
 
   // 5b-1. AutoHarness V2 outcome recorder (depends on HarnessStore from Phase 1.4)
   // TODO(ENG-2228): When Phase 1.4 adds `harnessStore` construction above,
-  // construct the recorder here:
+  // construct the recorder here. Note: the recorder constructor takes a
+  // SessionEventBus, but this is agent scope — resolve the session-vs-agent
+  // bus question flagged in ENG-2232's "Notes for reviewer" before wiring.
   //   const harnessOutcomeRecorder = new HarnessOutcomeRecorder(
-  //     harnessStore, sessionEventBus,
+  //     harnessStore, agentEventBus,
   //     logger.withSource('HarnessOutcomeRecorder'), config.harness,
   //   )
   //   sandboxService.setHarnessOutcomeRecorder(harnessOutcomeRecorder, logger)

--- a/src/agent/infra/harness/harness-outcome-recorder.ts
+++ b/src/agent/infra/harness/harness-outcome-recorder.ts
@@ -110,6 +110,23 @@ export class HarnessOutcomeRecorder {
   }
 
   /**
+   * Release all per-session state. Called on agent shutdown.
+   */
+  cleanup(): void {
+    this.commandTypesBySession.clear()
+    this.sessionCount.clear()
+  }
+
+  /**
+   * Release per-session state for a single session. Called when a session
+   * ends so the Maps don't grow unbounded in long-running agents.
+   */
+  clearSession(sessionId: string): void {
+    this.commandTypesBySession.delete(sessionId)
+    this.sessionCount.delete(sessionId)
+  }
+
+  /**
    * Returns the set of command types seen for a session. Phase 6 uses
    * this to trigger refinement only for command types the session touched.
    */

--- a/src/agent/infra/sandbox/sandbox-service.ts
+++ b/src/agent/infra/sandbox/sandbox-service.ts
@@ -164,8 +164,12 @@ export class SandboxService implements ISandboxService {
     // Fire-and-forget: record outcome in the background. The recorder's
     // internal contract (Task 2.1) swallows errors, but the try/catch +
     // .catch are belt-and-braces against programming bugs in the recorder.
-    if (this.harnessOutcomeRecorder) {
+    if (this.harnessOutcomeRecorder && this.environmentContext?.workingDirectory) {
       const ct = config?.commandType
+      if (ct !== undefined && ct !== 'chat' && ct !== 'curate' && ct !== 'query') {
+        this.logger?.debug('harness.record: unknown commandType mapped to chat', {commandType: ct})
+      }
+
       const commandType = ct === 'curate' || ct === 'query' ? ct : 'chat'
       try {
         this.harnessOutcomeRecorder
@@ -174,7 +178,7 @@ export class SandboxService implements ISandboxService {
             commandType,
             executionTimeMs: result.executionTime,
             harnessVersionId: this.harnessVersionIdBySession.get(sessionId),
-            projectId: this.environmentContext?.workingDirectory ?? 'unknown',
+            projectId: this.environmentContext.workingDirectory,
             projectType: this.resolveProjectType(),
             result,
             sessionId,

--- a/src/agent/infra/sandbox/sandbox-service.ts
+++ b/src/agent/infra/sandbox/sandbox-service.ts
@@ -57,6 +57,7 @@ export class SandboxService implements ISandboxService {
    * Clean up all resources (called on agent shutdown).
    */
   async cleanup(): Promise<void> {
+    this.harnessOutcomeRecorder?.cleanup()
     this.harnessVersionIdBySession.clear()
     this.sandboxes.clear()
     this.sandboxCommandTypes.clear()
@@ -69,6 +70,7 @@ export class SandboxService implements ISandboxService {
    * @param sessionId - Session identifier
    */
   async clearSession(sessionId: string): Promise<void> {
+    this.harnessOutcomeRecorder?.clearSession(sessionId)
     this.harnessVersionIdBySession.delete(sessionId)
     this.sandboxes.delete(sessionId)
     this.sandboxCommandTypes.delete(sessionId)

--- a/src/agent/infra/sandbox/sandbox-service.ts
+++ b/src/agent/infra/sandbox/sandbox-service.ts
@@ -1,14 +1,18 @@
 import type { EnvironmentContext } from '../../core/domain/environment/types.js'
+import type { ProjectType } from '../../core/domain/harness/types.js'
 import type { REPLResult, SandboxConfig } from '../../core/domain/sandbox/types.js'
 import type { IContentGenerator } from '../../core/interfaces/i-content-generator.js'
 import type { ICurateService } from '../../core/interfaces/i-curate-service.js'
 import type { IFileSystem } from '../../core/interfaces/i-file-system.js'
+import type { ILogger } from '../../core/interfaces/i-logger.js'
 import type { ISandboxService } from '../../core/interfaces/i-sandbox-service.js'
 import type { ISwarmCoordinator } from '../../core/interfaces/i-swarm-coordinator.js'
 import type { ValidatedHarnessConfig } from '../agent/agent-schemas.js'
+import type { HarnessOutcomeRecorder } from '../harness/harness-outcome-recorder.js'
 import type { SessionManager } from '../session/session-manager.js'
 import type { ISearchKnowledgeService, ToolsSDK } from './tools-sdk.js'
 
+import { ProjectTypeSchema } from '../../core/domain/harness/types.js'
 import {CurateResultCollector} from './curate-result-collector.js'
 import { LocalSandbox } from './local-sandbox.js'
 import { createToolsSDK } from './tools-sdk.js'
@@ -30,6 +34,12 @@ export class SandboxService implements ISandboxService {
   private fileSystem?: IFileSystem
   /** AutoHarness V2 config block, wired in before any session is created. */
   private harnessConfig?: ValidatedHarnessConfig
+  /** AutoHarness V2 outcome recorder — fire-and-forget from executeCode. */
+  private harnessOutcomeRecorder?: HarnessOutcomeRecorder
+  /** Current harness version ID per session, populated by Phase 3 loadHarness. */
+  private harnessVersionIdBySession = new Map<string, string>()
+  /** Logger for defensive .catch on fire-and-forget record calls. */
+  private logger?: ILogger
   /** Variables buffered before sandbox creation, keyed by sessionId */
   private pendingVariables = new Map<string, Record<string, unknown>>()
   /** Command type used to build each sandbox's ToolsSDK, keyed by sessionId */
@@ -47,6 +57,7 @@ export class SandboxService implements ISandboxService {
    * Clean up all resources (called on agent shutdown).
    */
   async cleanup(): Promise<void> {
+    this.harnessVersionIdBySession.clear()
     this.sandboxes.clear()
     this.sandboxCommandTypes.clear()
     this.pendingVariables.clear()
@@ -58,6 +69,7 @@ export class SandboxService implements ISandboxService {
    * @param sessionId - Session identifier
    */
   async clearSession(sessionId: string): Promise<void> {
+    this.harnessVersionIdBySession.delete(sessionId)
     this.sandboxes.delete(sessionId)
     this.sandboxCommandTypes.delete(sessionId)
     this.pendingVariables.delete(sessionId)
@@ -138,12 +150,44 @@ export class SandboxService implements ISandboxService {
       this.sandboxCommandTypes.set(sessionId, config?.commandType)
     }
 
+    let result: REPLResult
+
     if (this.collector) {
-      const {curateResults, result} = await this.collector.collect(() => sandbox.execute(code, config))
-      return curateResults.length > 0 ? {...result, curateResults} : result
+      const collected = await this.collector.collect(() => sandbox.execute(code, config))
+      result = collected.curateResults.length > 0
+        ? {...collected.result, curateResults: collected.curateResults}
+        : collected.result
+    } else {
+      result = await sandbox.execute(code, config)
     }
 
-    return sandbox.execute(code, config)
+    // Fire-and-forget: record outcome in the background. The recorder's
+    // internal contract (Task 2.1) swallows errors, but the try/catch +
+    // .catch are belt-and-braces against programming bugs in the recorder.
+    if (this.harnessOutcomeRecorder) {
+      const ct = config?.commandType
+      const commandType = ct === 'curate' || ct === 'query' ? ct : 'chat'
+      try {
+        this.harnessOutcomeRecorder
+          .record({
+            code,
+            commandType,
+            executionTimeMs: result.executionTime,
+            harnessVersionId: this.harnessVersionIdBySession.get(sessionId),
+            projectId: this.environmentContext?.workingDirectory ?? 'unknown',
+            projectType: this.resolveProjectType(),
+            result,
+            sessionId,
+          })
+          .catch((error: unknown) => {
+            this.logger?.warn('harness.record rejected', {error})
+          })
+      } catch (error) {
+        this.logger?.warn('harness.record threw', {error})
+      }
+    }
+
+    return result
   }
 
   /**
@@ -202,6 +246,19 @@ export class SandboxService implements ISandboxService {
    */
   setHarnessConfig(config: ValidatedHarnessConfig): void {
     this.harnessConfig = config
+  }
+
+  /**
+   * Wire in the AutoHarness V2 outcome recorder. When set, every
+   * `executeCode` call fire-and-forgets a `recorder.record(...)` with the
+   * sandbox result. Errors from the recorder never propagate to the caller.
+   *
+   * @param recorder - Outcome recorder instance
+   * @param logger - Logger for defensive .catch on fire-and-forget calls
+   */
+  setHarnessOutcomeRecorder(recorder: HarnessOutcomeRecorder, logger?: ILogger): void {
+    this.harnessOutcomeRecorder = recorder
+    this.logger = logger
   }
 
   /**
@@ -293,5 +350,16 @@ export class SandboxService implements ISandboxService {
       this.sandboxes.clear()
       this.sandboxCommandTypes.clear()
     }
+  }
+
+  /**
+   * Map `harnessConfig.language` to a `ProjectType`. `'auto'` and absent
+   * language both resolve to `'generic'`; Phase 4 bootstrap will formalize
+   * richer detection. Uses `ProjectTypeSchema.safeParse` so new values
+   * added to the schema are automatically accepted without a code change.
+   */
+  private resolveProjectType(): ProjectType {
+    const parsed = ProjectTypeSchema.safeParse(this.harnessConfig?.language)
+    return parsed.success ? parsed.data : 'generic'
   }
 }

--- a/test/unit/infra/sandbox/sandbox-service-harness-wiring.test.ts
+++ b/test/unit/infra/sandbox/sandbox-service-harness-wiring.test.ts
@@ -13,6 +13,7 @@
 import {expect} from 'chai'
 import sinon from 'sinon'
 
+import type {EnvironmentContext} from '../../../../src/agent/core/domain/environment/types.js'
 import type {ILogger} from '../../../../src/agent/core/interfaces/i-logger.js'
 import type {ValidatedHarnessConfig} from '../../../../src/agent/infra/agent/agent-schemas.js'
 import type {RecordParams} from '../../../../src/agent/infra/harness/harness-outcome-recorder.js'
@@ -60,6 +61,18 @@ function makeLogger(): ILogger & {calls: Record<string, Array<{context?: Record<
   }
 }
 
+function makeEnvironmentContext(workingDirectory = '/test/project'): EnvironmentContext {
+  return {
+    brvStructure: '',
+    fileTree: '',
+    isGitRepository: false,
+    nodeVersion: '22.0.0',
+    osVersion: 'test',
+    platform: 'darwin',
+    workingDirectory,
+  }
+}
+
 function createRecorder(
   config?: Partial<ValidatedHarnessConfig>,
 ): {logger: ReturnType<typeof makeLogger>; recorder: HarnessOutcomeRecorder; store: InMemoryHarnessStore} {
@@ -68,6 +81,18 @@ function createRecorder(
   const logger = makeLogger()
   const recorder = new HarnessOutcomeRecorder(store, bus, logger, makeHarnessConfig(config))
   return {logger, recorder, store}
+}
+
+/** Wire recorder + environment into a SandboxService ready for recording. */
+function wireService(
+  recorder: HarnessOutcomeRecorder,
+  overrides?: {config?: Partial<ValidatedHarnessConfig>; workingDirectory?: string},
+): SandboxService {
+  const service = new SandboxService()
+  service.setHarnessConfig(makeHarnessConfig(overrides?.config))
+  service.setEnvironmentContext(makeEnvironmentContext(overrides?.workingDirectory))
+  service.setHarnessOutcomeRecorder(recorder)
+  return service
 }
 
 // ---------------------------------------------------------------------------
@@ -94,9 +119,7 @@ describe('SandboxService — harness outcome recording', () => {
 
   it('calls recorder.record once per executeCode with correct params', async () => {
     const {recorder} = createRecorder()
-    const service = new SandboxService()
-    service.setHarnessConfig(makeHarnessConfig({language: 'typescript'}))
-    service.setHarnessOutcomeRecorder(recorder)
+    const service = wireService(recorder, {config: {language: 'typescript'}, workingDirectory: '/my/project'})
     const spy = sinon.spy(recorder, 'record')
 
     await service.executeCode('1 + 1', 'sess-1', {commandType: 'curate'})
@@ -110,13 +133,12 @@ describe('SandboxService — harness outcome recording', () => {
     expect(params.result).to.have.property('stderr')
     expect(params.executionTimeMs).to.be.a('number').and.to.be.at.least(0)
     expect(params.projectType).to.equal('typescript')
-    expect(params.projectId).to.be.a('string')
+    expect(params.projectId).to.equal('/my/project')
   })
 
   it('defaults commandType to chat when config.commandType is absent', async () => {
     const {recorder} = createRecorder()
-    const service = new SandboxService()
-    service.setHarnessOutcomeRecorder(recorder)
+    const service = wireService(recorder)
     const spy = sinon.spy(recorder, 'record')
 
     await service.executeCode('1', 'sess-1')
@@ -127,9 +149,7 @@ describe('SandboxService — harness outcome recording', () => {
 
   it('resolves projectType to generic when language is auto', async () => {
     const {recorder} = createRecorder()
-    const service = new SandboxService()
-    service.setHarnessConfig(makeHarnessConfig({language: 'auto'}))
-    service.setHarnessOutcomeRecorder(recorder)
+    const service = wireService(recorder, {config: {language: 'auto'}})
     const spy = sinon.spy(recorder, 'record')
 
     await service.executeCode('1', 'sess-1')
@@ -137,12 +157,23 @@ describe('SandboxService — harness outcome recording', () => {
     expect(spy.firstCall.args[0].projectType).to.equal('generic')
   })
 
+  it('skips recording when environmentContext is not set', async () => {
+    const {recorder} = createRecorder()
+    const service = new SandboxService()
+    service.setHarnessOutcomeRecorder(recorder)
+    const spy = sinon.spy(recorder, 'record')
+
+    const result = await service.executeCode('1 + 1', 'sess-1')
+
+    expect(spy.callCount).to.equal(0)
+    expect(result.returnValue).to.equal(2)
+  })
+
   // ── Error resilience ─────────────────────────────────────────────────────
 
   it('recorder throwing synchronously does not break executeCode', async () => {
     const {recorder} = createRecorder()
-    const service = new SandboxService()
-    service.setHarnessOutcomeRecorder(recorder)
+    const service = wireService(recorder)
     sinon.stub(recorder, 'record').throws(new Error('sync boom'))
 
     const result = await service.executeCode('1 + 1', 'sess-1')
@@ -153,8 +184,7 @@ describe('SandboxService — harness outcome recording', () => {
 
   it('recorder returning rejected promise does not break executeCode', async () => {
     const {recorder} = createRecorder()
-    const service = new SandboxService()
-    service.setHarnessOutcomeRecorder(recorder)
+    const service = wireService(recorder)
     sinon.stub(recorder, 'record').rejects(new Error('async boom'))
 
     const result = await service.executeCode('1 + 1', 'sess-1')
@@ -177,8 +207,7 @@ describe('SandboxService — harness outcome recording', () => {
     const t0 = performance.now() - t0Start
 
     // With slow recorder that takes 100ms
-    const service = new SandboxService()
-    service.setHarnessOutcomeRecorder(recorder)
+    const service = wireService(recorder)
     sinon.stub(recorder, 'record').callsFake(async () => {
       await new Promise<void>((resolve) => {
         setTimeout(resolve, 100)

--- a/test/unit/infra/sandbox/sandbox-service-harness-wiring.test.ts
+++ b/test/unit/infra/sandbox/sandbox-service-harness-wiring.test.ts
@@ -1,0 +1,198 @@
+/**
+ * SandboxService — harness outcome recording wiring tests.
+ *
+ * Validates that `SandboxService.executeCode` calls
+ * `HarnessOutcomeRecorder.record()` in a fire-and-forget fashion:
+ * the sandbox result is returned immediately, the recorder runs in
+ * the background, and errors from the recorder never propagate to
+ * the caller.
+ *
+ * ENG-2232 (Phase 2 Task 2.3)
+ */
+
+import {expect} from 'chai'
+import sinon from 'sinon'
+
+import type {ILogger} from '../../../../src/agent/core/interfaces/i-logger.js'
+import type {ValidatedHarnessConfig} from '../../../../src/agent/infra/agent/agent-schemas.js'
+import type {RecordParams} from '../../../../src/agent/infra/harness/harness-outcome-recorder.js'
+
+import {SessionEventBus} from '../../../../src/agent/infra/events/event-emitter.js'
+import {HarnessOutcomeRecorder} from '../../../../src/agent/infra/harness/harness-outcome-recorder.js'
+import {SandboxService} from '../../../../src/agent/infra/sandbox/sandbox-service.js'
+import {InMemoryHarnessStore} from '../../../helpers/in-memory-harness-store.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeHarnessConfig(overrides: Partial<ValidatedHarnessConfig> = {}): ValidatedHarnessConfig {
+  return {
+    autoLearn: true,
+    enabled: true,
+    language: 'typescript',
+    maxVersions: 20,
+    ...overrides,
+  }
+}
+
+function makeLogger(): ILogger & {calls: Record<string, Array<{context?: Record<string, unknown>; message: string}>>} {
+  const calls: Record<string, Array<{context?: Record<string, unknown>; message: string}>> = {
+    debug: [],
+    error: [],
+    info: [],
+    warn: [],
+  }
+  return {
+    calls,
+    debug(message: string, context?: Record<string, unknown>) {
+      calls.debug.push({context, message})
+    },
+    error(message: string, context?: Record<string, unknown>) {
+      calls.error.push({context, message})
+    },
+    info(message: string, context?: Record<string, unknown>) {
+      calls.info.push({context, message})
+    },
+    warn(message: string, context?: Record<string, unknown>) {
+      calls.warn.push({context, message})
+    },
+  }
+}
+
+function createRecorder(
+  config?: Partial<ValidatedHarnessConfig>,
+): {logger: ReturnType<typeof makeLogger>; recorder: HarnessOutcomeRecorder; store: InMemoryHarnessStore} {
+  const store = new InMemoryHarnessStore()
+  const bus = new SessionEventBus()
+  const logger = makeLogger()
+  const recorder = new HarnessOutcomeRecorder(store, bus, logger, makeHarnessConfig(config))
+  return {logger, recorder, store}
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SandboxService — harness outcome recording', () => {
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  // ── Regression guard ─────────────────────────────────────────────────────
+
+  it('without recorder set, executeCode behaves identically to today', async () => {
+    const service = new SandboxService()
+
+    const result = await service.executeCode('1 + 1', 'sess-1')
+
+    expect(result.returnValue).to.equal(2)
+    expect(result.stderr).to.equal('')
+  })
+
+  // ── Recording wiring ─────────────────────────────────────────────────────
+
+  it('calls recorder.record once per executeCode with correct params', async () => {
+    const {recorder} = createRecorder()
+    const service = new SandboxService()
+    service.setHarnessConfig(makeHarnessConfig({language: 'typescript'}))
+    service.setHarnessOutcomeRecorder(recorder)
+    const spy = sinon.spy(recorder, 'record')
+
+    await service.executeCode('1 + 1', 'sess-1', {commandType: 'curate'})
+
+    expect(spy.calledOnce).to.equal(true)
+    const params: RecordParams = spy.firstCall.args[0]
+    expect(params.code).to.equal('1 + 1')
+    expect(params.commandType).to.equal('curate')
+    expect(params.sessionId).to.equal('sess-1')
+    expect(params.result).to.have.property('stdout')
+    expect(params.result).to.have.property('stderr')
+    expect(params.executionTimeMs).to.be.a('number').and.to.be.at.least(0)
+    expect(params.projectType).to.equal('typescript')
+    expect(params.projectId).to.be.a('string')
+  })
+
+  it('defaults commandType to chat when config.commandType is absent', async () => {
+    const {recorder} = createRecorder()
+    const service = new SandboxService()
+    service.setHarnessOutcomeRecorder(recorder)
+    const spy = sinon.spy(recorder, 'record')
+
+    await service.executeCode('1', 'sess-1')
+
+    expect(spy.calledOnce).to.equal(true)
+    expect(spy.firstCall.args[0].commandType).to.equal('chat')
+  })
+
+  it('resolves projectType to generic when language is auto', async () => {
+    const {recorder} = createRecorder()
+    const service = new SandboxService()
+    service.setHarnessConfig(makeHarnessConfig({language: 'auto'}))
+    service.setHarnessOutcomeRecorder(recorder)
+    const spy = sinon.spy(recorder, 'record')
+
+    await service.executeCode('1', 'sess-1')
+
+    expect(spy.firstCall.args[0].projectType).to.equal('generic')
+  })
+
+  // ── Error resilience ─────────────────────────────────────────────────────
+
+  it('recorder throwing synchronously does not break executeCode', async () => {
+    const {recorder} = createRecorder()
+    const service = new SandboxService()
+    service.setHarnessOutcomeRecorder(recorder)
+    sinon.stub(recorder, 'record').throws(new Error('sync boom'))
+
+    const result = await service.executeCode('1 + 1', 'sess-1')
+
+    expect(result.returnValue).to.equal(2)
+    expect(result.stderr).to.equal('')
+  })
+
+  it('recorder returning rejected promise does not break executeCode', async () => {
+    const {recorder} = createRecorder()
+    const service = new SandboxService()
+    service.setHarnessOutcomeRecorder(recorder)
+    sinon.stub(recorder, 'record').rejects(new Error('async boom'))
+
+    const result = await service.executeCode('1 + 1', 'sess-1')
+
+    expect(result.returnValue).to.equal(2)
+    expect(result.stderr).to.equal('')
+  })
+
+  // ── Fire-and-forget latency ──────────────────────────────────────────────
+
+  it('executeCode latency is not blocked by slow recorder', async () => {
+    const {recorder} = createRecorder()
+
+    // Baseline: no recorder
+    const baseline = new SandboxService()
+    // Warm up to eliminate first-call overhead
+    await baseline.executeCode('1', 'sess-warm')
+    const t0Start = performance.now()
+    await baseline.executeCode('1 + 1', 'sess-warm')
+    const t0 = performance.now() - t0Start
+
+    // With slow recorder that takes 100ms
+    const service = new SandboxService()
+    service.setHarnessOutcomeRecorder(recorder)
+    sinon.stub(recorder, 'record').callsFake(async () => {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 100)
+      })
+    })
+
+    // Warm up
+    await service.executeCode('1', 'sess-warm2')
+    const t1Start = performance.now()
+    await service.executeCode('1 + 1', 'sess-warm2')
+    const t1 = performance.now() - t1Start
+
+    // Fire-and-forget: T1 must NOT include the 100ms recorder delay.
+    // Allow 2x baseline + 20ms tolerance for try/catch overhead.
+    expect(t1).to.be.at.most(2 * t0 + 20)
+  })
+})


### PR DESCRIPTION
## Summary

- Problem: SandboxService executes code but doesn't record outcomes for the AutoHarness V2 heuristic and refinement loop.
- Why it matters: Without outcome recording, the harness has no signal to compute H, select modes, or refine learned code helpers.
- What changed: SandboxService.executeCode now fire-and-forgets a recorder.record() call after every sandbox execution, capturing code, result, timing, and project metadata. CipherAgentServices exposes the recorder for Phase 7 consumers.
- What did NOT change (scope boundary): service-initializer.ts construction is a TODO — blocked by Phase 1.4 (ENG-2228) which adds HarnessStore. No taskDescription/conversationTurn threading (Task 2.4). No projectId normalization (Phase 4).

## Type of change

- [x] New feature

## Scope (select all touched areas)

- [x] Agent / Tools

## Linked issues

- Closes ENG-2232
- Related ENG-2229, ENG-2228

## Root cause (bug fixes only, otherwise write `N/A`)

N/A

## Test plan

- Coverage added:
  - [x] Unit test
- Test file(s): `test/unit/infra/sandbox/sandbox-service-harness-wiring.test.ts`
- Key scenario(s) covered:
  - Regression: executeCode without recorder behaves identically
  - record() called once per executeCode with correct RecordParams
  - commandType defaults to 'chat' when absent
  - projectType resolves via ProjectTypeSchema.safeParse ('auto' -> 'generic')
  - Sync throw from recorder does not break executeCode
  - Async rejection from recorder does not break executeCode
  - Fire-and-forget latency: slow recorder (100ms) does not block executeCode (T1 <= 2*T0 + 20ms)

## User-visible changes

None. Recorder is not wired in service-initializer.ts until Phase 1.4 lands.

## Evidence

```
SandboxService — harness outcome recording
  ✔ without recorder set, executeCode behaves identically to today
  ✔ calls recorder.record once per executeCode with correct params
  ✔ defaults commandType to chat when config.commandType is absent
  ✔ resolves projectType to generic when language is auto
  ✔ recorder throwing synchronously does not break executeCode
  ✔ recorder returning rejected promise does not break executeCode
  ✔ executeCode latency is not blocked by slow recorder

7 passing (74ms)
```

Full gate: 6631 passing, lint clean, typecheck clean, build clean.

## Checklist

- [x] Tests added or updated and passing (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow Conventional Commits format
- [x] No breaking changes
- [x] Branch is up to date with `proj/autoharness-v2`

## Risks and mitigations

- Risk: `harnessVersionIdBySession` Map is declared but never `.set()`-ed, could look like dead code.
  - Mitigation: JSDoc documents it as Phase 3 forward-compat. cleanup() and clearSession() already handle it.
- Risk: `harnessOutcomeRecorder?` on CipherAgentServices is unused until Phase 1.4 wires the construction.
  - Mitigation: JSDoc explains the dependency chain. Field is optional — no runtime impact.
- Risk: `projectId` uses raw `workingDirectory` which may contain backslashes on Windows.
  - Mitigation: Matches existing pattern in buildToolsSDK. Phase 4 bootstrap formalizes path normalization.