### PR TITLE
feat: [ENG-2241] AutoHarness V2 graceful-degradation tests

### DIFF
--- a/test/unit/agent/harness/graceful-degradation.test.ts
+++ b/test/unit/agent/harness/graceful-degradation.test.ts
@@ -1,0 +1,284 @@
+/**
+ * AutoHarness V2 — Phase 3 Task 3.4 graceful-degradation tests.
+ *
+ * Closes brutal-review item A4: the seven enumerated harness-failure
+ * cases that must all degrade to "continue with raw `tools.*`" or
+ * "surface a clean per-invocation error" instead of crashing the
+ * sandbox or leaving a partial harness state.
+ *
+ * Each test wires a real `SandboxService` + real `HarnessStore` +
+ * real `HarnessModuleBuilder` end-to-end, seeds a fixture harness
+ * version, calls `loadHarness`, then asserts the degradation shape.
+ * Three invariants per scenario:
+ *
+ *   1. `loadHarness` returns a typed `HarnessLoadResult` — either
+ *      `{loaded: false, reason}` for build-time failures or
+ *      `{loaded: true}` for templates that load successfully but
+ *      misbehave per-invocation.
+ *   2. For build-time failures, `harness.*` is NOT in the sandbox
+ *      context. For per-invocation failures, the harness IS loaded
+ *      but calling it throws (or resolves to `undefined` for the one
+ *      legitimate-undefined case) without corrupting the sandbox.
+ *   3. The sandbox continues to execute unrelated code correctly
+ *      after the harness has misbehaved — verified by evaluating
+ *      a plain JS expression that touches neither harness nor
+ *      tools.
+ *
+ * Tests that exercise the 5-second vm / Promise.race timeout each
+ * wait ~5s; total test-file runtime ≈ 15-20s.
+ */
+
+import {expect} from 'chai'
+import {createSandbox, type SinonSandbox} from 'sinon'
+
+import type {
+  HarnessContext,
+  HarnessLoadResult,
+  HarnessVersion,
+} from '../../../../src/agent/core/domain/harness/types.js'
+import type {IFileSystem} from '../../../../src/agent/core/interfaces/i-file-system.js'
+import type {ValidatedHarnessConfig} from '../../../../src/agent/infra/agent/agent-schemas.js'
+
+import {NoOpLogger} from '../../../../src/agent/core/interfaces/i-logger.js'
+import {HarnessModuleBuilder} from '../../../../src/agent/infra/harness/harness-module-builder.js'
+import {HarnessStore} from '../../../../src/agent/infra/harness/harness-store.js'
+import {SandboxService} from '../../../../src/agent/infra/sandbox/sandbox-service.js'
+import {FileKeyStorage} from '../../../../src/agent/infra/storage/file-key-storage.js'
+
+// Valid meta block used by per-invocation failure fixtures — `meta`
+// must parse cleanly so the module builder reaches the curate wrapper.
+const VALID_META = `
+  exports.meta = function meta() {
+    return {
+      capabilities: ['curate'],
+      commandType: 'curate',
+      projectPatterns: [],
+      version: 1,
+    }
+  }
+`
+
+function makeVersion(code: string): HarnessVersion {
+  return {
+    code,
+    commandType: 'curate',
+    createdAt: 1_700_000_000_000,
+    heuristic: 0.3,
+    id: 'v-1',
+    metadata: {
+      capabilities: ['curate'],
+      commandType: 'curate',
+      projectPatterns: [],
+      version: 1,
+    },
+    projectId: 'p',
+    projectType: 'typescript',
+    version: 1,
+  }
+}
+
+function makeCtx(): HarnessContext {
+  return {
+    abort: new AbortController().signal,
+    env: {commandType: 'curate', projectType: 'typescript', workingDirectory: '/'},
+    tools: {
+      // Stubs — none of the 7 tested failure scenarios invoke
+      // `ctx.tools.*` through the harness. A future scenario that
+      // exercises a successful tool call should replace these with
+      // properly-typed fixtures.
+      curate: (async () => ({})) as unknown as HarnessContext['tools']['curate'],
+      readFile: (async () => ({})) as unknown as HarnessContext['tools']['readFile'],
+    },
+  }
+}
+
+function makeEnabledConfig(): ValidatedHarnessConfig {
+  return {autoLearn: true, enabled: true, language: 'typescript', maxVersions: 20}
+}
+
+function makeStubFileSystem(sb: SinonSandbox): IFileSystem {
+  // `as unknown as IFileSystem` matches the pattern used by the
+  // existing sandbox test files — the `IFileSystem` surface is wider
+  // than what these tests need, and none of the 7 degradation
+  // scenarios invoke file-system methods through the sandbox. If a
+  // future scenario does, the missing stub will fail at runtime with
+  // a clear "is not a function" — acceptable because these tests are
+  // the failure-invariant harness, not the sandbox-behavior one.
+  return {
+    editFile: sb.stub().resolves({bytesWritten: 0, path: '/'}),
+    globFiles: sb.stub().resolves({files: [], totalFound: 0, truncated: false}),
+    initialize: sb.stub(),
+    listDirectory: sb.stub().resolves({files: [], tree: '', truncated: false}),
+    readFile: sb.stub().resolves({content: '', exists: true, path: '/'}),
+    searchContent: sb.stub().resolves({matches: [], totalMatches: 0, truncated: false}),
+    writeFile: sb.stub().resolves({bytesWritten: 0, path: '/'}),
+  } as unknown as IFileSystem
+}
+
+describe('graceful degradation — brutal-review A4', () => {
+  let sb: SinonSandbox
+  let service: SandboxService
+  let store: HarnessStore
+
+  beforeEach(async () => {
+    sb = createSandbox()
+    const keyStorage = new FileKeyStorage({inMemory: true})
+    await keyStorage.initialize()
+    store = new HarnessStore(keyStorage, new NoOpLogger())
+    const builder = new HarnessModuleBuilder(new NoOpLogger())
+
+    service = new SandboxService()
+    service.setHarnessConfig(makeEnabledConfig())
+    service.setHarnessStore(store)
+    service.setHarnessModuleBuilder(builder)
+    service.setFileSystem(makeStubFileSystem(sb))
+  })
+
+  afterEach(() => {
+    sb.restore()
+  })
+
+  async function seedAndLoad(code: string): Promise<HarnessLoadResult> {
+    await store.saveVersion(makeVersion(code))
+    return service.loadHarness('s1', 'p', 'curate')
+  }
+
+  /**
+   * Proves the sandbox is healthy after a harness failure by
+   * executing a plain JS expression that touches neither harness
+   * nor tools. If the harness failure somehow corrupted sandbox
+   * state, this assertion surfaces it.
+   */
+  async function expectSandboxHealthy(): Promise<void> {
+    const result = await service.executeCode('2 + 2', 's1')
+    expect(result.returnValue).to.equal(4)
+  }
+
+  // ── Build-time failures (harness NOT loaded) ──────────────────────────────
+
+  it('1. Syntax error at module load → {loaded:false, reason:syntax}', async () => {
+    const result = await seedAndLoad('function {{ invalid syntax')
+    expect(result).to.deep.equal({loaded: false, reason: 'syntax'})
+
+    const hasHarness = await service.executeCode(`typeof harness !== 'undefined'`, 's1')
+    expect(hasHarness.returnValue).to.equal(
+      false,
+      'harness namespace must not be injected on build-time failure',
+    )
+    await expectSandboxHealthy()
+  })
+
+  it('2. Throw in meta() → {loaded:false, reason:meta-threw}', async () => {
+    const code = `exports.meta = function meta() { throw new Error('bad meta') }`
+    const result = await seedAndLoad(code)
+    expect(result).to.deep.equal({loaded: false, reason: 'meta-threw'})
+
+    const hasHarness = await service.executeCode(`typeof harness !== 'undefined'`, 's1')
+    expect(hasHarness.returnValue).to.equal(
+      false,
+      'harness namespace must not be injected on build-time failure',
+    )
+    await expectSandboxHealthy()
+  })
+
+  // ── Per-invocation failures (harness loaded; per-call wrapper throws) ────
+
+  it('3. Throw in curate() → wrapper throws; module stays loaded', async () => {
+    const code = `${VALID_META}
+      exports.curate = async function curate(ctx) { throw new Error('user error') }
+    `
+    const result = await seedAndLoad(code)
+    expect(result.loaded).to.equal(true)
+    if (!result.loaded) return
+    if (result.module.curate === undefined) throw new Error('fixture must export curate')
+
+    try {
+      await result.module.curate(makeCtx())
+      expect.fail('expected throw')
+    } catch (error) {
+      expect((error as Error).message).to.match(/curate\(\) failed/)
+    }
+
+    await expectSandboxHealthy()
+  })
+
+  it('4. Infinite loop in curate() → vm timeout; wrapper throws', async () => {
+    const code = `${VALID_META}
+      exports.curate = function curate(ctx) { while(true){} }
+    `
+    const result = await seedAndLoad(code)
+    expect(result.loaded).to.equal(true)
+    if (!result.loaded) return
+    if (result.module.curate === undefined) throw new Error('fixture must export curate')
+
+    try {
+      await result.module.curate(makeCtx())
+      expect.fail('expected throw')
+    } catch (error) {
+      expect((error as Error).message).to.match(/curate\(\) failed/)
+    }
+
+    await expectSandboxHealthy()
+  }).timeout(8000)
+
+  it('5. Infinite recursion in curate() → stack overflow; wrapper throws', async () => {
+    const code = `${VALID_META}
+      function go() { go() }
+      exports.curate = function curate(ctx) { go() }
+    `
+    const result = await seedAndLoad(code)
+    expect(result.loaded).to.equal(true)
+    if (!result.loaded) return
+    if (result.module.curate === undefined) throw new Error('fixture must export curate')
+
+    try {
+      await result.module.curate(makeCtx())
+      expect.fail('expected throw')
+    } catch (error) {
+      expect((error as Error).message).to.match(/curate\(\) failed/)
+    }
+
+    await expectSandboxHealthy()
+  })
+
+  // ── Legitimate non-failure: returns undefined ────────────────────────────
+
+  it('6. Returns undefined from curate() → resolves to undefined (not a failure)', async () => {
+    // A template can legally return undefined. The caller (LLM-written
+    // sandbox code) is responsible for handling that. Test pins this
+    // as a non-warning case so a future "warn on undefined returns"
+    // drift would break here.
+    const code = `${VALID_META}
+      exports.curate = async function curate(ctx) { return undefined }
+    `
+    const result = await seedAndLoad(code)
+    expect(result.loaded).to.equal(true)
+    if (!result.loaded) return
+
+    if (result.module.curate === undefined) throw new Error('fixture must export curate')
+    const out = await result.module.curate(makeCtx())
+    expect(out).to.equal(undefined)
+
+    await expectSandboxHealthy()
+  })
+
+  it('7. Never-resolving Promise from curate() → Promise.race timer throws', async () => {
+    const code = `${VALID_META}
+      exports.curate = function curate(ctx) { return new Promise(function(){}) }
+    `
+    const result = await seedAndLoad(code)
+    expect(result.loaded).to.equal(true)
+    if (!result.loaded) return
+    if (result.module.curate === undefined) throw new Error('fixture must export curate')
+
+    try {
+      await result.module.curate(makeCtx())
+      expect.fail('expected throw')
+    } catch (error) {
+      expect((error as Error).message).to.match(/curate\(\) failed/)
+      expect((error as Error).message).to.match(/exceeded/)
+    }
+
+    await expectSandboxHealthy()
+  }).timeout(8000)
+})


