### PR TITLE
feat: [ENG-2230] default OAuth OpenAI model to gpt-5.4-mini

### DIFF
--- a/src/server/core/domain/entities/provider-registry.ts
+++ b/src/server/core/domain/entities/provider-registry.ts
@@ -239,7 +239,7 @@ export const PROVIDER_REGISTRY: Readonly<Record<string, ProviderDefinition>> = {
       // Public OAuth client ID (safe to commit — native app public client, no client secret)
       clientId: 'app_EMoamEEZ73f0CkXaXp7hrann',
       // OpenAI Codex model used for the ChatGPT OAuth (Codex CLI) flow
-      defaultModel: 'gpt-5.1-codex-mini',
+      defaultModel: 'gpt-5.4-mini',
       /* eslint-disable camelcase -- OAuth query params follow RFC 6749 naming */
       extraParams: {
         codex_cli_simplified_flow: 'true',


### PR DESCRIPTION
## Summary

- Problem: OpenAI OAuth (ChatGPT / Codex CLI) flow defaulted to `gpt-5.1-codex-mini`, which had degraded on non-code curate output and is no longer aligned with the current stack.
- Why it matters: Users who sign in with OpenAI OAuth inherit this default for curate/query. Stale model = degraded `/curate` output quality, especially for non-code content.
- What changed: Flipped `PROVIDER_REGISTRY.openai.oauth.defaultModel` from `gpt-5.1-codex-mini` to `gpt-5.4-mini` in `src/server/core/domain/entities/provider-registry.ts`.
- What did NOT change (scope boundary): No prompt changes, no changes to the non-OAuth OpenAI `defaultModel` (`gpt-4.1`), no other provider defaults, no OAuth client ID / scopes / endpoints, no tests.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [ ] Agent / Tools
- [x] LLM Providers
- [x] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes ENG-2230
- Related #

## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause: `PROVIDER_REGISTRY.openai.oauth.defaultModel` was pinned to `gpt-5.1-codex-mini` at the time ChatGPT OAuth (Codex CLI simplified flow) was wired up. OpenAI has since shipped `gpt-5.4-mini`, which performs materially better on non-code curate prompts; the pinned value did not get bumped with it.
- Why this was not caught earlier: The default is embedded in the provider registry and only exercised on fresh OAuth sign-in (or when no model override is set). There is no automated quality gate on curate output per model, so silent degradation went unnoticed until surfaced manually.

## Test plan

- Coverage added:
  - [ ] Unit test
  - [ ] Integration test
  - [x] Manual verification only
- Test file(s): N/A (single-constant change; no existing test asserts the OAuth default model string, and adding one would just pin the constant to itself)
- Key scenario(s) covered:
  - Sign in with OpenAI OAuth on a fresh profile, confirm resolved default model is `gpt-5.4-mini`.
  - Run `/curate` on a non-code snippet, confirm no obvious regression in output quality.
  - Run `/curate → /query` round-trip, confirm the curated content is retrievable and coherent.

## User-visible changes

- New ChatGPT OAuth sign-ins now default to `gpt-5.4-mini` instead of `gpt-5.1-codex-mini`. Users who already have an OpenAI OAuth profile with a stored / selected model are unaffected (only the default resolved on a fresh flow changes).

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording

(See Linear ENG-2230 attachment for repro evidence of the pre-change behavior.)

## Checklist

- [ ] Tests added or updated and passing (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Type check passes (`npm run typecheck`)
- [ ] Build succeeds (`npm run build`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Documentation updated (if applicable) — N/A, no user-facing docs reference the prior model ID
- [x] No breaking changes (or clearly documented above)
- [ ] Branch is up to date with `main`

## Risks and mitigations

- Risk: `gpt-5.4-mini` is not yet available on every OpenAI OAuth tenant / region, causing sign-in flows to fall through with a "model not found" error on first curate call.
  - Mitigation: Users can override via `brv model set` / their provider config; the OAuth flow itself does not validate the model up front, so sign-in still succeeds and only the first call surfaces the issue. If reports come in, fall back to `gpt-5-mini` (widely available) as a hotfix.
- Risk: Output shape / token pricing differs between `gpt-5.1-codex-mini` and `gpt-5.4-mini`, subtly shifting `/curate` results or cost per call.
  - Mitigation: Ticket acceptance criteria explicitly verified `/curate → /query` round-trip quality. Cost delta is documented in OpenAI pricing; if material, surface in release notes.