### PR TITLE
feat: [ENG-2238] AutoHarness V2 HarnessContext + module contract

### DIFF
--- a/src/agent/core/domain/harness/index.ts
+++ b/src/agent/core/domain/harness/index.ts
@@ -1,0 +1,9 @@
+/**
+ * AutoHarness V2 core-domain barrel.
+ *
+ * Re-exports every harness domain type so consumers import from a
+ * single path: `import type {HarnessContext, HarnessModule} from
+ * '.../core/domain/harness'`.
+ */
+
+export * from './types.js'

--- a/src/agent/core/domain/harness/types.ts
+++ b/src/agent/core/domain/harness/types.ts
@@ -8,6 +8,16 @@
 
 import {z} from 'zod'
 
+import type {
+  CurateOperation,
+  CurateOptions,
+  CurateResult,
+} from '../../interfaces/i-curate-service.js'
+import type {
+  FileContent,
+  ReadFileOptions,
+} from '../file-system/types.js'
+
 // ---------------------------------------------------------------------------
 // Enums
 // ---------------------------------------------------------------------------
@@ -169,3 +179,86 @@ export const EvaluationScenarioSchema = z
   .strict()
 export type EvaluationScenario = z.input<typeof EvaluationScenarioSchema>
 export type ValidatedEvaluationScenario = z.output<typeof EvaluationScenarioSchema>
+
+// ---------------------------------------------------------------------------
+// Phase 3 — HarnessContext + module contract
+// ---------------------------------------------------------------------------
+
+/**
+ * Environment metadata surfaced to a harness function at call time.
+ * Scoped deliberately narrow — the context must be cheap to construct
+ * per call and must not leak session-specific references beyond what
+ * the template actually uses. Extend additively when a real consumer
+ * materializes.
+ */
+export interface HarnessContextEnv {
+  readonly commandType: 'chat' | 'curate' | 'query'
+  readonly projectType: ProjectType
+  readonly workingDirectory: string
+}
+
+/**
+ * Tool surface exposed to harness functions inside the VM. Each member
+ * is a bound proxy into the outer sandbox's `ToolsSDK` — harness code
+ * calls `ctx.tools.curate(...)` and the call bridges out to the real
+ * `tools.curate`.
+ *
+ * Signatures mirror `ToolsSDK` exactly. Every referenced type lives in
+ * `core/` — `CurateOperation` / `CurateOptions` / `CurateResult` in
+ * `core/interfaces/i-curate-service.ts`; `ReadFileOptions` / `FileContent`
+ * in `core/domain/file-system/types.ts`. That keeps `HarnessContextTools`
+ * free of `infra/` imports.
+ *
+ * v1.0 surface is `curate` + `readFile` — exactly what Phase 4's
+ * pass-through templates need. Adding more members (`grep`,
+ * `searchKnowledge`, etc.) is additive when a real consumer asks.
+ * The cost of a new member is moving its types into `core/` if they
+ * don't live there already; for `grep` / `searchKnowledge` that means
+ * splitting `SearchKnowledgeOptions` / `GrepOptions` out of
+ * `infra/sandbox/tools-sdk.ts` first.
+ */
+export interface HarnessContextTools {
+  readonly curate: (
+    operations: CurateOperation[],
+    options?: CurateOptions,
+  ) => Promise<CurateResult>
+  readonly readFile: (filePath: string, options?: ReadFileOptions) => Promise<FileContent>
+}
+
+/**
+ * Context passed as the sole argument to every harness function call.
+ * Frozen at call boundary so a compromised harness can't mutate what
+ * it sees. `readonly` is compile-time; Phase 3 Task 3.2's module
+ * builder enforces the invariant at runtime via `Object.freeze`.
+ */
+export interface HarnessContext {
+  readonly abort: AbortSignal
+  readonly env: HarnessContextEnv
+  readonly tools: HarnessContextTools
+}
+
+/**
+ * Shape exported by every harness module (template or refined).
+ * `meta` is always required; `curate` / `query` are optional and must
+ * be present iff declared in `meta().capabilities`. Phase 3 Task 3.2
+ * validates this invariant at load time.
+ */
+export interface HarnessModule {
+  readonly curate?: (ctx: HarnessContext) => Promise<CurateResult>
+  readonly meta: () => HarnessMeta
+  readonly query?: (ctx: HarnessContext) => Promise<unknown>
+}
+
+/**
+ * Result of `SandboxService.loadHarness`. Discriminated on `loaded` so
+ * consumers narrow cleanly: `{loaded: true}` carries the module and
+ * its source version; `{loaded: false}` carries a machine-readable
+ * `reason` that distinguishes "nothing to load" from "harness code is
+ * broken."
+ *
+ * Consumers never throw on a failed load — the sandbox degrades to
+ * raw `tools.*` orchestration transparently.
+ */
+export type HarnessLoadResult =
+  | {loaded: false; reason: 'meta-invalid' | 'meta-threw' | 'no-version' | 'syntax'}
+  | {loaded: true; module: HarnessModule; version: HarnessVersion}