### PR DESCRIPTION
## Summary

- Problem: brutal-review A4 enumerated 7 harness-failure scenarios that Phase 3 must degrade on — none of them can crash the sandbox, leak a partial harness state, or surface an unhelpful error. Up to now these have only been individually tested at the module-builder level (Task 3.2) or the injection level (Task 3.3). No single test suite proves the whole pipeline degrades end-to-end.
- Why it matters: Phase 3's security story leans on this. Task 3.5 (isolation integration test) assumes the degradation contract is sound; Phase 5's mode selector assumes `loadHarness` never throws regardless of what the harness code does. If any scenario here regressed, a bug in the evaluator would silently crash user sessions.
- What changed: new `test/unit/agent/harness/graceful-degradation.test.ts` — 7 scenarios, one per A4 case, each exercising the full `SandboxService.loadHarness` → builder → sandbox pipeline. Three-invariant assertion per test: return shape, namespace presence/per-call throw, sandbox-stays-healthy.
- What did NOT change (scope boundary): No new source code. No test helpers added. No mutations to `HarnessModuleBuilder`, `SandboxService`, or `HarnessStore` — only exercising them. This is a pure coverage PR.

## Type of change

- [ ] New feature
- [ ] Bug fix
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [x] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [x] Agent / Tools
- [ ] LLM Providers
- [ ] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes ENG-2241
- Closes brutal-review item A4 (graceful degradation of all 7 enumerated harness failure cases)
- Depends on (merged): ENG-2239 (HarnessModuleBuilder), ENG-2240 (SandboxService.loadHarness + injection), ENG-2227/2228 (HarnessStore)
- Unblocks Phase 3 Task 3.5 (isolation integration test — runs in parallel but shares the "degradation never crashes sandbox" contract)

## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause: N/A
- Why this was not caught earlier: N/A

## Test plan

- Coverage added:
  - [x] Unit test
  - [ ] Integration test
  - [ ] Manual verification only
- Test file(s): `test/unit/agent/harness/graceful-degradation.test.ts`
- Key scenario(s) covered (7 tests, one per brutal-review A4 case):
  - **Build-time failures (harness NOT loaded)**:
    - `1. Syntax error at module load` → `{loaded: false, reason: 'syntax'}` + no `harness` in sandbox + `2 + 2` returns 4
    - `2. Throw in meta()` → `{loaded: false, reason: 'meta-threw'}` + no `harness` in sandbox + `2 + 2` returns 4
  - **Per-invocation failures (harness loads; per-call wrapper throws)**:
    - `3. Throw in curate()` → `loaded: true`; `module.curate(ctx)` throws with `/curate\(\) failed/`; sandbox healthy
    - `4. Infinite loop in curate()` → `loaded: true`; V8 vm timeout (~5003ms); sandbox healthy
    - `5. Infinite recursion in curate()` → `loaded: true`; stack overflow caught; sandbox healthy
    - `7. Never-resolving Promise from curate()` → `loaded: true`; Promise.race timer (~5003ms) with `/exceeded/` message; sandbox healthy
  - **Non-failure (legal undefined)**:
    - `6. Returns undefined from curate()` → `loaded: true`; `module.curate(ctx)` resolves to `undefined`; sandbox healthy. Pinned explicitly as NOT a warning case so a future "warn on undefined returns" drift breaks this test.

