### PR TITLE
feat: [ENG-2167] expose context-tree remote URL via project config

### DIFF
--- a/src/server/infra/context-tree/read-context-tree-remote.ts
+++ b/src/server/infra/context-tree/read-context-tree-remote.ts
@@ -1,0 +1,22 @@
+import * as git from 'isomorphic-git'
+import fs from 'node:fs'
+import {join} from 'node:path'
+
+import {BRV_DIR, CONTEXT_TREE_DIR} from '../../constants.js'
+
+/**
+ * Reads a remote URL from the project's context-tree git repo
+ * (`<projectPath>/.brv/context-tree/.git/config`).
+ *
+ * Returns `undefined` silently when the context-tree dir isn't a git repo
+ * yet or the requested remote isn't configured — callers treat "no remote"
+ * and "no repo" identically.
+ */
+export async function readContextTreeRemoteUrl(projectPath: string, remote = 'origin'): Promise<string | undefined> {
+  const dir = join(projectPath, BRV_DIR, CONTEXT_TREE_DIR)
+  try {
+    return await git.getConfig({dir, fs, path: `remote.${remote}.url`})
+  } catch {
+    return undefined
+  }
+}

--- a/src/server/infra/daemon/brv-server.ts
+++ b/src/server/infra/daemon/brv-server.ts
@@ -23,10 +23,9 @@
 
 import {GlobalInstanceManager} from '@campfirein/brv-transport-client'
 import express from 'express'
-import * as git from 'isomorphic-git'
 import {fork, type StdioOptions} from 'node:child_process'
 import {randomUUID} from 'node:crypto'
-import fs, {mkdirSync, readdirSync, readFileSync, unlinkSync} from 'node:fs'
+import {mkdirSync, readdirSync, readFileSync, unlinkSync} from 'node:fs'
 import {dirname, join} from 'node:path'
 import {fileURLToPath} from 'node:url'
 
@@ -38,7 +37,6 @@ import {
   AGENT_IDLE_TIMEOUT_MS,
   AGENT_POOL_MAX_SIZE,
   BRV_DIR,
-  CONTEXT_TREE_DIR,
   HEARTBEAT_FILE,
   WEBUI_DEFAULT_PORT,
 } from '../../constants.js'
@@ -53,6 +51,7 @@ import {getProjectDataDir} from '../../utils/path-utils.js'
 import {crashLog, processLog} from '../../utils/process-logger.js'
 import {ClientManager} from '../client/client-manager.js'
 import {ProjectConfigStore} from '../config/file-config-store.js'
+import {readContextTreeRemoteUrl} from '../context-tree/read-context-tree-remote.js'
 import {DreamStateService} from '../dream/dream-state-service.js'
 import {DreamTrigger} from '../dream/dream-trigger.js'
 import {createReviewApiRouter} from '../http/review-api-handler.js'
@@ -84,15 +83,6 @@ import {HeartbeatWriter} from './heartbeat.js'
 import {IdleTimeoutPolicy} from './idle-timeout-policy.js'
 import {selectDaemonPort} from './port-selector.js'
 import {ShutdownHandler} from './shutdown-handler.js'