--- a/test/unit/agent/harness/types-context.test.ts
+++ b/test/unit/agent/harness/types-context.test.ts
@@ -1,0 +1,125 @@
+import {expect} from 'chai'
+import {expectTypeOf} from 'expect-type'
+
+import type {
+  HarnessContext,
+  HarnessContextEnv,
+  HarnessContextTools,
+  HarnessLoadResult,
+  HarnessModule,
+  HarnessVersion,
+} from '../../../../src/agent/core/domain/harness/index.js'
+import type {CurateResult} from '../../../../src/agent/core/interfaces/i-curate-service.js'
+
+describe('HarnessContext + module contract', () => {
+  describe('HarnessModule', () => {
+    it('requires `meta` and makes `curate` / `query` optional', () => {
+      // Minimal valid module: just meta.
+      const minimal: HarnessModule = {
+        meta: () => ({
+          capabilities: [],
+          commandType: 'curate',
+          projectPatterns: [],
+          version: 1,
+        }),
+      }
+      expect(minimal.curate).to.equal(undefined)
+      expect(minimal.query).to.equal(undefined)
+      expectTypeOf(minimal.meta).returns.toMatchTypeOf<{commandType: string}>()
+    })
+
+    it('rejects a module missing `meta` at compile time', () => {
+      // @ts-expect-error — meta is required
+      const broken: HarnessModule = {curate: async () => ({} as CurateResult)}
+      expect(broken).to.exist
+    })
+  })
+
+  describe('HarnessContext readonly enforcement (compile-time only)', () => {
+    // `readonly` is a TypeScript-level invariant. The tests below pass
+    // iff the `@ts-expect-error` directives are consumed (i.e., TS would
+    // report an error without them). Runtime writes still execute —
+    // that's fine; the guarantee we're testing is the compile-time one,
+    // and Phase 3 Task 3.2's module builder enforces runtime frozenness
+    // via `Object.freeze` separately.
+
+    it('rejects reassigning `ctx.env`', () => {
+      const ctx: HarnessContext = {
+        abort: new AbortController().signal,
+        env: {commandType: 'curate', projectType: 'typescript', workingDirectory: '/'},
+        tools: {} as HarnessContextTools,
+      }
+      const replacement: HarnessContextEnv = {
+        commandType: 'chat',
+        projectType: 'generic',
+        workingDirectory: '/other',
+      }
+      // @ts-expect-error — env is readonly on HarnessContext
+      ctx.env = replacement
+      expect(ctx).to.exist
+    })
+
+    it('rejects reassigning `env.workingDirectory`', () => {
+      const env: HarnessContextEnv = {
+        commandType: 'curate',
+        projectType: 'typescript',
+        workingDirectory: '/tmp',
+      }
+      // @ts-expect-error — workingDirectory is readonly
+      env.workingDirectory = '/elsewhere'
+      expect(env).to.exist
+    })
+
+    it('rejects reassigning `tools.curate`', () => {
+      const tools: HarnessContextTools = {
+        curate: (async () => ({}) as CurateResult) as HarnessContextTools['curate'],
+        readFile: (async () => ({}) as never) as HarnessContextTools['readFile'],
+      }
+      const replacement = (async () => ({}) as CurateResult) as HarnessContextTools['curate']
+      // @ts-expect-error — curate is readonly
+      tools.curate = replacement
+      expect(tools).to.exist
+    })
+  })
+
+  describe('HarnessLoadResult discriminated union', () => {
+    it('narrows to `module` + `version` when `loaded === true`', () => {
+      const result: HarnessLoadResult = {
+        loaded: true,
+        module: {
+          meta: () => ({
+            capabilities: [],
+            commandType: 'curate',
+            projectPatterns: [],
+            version: 1,
+          }),
+        },
+        version: {} as HarnessVersion,
+      }
+
+      if (result.loaded) {
+        expectTypeOf(result.module).toEqualTypeOf<HarnessModule>()
+        expectTypeOf(result.version).toEqualTypeOf<HarnessVersion>()
+      }
+    })
+
+    it('narrows to `reason` when `loaded === false`', () => {
+      const result: HarnessLoadResult = {loaded: false, reason: 'no-version'}
+
+      if (!result.loaded) {
+        expectTypeOf(result.reason).toEqualTypeOf<
+          'meta-invalid' | 'meta-threw' | 'no-version' | 'syntax'
+        >()
+      }
+    })
+
+    it('does NOT expose `module` on the `loaded: false` variant', () => {
+      // Type-level assertion: the failure variant's keys exclude `module`.
+      // Extracting the failure variant from the union and checking its
+      // keys is safer than trying `@ts-expect-error` inside a runtime
+      // narrowing block, which is sensitive to unrelated TS lenience.
+      type FailureVariant = Extract<HarnessLoadResult, {loaded: false}>
+      expectTypeOf<keyof FailureVariant>().toEqualTypeOf<'loaded' | 'reason'>()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Problem: Phase 4's templates (Task 4.3) import `HarnessContext` to declare their function signatures. Without the type surface shipped, can't write a single line of Phase 4 implementation that compiles. This PR is the seam.
- Why it matters: Same role as Phase 1.1's in-memory test double — the first PR of a phase whose entire purpose is unblocking the other engineer.
- What changed: Added 5 new type declarations (`HarnessContextEnv`, `HarnessContextTools`, `HarnessContext`, `HarnessModule`, `HarnessLoadResult`) to `src/agent/core/domain/harness/types.ts`. New barrel at `src/agent/core/domain/harness/index.ts`. 8-scenario type-level test suite.
- What did NOT change (scope boundary): No runtime code. No `HarnessModuleBuilder` (Task 3.2). No `SandboxService` modifications (Task 3.3). No template content (Phase 4). No consumer imports these types yet.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [x] Agent / Tools
- [ ] LLM Providers
- [ ] Server / Daemon
- [x] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes ENG-2234
- Related ENG-2228 (Phase 1 Task 1.4 — service-initializer wiring, merged — closed Phase 1)
- Related ENG-2222 (ENG that moved harness types out of `infra/` — the layering discipline this PR preserves)
- Unblocks Phase 4 Task 4.3

## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause: N/A
- Why this was not caught earlier: N/A

## Test plan

- Coverage added:
  - [x] Unit test
  - [ ] Integration test
  - [ ] Manual verification only
- Test file(s): `test/unit/agent/harness/types-context.test.ts`
- Key scenario(s) covered:
  - `HarnessModule.meta` required; `curate`/`query` optional (2 tests, one positive + one `@ts-expect-error` negative)
  - `HarnessContext` / `HarnessContextEnv` / `HarnessContextTools` readonly enforcement (3 tests, all `@ts-expect-error`-based — compile-time invariants)
  - `HarnessLoadResult` discriminated-union narrowing (3 tests: `loaded: true` exposes `module`+`version`; `loaded: false` exposes `reason`; failure variant's `keyof` excludes `module`)

## User-visible changes

None. Types-only addition; no runtime behavior. `harness.enabled = false` remains the public default.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording

Before this PR, the test file didn't exist and the types weren't declared. After: all 8 pass. Full suite: 6665 passing / 0 failing.

```
$ npm test -- --grep "HarnessContext \+ module contract"
  HarnessContext + module contract
    HarnessModule
      ✔ requires `meta` and makes `curate` / `query` optional
      ✔ rejects a module missing `meta` at compile time
    HarnessContext readonly enforcement (compile-time only)
      ✔ rejects reassigning `ctx.env`
      ✔ rejects reassigning `env.workingDirectory`
      ✔ rejects reassigning `tools.curate`
    HarnessLoadResult discriminated union
      ✔ narrows to `module` + `version` when `loaded === true`
      ✔ narrows to `reason` when `loaded === false`
      ✔ does NOT expose `module` on the `loaded: false` variant
  8 passing (15ms)
```

## Checklist

- [x] Tests added or updated and passing (`npm test`) — 8 new tests; full suite 6665 passing / 0 failing
- [x] Lint passes (`npm run lint`) — 0 errors, 224 pre-existing warnings
- [x] Type check passes (`npm run typecheck`) — exit=0
- [x] Build succeeds (`npm run build`) — exit=0
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format — `feat: [ENG-2234] ...`
- [x] Documentation updated (if applicable) — task doc at `features/autoharness-v2/tasks/phase_3/task_01-harness-module-contract.md` (research repo) describes the scope; the 2-methods-vs-4 deviation is flagged in "Notes for reviewers" for post-merge task-doc tightening (same pattern as Tasks 0.5/0.6/1.2/1.3/1.4)
- [x] No breaking changes (or clearly documented above) — purely additive to an already-shipped types module
- [ ] Branch is up to date with `main` — targets `proj/autoharness-v2`, not `main`

## Risks and mitigations

- **Risk**: `HarnessContextTools` ships with 2 methods (`curate`, `readFile`), not the 4 the task doc sketched. If Phase 4 Task 4.3's query template needs `searchKnowledge` on the context (likely), it'll fail to compile until the type is extended.
  - **Mitigation**: Extending is a one-line addition to `HarnessContextTools`. The prerequisite is moving `SearchKnowledgeOptions` / `SearchKnowledgeResult` (and for `grep`, `GrepOptions`) from `src/agent/infra/sandbox/tools-sdk.ts` into `core/domain/` or `core/interfaces/` — a small mechanical PR that preserves the layering discipline. When Phat reaches Task 4.3 and declares what his query template actually needs, we decide together whether to extend `HarnessContextTools` (my preference) or inline the call differently in the template.

- **Risk**: Task doc (research repo) drafted the surface as 4 methods (`curate`, `query`, `search`, `readFile`) with invented type names (`CurateArgs`, `SearchOpts`, `FileReadResult`). Shipped uses real tools-SDK signatures. Anyone reading the task doc in isolation will expect 4 methods.
  - **Mitigation**: Per the established pattern (Tasks 0.5/0.6/1.2/1.3/1.4), tighten the task doc post-merge to reflect what shipped. The invented type names were always placeholders — the real signatures are what belong in the contract.

- **Risk**: `readonly` is TypeScript-only. At runtime the context is mutable unless frozen.
  - **Mitigation**: Task 3.2's module builder is explicitly responsible for `Object.freeze(ctx)` before passing into VM evaluation. Called out in this PR's test file comments and in Task 3.2's task doc. A bug that skipped the freeze would leak only to harness code, not to outer sandbox — and the isolation integration test (Task 3.5) would catch real escapes.

## Notes for reviewers

**The `HarnessContextTools` surface decision** is the only interesting design call in this PR. Task doc sketched 4 methods; shipped 2. The reasoning is in the JSDoc on `HarnessContextTools` itself — imports from `infra/` would violate the layering we established in ENG-2222. If the team prefers the fuller surface, the fix is a separate PR moving `SearchKnowledgeOptions` / `SearchKnowledgeResult` / `GrepOptions` into `core/` first. I recommend deferring that move until a real consumer (Phase 4 Task 4.3 or Phase 6 refinement) materializes, so we're not moving types speculatively.

**`readonly` vs. `Readonly<T>` modifier choice.** I used inline `readonly` on every field rather than wrapping the interface in `Readonly<...>`. Reason: property-level `readonly` composes better with discriminated unions and partial mocks in tests. The tradeoff is 5 extra characters per field declaration.

**`HarnessModule.query` is typed `Promise<unknown>`** — not `Promise<QueryResult>` as the task doc draft suggested. Reason: `QueryResult` doesn't exist in the codebase yet; the closest analog is `SearchKnowledgeResult`, which lives in infra and can't be imported into core per the layering rule. `unknown` is the safe placeholder — Phase 4 Task 4.3's query template will produce whatever shape matches its use case, and Phase 5's mode-selector / LLM surface layer-over the result when it matters. If tightening to a concrete type becomes useful, that's additive in a later PR.

**The "does NOT expose `module` on loaded: false" test** uses `Extract<...>` + `keyof` rather than an in-branch `@ts-expect-error` access. Reason: `@ts-expect-error` inside a narrowed-type branch is TS-version-sensitive — some versions allow "harmless" property access on narrowed unions, and a passing-by-accident test would mask real drift. The `Extract<HarnessLoadResult, {loaded: false}>['keyof']` assertion is explicit and version-stable.


## Related

- Types this PR extends: `src/agent/core/domain/harness/types.ts`
- Domain barrel: `src/agent/core/domain/harness/index.ts` (new)
- Test file: `test/unit/agent/harness/types-context.test.ts` (new)
- Task doc: `features/autoharness-v2/tasks/phase_3/task_01-harness-module-contract.md` (research repo)
- Execution plan: `features/autoharness-v2/execution-plan.md § Phase 3`
- Next (me): Phase 3 Task 3.2 — `HarnessModuleBuilder`