### PR TITLE
feat: [ENG-2239] AutoHarness V2 HarnessModuleBuilder

### DIFF
--- a/src/agent/infra/harness/harness-module-builder.ts
+++ b/src/agent/infra/harness/harness-module-builder.ts
@@ -154,13 +154,16 @@ export class HarnessModuleBuilder {
       return {loaded: false, reason: 'syntax'}
     }
 
-    // 4. Call `meta()` once via a fresh vm.Script.runInContext with
-    //    timeout — catches sync infinite loops in meta(). The result
-    //    is cached; subsequent `module.meta()` calls return the
-    //    captured value without re-invoking the VM function.
+    // 4. Pre-compile the invoke scripts once per `build()`. Each
+    //    maps an exported function name to a `vm.Script` that reads
+    //    `module.exports.<name>(__harnessArg)` and writes the result
+    //    to `__harnessResult`. Compiling once here saves
+    //    `new vm.Script(...)` work on every `curate`/`query`
+    //    invocation.
+    const metaInvokeScript = this.compileInvokeScript('meta', version.id)
     let rawMeta: unknown
     try {
-      rawMeta = this.invokeInVm(scriptContext, 'meta', undefined, version.id)
+      rawMeta = this.invokeInVm(scriptContext, metaInvokeScript)
     } catch (error) {
       this.logger.warn('HarnessModuleBuilder: meta() threw', {
         error: error instanceof Error ? error.message : String(error),
@@ -180,14 +183,20 @@ export class HarnessModuleBuilder {
 
     const meta = parsed.data
 
-    // 5. Build the callable wrappers.
-    const harnessModule: HarnessModule = this.buildModule(
+    // 5. Build the callable wrappers. Pre-compile curate/query
+    //    invoke scripts only when the template actually exported them.
+    const curateInvokeScript =
+      curateFn === undefined ? undefined : this.compileInvokeScript('curate', version.id)
+    const queryInvokeScript =
+      queryFn === undefined ? undefined : this.compileInvokeScript('query', version.id)
+
+    const harnessModule: HarnessModule = this.buildModule({
+      curateInvokeScript,
       meta,
-      curateFn === undefined ? undefined : 'curate',
-      queryFn === undefined ? undefined : 'query',
+      queryInvokeScript,
       scriptContext,
-      version.id,
-    )
+      versionId: version.id,
+    })
 
     return {loaded: true, module: harnessModule, version}
   }
@@ -197,34 +206,36 @@ export class HarnessModuleBuilder {
    * becomes a `wrapInvocation`-backed wrapper; `meta()` returns the
    * already-captured value so the VM function is never re-invoked.
    */
-  private buildModule(
-    meta: ValidatedHarnessMeta,
-    curateExport: 'curate' | undefined,
-    queryExport: 'query' | undefined,
-    scriptContext: vm.Context,
-    versionId: string,
-  ): HarnessModule {
+  private buildModule(opts: {
+    curateInvokeScript: undefined | vm.Script
+    meta: ValidatedHarnessMeta
+    queryInvokeScript: undefined | vm.Script
+    scriptContext: vm.Context
+    versionId: string
+  }): HarnessModule {
     const built: {
       curate?: HarnessModule['curate']
       meta: HarnessModule['meta']
       query?: HarnessModule['query']
     } = {
-      meta: (): HarnessMeta => meta,
+      meta: (): HarnessMeta => opts.meta,
     }
 
-    if (curateExport !== undefined) {
+    if (opts.curateInvokeScript !== undefined) {
       built.curate = this.wrapInvocation(
-        scriptContext,
+        opts.scriptContext,
+        opts.curateInvokeScript,
         'curate',
-        versionId,
+        opts.versionId,
       ) as HarnessModule['curate']
     }
 
-    if (queryExport !== undefined) {
+    if (opts.queryInvokeScript !== undefined) {
       built.query = this.wrapInvocation(
-        scriptContext,
+        opts.scriptContext,
+        opts.queryInvokeScript,
         'query',
-        versionId,
+        opts.versionId,
       ) as HarnessModule['query']
     }
 
@@ -232,27 +243,33 @@ export class HarnessModuleBuilder {
   }
 
   /**
-   * Invoke `module.exports[name](__harnessArg)` inside the
-   * `scriptContext` via a fresh `vm.Script.runInContext` call with
-   * the timeout option. Any sync infinite loop is caught by V8's
-   * wall-clock timeout. The invocation's return value (including a
-   * Promise) is returned to the caller — async hang detection is a
-   * later-stage concern, handled by `wrapInvocation`.
+   * Compile once — the invoke script is the same string for a given
+   * `name` per `build()` call, so reusing it across invocations saves
+   * `new vm.Script(...)` work.
+   */
+  private compileInvokeScript(name: 'curate' | 'meta' | 'query', versionId: string): vm.Script {
+    return new vm.Script(`__harnessResult = module.exports.${name}(__harnessArg)`, {
+      filename: `harness:${versionId}#${name}`,
+    })
+  }
+
+  /**
+   * Run a pre-compiled invoke script inside the `scriptContext`.
+   * The script reads `module.exports.<name>(__harnessArg)` and writes
+   * its return value to `__harnessResult`. V8's wall-clock timeout on
+   * `runInContext` catches sync infinite loops; async hang detection
+   * is the caller's concern (see `wrapInvocation`).
    */
   private invokeInVm(
     scriptContext: vm.Context,
-    name: 'curate' | 'meta' | 'query',
-    arg: unknown,
-    versionId: string,
+    invokeScript: vm.Script,
+    arg?: unknown,
   ): unknown {
     const contextRef = scriptContext as unknown as ScriptContext
     // Thread the argument through the context. Safe because we
     // assume serial invocations per scriptContext (a harness module
     // is loaded once per session and one code_exec runs at a time).
     contextRef.__harnessArg = arg
-    const invokeScript = new vm.Script(`__harnessResult = module.exports.${name}(__harnessArg)`, {
-      filename: `harness:${versionId}#${name}`,
-    })
     try {
       invokeScript.runInContext(scriptContext, {timeout: VM_TIMEOUT_MS})
       return contextRef.__harnessResult
@@ -274,18 +291,29 @@ export class HarnessModuleBuilder {
    */
   private wrapInvocation(
     scriptContext: vm.Context,
+    invokeScript: vm.Script,
     name: 'curate' | 'query',
     versionId: string,
   ): (ctx: HarnessContext) => Promise<unknown> {
     const {logger} = this
     const invokeInVm = this.invokeInVm.bind(this)
     return async (ctx: HarnessContext): Promise<unknown> => {
-      const frozenCtx = Object.freeze(ctx)
+      // Deep-freeze at the boundary. `Object.freeze` is shallow, so we
+      // also freeze `ctx.env` and `ctx.tools` (both copied via spread so
+      // the caller's originals stay untouched). Without this, a harness
+      // could mutate `ctx.env.commandType = 'hacked'` or
+      // `ctx.tools.curate = evilFn` — the top-level freeze catches
+      // `ctx.env = ...` but not nested writes.
+      const frozenCtx: HarnessContext = Object.freeze({
+        ...ctx,
+        env: Object.freeze({...ctx.env}),
+        tools: Object.freeze({...ctx.tools}),
+      })
 
       let syncResult: unknown
       try {
         // Sync invocation — vm timeout catches infinite loops.
-        syncResult = invokeInVm(scriptContext, name, frozenCtx, versionId)
+        syncResult = invokeInVm(scriptContext, invokeScript, frozenCtx)
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
         logger.warn(`HarnessModuleBuilder: ${name}() sync failure`, {error: message, versionId})

--- a/src/agent/infra/harness/harness-module-builder.ts
+++ b/src/agent/infra/harness/harness-module-builder.ts
@@ -1,0 +1,330 @@
+/**
+ * AutoHarness V2 — module builder.
+ *
+ * Evaluates a `HarnessVersion.code` string inside `vm.createContext`,
+ * validates the exported shape, and returns a callable `HarnessModule`
+ * wrapped in a `HarnessLoadResult`. Every failure mode is normalized
+ * into a `{loaded: false, reason}` variant — this class never throws.
+ *
+ * ## Security surface
+ *
+ * This is the entry point for all template + refined harness code
+ * execution. Isolation guarantees enforced here:
+ *
+ *   - Fresh `vm.createContext` per `build()` call — no state shared
+ *     across loads.
+ *   - EVERY function invocation (`meta()`, `curate(ctx)`, `query(ctx)`)
+ *     runs inside a fresh `vm.Script.runInContext` call with
+ *     `{timeout: VM_TIMEOUT_MS}`. This catches synchronous infinite
+ *     loops — V8 enforces the wall-clock timeout on sync execution
+ *     and throws a `Script execution timed out` error.
+ *   - Async results are then raced against a JS-level timer —
+ *     `vm` timeout only covers sync execution, so a function that
+ *     returns a never-resolving Promise needs the `Promise.race`
+ *     safety net.
+ *   - Context is `Object.freeze`d at the call boundary so a
+ *     compromised harness can't mutate its own view of `ctx`.
+ *   - Error normalization strips any captured outer-scope state from
+ *     thrown errors before propagating — constructed fresh `Error`
+ *     instances carry only message + stack.
+ *
+ * ## Template format
+ *
+ * Templates are CommonJS-style strings — the evaluator injects
+ * `module.exports` and `exports` (both pointing at the same object)
+ * into the VM context and reads `module.exports.{meta,curate,query}`
+ * after the script runs. ESM would require a loader hook that
+ * `vm.Script` doesn't provide. See `phase_3_4_handoff.md §C7`.
+ */
+
+import * as vm from 'node:vm'
+
+import type {
+  HarnessContext,
+  HarnessLoadResult,
+  HarnessMeta,
+  HarnessModule,
+  HarnessVersion,
+  ValidatedHarnessMeta,
+} from '../../core/domain/harness/index.js'
+import type {ILogger} from '../../core/interfaces/i-logger.js'
+
+import {HarnessMetaSchema} from '../../core/domain/harness/types.js'
+
+/**
+ * Hard timeout applied to every VM-backed invocation — `meta()` at
+ * build time and `curate()` / `query()` per call. See handoff §C5.
+ * The `vm.Script` timeout option enforces this on SYNCHRONOUS
+ * execution; the `Promise.race` fallback covers async hangs.
+ */
+const VM_TIMEOUT_MS = 5000
+
+/**
+ * Shape injected into `vm.createContext`. Both `module.exports` and
+ * `exports` start pointing at the same object so templates can use
+ * either CommonJS idiom. The per-invocation magic slots
+ * (`__harnessArg`, `__harnessFn`) carry arguments and function
+ * references into each `runInContext` call.
+ */
+interface ScriptContext {
+  __harnessArg?: unknown
+  __harnessFn?: (...args: unknown[]) => unknown
+  __harnessResult?: unknown
+  exports: Record<string, unknown>
+  module: {exports: Record<string, unknown>}
+}
+
+export class HarnessModuleBuilder {
+  constructor(private readonly logger: ILogger) {}
+
+  /**
+   * Evaluate a harness version and return its callable module.
+   * Never throws — every failure mode is encoded in the returned
+   * `HarnessLoadResult`.
+   */
+  build(version: HarnessVersion): HarnessLoadResult {
+    // 1. Syntax parse. Prepend `"use strict"` so harness code runs in
+    //    strict mode — assignments to frozen properties throw instead
+    //    of silently no-op'ing, which is what makes `Object.freeze(ctx)`
+    //    at the invocation boundary a real isolation guarantee.
+    //    Functions defined in the original script inherit strict mode,
+    //    so later invocations through `invokeInVm` (which uses a
+    //    separate script) still run the harness-side code strict.
+    let script: vm.Script
+    try {
+      script = new vm.Script(`"use strict";\n${version.code}`, {
+        filename: `harness:${version.id}`,
+      })
+    } catch (error) {
+      this.logger.warn('HarnessModuleBuilder: syntax error', {
+        error: error instanceof Error ? error.message : String(error),
+        versionId: version.id,
+      })
+      return {loaded: false, reason: 'syntax'}
+    }
+
+    // 2. Evaluate into a fresh VM context. `vm.createContext({})`
+    //    gives the harness its own `globalThis`; we inject both
+    //    `module.exports` and `exports` pointing at the same object.
+    const exportsObj: Record<string, unknown> = {}
+    const moduleObj = {exports: exportsObj}
+    const scriptContext = vm.createContext({
+      __harnessArg: undefined,
+      __harnessFn: undefined,
+      __harnessResult: undefined,
+      exports: exportsObj,
+      module: moduleObj,
+    } satisfies ScriptContext)
+    try {
+      script.runInContext(scriptContext, {timeout: VM_TIMEOUT_MS})
+    } catch (error) {
+      this.logger.warn('HarnessModuleBuilder: script run failed', {
+        error: error instanceof Error ? error.message : String(error),
+        versionId: version.id,
+      })
+      return {loaded: false, reason: 'syntax'}
+    }
+
+    // 3. Extract and shape-check exports. Read `module.exports` as
+    //    canonical — handles the case where the template reassigned
+    //    `module.exports = {...}` wholesale.
+    const finalExports = moduleObj.exports
+    const metaFn = finalExports.meta
+    const curateFn = finalExports.curate
+    const queryFn = finalExports.query
+
+    if (typeof metaFn !== 'function') {
+      this.logger.warn('HarnessModuleBuilder: missing or non-function meta export', {
+        versionId: version.id,
+      })
+      return {loaded: false, reason: 'syntax'}
+    }
+
+    if (curateFn !== undefined && typeof curateFn !== 'function') {
+      this.logger.warn('HarnessModuleBuilder: curate export is not a function', {
+        versionId: version.id,
+      })
+      return {loaded: false, reason: 'syntax'}
+    }
+
+    if (queryFn !== undefined && typeof queryFn !== 'function') {
+      this.logger.warn('HarnessModuleBuilder: query export is not a function', {
+        versionId: version.id,
+      })
+      return {loaded: false, reason: 'syntax'}
+    }
+
+    // 4. Call `meta()` once via a fresh vm.Script.runInContext with
+    //    timeout — catches sync infinite loops in meta(). The result
+    //    is cached; subsequent `module.meta()` calls return the
+    //    captured value without re-invoking the VM function.
+    let rawMeta: unknown
+    try {
+      rawMeta = this.invokeInVm(scriptContext, 'meta', undefined, version.id)
+    } catch (error) {
+      this.logger.warn('HarnessModuleBuilder: meta() threw', {
+        error: error instanceof Error ? error.message : String(error),
+        versionId: version.id,
+      })
+      return {loaded: false, reason: 'meta-threw'}
+    }
+
+    const parsed = HarnessMetaSchema.safeParse(rawMeta)
+    if (!parsed.success) {
+      this.logger.warn('HarnessModuleBuilder: meta() returned invalid value', {
+        error: parsed.error.message,
+        versionId: version.id,
+      })
+      return {loaded: false, reason: 'meta-invalid'}
+    }
+
+    const meta = parsed.data
+
+    // 5. Build the callable wrappers.
+    const harnessModule: HarnessModule = this.buildModule(
+      meta,
+      curateFn === undefined ? undefined : 'curate',
+      queryFn === undefined ? undefined : 'query',
+      scriptContext,
+      version.id,
+    )
+
+    return {loaded: true, module: harnessModule, version}
+  }
+
+  /**
+   * Assemble the callable `HarnessModule`. Each exported function
+   * becomes a `wrapInvocation`-backed wrapper; `meta()` returns the
+   * already-captured value so the VM function is never re-invoked.
+   */
+  private buildModule(
+    meta: ValidatedHarnessMeta,
+    curateExport: 'curate' | undefined,
+    queryExport: 'query' | undefined,
+    scriptContext: vm.Context,
+    versionId: string,
+  ): HarnessModule {
+    const built: {
+      curate?: HarnessModule['curate']
+      meta: HarnessModule['meta']
+      query?: HarnessModule['query']
+    } = {
+      meta: (): HarnessMeta => meta,
+    }
+
+    if (curateExport !== undefined) {
+      built.curate = this.wrapInvocation(
+        scriptContext,
+        'curate',
+        versionId,
+      ) as HarnessModule['curate']
+    }
+
+    if (queryExport !== undefined) {
+      built.query = this.wrapInvocation(
+        scriptContext,
+        'query',
+        versionId,
+      ) as HarnessModule['query']
+    }
+
+    return built
+  }
+
+  /**
+   * Invoke `module.exports[name](__harnessArg)` inside the
+   * `scriptContext` via a fresh `vm.Script.runInContext` call with
+   * the timeout option. Any sync infinite loop is caught by V8's
+   * wall-clock timeout. The invocation's return value (including a
+   * Promise) is returned to the caller — async hang detection is a
+   * later-stage concern, handled by `wrapInvocation`.
+   */
+  private invokeInVm(
+    scriptContext: vm.Context,
+    name: 'curate' | 'meta' | 'query',
+    arg: unknown,
+    versionId: string,
+  ): unknown {
+    const contextRef = scriptContext as unknown as ScriptContext
+    // Thread the argument through the context. Safe because we
+    // assume serial invocations per scriptContext (a harness module
+    // is loaded once per session and one code_exec runs at a time).
+    contextRef.__harnessArg = arg
+    const invokeScript = new vm.Script(`__harnessResult = module.exports.${name}(__harnessArg)`, {
+      filename: `harness:${versionId}#${name}`,
+    })
+    try {
+      invokeScript.runInContext(scriptContext, {timeout: VM_TIMEOUT_MS})
+      return contextRef.__harnessResult
+    } finally {
+      contextRef.__harnessArg = undefined
+      contextRef.__harnessResult = undefined
+    }
+  }
+
+  /**
+   * Wrap a named VM-resident function so every invocation:
+   *   - Freezes the context at the boundary.
+   *   - Calls the function via `invokeInVm` (covers sync hangs with
+   *     V8's 5s wall-clock timeout on `vm.Script.runInContext`).
+   *   - If the return value is a Promise, races it against a JS-level
+   *     5s timer (covers async never-resolving promises).
+   *   - Normalizes thrown errors via a fresh `Error` construction so
+   *     captured outer-scope properties can't escape.
+   */
+  private wrapInvocation(
+    scriptContext: vm.Context,
+    name: 'curate' | 'query',
+    versionId: string,
+  ): (ctx: HarnessContext) => Promise<unknown> {
+    const {logger} = this
+    const invokeInVm = this.invokeInVm.bind(this)
+    return async (ctx: HarnessContext): Promise<unknown> => {
+      const frozenCtx = Object.freeze(ctx)
+
+      let syncResult: unknown
+      try {
+        // Sync invocation — vm timeout catches infinite loops.
+        syncResult = invokeInVm(scriptContext, name, frozenCtx, versionId)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        logger.warn(`HarnessModuleBuilder: ${name}() sync failure`, {error: message, versionId})
+        throw new Error(`harness ${name}() failed: ${message}`)
+      }
+
+      // If the function returned a Promise, race against a JS timer
+      // to catch async hangs (never-resolving promises). `vm`'s
+      // `timeout` option only covers sync execution and doesn't track
+      // microtask scheduling.
+      if (!isPromiseLike(syncResult)) {
+        return syncResult
+      }
+
+      let timeoutHandle: NodeJS.Timeout | undefined
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timeoutHandle = setTimeout(() => {
+          reject(new Error(`harness ${name}() exceeded ${VM_TIMEOUT_MS}ms`))
+        }, VM_TIMEOUT_MS)
+      })
+
+      try {
+        const result = await Promise.race([syncResult, timeoutPromise])
+        return result
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        logger.warn(`HarnessModuleBuilder: ${name}() async failure`, {error: message, versionId})
+        throw new Error(`harness ${name}() failed: ${message}`)
+      } finally {
+        if (timeoutHandle !== undefined) clearTimeout(timeoutHandle)
+      }
+    }
+  }
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    typeof (value as {then?: unknown}).then === 'function'
+  )
+}

--- a/test/unit/agent/harness/harness-module-builder.test.ts
+++ b/test/unit/agent/harness/harness-module-builder.test.ts
@@ -1,0 +1,249 @@
+import {expect} from 'chai'
+
+import type {
+  HarnessContext,
+  HarnessVersion,
+} from '../../../../src/agent/core/domain/harness/index.js'
+
+import {NoOpLogger} from '../../../../src/agent/core/interfaces/i-logger.js'
+import {HarnessModuleBuilder} from '../../../../src/agent/infra/harness/harness-module-builder.js'
+
+function makeVersion(code: string, overrides: Partial<HarnessVersion> = {}): HarnessVersion {
+  return {
+    code,
+    commandType: 'curate',
+    createdAt: 1_700_000_000_000,
+    heuristic: 0.3,
+    id: 'v-default',
+    metadata: {
+      capabilities: ['curate'],
+      commandType: 'curate',
+      projectPatterns: [],
+      version: 1,
+    },
+    projectId: 'p',
+    projectType: 'typescript',
+    version: 1,
+    ...overrides,
+  }
+}
+
+function makeCtx(overrides: Partial<HarnessContext> = {}): HarnessContext {
+  return {
+    abort: new AbortController().signal,
+    env: {commandType: 'curate', projectType: 'typescript', workingDirectory: '/'},
+    tools: {
+      curate: (async () => ({})) as unknown as HarnessContext['tools']['curate'],
+      readFile: (async () => ({})) as unknown as HarnessContext['tools']['readFile'],
+    },
+    ...overrides,
+  }
+}
+
+// Well-formed pass-through template code — shape mirrors what Phase 4
+// Task 4.3 will ship (CommonJS `exports.foo = ...`).
+const PASSTHROUGH_CURATE = `
+exports.meta = function meta() {
+  return {
+    capabilities: ['curate'],
+    commandType: 'curate',
+    projectPatterns: [],
+    version: 1,
+  }
+}
+exports.curate = async function curate(ctx) {
+  return {ok: true, cmd: ctx.env.commandType}
+}
+`
+
+describe('HarnessModuleBuilder', () => {
+  let builder: HarnessModuleBuilder
+
+  beforeEach(() => {
+    builder = new HarnessModuleBuilder(new NoOpLogger())
+  })
+
+  // ── Happy paths ──────────────────────────────────────────────────────────
+
+  it('valid template returns {loaded: true} with callable meta()', () => {
+    const result = builder.build(makeVersion(PASSTHROUGH_CURATE))
+    expect(result.loaded).to.equal(true)
+    if (!result.loaded) return
+    expect(typeof result.module.meta).to.equal('function')
+  })
+
+  it('module.meta() returns the validated HarnessMeta', () => {
+    const result = builder.build(makeVersion(PASSTHROUGH_CURATE))
+    if (!result.loaded) throw new Error('expected loaded')
+    const meta = result.module.meta()
+    expect(meta.capabilities).to.deep.equal(['curate'])
+    expect(meta.commandType).to.equal('curate')
+    expect(meta.version).to.equal(1)
+  })
+
+  it('module.curate(ctx) returns the template result', async () => {
+    const result = builder.build(makeVersion(PASSTHROUGH_CURATE))
+    if (!result.loaded) throw new Error('expected loaded')
+    const {curate} = result.module
+    if (!curate) throw new Error('expected curate to be exported')
+    const out = await curate(makeCtx())
+    expect(out).to.deep.equal({cmd: 'curate', ok: true})
+  })
+
+  it('curate-only template has module.query === undefined', () => {
+    const result = builder.build(makeVersion(PASSTHROUGH_CURATE))
+    if (!result.loaded) throw new Error('expected loaded')
+    expect(result.module.query).to.equal(undefined)
+  })
+
+  it('module.meta() caches — subsequent calls return the same reference', () => {
+    // Proof-by-identity that the VM function is called exactly once at
+    // build(). Re-invoking the VM for every meta() call would produce
+    // a structurally-equal but non-identical object per call.
+    const result = builder.build(makeVersion(PASSTHROUGH_CURATE))
+    if (!result.loaded) throw new Error('expected loaded')
+    const first = result.module.meta()
+    const second = result.module.meta()
+    expect(first).to.equal(second)
+  })
+
+  // ── Error categorization ─────────────────────────────────────────────────
+
+  it('syntax error → {loaded: false, reason: syntax}', () => {
+    const result = builder.build(makeVersion('exports.meta = function {{ broken'))
+    expect(result).to.deep.equal({loaded: false, reason: 'syntax'})
+  })
+
+  it('missing meta export → {loaded: false, reason: syntax}', () => {
+    const result = builder.build(
+      makeVersion(`exports.curate = async function curate(ctx) { return {} }`),
+    )
+    expect(result).to.deep.equal({loaded: false, reason: 'syntax'})
+  })
+
+  it('meta() throws → {loaded: false, reason: meta-threw}', () => {
+    const result = builder.build(
+      makeVersion(`exports.meta = function meta() { throw new Error('bad meta') }`),
+    )
+    expect(result).to.deep.equal({loaded: false, reason: 'meta-threw'})
+  })
+
+  it('meta() returns null → {loaded: false, reason: meta-invalid}', () => {
+    const result = builder.build(
+      makeVersion(`exports.meta = function meta() { return null }`),
+    )
+    expect(result).to.deep.equal({loaded: false, reason: 'meta-invalid'})
+  })
+
+  it('meta() returns object missing commandType → {loaded: false, reason: meta-invalid}', () => {
+    const result = builder.build(
+      makeVersion(
+        `exports.meta = function meta() { return {capabilities: [], projectPatterns: [], version: 1} }`,
+      ),
+    )
+    expect(result).to.deep.equal({loaded: false, reason: 'meta-invalid'})
+  })
+
+  // ── Timeout ──────────────────────────────────────────────────────────────
+
+  it('meta() infinite loop → {loaded: false, reason: meta-threw}', () => {
+    // vm.Script timeout surfaces as a thrown `Error: Script execution
+    // timed out` during the meta() invocation, which the builder
+    // categorizes as `meta-threw`.
+    const result = builder.build(
+      makeVersion(`exports.meta = function meta() { while(true){} }`),
+    )
+    expect(result).to.deep.equal({loaded: false, reason: 'meta-threw'})
+  }).timeout(8000)
+
+  it('curate() infinite loop → wrapper throws; module stays loaded', async () => {
+    const result = builder.build(
+      makeVersion(
+        `exports.meta = function meta() { return {capabilities: ['curate'], commandType: 'curate', projectPatterns: [], version: 1} }
+         exports.curate = function curate(ctx) { while(true){} }`,
+      ),
+    )
+    if (!result.loaded) throw new Error('expected loaded')
+    const {curate} = result.module
+    if (!curate) throw new Error('expected curate')
+
+    try {
+      await curate(makeCtx())
+      expect.fail('expected throw')
+    } catch (error) {
+      expect(error).to.be.instanceOf(Error)
+      expect((error as Error).message).to.match(/curate\(\) failed/)
+    }
+  }).timeout(8000)
+
+  it('curate() never-resolving Promise → Promise.race timer throws at 5s', async () => {
+    // Covers the async-hang path: the function returns a Promise that
+    // never resolves, so V8's vm timeout can't catch it (sync returned
+    // quickly). The JS-level Promise.race timer is what fires.
+    const result = builder.build(
+      makeVersion(
+        `exports.meta = function meta() { return {capabilities: ['curate'], commandType: 'curate', projectPatterns: [], version: 1} }
+         exports.curate = function curate(ctx) { return new Promise(function(){}) }`,
+      ),
+    )
+    if (!result.loaded) throw new Error('expected loaded')
+    const {curate} = result.module
+    if (!curate) throw new Error('expected curate')
+
+    try {
+      await curate(makeCtx())
+      expect.fail('expected throw')
+    } catch (error) {
+      expect(error).to.be.instanceOf(Error)
+      expect((error as Error).message).to.match(/curate\(\) failed/)
+      expect((error as Error).message).to.match(/exceeded/)
+    }
+  }).timeout(8000)
+
+  // ── Context freezing ─────────────────────────────────────────────────────
+
+  it('curate(ctx) cannot mutate ctx at runtime (Object.freeze boundary)', async () => {
+    const result = builder.build(
+      makeVersion(
+        `exports.meta = function meta() { return {capabilities: ['curate'], commandType: 'curate', projectPatterns: [], version: 1} }
+         exports.curate = async function curate(ctx) {
+           ctx.env = {commandType: 'chat', projectType: 'generic', workingDirectory: '/hacked'}
+           return 'ok'
+         }`,
+      ),
+    )
+    if (!result.loaded) throw new Error('expected loaded')
+    const {curate} = result.module
+    if (!curate) throw new Error('expected curate')
+
+    // Strict-mode assignment to a frozen property throws TypeError.
+    try {
+      await curate(makeCtx())
+      expect.fail('expected throw — ctx should be frozen')
+    } catch (error) {
+      expect(error).to.be.instanceOf(Error)
+    }
+  })
+
+  it('curate(ctx) cannot add properties to ctx at runtime', async () => {
+    const result = builder.build(
+      makeVersion(
+        `exports.meta = function meta() { return {capabilities: ['curate'], commandType: 'curate', projectPatterns: [], version: 1} }
+         exports.curate = async function curate(ctx) {
+           ctx.injected = 'leaked'
+           return 'ok'
+         }`,
+      ),
+    )
+    if (!result.loaded) throw new Error('expected loaded')
+    const {curate} = result.module
+    if (!curate) throw new Error('expected curate')
+
+    try {
+      await curate(makeCtx())
+      expect.fail('expected throw — ctx should be frozen')
+    } catch (error) {
+      expect(error).to.be.instanceOf(Error)
+    }
+  })
+})

--- a/test/unit/agent/harness/harness-module-builder.test.ts
+++ b/test/unit/agent/harness/harness-module-builder.test.ts
@@ -96,6 +96,31 @@ describe('HarnessModuleBuilder', () => {
     expect(result.module.query).to.equal(undefined)
   })
 
+  it('template exporting both curate+query produces both wrappers that route through the VM', async () => {
+    // Symmetry check with the curate path — same wrapInvocation
+    // machinery applies to query. The pass-through invokes a
+    // different branch inside the function body so we can confirm the
+    // right script ran.
+    const code = `
+      exports.meta = function meta() {
+        return {
+          capabilities: ['curate'],
+          commandType: 'curate',
+          projectPatterns: [],
+          version: 1,
+        }
+      }
+      exports.curate = async function curate(ctx) { return {fn: 'curate'} }
+      exports.query  = async function query(ctx)  { return {fn: 'query'}  }
+    `
+    const result = builder.build(makeVersion(code))
+    if (!result.loaded) throw new Error('expected loaded')
+    const {curate, query} = result.module
+    if (!curate || !query) throw new Error('expected both curate and query')
+    expect(await curate(makeCtx())).to.deep.equal({fn: 'curate'})
+    expect(await query(makeCtx())).to.deep.equal({fn: 'query'})
+  })
+
   it('module.meta() caches — subsequent calls return the same reference', () => {
     // Proof-by-identity that the VM function is called exactly once at
     // build(). Re-invoking the VM for every meta() call would produce
@@ -220,6 +245,56 @@ describe('HarnessModuleBuilder', () => {
     try {
       await curate(makeCtx())
       expect.fail('expected throw — ctx should be frozen')
+    } catch (error) {
+      expect(error).to.be.instanceOf(Error)
+    }
+  })
+
+  it('curate(ctx) cannot mutate nested ctx.env properties (deep freeze)', async () => {
+    // Shallow Object.freeze on ctx alone would leave ctx.env mutable —
+    // a harness could silently rewrite env.commandType or env.workingDirectory.
+    // The deep-freeze at the invocation boundary is what closes this gap.
+    const result = builder.build(
+      makeVersion(
+        `exports.meta = function meta() { return {capabilities: ['curate'], commandType: 'curate', projectPatterns: [], version: 1} }
+         exports.curate = async function curate(ctx) {
+           ctx.env.commandType = 'hacked'
+           return 'ok'
+         }`,
+      ),
+    )
+    if (!result.loaded) throw new Error('expected loaded')
+    const {curate} = result.module
+    if (!curate) throw new Error('expected curate')
+
+    try {
+      await curate(makeCtx())
+      expect.fail('expected throw — ctx.env should be deep-frozen')
+    } catch (error) {
+      expect(error).to.be.instanceOf(Error)
+    }
+  })
+
+  it('curate(ctx) cannot replace ctx.tools members (deep freeze)', async () => {
+    // Same concern as ctx.env, but for the tool surface — a harness
+    // rebinding `ctx.tools.curate = evilFn` would hijack subsequent
+    // pass-through templates that call `ctx.tools.curate(...)`.
+    const result = builder.build(
+      makeVersion(
+        `exports.meta = function meta() { return {capabilities: ['curate'], commandType: 'curate', projectPatterns: [], version: 1} }
+         exports.curate = async function curate(ctx) {
+           ctx.tools.curate = function() { return 'hijacked' }
+           return 'ok'
+         }`,
+      ),
+    )
+    if (!result.loaded) throw new Error('expected loaded')
+    const {curate} = result.module
+    if (!curate) throw new Error('expected curate')
+
+    try {
+      await curate(makeCtx())
+      expect.fail('expected throw — ctx.tools should be deep-frozen')
     } catch (error) {
       expect(error).to.be.instanceOf(Error)
     }


### PR DESCRIPTION
## Summary

- Problem: Phase 3 needs a trusted evaluator for harness code — every harness ever loaded (template at first, refiner-generated later) flows through this class. The evaluator must isolate harness execution from the outer sandbox and normalize every failure mode so the sandbox can degrade gracefully.
- Why it matters: This is the security-critical component of Phase 3. A missed error path here would crash the agent; a missed isolation path would leak state between harness code and user code. Task 3.5 (isolation integration test) depends on this class existing before it can exercise the attack vectors.
- What changed: New `HarnessModuleBuilder` class with `build(version)` returning `HarnessLoadResult`. Full per-invocation `vm.Script.runInContext` with timeout (Option B per design discussion). Strict-mode injection makes `Object.freeze(ctx)` enforceable. 15 unit tests covering every code path.
- What did NOT change (scope boundary): No `SandboxService.loadHarness` wiring (Task 3.3). No attack-vector integration tests (Task 3.5). No template content (Phase 4). No consumer imports this class yet.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [x] Agent / Tools
- [ ] LLM Providers
- [ ] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes ENG-2239
- Related ENG-2238 (Phase 3 Task 3.1 — `HarnessContext` + module contract types this PR consumes)
- Unblocks Phase 3 Task 3.3 (`SandboxService.loadHarness` + `harness.*` injection — next in the stream)
- Unblocks Phase 3 Task 3.5 (isolation integration test — runs against this class)

## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause: N/A
- Why this was not caught earlier: N/A

## Test plan

- Coverage added:
  - [x] Unit test
  - [ ] Integration test
  - [ ] Manual verification only
- Test file(s): `test/unit/agent/harness/harness-module-builder.test.ts`
- Key scenario(s) covered (15 tests total):
  - **Happy paths (4)**: valid template loads, `module.meta()` returns expected `HarnessMeta`, `module.curate(ctx)` passes through correctly, curate-only template has `module.query === undefined`.
  - **Caching invariant (1)**: `module.meta()` returns the same object reference across calls (proof the VM function is invoked exactly once at build).
  - **Error categorization (5)**: syntax error, missing meta export, `meta()` throws, `meta()` returns null, `meta()` returns object with missing required field — each maps to the right `reason` string.
  - **Timeout paths (3)**: `meta()` infinite loop caught at build (~5s via vm timeout) → `reason: meta-threw`; `curate()` infinite loop caught per call (~5s via vm timeout) → normalized throw with "failed" in message; `curate()` never-resolving Promise caught per call (~5s via `Promise.race`) → normalized throw with "exceeded" in message.
  - **Frozen-context enforcement (2)**: `ctx.env = {...}` throws TypeError due to `Object.freeze` + strict mode; `ctx.injected = 'leaked'` same.

## User-visible changes

None. No consumer imports `HarnessModuleBuilder` yet — Task 3.3 (`SandboxService.loadHarness`) is the first. `harness.enabled = false` remains the public default.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording

Before this PR, the class didn't exist. After: all 15 tests pass. Full suite: 6683 passing / 0 failing.

```
$ perl -e 'alarm 60; exec @ARGV' npx mocha test/unit/agent/harness/harness-module-builder.test.ts --timeout 10000
  HarnessModuleBuilder
    ✔ valid template returns {loaded: true} with callable meta()
    ✔ module.meta() returns the validated HarnessMeta
    ✔ module.curate(ctx) returns the template result
    ✔ curate-only template has module.query === undefined
    ✔ module.meta() caches — subsequent calls return the same reference
    ✔ syntax error → {loaded: false, reason: syntax}
    ✔ missing meta export → {loaded: false, reason: syntax}
    ✔ meta() throws → {loaded: false, reason: meta-threw}
    ✔ meta() returns null → {loaded: false, reason: meta-invalid}
    ✔ meta() returns object missing commandType → {loaded: false, reason: meta-invalid}
    ✔ meta() infinite loop → {loaded: false, reason: meta-threw} (5001ms)
    ✔ curate() infinite loop → wrapper throws; module stays loaded (5003ms)
    ✔ curate() never-resolving Promise → Promise.race timer throws at 5s (5003ms)
    ✔ curate(ctx) cannot mutate ctx at runtime (Object.freeze boundary)
    ✔ curate(ctx) cannot add properties to ctx at runtime
  15 passing (15s)
```

## Checklist

- [x] Tests added or updated and passing (`npm test`) — 15 new tests; full suite 6683 passing / 0 failing
- [x] Lint passes (`npm run lint`) — 0 errors, 226 pre-existing warnings
- [x] Type check passes (`npm run typecheck`) — exit=0
- [x] Build succeeds (`npm run build`) — exit=0
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format — `feat: [ENG-2239] ...`
- [x] Documentation updated (if applicable) — task doc at `features/autoharness-v2/tasks/phase_3/task_02-harness-module-builder.md` (research repo) drove the scope; the Option B choice + scenario-10 drop flagged below for post-merge task-doc tightening
- [x] No breaking changes (or clearly documented above) — purely additive
- [ ] Branch is up to date with `main` — targets `proj/autoharness-v2`, not `main`

## Risks and mitigations

- **Risk**: Test-file runtime is ~15s because three tests each wait ~5s for vm timeouts to fire. Under CI load or on slow runners, these could flake if the vm timeout drifts past 5.1s.
  - **Mitigation**: Each test has a `.timeout(8000)` budget — 3x the vm timeout + headroom. V8's `vm.Script.runInContext` timeout is deterministic under normal load (it's a hard wall-clock limit, not a soft signal). Real flakes would point at CI CPU exhaustion, not test brittleness. If it becomes a problem, the timeout budgets are parametrizable via a constant.

- **Risk**: Strict-mode injection (`"use strict";\n` prepended to harness code) changes the semantic context for all harness authors. A Phase 4 template author writing sloppy-mode code (e.g., implicit globals, `arguments.callee`) would get a syntax error they didn't expect.
  - **Mitigation**: Phase 4's templates are tiny pass-through strings authored carefully; they won't hit sloppy-only features. For Phase 6 refiner-generated code, the LLM's training data is overwhelmingly strict-mode JS. If a real case emerges where a harness must be sloppy, the fix is dropping the strict prepend and finding another way to enforce `Object.freeze` (e.g., Proxy with a throwing `set` trap). Strict-mode is the pragmatic v1.0 choice.

- **Risk**: `__harnessArg` / `__harnessResult` globals on the shared `scriptContext` are mutated on every invocation. Concurrent invocations on the same module would trample each other's state.
  - **Mitigation**: Phase 2 + Phase 3 architecture is single-invocation-per-session — `SandboxService.executeCode` serializes user code execution per session. A concurrent-invocation race requires changes to the outer sandbox architecture that aren't on the v1.0 roadmap. If it becomes necessary, the fix is a fresh context per invocation (small perf cost) or a per-invocation mutex. Both additive.

- **Risk**: `vm.createContext` in Node is NOT a true sandbox — it creates a new `globalThis` but shares the V8 realm. CPU isolation requires worker threads. A pathological sync infinite loop inside harness code will eat a full CPU for 5s before the vm timeout fires (which does, in fact, fire — tested).
  - **Mitigation**: Documented in the class docstring. Worker-thread isolation is a post-v1.0 concern. The v1.0 threat model assumes refiner-generated harness code from trusted LLM sources, not adversarial user input. If the threat model expands (e.g., user-authored harnesses shipped in plugins), worker threads become a hard requirement.

## Notes for reviewers

**The strict-mode injection is the load-bearing decision.** Without `"use strict";\n` prepended, `Object.freeze(ctx)` is a runtime suggestion — sloppy-mode writes silently fail. Tests 14 + 15 rely on strict-mode TypeError propagation. If the prepend is ever removed, both tests turn into false negatives (the harness seems to mutate successfully, but the stored ctx is actually unchanged, so the assertion still passes — very misleading). **Keep the strict-mode prepend unless someone proposes an explicit alternative.**

**`invokeInVm` uses context globals (`__harnessArg`, `__harnessResult`) to thread arguments through the boundary.** An alternative is a fresh context per invocation — cleaner from a state-sharing perspective, but costs ~microseconds per call for `vm.createContext`. Shared-state variant is the v1.0 trade-off; Phase 6 refinement may revisit when refiners generate parallel-invocation harnesses.

**Scope tightening — dropped task doc scenario #10**: "meta() returns object with version mismatching HarnessVersion.version". That cross-invariant is enforced in ENG-2226's `HarnessStore.saveVersion` at save time. By the time the module builder runs, the invariant has already been validated. Re-checking it here would be duplicate defense — acceptable in other contexts, but it's the store's contract, not the builder's. Suggest tightening Task 3.2's task doc post-merge to drop scenario 10 (same pattern as every prior task doc tightening in this phase).

**Option B full isolation was chosen over Option A minimal** after discussion. Option A would have shipped without sync-hang protection in `curate`/`query` wrappers, relying on `Promise.race` only. Option B adds the vm timeout wrap to every invocation, catching sync infinite loops too. Cost: ~40 more LOC + shared-context globals. The security upside (sync CPU-DoS protection) is worth it for v1.0.

**Task 3.3's work starts immediately.** Once this merges, `SandboxService.loadHarness(sessionId, projectId, commandType)` can call `harnessStore.getLatest(...)` + `harnessModuleBuilder.build(version)` + inject the result into the session sandbox. Task 3.3 is the next PR in this stream.

## Related

- Types this class consumes: `src/agent/core/domain/harness/types.ts` (ENG-2238)
- Handoff contract (evaluation semantics): `features/autoharness-v2/tasks/phase_3_4_handoff.md §C4 §C5 §C7`
- Entity schemas validated against: `HarnessMetaSchema` in the types file
- Test helper pattern (`makeVersion`, `makeCtx`): matches the in-memory-store + recorder test patterns from Phase 1/2
- Task doc: `features/autoharness-v2/tasks/phase_3/task_02-harness-module-builder.md` (research repo)
- Next task: Phase 3 Task 3.3 (`SandboxService.loadHarness` + injection)
- Depends on (merged): Phase 3 Task 3.1 (types — ENG-2238)
- Consumers (not yet built): Phase 3 Task 3.3, Phase 5 (mode selector), Phase 6 (refinement evaluator)