## User-visible changes

None. Pure test coverage addition. No consumer of the tested paths changes behavior.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording

Before this PR, the test file didn't exist. After: all 7 pass. Full suite: 6705 passing / 0 failing.

```
$ perl -e 'alarm 60; exec @ARGV' npx mocha test/unit/agent/harness/graceful-degradation.test.ts --timeout 10000
  graceful degradation — brutal-review A4
    ✔ 1. Syntax error at module load → {loaded:false, reason:syntax} (44ms)
    ✔ 2. Throw in meta() → {loaded:false, reason:meta-threw}
    ✔ 3. Throw in curate() → wrapper throws; module stays loaded
    ✔ 4. Infinite loop in curate() → vm timeout; wrapper throws (5003ms)
    ✔ 5. Infinite recursion in curate() → stack overflow; wrapper throws
    ✔ 6. Returns undefined from curate() → resolves to undefined (not a failure)
    ✔ 7. Never-resolving Promise from curate() → Promise.race timer throws (5003ms)
  7 passing (10s)
```

## Checklist

- [x] Tests added or updated and passing (`npm test`) — 7 new tests; full suite 6705 passing / 0 failing
- [x] Lint passes (`npm run lint`) — 0 errors, 226 pre-existing warnings
- [x] Type check passes (`npm run typecheck`) — exit=0
- [x] Build succeeds (`npm run build`) — exit=0
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format — `feat: [ENG-2241] ...`
- [x] Documentation updated (if applicable) — task doc at `features/autoharness-v2/tasks/phase_3/task_04-graceful-degradation.md` (research repo) drove the scope; the stub-vs-real-store deviation + per-invocation-direct-call design choice flagged below for post-merge task-doc tightening
- [x] No breaking changes (or clearly documented above) — test-only addition
- [ ] Branch is up to date with `main` — targets `proj/autoharness-v2`, not `main`

## Risks and mitigations

