### PR TITLE
feat: [ENG-2233] thread taskDescription and conversationTurn into SandboxConfig

### DIFF
--- a/src/agent/core/domain/sandbox/types.ts
+++ b/src/agent/core/domain/sandbox/types.ts
@@ -39,11 +39,26 @@ export interface SandboxConfig {
   /** Context data to preload as "context" variable */
   contextPayload?: Record<string, unknown> | string | unknown[]
 
+  /**
+   * Conversation turn index (zero-based, user-messages only) — the Nth
+   * user message in the session when this code_exec fired. Used by
+   * Phase 6 refinement to cluster outcomes by task stage.
+   */
+  conversationTurn?: number
+
   /** Language: 'javascript' or 'typescript' (default: auto-detect) */
   language?: 'javascript' | 'typescript'
 
   /** Cap stdout buffer at this many characters. undefined = unlimited. */
   maxStdoutChars?: number
+
+  /**
+   * Free-text description of the task the user requested when this
+   * code_exec fired. Truncated to 500 chars at the call site. Used by
+   * Phase 6 refinement as the primary signal for matching outcomes to
+   * evaluation scenarios.
+   */
+  taskDescription?: string
 
   /** Timeout in ms (default: 30000, max: 300000) */
   timeout?: number

--- a/src/agent/core/domain/sandbox/types.ts
+++ b/src/agent/core/domain/sandbox/types.ts
@@ -42,7 +42,7 @@ export interface SandboxConfig {
   /**
    * Conversation turn index (zero-based, user-messages only) — the Nth
    * user message in the session when this code_exec fired. Used by
-   * Phase 6 refinement to cluster outcomes by task stage.
+   * refinement to cluster outcomes by task stage.
    */
   conversationTurn?: number
 
@@ -55,8 +55,8 @@ export interface SandboxConfig {
   /**
    * Free-text description of the task the user requested when this
    * code_exec fired. Truncated to 500 chars at the call site. Used by
-   * Phase 6 refinement as the primary signal for matching outcomes to
-   * evaluation scenarios.
+   * refinement as the primary signal for matching outcomes to evaluation
+   * scenarios.
    */
   taskDescription?: string
 

--- a/src/agent/core/domain/tools/types.ts
+++ b/src/agent/core/domain/tools/types.ts
@@ -103,7 +103,7 @@ export interface ToolExecutionContext {
 
   /**
    * Conversation turn index (zero-based, user-messages only). Threaded
-   * from AgentLLMService for outcome recording (Phase 2).
+   * from AgentLLMService for outcome recording.
    */
   conversationTurn?: number
 
@@ -124,7 +124,7 @@ export interface ToolExecutionContext {
 
   /**
    * Free-text description of the user's task, truncated to 500 chars.
-   * Threaded from AgentLLMService for outcome recording (Phase 2).
+   * Threaded from AgentLLMService for outcome recording.
    */
   taskDescription?: string
 

--- a/src/agent/core/domain/tools/types.ts
+++ b/src/agent/core/domain/tools/types.ts
@@ -102,6 +102,12 @@ export interface ToolExecutionContext {
   commandType?: string
 
   /**
+   * Conversation turn index (zero-based, user-messages only). Threaded
+   * from AgentLLMService for outcome recording (Phase 2).
+   */
+  conversationTurn?: number
+
+  /**
    * Callback for streaming metadata updates during execution.
    * Tools can use this to push real-time output (e.g., bash streaming).
    */
@@ -115,6 +121,12 @@ export interface ToolExecutionContext {
    * Tools should check this signal periodically and abort gracefully.
    */
   signal?: AbortSignal
+
+  /**
+   * Free-text description of the user's task, truncated to 500 chars.
+   * Threaded from AgentLLMService for outcome recording (Phase 2).
+   */
+  taskDescription?: string
 
   /** Task ID from usecase for billing tracking */
   taskId?: string

--- a/src/agent/infra/llm/agent-llm-service.ts
+++ b/src/agent/infra/llm/agent-llm-service.ts
@@ -58,6 +58,7 @@ import {OpenRouterTokenizer} from './tokenizers/openrouter-tokenizer.js'
 import {type ProcessedOutput, ToolOutputProcessor, type TruncationConfig} from './tool-output-processor.js'
 
 /** Target utilization ratio for message tokens (leaves headroom for response) */
+const MAX_TASK_DESCRIPTION_LENGTH = 500
 const TARGET_MESSAGE_TOKEN_UTILIZATION = 0.7
 
 /**
@@ -1132,11 +1133,22 @@ export class AgentLLMService implements ILLMService {
       // Create metadata callback for streaming tool output
       const metadataCallback = this.metadataHandler.createCallback(toolCall.id, toolName)
 
+      // Compute harness outcome context from conversation state (Phase 2 Task 2.4).
+      // taskDescription = last user message truncated to 500 chars; conversationTurn = zero-based user-only count.
+      const messages = this.contextManager.getMessages()
+      const userMessages = messages.filter((m) => m.role === 'user')
+      const lastUserContent = userMessages.length > 0
+        ? String(userMessages.at(-1)?.content ?? '').slice(0, MAX_TASK_DESCRIPTION_LENGTH)
+        : undefined
+      const conversationTurn = userMessages.length > 0 ? userMessages.length - 1 : undefined
+
       // Execute tool via ToolManager (returns structured result)
-      // Pass taskId and commandType in context for subagent billing tracking and context-aware behavior
+      // Pass taskId, commandType, and harness context for subagent billing tracking and context-aware behavior
       const result: ToolExecutionResult = await this.toolManager.executeTool(toolName, toolArgs, this.sessionId, {
         commandType: executionContext?.commandType,
+        conversationTurn,
         metadata: metadataCallback,
+        taskDescription: lastUserContent,
         taskId,
       })
 

--- a/src/agent/infra/llm/agent-llm-service.ts
+++ b/src/agent/infra/llm/agent-llm-service.ts
@@ -1133,14 +1133,14 @@ export class AgentLLMService implements ILLMService {
       // Create metadata callback for streaming tool output
       const metadataCallback = this.metadataHandler.createCallback(toolCall.id, toolName)
 
-      // Compute harness outcome context from conversation state (Phase 2 Task 2.4).
-      // taskDescription = last user message truncated to 500 chars; conversationTurn = zero-based user-only count.
+      // Derive harness context from current conversation state.
       const messages = this.contextManager.getMessages()
       const userMessages = messages.filter((m) => m.role === 'user')
-      const lastUserContent = userMessages.length > 0
-        ? String(userMessages.at(-1)?.content ?? '').slice(0, MAX_TASK_DESCRIPTION_LENGTH)
+      const lastUser = userMessages.at(-1)
+      const lastUserContent = lastUser
+        ? (this.extractTextContent(lastUser) || undefined)?.slice(0, MAX_TASK_DESCRIPTION_LENGTH)
         : undefined
-      const conversationTurn = userMessages.length > 0 ? userMessages.length - 1 : undefined
+      const conversationTurn = lastUser ? userMessages.length - 1 : undefined
 
       // Execute tool via ToolManager (returns structured result)
       // Pass taskId, commandType, and harness context for subagent billing tracking and context-aware behavior

--- a/src/agent/infra/sandbox/sandbox-service.ts
+++ b/src/agent/infra/sandbox/sandbox-service.ts
@@ -178,12 +178,14 @@ export class SandboxService implements ISandboxService {
           .record({
             code,
             commandType,
+            conversationTurn: config?.conversationTurn,
             executionTimeMs: result.executionTime,
             harnessVersionId: this.harnessVersionIdBySession.get(sessionId),
             projectId: this.environmentContext.workingDirectory,
             projectType: this.resolveProjectType(),
             result,
             sessionId,
+            taskDescription: config?.taskDescription,
           })
           .catch((error: unknown) => {
             this.logger?.warn('harness.record rejected', {error})

--- a/src/agent/infra/tools/implementations/code-exec-tool.ts
+++ b/src/agent/infra/tools/implementations/code-exec-tool.ts
@@ -101,8 +101,10 @@ export function createCodeExecTool(sandboxService: ISandboxService): Tool {
       const result = await sandboxService.executeCode(code, sessionId, {
         commandType: context?.commandType,
         contextPayload,
+        conversationTurn: context?.conversationTurn,
         language,
         maxStdoutChars,
+        taskDescription: context?.taskDescription,
         timeout,
       })
 

--- a/test/unit/infra/sandbox/sandbox-service-harness-wiring.test.ts
+++ b/test/unit/infra/sandbox/sandbox-service-harness-wiring.test.ts
@@ -122,7 +122,11 @@ describe('SandboxService — harness outcome recording', () => {
     const service = wireService(recorder, {config: {language: 'typescript'}, workingDirectory: '/my/project'})
     const spy = sinon.spy(recorder, 'record')
 
-    await service.executeCode('1 + 1', 'sess-1', {commandType: 'curate'})
+    await service.executeCode('1 + 1', 'sess-1', {
+      commandType: 'curate',
+      conversationTurn: 2,
+      taskDescription: 'find the auth module',
+    })
 
     expect(spy.calledOnce).to.equal(true)
     const params: RecordParams = spy.firstCall.args[0]
@@ -134,6 +138,8 @@ describe('SandboxService — harness outcome recording', () => {
     expect(params.executionTimeMs).to.be.a('number').and.to.be.at.least(0)
     expect(params.projectType).to.equal('typescript')
     expect(params.projectId).to.equal('/my/project')
+    expect(params.conversationTurn).to.equal(2)
+    expect(params.taskDescription).to.equal('find the auth module')
   })
 
   it('defaults commandType to chat when config.commandType is absent', async () => {

--- a/test/unit/infra/tools/code-exec-tool-harness-fields.test.ts
+++ b/test/unit/infra/tools/code-exec-tool-harness-fields.test.ts
@@ -5,7 +5,7 @@
  * `ToolExecutionContext` are forwarded into `SandboxConfig` when
  * `code_exec` calls `sandboxService.executeCode()`.
  *
- * ENG-2233 (Phase 2 Task 2.4)
+ * ENG-2233
  */
 
 import {expect} from 'chai'

--- a/test/unit/infra/tools/code-exec-tool-harness-fields.test.ts
+++ b/test/unit/infra/tools/code-exec-tool-harness-fields.test.ts
@@ -91,7 +91,7 @@ describe('code_exec tool — harness field forwarding', () => {
     const tool = createCodeExecTool(sandbox)
 
     // The tool forwards whatever it receives — truncation happens in AgentLLMService
-    const longDesc = 'x'.repeat(500)
+    const longDesc = 'x'.repeat(600)
     const context: ToolExecutionContext = {
       sessionId: 'sess-1',
       taskDescription: longDesc,
@@ -100,7 +100,7 @@ describe('code_exec tool — harness field forwarding', () => {
     await tool.execute({code: '1'}, context)
 
     expect(sandbox.lastConfig?.taskDescription).to.equal(longDesc)
-    expect(sandbox.lastConfig?.taskDescription).to.have.length(500)
+    expect(sandbox.lastConfig?.taskDescription).to.have.length(600)
   })
 
   it('forwards both fields together alongside existing config fields', async () => {

--- a/test/unit/infra/tools/code-exec-tool-harness-fields.test.ts
+++ b/test/unit/infra/tools/code-exec-tool-harness-fields.test.ts
@@ -1,0 +1,124 @@
+/**
+ * code_exec tool — harness field forwarding tests.
+ *
+ * Verifies that `taskDescription` and `conversationTurn` on
+ * `ToolExecutionContext` are forwarded into `SandboxConfig` when
+ * `code_exec` calls `sandboxService.executeCode()`.
+ *
+ * ENG-2233 (Phase 2 Task 2.4)
+ */
+
+import {expect} from 'chai'
+import sinon from 'sinon'
+
+import type {SandboxConfig} from '../../../../src/agent/core/domain/sandbox/types.js'
+import type {ToolExecutionContext} from '../../../../src/agent/core/domain/tools/types.js'
+import type {ISandboxService} from '../../../../src/agent/core/interfaces/i-sandbox-service.js'
+
+import {createCodeExecTool} from '../../../../src/agent/infra/tools/implementations/code-exec-tool.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSandboxService(): ISandboxService & {lastConfig?: SandboxConfig} {
+  const svc: ISandboxService & {lastConfig?: SandboxConfig} = {
+    async cleanup() {},
+    async clearSession() {},
+    deleteSandboxVariable() {},
+    async executeCode(_code: string, _sessionId: string, config?: SandboxConfig) {
+      svc.lastConfig = config
+      return {executionTime: 1, locals: {}, stderr: '', stdout: ''}
+    },
+    setSandboxVariable() {},
+  }
+  return svc
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('code_exec tool — harness field forwarding', () => {
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  it('forwards taskDescription from ToolExecutionContext to SandboxConfig', async () => {
+    const sandbox = makeSandboxService()
+    const tool = createCodeExecTool(sandbox)
+
+    const context: ToolExecutionContext = {
+      sessionId: 'sess-1',
+      taskDescription: 'find the auth module',
+    }
+
+    await tool.execute({code: '1 + 1'}, context)
+
+    expect(sandbox.lastConfig?.taskDescription).to.equal('find the auth module')
+  })
+
+  it('forwards conversationTurn from ToolExecutionContext to SandboxConfig', async () => {
+    const sandbox = makeSandboxService()
+    const tool = createCodeExecTool(sandbox)
+
+    const context: ToolExecutionContext = {
+      conversationTurn: 3,
+      sessionId: 'sess-1',
+    }
+
+    await tool.execute({code: '1 + 1'}, context)
+
+    expect(sandbox.lastConfig?.conversationTurn).to.equal(3)
+  })
+
+  it('leaves both fields undefined when context does not provide them', async () => {
+    const sandbox = makeSandboxService()
+    const tool = createCodeExecTool(sandbox)
+
+    const context: ToolExecutionContext = {
+      sessionId: 'sess-1',
+    }
+
+    await tool.execute({code: '1 + 1'}, context)
+
+    expect(sandbox.lastConfig?.taskDescription).to.equal(undefined)
+    expect(sandbox.lastConfig?.conversationTurn).to.equal(undefined)
+  })
+
+  it('preserves taskDescription as-is (truncation is the caller responsibility)', async () => {
+    const sandbox = makeSandboxService()
+    const tool = createCodeExecTool(sandbox)
+
+    // The tool forwards whatever it receives — truncation happens in AgentLLMService
+    const longDesc = 'x'.repeat(500)
+    const context: ToolExecutionContext = {
+      sessionId: 'sess-1',
+      taskDescription: longDesc,
+    }
+
+    await tool.execute({code: '1'}, context)
+
+    expect(sandbox.lastConfig?.taskDescription).to.equal(longDesc)
+    expect(sandbox.lastConfig?.taskDescription).to.have.length(500)
+  })
+
+  it('forwards both fields together alongside existing config fields', async () => {
+    const sandbox = makeSandboxService()
+    const tool = createCodeExecTool(sandbox)
+
+    const context: ToolExecutionContext = {
+      commandType: 'curate',
+      conversationTurn: 0,
+      sessionId: 'sess-1',
+      taskDescription: 'curate project docs',
+    }
+
+    await tool.execute({code: '1 + 1', timeout: 5000}, context)
+
+    expect(sandbox.lastConfig?.commandType).to.equal('curate')
+    expect(sandbox.lastConfig?.taskDescription).to.equal('curate project docs')
+    expect(sandbox.lastConfig?.conversationTurn).to.equal(0)
+    expect(sandbox.lastConfig?.timeout).to.equal(5000)
+  })
+})


### PR DESCRIPTION
## Summary

- Extends `SandboxConfig` and `ToolExecutionContext` with `conversationTurn` (zero-based user-message index) and `taskDescription` (last user message, truncated to 500 chars)
- `AgentLLMService.executeToolCallParallel` computes both from conversation state and passes them through the tool execution chain
- `code_exec` tool forwards both fields to `SandboxConfig`, `SandboxService` forwards them to `RecordParams` for outcome recording
- Phase 6 refinement will use these to cluster outcomes by task stage and match them to evaluation scenarios

## Test plan

- [x] 5 unit tests in `test/unit/infra/tools/code-exec-tool-harness-fields.test.ts` (forwarding, undefined passthrough, length preservation, combined fields)
- [x] Updated sandbox-service wiring test to assert both new fields in `RecordParams`
- [x] Full suite: 6662 passing, 0 failing
- [x] typecheck / lint / build clean
- [x] No interactive CLI testing — internal pipeline fields only, consumer is Phase 6