-
-async function readContextTreeRemoteUrl(projectPath: string, remote = 'origin'): Promise<string | undefined> {
-  const dir = join(projectPath, BRV_DIR, CONTEXT_TREE_DIR)
-  try {
-    return await git.getConfig({dir, fs, path: `remote.${remote}.url`})
-  } catch {
-    return undefined
-  }
-}
 
 function log(msg: string): void {
   processLog(`[Daemon] ${msg}`)

--- a/src/server/infra/daemon/brv-server.ts
+++ b/src/server/infra/daemon/brv-server.ts
@@ -23,9 +23,10 @@
 
 import {GlobalInstanceManager} from '@campfirein/brv-transport-client'
 import express from 'express'
+import * as git from 'isomorphic-git'
 import {fork, type StdioOptions} from 'node:child_process'
 import {randomUUID} from 'node:crypto'
-import {mkdirSync, readdirSync, readFileSync, unlinkSync} from 'node:fs'
+import fs, {mkdirSync, readdirSync, readFileSync, unlinkSync} from 'node:fs'
 import {dirname, join} from 'node:path'
 import {fileURLToPath} from 'node:url'
 
@@ -37,6 +38,7 @@ import {
   AGENT_IDLE_TIMEOUT_MS,
   AGENT_POOL_MAX_SIZE,
   BRV_DIR,
+  CONTEXT_TREE_DIR,
   HEARTBEAT_FILE,
   WEBUI_DEFAULT_PORT,
 } from '../../constants.js'
@@ -82,6 +84,15 @@ import {HeartbeatWriter} from './heartbeat.js'
 import {IdleTimeoutPolicy} from './idle-timeout-policy.js'
 import {selectDaemonPort} from './port-selector.js'
 import {ShutdownHandler} from './shutdown-handler.js'
+
+async function readContextTreeRemoteUrl(projectPath: string, remote = 'origin'): Promise<string | undefined> {
+  const dir = join(projectPath, BRV_DIR, CONTEXT_TREE_DIR)
+  try {
+    return await git.getConfig({dir, fs, path: `remote.${remote}.url`})
+  } catch {
+    return undefined
+  }
+}
 
 function log(msg: string): void {
   processLog(`[Daemon] ${msg}`)
@@ -470,7 +481,7 @@ async function main(): Promise<void> {
     // State server endpoints — agent child processes request config on startup
     transportServer.onRequest<
       {projectPath: string},
-      {brvConfig?: BrvConfig; spaceId: string; storagePath: string; teamId: string}
+      {brvConfig?: BrvConfig; remoteUrl?: string; spaceId: string; storagePath: string; teamId: string}
     >(TransportStateEventNames.GET_PROJECT_CONFIG, async (data) => {
       // Smart invalidation: only invalidate if config file was modified since last load
       // This prevents unnecessary disk I/O while still catching changes from
@@ -481,11 +492,15 @@ async function main(): Promise<void> {
         log(`Config invalidated due to file modification: ${data.projectPath}`)
       }
 
-      const config = await projectStateLoader.getProjectConfig(data.projectPath)
+      const [config, remoteUrl] = await Promise.all([
+        projectStateLoader.getProjectConfig(data.projectPath),
+        readContextTreeRemoteUrl(data.projectPath),
+      ])
       // Register project (idempotent) to ensure XDG storage directories exist
       const projectInfo = projectRegistry.register(data.projectPath)
       return {
         brvConfig: config,
+        remoteUrl,
         spaceId: config?.spaceId ?? '',
         storagePath: projectInfo.storagePath,
         teamId: config?.teamId ?? '',

--- a/src/webui/features/project/api/get-project-config.ts
+++ b/src/webui/features/project/api/get-project-config.ts
@@ -22,6 +22,8 @@ interface GetProjectConfigRequest {
  */
 interface GetProjectConfigResponse {
   brvConfig?: BrvConfigDTO
+  /** Git remote URL of the project's context tree (`.brv/context-tree`), if any. */
+  remoteUrl?: string
   spaceId: string
   storagePath: string
   teamId: string

--- a/src/webui/features/project/components/project-dropdown.tsx
+++ b/src/webui/features/project/components/project-dropdown.tsx
@@ -25,10 +25,8 @@ import {useMemo, useState} from 'react'
 
 import {ProjectLocationDTO} from '../../../../shared/transport/events'
 import {useTransportStore} from '../../../stores/transport-store'
-import {useGetEnvironmentConfig} from '../../config/api/get-environment-config'
 import {useGetProjectConfig} from '../api/get-project-config'
 import {useGetProjectList} from '../api/get-project-list'
-import {buildRemoteSpaceUrl} from '../utils/build-remote-space-url'
 import {displayPath} from '../utils/display-path'
 import {getProjectName} from '../utils/project-name'
 import {AllProjectsDialog} from './all-projects-dialog'
@@ -93,16 +91,15 @@ type OpenProjectItemProps = {
   isSelected: boolean
   onSelect: () => void
   project: ProjectLocationDTO
-  webAppUrl: string | undefined
 }
 
-function OpenProjectItem({isSelected, onSelect, project, webAppUrl}: OpenProjectItemProps) {
+function OpenProjectItem({isSelected, onSelect, project}: OpenProjectItemProps) {
   const name = getProjectName(project.projectPath)
   const {data: projectConfig} = useGetProjectConfig({projectPath: project.projectPath})
   const teamName = projectConfig?.brvConfig?.teamName
   const spaceName = projectConfig?.brvConfig?.spaceName
   const remoteLabel = teamName && spaceName ? `${teamName} / ${spaceName}` : undefined
-  const remoteSpaceUrl = buildRemoteSpaceUrl({spaceName, teamName, webAppUrl})
+  const remoteUrl = projectConfig?.remoteUrl
 
   return (
     <DropdownMenuSub>
@@ -115,9 +112,9 @@ function OpenProjectItem({isSelected, onSelect, project, webAppUrl}: OpenProject
           <span className="text-sm">{isSelected ? 'Current project' : 'Switch to this project'}</span>
         </DropdownMenuItem>
         <DropdownMenuItem
-          disabled={!remoteSpaceUrl}
+          disabled={!remoteUrl}
           onClick={() => {
-            if (remoteSpaceUrl) window.open(remoteSpaceUrl, '_blank', 'noopener,noreferrer')
+            if (remoteUrl) window.open(remoteUrl, '_blank', 'noopener,noreferrer')
           }}
         >
           <SquareArrowOutUpRight className="size-4" />
@@ -138,7 +135,6 @@ export function ProjectDropdown() {
       staleTime: 30 * 1000,
     },
   })
-  const {data: envConfig} = useGetEnvironmentConfig()
 
   const projects = useMemo(() => projResp?.locations ?? [], [projResp])
   const {openProjects, recentProjects} = useMemo(() => {
@@ -187,7 +183,6 @@ export function ProjectDropdown() {
                   key={p.projectPath}
                   onSelect={() => handleSelect(p)}
                   project={p}
-                  webAppUrl={envConfig?.webAppUrl}
                 />
               ))}
 

--- a/src/webui/features/project/components/project-dropdown.tsx
+++ b/src/webui/features/project/components/project-dropdown.tsx
@@ -25,6 +25,7 @@ import {useMemo, useState} from 'react'
 
 import {ProjectLocationDTO} from '../../../../shared/transport/events'
 import {useTransportStore} from '../../../stores/transport-store'
+import {isSafeHttpUrl} from '../../auth/utils/is-safe-http-url'
 import {useGetProjectConfig} from '../api/get-project-config'
 import {useGetProjectList} from '../api/get-project-list'
 import {displayPath} from '../utils/display-path'
@@ -99,7 +100,11 @@ function OpenProjectItem({isSelected, onSelect, project}: OpenProjectItemProps) 
   const teamName = projectConfig?.brvConfig?.teamName
   const spaceName = projectConfig?.brvConfig?.spaceName
   const remoteLabel = teamName && spaceName ? `${teamName} / ${spaceName}` : undefined
-  const remoteUrl = projectConfig?.remoteUrl
+  // Only open http(s) URLs — SSH remotes (git@host:…) can't open in a browser,
+  // and a tampered `.git/config` could otherwise smuggle `javascript:` / `file:` URIs.
+  const openableRemoteUrl = projectConfig?.remoteUrl && isSafeHttpUrl(projectConfig.remoteUrl)
+    ? projectConfig.remoteUrl
+    : undefined
 
   return (
     <DropdownMenuSub>
@@ -112,9 +117,9 @@ function OpenProjectItem({isSelected, onSelect, project}: OpenProjectItemProps) 
           <span className="text-sm">{isSelected ? 'Current project' : 'Switch to this project'}</span>
         </DropdownMenuItem>
         <DropdownMenuItem
-          disabled={!remoteUrl}
+          disabled={!openableRemoteUrl}
           onClick={() => {
-            if (remoteUrl) window.open(remoteUrl, '_blank', 'noopener,noreferrer')
+            if (openableRemoteUrl) window.open(openableRemoteUrl, '_blank', 'noopener,noreferrer')
           }}
         >
           <SquareArrowOutUpRight className="size-4" />

--- a/test/unit/infra/context-tree/read-context-tree-remote.test.ts
+++ b/test/unit/infra/context-tree/read-context-tree-remote.test.ts
@@ -1,0 +1,62 @@
+import {expect} from 'chai'
+import * as git from 'isomorphic-git'
+import fs, {mkdirSync, rmSync} from 'node:fs'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+
+import {readContextTreeRemoteUrl} from '../../../../src/server/infra/context-tree/read-context-tree-remote.js'
+
+function makeTmpProject(): string {
+  const path = join(tmpdir(), `brv-remote-url-test-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`)
+  mkdirSync(join(path, '.brv', 'context-tree'), {recursive: true})
+  return path
+}
+
+describe('readContextTreeRemoteUrl', () => {
+  let projectPath: string
+
+  beforeEach(() => {
+    projectPath = makeTmpProject()
+  })
+
+  afterEach(() => {
+    rmSync(projectPath, {force: true, recursive: true})
+  })
+
+  it('returns the remote URL when the context-tree git repo has one configured', async () => {
+    const contextTreeDir = join(projectPath, '.brv', 'context-tree')
+    await git.init({dir: contextTreeDir, fs})
+    await git.setConfig({dir: contextTreeDir, fs, path: 'remote.origin.url', value: 'https://example.com/acme/repo.git'})
+
+    const result = await readContextTreeRemoteUrl(projectPath)
+    expect(result).to.equal('https://example.com/acme/repo.git')
+  })
+
+  it('returns undefined when the context-tree dir is not a git repo', async () => {
+    const result = await readContextTreeRemoteUrl(projectPath)
+    expect(result).to.equal(undefined)
+  })
+
+  it('returns undefined when the git repo has no remote configured', async () => {
+    const contextTreeDir = join(projectPath, '.brv', 'context-tree')
+    await git.init({dir: contextTreeDir, fs})
+
+    const result = await readContextTreeRemoteUrl(projectPath)
+    expect(result).to.equal(undefined)
+  })
+
+  it('reads a non-default remote name when one is passed', async () => {
+    const contextTreeDir = join(projectPath, '.brv', 'context-tree')
+    await git.init({dir: contextTreeDir, fs})
+    await git.setConfig({dir: contextTreeDir, fs, path: 'remote.upstream.url', value: 'https://example.com/owner/fork.git'})
+
+    const result = await readContextTreeRemoteUrl(projectPath, 'upstream')
+    expect(result).to.equal('https://example.com/owner/fork.git')
+  })
+
+  it('returns undefined for a non-existent project path (no throw)', async () => {
+    const missingPath = join(tmpdir(), `brv-remote-url-missing-${Date.now()}`)
+    const result = await readContextTreeRemoteUrl(missingPath)
+    expect(result).to.equal(undefined)
+  })
+})


### PR DESCRIPTION
The daemon's state:getProjectConfig handler now also reads the context-tree git remote (defaulting to origin) off disk and returns it alongside the existing project config, running in parallel with the config load so the handler's latency is unchanged. The web UI's project dropdown drops buildRemoteSpaceUrl + the webAppUrl prop threading in favour of reading remoteUrl directly from the config response, so "Open Remote space" now opens whatever the git remote actually points at.

## Summary

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [ ] Agent / Tools
- [ ] LLM Providers
- [ ] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes #
- Related #

## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause:
- Why this was not caught earlier:

## Test plan

- Coverage added:
  - [ ] Unit test
  - [ ] Integration test
  - [ ] Manual verification only
- Test file(s):
- Key scenario(s) covered:

## User-visible changes

List user-visible changes (including defaults, config, or CLI output).
If none, write `None`.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording

## Checklist

- [ ] Tests added or updated and passing (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Type check passes (`npm run typecheck`)
- [ ] Build succeeds (`npm run build`)
- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or clearly documented above)
- [ ] Branch is up to date with `main`

## Risks and mitigations

List real risks for this PR. If none, write `None`.

- Risk:
  - Mitigation:
