### PR TITLE
feat: [ENG-2227] AutoHarness V2 HarnessStore — outcome + scenario CRUD

### DIFF
--- a/src/agent/core/domain/errors/harness-store-error.ts
+++ b/src/agent/core/domain/errors/harness-store-error.ts
@@ -3,6 +3,14 @@
  */
 export enum HarnessStoreErrorCode {
   /**
+   * `recordFeedback` was called with an `outcomeId` that does not exist
+   * under the given `(projectId, commandType)` partition. Callers should
+   * only flag outcomes they obtained from `listOutcomes` — a miss here
+   * is a real bug, not a racy fallback.
+   */
+  OUTCOME_NOT_FOUND = 'OUTCOME_NOT_FOUND',
+
+  /**
    * A version with the same `id`, or the same
    * `(projectId, commandType, version)` tuple, already exists.
    */
@@ -31,6 +39,18 @@ export class HarnessStoreError extends Error {
 
   static isHarnessStoreError(error: unknown): error is HarnessStoreError {
     return error instanceof HarnessStoreError
+  }
+
+  static outcomeNotFound(
+    projectId: string,
+    commandType: string,
+    outcomeId: string,
+  ): HarnessStoreError {
+    return new HarnessStoreError(
+      `Outcome not found for (${projectId}, ${commandType}): ${outcomeId}`,
+      HarnessStoreErrorCode.OUTCOME_NOT_FOUND,
+      {commandType, outcomeId, projectId},
+    )
   }
 
   static versionConflict(

--- a/src/agent/infra/harness/harness-store.ts
+++ b/src/agent/infra/harness/harness-store.ts
@@ -2,16 +2,16 @@
  * AutoHarness V2 storage — `IKeyStorage`-backed implementation.
  *
  * Facade over `IKeyStorage` that partitions harness versions, outcomes,
- * and scenarios under composite key prefixes. This file ships the
- * version CRUD (Phase 1 Task 1.2); outcome and scenario CRUD land in
- * Task 1.3 — those methods are `throw 'not implemented yet'` stubs
- * here so the class satisfies the interface and stays compile-valid
- * mid-phase.
+ * and scenarios under composite key prefixes.
  *
  * Key-space layout (see `tasks/phase_1_2_handoff.md §C4`):
  *   ["harness", "version",  projectId, commandType, versionId]
- *   ["harness", "outcome",  projectType, projectId, commandType, outcomeId]   (Task 1.3)
- *   ["harness", "scenario", projectType, projectId, commandType, scenarioId]  (Task 1.3)
+ *   ["harness", "outcome",  projectType, projectId, commandType, outcomeId]
+ *   ["harness", "scenario", projectType, projectId, commandType, scenarioId]
+ *
+ * `projectType` appears in the outcome/scenario prefix (not version) —
+ * enables a v1.1 cross-project aggregation query
+ * (`list(["harness", "outcome", "typescript"])`) without a migration.
  *
  * `HarnessVersion` bodies are inlined in the key record — typical
  * harness code is <10KB. If that ceiling moves, swap the code field to
@@ -33,13 +33,24 @@ import type {BatchOperation, IKeyStorage, StorageKey} from '../../core/interface
 import type {ILogger} from '../../core/interfaces/i-logger.js'
 
 import {HarnessStoreError} from '../../core/domain/errors/harness-store-error.js'
-import {HarnessVersionSchema} from '../../core/domain/harness/types.js'
+import {
+  CodeExecOutcomeSchema,
+  EvaluationScenarioSchema,
+  HarnessVersionSchema,
+  ProjectTypeSchema,
+} from '../../core/domain/harness/types.js'
 
 const HARNESS_PREFIX = 'harness'
 const VERSION_PREFIX = 'version'
+const OUTCOME_PREFIX = 'outcome'
+const SCENARIO_PREFIX = 'scenario'
 
-const TASK_1_3_PENDING =
-  'Not implemented — HarnessStore: outcome/scenario CRUD lands in Phase 1 Task 1.3'
+/**
+ * Default cap when `listOutcomes` is called without an explicit `limit`.
+ * Keeps the heuristic's 50-outcome window comfortably within range while
+ * bounding memory for bad callers.
+ */
+const DEFAULT_LIST_OUTCOMES_LIMIT = 100
 
 export class HarnessStore implements IHarnessStore {
   constructor(
@@ -47,10 +58,33 @@ export class HarnessStore implements IHarnessStore {
     private readonly logger: ILogger,
   ) {}
 
-  // ── outcomes (Task 1.3 stubs) ──────────────────────────────────────────────
+  // ── outcomes ──────────────────────────────────────────────────────────────
 
-  async deleteOutcomes(_projectId: string, _commandType: string): Promise<number> {
-    throw new Error(TASK_1_3_PENDING)
+  async deleteOutcomes(projectId: string, commandType: string): Promise<number> {
+    const keys: StorageKey[] = []
+    for (const projectType of ProjectTypeSchema.options) {
+      // eslint-disable-next-line no-await-in-loop
+      const entries = await this.keyStorage.listWithValues<CodeExecOutcome>([
+        HARNESS_PREFIX,
+        OUTCOME_PREFIX,
+        projectType,
+        projectId,
+        commandType,
+      ])
+      for (const entry of entries) keys.push(entry.key)
+    }
+
+    if (keys.length === 0) return 0
+
+    const operations: BatchOperation[] = keys.map((key) => ({key, type: 'delete' as const}))
+    await this.keyStorage.batch(operations)
+    this.logger.debug('HarnessStore.deleteOutcomes cleared partition', {
+      commandType,
+      deleted: keys.length,
+      projectId,
+    })
+
+    return keys.length
   }
 
   // ── versions ───────────────────────────────────────────────────────────────
@@ -73,15 +107,40 @@ export class HarnessStore implements IHarnessStore {
   }
 
   async listOutcomes(
-    _projectId: string,
-    _commandType: string,
-    _limit?: number,
+    projectId: string,
+    commandType: string,
+    limit?: number,
   ): Promise<CodeExecOutcome[]> {
-    throw new Error(TASK_1_3_PENDING)
+    // Precondition: `limit` (when provided) is a positive integer. Invalid
+    // values degrade silently to the default rather than throwing, since
+    // this method is read-only and a bad limit is strictly a caller hint.
+    const cap =
+      limit !== undefined && Number.isInteger(limit) && limit > 0
+        ? limit
+        : DEFAULT_LIST_OUTCOMES_LIMIT
+
+    const matches = await this.listOutcomesAcrossPartitions(projectId, commandType)
+    matches.sort((a, b) => b.timestamp - a.timestamp)
+    return matches.slice(0, cap)
   }
 
-  async listScenarios(_projectId: string, _commandType: string): Promise<EvaluationScenario[]> {
-    throw new Error(TASK_1_3_PENDING)
+  async listScenarios(projectId: string, commandType: string): Promise<EvaluationScenario[]> {
+    const matches: EvaluationScenario[] = []
+    for (const projectType of ProjectTypeSchema.options) {
+      // eslint-disable-next-line no-await-in-loop
+      const entries = await this.keyStorage.listWithValues<EvaluationScenario>([
+        HARNESS_PREFIX,
+        SCENARIO_PREFIX,
+        projectType,
+        projectId,
+        commandType,
+      ])
+      for (const entry of entries) matches.push(entry.value)
+    }
+
+    // No temporal order on scenarios — return in insertion-stable order
+    // per the interface docstring.
+    return matches
   }
 
   async listVersions(projectId: string, commandType: string): Promise<HarnessVersion[]> {
@@ -164,20 +223,56 @@ export class HarnessStore implements IHarnessStore {
   }
 
   async recordFeedback(
-    _projectId: string,
-    _commandType: string,
-    _outcomeId: string,
-    _verdict: 'bad' | 'good' | null,
+    projectId: string,
+    commandType: string,
+    outcomeId: string,
+    verdict: 'bad' | 'good' | null,
   ): Promise<void> {
-    throw new Error(TASK_1_3_PENDING)
+    // `recordFeedback`'s signature doesn't carry `projectType`, so we
+    // locate the outcome by scanning all partitions first.
+    //
+    // Uses `get` + `set` rather than `keyStorage.update` because
+    // `FileKeyStorage.update` wraps thrown errors as plain `Error`,
+    // which would mangle the typed `HarnessStoreError.outcomeNotFound`
+    // we want to surface on the narrow race where the outcome is
+    // deleted between our locate scan and the read. That race window
+    // is non-corrupting — we simply report `OUTCOME_NOT_FOUND` to the
+    // caller. In practice Phase 2 callers flag outcomes they just
+    // read from `listOutcomes`, so the race is negligible.
+    const locatedKey = await this.findOutcomeKey(projectId, commandType, outcomeId)
+    if (locatedKey === undefined) {
+      throw HarnessStoreError.outcomeNotFound(projectId, commandType, outcomeId)
+    }
+
+    const current = await this.keyStorage.get<CodeExecOutcome>(locatedKey)
+    if (current === undefined) {
+      throw HarnessStoreError.outcomeNotFound(projectId, commandType, outcomeId)
+    }
+
+    await this.keyStorage.set(locatedKey, {...current, userFeedback: verdict})
   }
 
-  async saveOutcome(_outcome: CodeExecOutcome): Promise<void> {
-    throw new Error(TASK_1_3_PENDING)
+  async saveOutcome(outcome: CodeExecOutcome): Promise<void> {
+    const parsed = CodeExecOutcomeSchema.parse(outcome)
+    const key = this.outcomeKey(
+      parsed.projectType,
+      parsed.projectId,
+      parsed.commandType,
+      parsed.id,
+    )
+    // Duplicate `id` is an idempotent overwrite per the interface docs.
+    await this.keyStorage.set(key, parsed)
   }
 
-  async saveScenario(_scenario: EvaluationScenario): Promise<void> {
-    throw new Error(TASK_1_3_PENDING)
+  async saveScenario(scenario: EvaluationScenario): Promise<void> {
+    const parsed = EvaluationScenarioSchema.parse(scenario)
+    const key = this.scenarioKey(
+      parsed.projectType,
+      parsed.projectId,
+      parsed.commandType,
+      parsed.id,
+    )
+    await this.keyStorage.set(key, parsed)
   }
 
   async saveVersion(version: HarnessVersion): Promise<void> {
@@ -226,6 +321,41 @@ export class HarnessStore implements IHarnessStore {
 
   // ── internals ──────────────────────────────────────────────────────────────
 
+  private async findOutcomeKey(
+    projectId: string,
+    commandType: string,
+    outcomeId: string,
+  ): Promise<StorageKey | undefined> {
+    for (const projectType of ProjectTypeSchema.options) {
+      const key = this.outcomeKey(projectType, projectId, commandType, outcomeId)
+      // eslint-disable-next-line no-await-in-loop
+      const hit = await this.keyStorage.exists(key)
+      if (hit) return key
+    }
+
+    return undefined
+  }
+
+  private async listOutcomesAcrossPartitions(
+    projectId: string,
+    commandType: string,
+  ): Promise<CodeExecOutcome[]> {
+    const matches: CodeExecOutcome[] = []
+    for (const projectType of ProjectTypeSchema.options) {
+      // eslint-disable-next-line no-await-in-loop
+      const entries = await this.keyStorage.listWithValues<CodeExecOutcome>([
+        HARNESS_PREFIX,
+        OUTCOME_PREFIX,
+        projectType,
+        projectId,
+        commandType,
+      ])
+      for (const entry of entries) matches.push(entry.value)
+    }
+
+    return matches
+  }
+
   private async listVersionsForPair(
     projectId: string,
     commandType: string,
@@ -237,6 +367,24 @@ export class HarnessStore implements IHarnessStore {
       commandType,
     ])
     return entries.map((e) => e.value)
+  }
+
+  private outcomeKey(
+    projectType: string,
+    projectId: string,
+    commandType: string,
+    outcomeId: string,
+  ): StorageKey {
+    return [HARNESS_PREFIX, OUTCOME_PREFIX, projectType, projectId, commandType, outcomeId]
+  }
+
+  private scenarioKey(
+    projectType: string,
+    projectId: string,
+    commandType: string,
+    scenarioId: string,
+  ): StorageKey {
+    return [HARNESS_PREFIX, SCENARIO_PREFIX, projectType, projectId, commandType, scenarioId]
   }
 
   private versionKey(projectId: string, commandType: string, versionId: string): StorageKey {

--- a/test/unit/agent/harness/harness-store-outcomes.test.ts
+++ b/test/unit/agent/harness/harness-store-outcomes.test.ts
@@ -1,0 +1,244 @@
+import {expect} from 'chai'
+
+import type {
+  CodeExecOutcome,
+  EvaluationScenario,
+} from '../../../../src/agent/core/domain/harness/types.js'
+
+import {
+  HarnessStoreError,
+  HarnessStoreErrorCode,
+} from '../../../../src/agent/core/domain/errors/harness-store-error.js'
+import {NoOpLogger} from '../../../../src/agent/core/interfaces/i-logger.js'
+import {HarnessStore} from '../../../../src/agent/infra/harness/harness-store.js'
+import {FileKeyStorage} from '../../../../src/agent/infra/storage/file-key-storage.js'
+
+function makeOutcome(overrides: Partial<CodeExecOutcome> = {}): CodeExecOutcome {
+  return {
+    code: 'tools.search("x")',
+    commandType: 'curate',
+    executionTimeMs: 10,
+    id: 'o-default',
+    projectId: 'p',
+    projectType: 'typescript',
+    sessionId: 's',
+    success: true,
+    timestamp: 1_700_000_000_000,
+    usedHarness: false,
+    ...overrides,
+  }
+}
+
+function makeScenario(overrides: Partial<EvaluationScenario> = {}): EvaluationScenario {
+  return {
+    code: 'tools.search("x")',
+    commandType: 'curate',
+    expectedBehavior: 'returns results',
+    id: 's-default',
+    projectId: 'p',
+    projectType: 'typescript',
+    taskDescription: 'find auth module',
+    ...overrides,
+  }
+}
+
+async function newStore(): Promise<HarnessStore> {
+  const keyStorage = new FileKeyStorage({inMemory: true})
+  await keyStorage.initialize()
+  return new HarnessStore(keyStorage, new NoOpLogger())
+}
+
+describe('HarnessStore — outcome + scenario CRUD', () => {
+  // ── Outcome round-trip ────────────────────────────────────────────────────
+
+  it('saveOutcome + listOutcomes returns the entry', async () => {
+    const store = await newStore()
+    const o = makeOutcome({id: 'o1'})
+    await store.saveOutcome(o)
+
+    const list = await store.listOutcomes('p', 'curate')
+    expect(list).to.have.lengthOf(1)
+    expect(list[0].id).to.equal('o1')
+  })
+
+  it('listOutcomes newest-first with limit caps to the N newest', async () => {
+    const store = await newStore()
+    for (let i = 0; i < 5; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      await store.saveOutcome(makeOutcome({id: `o${i}`, timestamp: 1000 + i}))
+    }
+
+    const top2 = await store.listOutcomes('p', 'curate', 2)
+    expect(top2.map((o) => o.id)).to.deep.equal(['o4', 'o3'])
+  })
+
+  it('listOutcomes default limit is 100 when more outcomes exist', async () => {
+    const store = await newStore()
+    const saves = Array.from({length: 150}, (_, i) =>
+      store.saveOutcome(makeOutcome({id: `o${i}`, timestamp: 1000 + i})),
+    )
+    await Promise.all(saves)
+
+    const defaulted = await store.listOutcomes('p', 'curate')
+    expect(defaulted).to.have.lengthOf(100)
+  })
+
+  it('saveOutcome with duplicate id overwrites (no throw, idempotent)', async () => {
+    const store = await newStore()
+    await store.saveOutcome(makeOutcome({id: 'o1', success: true}))
+    await store.saveOutcome(makeOutcome({id: 'o1', success: false}))
+
+    const list = await store.listOutcomes('p', 'curate')
+    expect(list).to.have.lengthOf(1)
+    expect(list[0].success).to.equal(false)
+  })
+
+  // ── Outcome deletion ─────────────────────────────────────────────────────
+
+  it('deleteOutcomes on an empty partition returns 0', async () => {
+    const store = await newStore()
+    expect(await store.deleteOutcomes('p', 'curate')).to.equal(0)
+  })
+
+  it('deleteOutcomes clears every outcome under the pair and returns the count', async () => {
+    const store = await newStore()
+    await store.saveOutcome(makeOutcome({id: 'o1'}))
+    await store.saveOutcome(makeOutcome({id: 'o2'}))
+    await store.saveOutcome(makeOutcome({id: 'o3'}))
+
+    expect(await store.deleteOutcomes('p', 'curate')).to.equal(3)
+    expect(await store.listOutcomes('p', 'curate')).to.have.lengthOf(0)
+  })
+
+  it('deleteOutcomes leaves outcomes under other (projectId, commandType) pairs intact', async () => {
+    const store = await newStore()
+    await store.saveOutcome(makeOutcome({id: 'o1', projectId: 'p1'}))
+    await store.saveOutcome(makeOutcome({id: 'o2', projectId: 'p1'}))
+    await store.saveOutcome(makeOutcome({id: 'o3', projectId: 'p2'}))
+
+    const deleted = await store.deleteOutcomes('p1', 'curate')
+    expect(deleted).to.equal(2)
+
+    expect(await store.listOutcomes('p1', 'curate')).to.have.lengthOf(0)
+    expect(await store.listOutcomes('p2', 'curate')).to.have.lengthOf(1)
+  })
+
+  // ── Feedback ─────────────────────────────────────────────────────────────
+
+  it('recordFeedback sets userFeedback on the named outcome', async () => {
+    const store = await newStore()
+    await store.saveOutcome(makeOutcome({id: 'o1'}))
+
+    await store.recordFeedback('p', 'curate', 'o1', 'bad')
+    const [after] = await store.listOutcomes('p', 'curate')
+    expect(after.userFeedback).to.equal('bad')
+  })
+
+  it('recordFeedback with null clears a prior flag', async () => {
+    const store = await newStore()
+    await store.saveOutcome(makeOutcome({id: 'o1', userFeedback: 'good'}))
+
+    await store.recordFeedback('p', 'curate', 'o1', null)
+    const [after] = await store.listOutcomes('p', 'curate')
+    expect(after.userFeedback).to.equal(null)
+  })
+
+  it('recordFeedback on a nonexistent outcome throws OUTCOME_NOT_FOUND', async () => {
+    const store = await newStore()
+    try {
+      await store.recordFeedback('p', 'curate', 'does-not-exist', 'bad')
+      expect.fail('expected throw')
+    } catch (error) {
+      expect(HarnessStoreError.isCode(error, HarnessStoreErrorCode.OUTCOME_NOT_FOUND)).to.equal(
+        true,
+      )
+      if (!HarnessStoreError.isHarnessStoreError(error)) expect.fail('not a HarnessStoreError')
+      expect(error.details?.outcomeId).to.equal('does-not-exist')
+    }
+  })
+
+  // ── Scenario round-trip ──────────────────────────────────────────────────
+
+  it('saveScenario + listScenarios round-trips', async () => {
+    const store = await newStore()
+    const s = makeScenario({id: 's1'})
+    await store.saveScenario(s)
+
+    const list = await store.listScenarios('p', 'curate')
+    expect(list).to.deep.equal([s])
+  })
+
+  it('listScenarios on an empty partition returns an empty array', async () => {
+    const store = await newStore()
+    expect(await store.listScenarios('p', 'curate')).to.deep.equal([])
+  })
+
+  it('saveScenario with duplicate id overwrites', async () => {
+    const store = await newStore()
+    await store.saveScenario(makeScenario({id: 's1', taskDescription: 'original'}))
+    await store.saveScenario(makeScenario({id: 's1', taskDescription: 'replaced'}))
+
+    const list = await store.listScenarios('p', 'curate')
+    expect(list).to.have.lengthOf(1)
+    expect(list[0].taskDescription).to.equal('replaced')
+  })
+
+  // ── Cross-projectType partition ──────────────────────────────────────────
+
+  it('listOutcomes merges entries across projectType partitions under the same (projectId, commandType)', async () => {
+    const store = await newStore()
+    await store.saveOutcome(makeOutcome({id: 'ts1', projectType: 'typescript', timestamp: 1000}))
+    await store.saveOutcome(makeOutcome({id: 'ts2', projectType: 'typescript', timestamp: 2000}))
+    await store.saveOutcome(makeOutcome({id: 'ts3', projectType: 'typescript', timestamp: 3000}))
+    await store.saveOutcome(makeOutcome({id: 'py1', projectType: 'python', timestamp: 4000}))
+    await store.saveOutcome(makeOutcome({id: 'py2', projectType: 'python', timestamp: 5000}))
+
+    const list = await store.listOutcomes('p', 'curate')
+    expect(list).to.have.lengthOf(5)
+    expect(list.map((o) => o.id)).to.deep.equal(['py2', 'py1', 'ts3', 'ts2', 'ts1'])
+  })
+
+  it('listScenarios merges entries across projectType partitions', async () => {
+    const store = await newStore()
+    await store.saveScenario(makeScenario({id: 'ts1', projectType: 'typescript'}))
+    await store.saveScenario(makeScenario({id: 'py1', projectType: 'python'}))
+    await store.saveScenario(makeScenario({id: 'gn1', projectType: 'generic'}))
+
+    const list = await store.listScenarios('p', 'curate')
+    expect(list).to.have.lengthOf(3)
+    expect(list.map((s) => s.id).sort()).to.deep.equal(['gn1', 'py1', 'ts1'])
+  })
+
+  // ── Concurrency ──────────────────────────────────────────────────────────
+
+  it('100 parallel saveOutcome calls on distinct ids all persist', async () => {
+    const store = await newStore()
+    const saves = Array.from({length: 100}, (_, i) =>
+      store.saveOutcome(makeOutcome({id: `o${i}`, timestamp: 1000 + i})),
+    )
+    await Promise.all(saves)
+
+    const list = await store.listOutcomes('p', 'curate', 200)
+    expect(list).to.have.lengthOf(100)
+  })
+
+  it('50 seeded outcomes + 50 parallel recordFeedback calls all set the field correctly', async () => {
+    const store = await newStore()
+    // Seed first so the feedback calls can't race ahead of the saves.
+    const seeds = Array.from({length: 50}, (_, i) =>
+      store.saveOutcome(makeOutcome({id: `o${i}`, timestamp: 1000 + i})),
+    )
+    await Promise.all(seeds)
+
+    const feedbacks = Array.from({length: 50}, (_, i) =>
+      store.recordFeedback('p', 'curate', `o${i}`, 'bad'),
+    )
+    await Promise.all(feedbacks)
+
+    const list = await store.listOutcomes('p', 'curate', 100)
+    expect(list).to.have.lengthOf(50)
+    for (const outcome of list) {
+      expect(outcome.userFeedback).to.equal('bad')
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- Problem: `HarnessStore` shipped in ENG-2226 with 6 methods stubbed as `throw new Error('not implemented yet')`. Phat's Phase 2 Task 2.2 (`attachFeedback` orchestration) and every downstream phase that reads outcomes/scenarios cannot land until those stubs become real.
- Why it matters: This closes the last remaining implementation gap in Phase 1's core store. Once ENG-2228 (service-initializer wiring) follows, the full `HarnessStore` is live on `proj/autoharness-v2` and every consumer gates on it unblock.
- What changed: Replaced the 6 stubs with full implementations — `saveOutcome`, `listOutcomes`, `deleteOutcomes`, `recordFeedback`, `saveScenario`, `listScenarios`. Extended `HarnessStoreError` with `OUTCOME_NOT_FOUND`. Added 17 unit tests.
- What did NOT change (scope boundary): `saveVersion` / `getVersion` / `getLatest` / `listVersions` / `pruneOldVersions` untouched (shipped in ENG-2226). `service-initializer.ts` not modified (that's ENG-2228). No consumer wiring. No breaking signature changes to `IHarnessStore`.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [x] Agent / Tools
- [ ] LLM Providers
- [ ] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes ENG-2227
- Related ENG-2226 (Phase 1 Task 1.2 — version CRUD, merged)
- Related ENG-2229 (Phase 2 Task 2.1 — recorder core, merged — Phat)
- Related ENG-2232 (Phase 2 Task 2.3 — SandboxService wiring, merged — Phat)
- Unblocks Phase 2 Task 2.2 (`attachFeedback` orchestration — Phat)

## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause: N/A
- Why this was not caught earlier: N/A

## Test plan

- Coverage added:
  - [x] Unit test
  - [ ] Integration test
  - [ ] Manual verification only
- Test file(s): `test/unit/agent/harness/harness-store-outcomes.test.ts`
- Key scenario(s) covered:
  - Outcome round-trip: save + list, `limit` caps, default limit 100 on 150-outcome seed, duplicate id overwrites
  - Outcome deletion: empty-partition returns 0, clears all entries + returns count, leaves other pairs intact
  - Feedback: sets field, `null` clears, nonexistent outcome throws `OUTCOME_NOT_FOUND`
  - Scenario round-trip: save + list, empty → `[]`, duplicate id overwrites
  - Cross-partition merge: outcomes across `typescript` + `python` + `generic` partitions merge into one `listOutcomes` result (5 total, newest-first); same for scenarios
  - Concurrency: 100 parallel `saveOutcome` on distinct ids → all 100 persist; 50 seeded + 50 parallel `recordFeedback` → all flags land

## User-visible changes

None. No consumer imports the outcome/scenario methods yet — ENG-2228 (service-initializer wiring) is the first step in the import chain. `harness.enabled = false` remains the public default.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording

Before this PR, every test in `harness-store-outcomes.test.ts` would have thrown `Not implemented — HarnessStore: outcome/scenario CRUD lands in Phase 1 Task 1.3`. After, all 17 pass. Full suite: 6649 passing / 0 failing.

```
$ npm test -- --grep "HarnessStore — outcome \+ scenario CRUD"
  HarnessStore — outcome + scenario CRUD
    ✔ saveOutcome + listOutcomes returns the entry
    ✔ listOutcomes newest-first with limit caps to the N newest
    ✔ listOutcomes default limit is 100 when more outcomes exist
    ✔ saveOutcome with duplicate id overwrites (no throw, idempotent)
    ✔ deleteOutcomes on an empty partition returns 0
    ✔ deleteOutcomes clears every outcome under the pair and returns the count
    ✔ deleteOutcomes leaves outcomes under other (projectId, commandType) pairs intact
    ✔ recordFeedback sets userFeedback on the named outcome
    ✔ recordFeedback with null clears a prior flag
    ✔ recordFeedback on a nonexistent outcome throws OUTCOME_NOT_FOUND
    ✔ saveScenario + listScenarios round-trips
    ✔ listScenarios on an empty partition returns an empty array
    ✔ saveScenario with duplicate id overwrites
    ✔ listOutcomes merges entries across projectType partitions under the same (projectId, commandType)
    ✔ listScenarios merges entries across projectType partitions
    ✔ 100 parallel saveOutcome calls on distinct ids all persist
    ✔ 50 seeded outcomes + 50 parallel recordFeedback calls all set the field correctly
  17 passing (22ms)
```

## Checklist

- [x] Tests added or updated and passing (`npm test`) — 17 new tests; full suite 6649 passing / 0 failing
- [x] Lint passes (`npm run lint`) — 0 errors, 222 pre-existing warnings (none new from this PR; warning count moved from 206 → 222 because Phat's intermediate PRs merged since ENG-2226)
- [x] Type check passes (`npm run typecheck`) — exit=0
- [x] Build succeeds (`npm run build`) — exit=0
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format — `feat: [ENG-2227] ...`
- [x] Documentation updated (if applicable) — task doc at `features/autoharness-v2/tasks/phase_1/task_03-harness-store-outcome-scenario-crud.md` (research repo) is the spec this PR implements; two AC-wording tweaks flagged in "Notes for reviewers" are post-merge tightenings matching the pattern used for Tasks 0.5 / 0.6 / 1.2
- [x] No breaking changes (or clearly documented above) — additive; the only pre-existing consumer (ENG-2226's `saveVersion`) is untouched
- [ ] Branch is up to date with `main` — targets `proj/autoharness-v2`, not `main`

## Risks and mitigations

- **Risk**: `recordFeedback` has a narrow TOCTOU window between `findOutcomeKey` (scan) and `get` (read). A concurrent `deleteOutcomes` could slip in and remove the outcome mid-call.
  - **Mitigation**: Both the pre-scan and the post-get paths throw the same typed `OUTCOME_NOT_FOUND` error, so the caller sees a consistent signal. The Phase 2 recorder (Phat's attachFeedback) flags outcomes it just read from `listOutcomes` — the race is negligible in practice. Documented in-source at `harness-store.ts:233-241`.

- **Risk**: Concurrent `saveOutcome` + `recordFeedback` on the same outcome id could race, with one wiping the other. `get`+`set` in `recordFeedback` doesn't serialize against concurrent `saveOutcome` writes.
  - **Mitigation**: This racing pattern doesn't occur in practice — the Phase 2 recorder writes each outcome once (on code_exec return) and user feedback flows write later via `attachFeedback`. If a future consumer ever needs to race these two operations, the right fix is adding a per-key merge semantic at the store layer, not a retry loop at the caller. Test 17 demonstrates 50 seeded outcomes + 50 parallel feedbacks work correctly (no concurrent saves on those keys).

- **Risk**: `listOutcomes` scans 3 `projectType` partitions even though a project pins one. Perf cost scales with `ProjectType.options.length`.
  - **Mitigation**: Currently 3 values (`typescript`, `python`, `generic`). Two partitions return empty, one has the data. Cost bound at `O(3) = O(1)`. If `ProjectType` grows in v1.x (e.g., adding `rust`, `go`), the cost still scales linearly and remains cheap. The alternative — requiring `projectType` in the method signature — would leak a detail that doesn't belong in `(projectId, commandType)`-partitioned queries.

## Notes for reviewers

**Two AC-wording deviations from the task doc**, both principled and documented in-source:

1. **AC6: "updates via optimistic `update`"** — Ships with `get`+`set` instead. Reason: `FileKeyStorage.update` wraps thrown errors as plain `Error`, discarding the typed `HarnessStoreError`. Using `update` for the feedback path would force a sentinel-value workaround similar to `saveVersion`'s closure-flag pattern, with no semantic gain (the observable contract — throw `OUTCOME_NOT_FOUND` on miss, set the field otherwise — holds either way). Suggest tightening the task doc AC post-merge to "atomic lookup + write of `userFeedback`", matching the other task-doc tightenings we did for Tasks 0.5 / 0.6 / 1.2.

2. **AC9: "100 parallel `saveOutcome` + `recordFeedback` calls mixed on distinct outcomes"** — Covered by two separate concurrency tests (16: 100 parallel saves; 17: 50 seeded + 50 parallel feedbacks) instead of one combined `Promise.all`. Reason: a strictly "mixed" test has feedback calls that fire before their saves complete, throwing `OUTCOME_NOT_FOUND` non-deterministically. Writing the test to be deterministic requires seeding first, at which point it becomes test 17. The property the AC protects (no corruption under concurrent write + feedback) is demonstrated by the pair.

**`recordFeedback`'s partition scan is the perf hot spot** to watch. It calls `keyStorage.exists` up to 3 times (once per `projectType`) before the actual set. For Phase 2's single-per-outcome-lifetime call, this is fine. If a future consumer flags outcomes in a tight loop, add a `projectType`-aware variant to the interface.

**No `IBlobStorage` in the constructor (still).** Carried over from ENG-2226. Task 1.4's construction line stays `new HarnessStore(keyStorage, logger.withSource('HarnessStore'))`.

**The `DEFAULT_LIST_OUTCOMES_LIMIT = 100`** matches the in-memory test double (`test/helpers/in-memory-harness-store.ts` from ENG-2225). If the real store defaults ever drift from the double, recorder tests against the double will pass while production fails — keep them in sync.