- **Risk**: Test-file runtime is ~10s because two tests wait ~5s each for vm / Promise.race timeouts to fire. Under CI load the vm timeout could drift past 5.1s.
  - **Mitigation**: Each timeout test has a `.timeout(8000)` budget — vm timeout + 3s headroom. V8's `vm.Script.runInContext` timeout is a hard wall-clock limit, not a soft signal. Real flakes would point at CI CPU exhaustion rather than test brittleness. If the runtime becomes painful, extract the two timeout tests to a dedicated "slow" file that runs on a nightly cadence; correctness signals stay in the PR gate.

- **Risk**: The per-invocation failure tests (3-7) call `result.module.curate!(ctx)` directly rather than through `service.executeCode('harness.curate(...)', 's1')`. If the sandbox's `harness.curate` wrapper in `buildHarnessNamespace` ever diverges from a naked `module.curate(ctx)` call, this test file wouldn't catch the divergence.
  - **Mitigation**: Task 3.3's behavioral test (`harness.* visible inside sandbox code`) verifies the injection-wrapper contract directly — if a regression made the wrapper add behavior (logging, retry, state-tracking) beyond a pass-through call, that test would catch it. This file's job is degradation semantics, not injection plumbing.

- **Risk**: Task doc prescribes "stub `IHarnessStore`"; shipped with real `HarnessStore` backed by `FileKeyStorage({inMemory: true})`.
  - **Mitigation**: Documented in the commit message + "Notes for reviewers" below. The real store is a strict pass-through in these tests (save + getLatest); stubbing adds setup without coverage benefit. If stub-strict is preferred, swap to `InMemoryHarnessStore` (from `test/helpers/`, shipped by Phat in Phase 1 Task 1.1) — one-line change.

## Notes for reviewers

**All 7 titles lead with the verbatim scenario name from the execution plan**, then append the expected outcome. Reading the titles in isolation tells you exactly what's under test: `"1. Syntax error at module load → {loaded:false, reason:syntax}"`. If the outcome clause is ever wrong, a failing test report points directly at the contract drift.

**The sandbox-healthy invariant is load-bearing.** Every test ends with `expectSandboxHealthy()` — a one-liner that runs `2 + 2` through the sandbox and asserts `4`. Cheap proof that the harness failure didn't corrupt sandbox state (e.g., by leaking a broken VM context or mangling session maps). If any test's sandbox-healthy assertion ever fails, the evaluator or the sandbox injection has a real bug; don't retry, debug.

**Case 6 (`returns undefined`) is explicitly pinned as NOT a failure** — the test comment documents this so a future "defensive warning on undefined return" drift would break the test and force an explicit decision. Templates can legally return undefined; the LLM-side caller handles that. The module builder must not emit a warning or wrap the result.

**Cases 4 and 5 cover distinct timeout mechanisms**: case 4 (`while(true){}`) is caught by V8's vm wall-clock timeout on `vm.Script.runInContext`; case 5 (`function go(){go()}; go()`) is a stack overflow caught by V8 as a native error. Same normalized outcome (`curate() failed: ...`) but the underlying mechanisms are orthogonal — both need to be wrapped by the same error-normalization path in `HarnessModuleBuilder.wrapInvocation`.

**Task 3.5 (isolation integration test) will replace this file's unit-level setup** with a real file-backed sandbox + attack fixtures. That PR exercises orthogonal concerns (cross-context isolation); this one proves per-scenario degradation. Both are in scope for Phase 3's ship gate.

## Related

- Test file: `test/unit/agent/harness/graceful-degradation.test.ts`
- Builder under test: `src/agent/infra/harness/harness-module-builder.ts` (ENG-2239)
- Store under test: `src/agent/infra/harness/harness-store.ts` (ENG-2227 + ENG-2228)
- Load pipeline under test: `src/agent/infra/sandbox/sandbox-service.ts` `.loadHarness()` (ENG-2240)
- Brutal-review item closed: A4 (graceful degradation of 7 enumerated harness failure cases)
- Task doc: `features/autoharness-v2/tasks/phase_3/task_04-graceful-degradation.md` (research repo)
- Next task in stream: Phase 3 Task 3.5 (isolation integration test — brutal-review A3, the 5 cross-VM attack vectors)