### PR TITLE
feat: [ENG-2246] AutoHarness V2 project type detector

### DIFF
--- a/src/agent/infra/harness/project-detector.ts
+++ b/src/agent/infra/harness/project-detector.ts
@@ -3,15 +3,6 @@ import {join} from 'node:path'
 import type {ProjectType} from '../../core/domain/harness/types.js'
 import type {IFileSystem} from '../../core/interfaces/i-file-system.js'
 
-/**
- * AutoHarness V2 Phase 4 Task 4.1 — project type detector.
- *
- * Pure async function consumed by `HarnessBootstrap` (Task 4.2) to decide
- * which template to materialize for a newly-bootstrapped project. Polyglot
- * fallback (choosing between detected types, config override) is Task 4.4;
- * this function returns evidence only.
- */
-
 export interface DetectResult {
   readonly detected: readonly ProjectType[]
 }
@@ -64,9 +55,14 @@ async function packageJsonDeclaresTypeScript(
     return false
   }
 
-  if (typeof parsed !== 'object' || parsed === null) return false
-  const pkg = parsed as {dependencies?: unknown; devDependencies?: unknown}
-  return hasTypeScriptEntry(pkg.dependencies) || hasTypeScriptEntry(pkg.devDependencies)
+  if (!isPackageLike(parsed)) return false
+  return hasTypeScriptEntry(parsed.dependencies) || hasTypeScriptEntry(parsed.devDependencies)
+}
+
+function isPackageLike(
+  value: unknown,
+): value is {dependencies?: unknown; devDependencies?: unknown} {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
 function hasTypeScriptEntry(deps: unknown): boolean {

--- a/src/agent/infra/harness/project-detector.ts
+++ b/src/agent/infra/harness/project-detector.ts
@@ -1,0 +1,75 @@
+import {join} from 'node:path'
+
+import type {ProjectType} from '../../core/domain/harness/types.js'
+import type {IFileSystem} from '../../core/interfaces/i-file-system.js'
+
+/**
+ * AutoHarness V2 Phase 4 Task 4.1 — project type detector.
+ *
+ * Pure async function consumed by `HarnessBootstrap` (Task 4.2) to decide
+ * which template to materialize for a newly-bootstrapped project. Polyglot
+ * fallback (choosing between detected types, config override) is Task 4.4;
+ * this function returns evidence only.
+ */
+
+export interface DetectResult {
+  readonly detected: readonly ProjectType[]
+}
+
+export async function detectProjectType(
+  workingDirectory: string,
+  fileSystem: IFileSystem,
+): Promise<DetectResult> {
+  const [hasTsconfig, packageJsonHasTs, hasPyproject, hasSetupPy, hasSetupCfg] = await Promise.all([
+    fileExists(fileSystem, join(workingDirectory, 'tsconfig.json')),
+    packageJsonDeclaresTypeScript(fileSystem, join(workingDirectory, 'package.json')),
+    fileExists(fileSystem, join(workingDirectory, 'pyproject.toml')),
+    fileExists(fileSystem, join(workingDirectory, 'setup.py')),
+    fileExists(fileSystem, join(workingDirectory, 'setup.cfg')),
+  ])
+
+  const detected: ProjectType[] = []
+  if (hasTsconfig || packageJsonHasTs) detected.push('typescript')
+  if (hasPyproject || hasSetupPy || hasSetupCfg) detected.push('python')
+
+  if (detected.length === 0) return {detected: ['generic']}
+  return {detected}
+}
+
+async function fileExists(fileSystem: IFileSystem, filePath: string): Promise<boolean> {
+  try {
+    await fileSystem.readFile(filePath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function packageJsonDeclaresTypeScript(
+  fileSystem: IFileSystem,
+  packageJsonPath: string,
+): Promise<boolean> {
+  let content: string
+  try {
+    const result = await fileSystem.readFile(packageJsonPath)
+    content = result.content
+  } catch {
+    return false
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(content)
+  } catch {
+    return false
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) return false
+  const pkg = parsed as {dependencies?: unknown; devDependencies?: unknown}
+  return hasTypeScriptEntry(pkg.dependencies) || hasTypeScriptEntry(pkg.devDependencies)
+}
+
+function hasTypeScriptEntry(deps: unknown): boolean {
+  if (typeof deps !== 'object' || deps === null) return false
+  return Object.hasOwn(deps, 'typescript')
+}

--- a/test/unit/agent/harness/project-detector.test.ts
+++ b/test/unit/agent/harness/project-detector.test.ts
@@ -1,0 +1,119 @@
+import {expect} from 'chai'
+import {join} from 'node:path'
+import {createSandbox, type SinonSandbox} from 'sinon'
+
+import type {IFileSystem} from '../../../../src/agent/core/interfaces/i-file-system.js'
+
+import {detectProjectType} from '../../../../src/agent/infra/harness/project-detector.js'
+
+const CWD = '/proj'
+
+type FilePresence = {
+  readonly [filename: string]: string | undefined
+}
+
+function makeFileSystem(sb: SinonSandbox, files: FilePresence): IFileSystem {
+  const readFile = sb.stub()
+  readFile.callsFake(async (filePath: string) => {
+    const content = files[filePath]
+    if (content === undefined) throw new Error(`ENOENT: ${filePath}`)
+    return {content, encoding: 'utf8', formattedContent: content, lines: 1, message: ''}
+  })
+
+  return {
+    editFile: sb.stub(),
+    globFiles: sb.stub(),
+    initialize: sb.stub(),
+    listDirectory: sb.stub(),
+    readFile,
+    searchContent: sb.stub(),
+    writeFile: sb.stub(),
+  } as unknown as IFileSystem
+}
+
+describe('detectProjectType', () => {
+  let sb: SinonSandbox
+
+  beforeEach(() => {
+    sb = createSandbox()
+  })
+
+  afterEach(() => {
+    sb.restore()
+  })
+
+  it('returns [typescript] when only tsconfig.json is present', async () => {
+    const fs = makeFileSystem(sb, {[join(CWD, 'tsconfig.json')]: '{}'})
+    const result = await detectProjectType(CWD, fs)
+    expect(result).to.deep.equal({detected: ['typescript']})
+  })
+
+  it('returns [python] when only pyproject.toml is present', async () => {
+    const fs = makeFileSystem(sb, {[join(CWD, 'pyproject.toml')]: '[project]\nname="x"\n'})
+    const result = await detectProjectType(CWD, fs)
+    expect(result).to.deep.equal({detected: ['python']})
+  })
+
+  it('returns [typescript, python] when both TS and Python signals fire (polyglot)', async () => {
+    const fs = makeFileSystem(sb, {
+      [join(CWD, 'pyproject.toml')]: '[project]\nname="x"\n',
+      [join(CWD, 'tsconfig.json')]: '{}',
+    })
+    const result = await detectProjectType(CWD, fs)
+    expect(result).to.deep.equal({detected: ['typescript', 'python']})
+  })
+
+  it('returns [generic] when no signals fire', async () => {
+    const fs = makeFileSystem(sb, {})
+    const result = await detectProjectType(CWD, fs)
+    expect(result).to.deep.equal({detected: ['generic']})
+  })
+
+  it('returns [python] when only setup.py is present', async () => {
+    const fs = makeFileSystem(sb, {[join(CWD, 'setup.py')]: 'from setuptools import setup\n'})
+    const result = await detectProjectType(CWD, fs)
+    expect(result).to.deep.equal({detected: ['python']})
+  })
+
+  it('returns [typescript] when package.json declares typescript but tsconfig.json is absent', async () => {
+    const fs = makeFileSystem(sb, {
+      [join(CWD, 'package.json')]: JSON.stringify({devDependencies: {typescript: '^5.0.0'}}),
+    })
+    const result = await detectProjectType(CWD, fs)
+    expect(result).to.deep.equal({detected: ['typescript']})
+  })
+
+  it('deduplicates when both tsconfig.json and package.json TS dep fire', async () => {
+    const fs = makeFileSystem(sb, {
+      [join(CWD, 'package.json')]: JSON.stringify({dependencies: {typescript: '^5.0.0'}}),
+      [join(CWD, 'tsconfig.json')]: '{}',
+    })
+    const result = await detectProjectType(CWD, fs)
+    expect(result).to.deep.equal({detected: ['typescript']})
+  })
+
+  // ── Additional safety checks beyond the 7 enumerated scenarios ──────────
+
+  it('does not treat package.json without a typescript dep as a TypeScript signal', async () => {
+    const fs = makeFileSystem(sb, {
+      [join(CWD, 'package.json')]: JSON.stringify({dependencies: {lodash: '^4.0.0'}}),
+    })
+    const result = await detectProjectType(CWD, fs)
+    expect(result).to.deep.equal({detected: ['generic']})
+  })
+
+  it('treats a corrupt package.json as no TypeScript signal (does not throw)', async () => {
+    const fs = makeFileSystem(sb, {[join(CWD, 'package.json')]: 'not valid json {{{'})
+    const result = await detectProjectType(CWD, fs)
+    expect(result).to.deep.equal({detected: ['generic']})
+  })
+
+  it('runs filesystem probes in parallel', async () => {
+    // Verify via call count: every probe fires, regardless of early returns.
+    const fs = makeFileSystem(sb, {[join(CWD, 'tsconfig.json')]: '{}'})
+    await detectProjectType(CWD, fs)
+    // 5 parallel readFile calls: tsconfig, package.json, pyproject, setup.py, setup.cfg
+    const readFile = fs.readFile as unknown as {callCount: number}
+    expect(readFile.callCount).to.equal(5)
+  })
+})

--- a/test/unit/agent/harness/project-detector.test.ts
+++ b/test/unit/agent/harness/project-detector.test.ts
@@ -1,7 +1,8 @@
 import {expect} from 'chai'
 import {join} from 'node:path'
-import {createSandbox, type SinonSandbox} from 'sinon'
+import {createSandbox, type SinonSandbox, type SinonStub} from 'sinon'
 
+import type {FileContent} from '../../../../src/agent/core/domain/file-system/types.js'
 import type {IFileSystem} from '../../../../src/agent/core/interfaces/i-file-system.js'
 
 import {detectProjectType} from '../../../../src/agent/infra/harness/project-detector.js'
@@ -12,23 +13,37 @@ type FilePresence = {
   readonly [filename: string]: string | undefined
 }
 
-function makeFileSystem(sb: SinonSandbox, files: FilePresence): IFileSystem {
-  const readFile = sb.stub()
-  readFile.callsFake(async (filePath: string) => {
+function makeFileSystem(
+  sb: SinonSandbox,
+  files: FilePresence,
+): {readonly fileSystem: IFileSystem; readonly readFileStub: SinonStub} {
+  const readFileStub = sb.stub()
+  readFileStub.callsFake(async (filePath: string): Promise<FileContent> => {
     const content = files[filePath]
     if (content === undefined) throw new Error(`ENOENT: ${filePath}`)
-    return {content, encoding: 'utf8', formattedContent: content, lines: 1, message: ''}
+    return {
+      content,
+      encoding: 'utf8',
+      formattedContent: content,
+      lines: 1,
+      message: '',
+      size: content.length,
+      totalLines: 1,
+      truncated: false,
+    }
   })
 
-  return {
+  const fileSystem = {
     editFile: sb.stub(),
     globFiles: sb.stub(),
     initialize: sb.stub(),
     listDirectory: sb.stub(),
-    readFile,
+    readFile: readFileStub,
     searchContent: sb.stub(),
     writeFile: sb.stub(),
-  } as unknown as IFileSystem
+  } satisfies IFileSystem
+
+  return {fileSystem, readFileStub}
 }
 
 describe('detectProjectType', () => {
@@ -43,77 +58,83 @@ describe('detectProjectType', () => {
   })
 
   it('returns [typescript] when only tsconfig.json is present', async () => {
-    const fs = makeFileSystem(sb, {[join(CWD, 'tsconfig.json')]: '{}'})
-    const result = await detectProjectType(CWD, fs)
+    const {fileSystem} = makeFileSystem(sb, {[join(CWD, 'tsconfig.json')]: '{}'})
+    const result = await detectProjectType(CWD, fileSystem)
     expect(result).to.deep.equal({detected: ['typescript']})
   })
 
   it('returns [python] when only pyproject.toml is present', async () => {
-    const fs = makeFileSystem(sb, {[join(CWD, 'pyproject.toml')]: '[project]\nname="x"\n'})
-    const result = await detectProjectType(CWD, fs)
+    const {fileSystem} = makeFileSystem(sb, {[join(CWD, 'pyproject.toml')]: '[project]\nname="x"\n'})
+    const result = await detectProjectType(CWD, fileSystem)
     expect(result).to.deep.equal({detected: ['python']})
   })
 
   it('returns [typescript, python] when both TS and Python signals fire (polyglot)', async () => {
-    const fs = makeFileSystem(sb, {
+    const {fileSystem} = makeFileSystem(sb, {
       [join(CWD, 'pyproject.toml')]: '[project]\nname="x"\n',
       [join(CWD, 'tsconfig.json')]: '{}',
     })
-    const result = await detectProjectType(CWD, fs)
+    const result = await detectProjectType(CWD, fileSystem)
     expect(result).to.deep.equal({detected: ['typescript', 'python']})
   })
 
   it('returns [generic] when no signals fire', async () => {
-    const fs = makeFileSystem(sb, {})
-    const result = await detectProjectType(CWD, fs)
+    const {fileSystem} = makeFileSystem(sb, {})
+    const result = await detectProjectType(CWD, fileSystem)
     expect(result).to.deep.equal({detected: ['generic']})
   })
 
   it('returns [python] when only setup.py is present', async () => {
-    const fs = makeFileSystem(sb, {[join(CWD, 'setup.py')]: 'from setuptools import setup\n'})
-    const result = await detectProjectType(CWD, fs)
+    const {fileSystem} = makeFileSystem(sb, {
+      [join(CWD, 'setup.py')]: 'from setuptools import setup\n',
+    })
+    const result = await detectProjectType(CWD, fileSystem)
+    expect(result).to.deep.equal({detected: ['python']})
+  })
+
+  it('returns [python] when only setup.cfg is present', async () => {
+    const {fileSystem} = makeFileSystem(sb, {[join(CWD, 'setup.cfg')]: '[metadata]\nname=x\n'})
+    const result = await detectProjectType(CWD, fileSystem)
     expect(result).to.deep.equal({detected: ['python']})
   })
 
   it('returns [typescript] when package.json declares typescript but tsconfig.json is absent', async () => {
-    const fs = makeFileSystem(sb, {
+    const {fileSystem} = makeFileSystem(sb, {
       [join(CWD, 'package.json')]: JSON.stringify({devDependencies: {typescript: '^5.0.0'}}),
     })
-    const result = await detectProjectType(CWD, fs)
+    const result = await detectProjectType(CWD, fileSystem)
     expect(result).to.deep.equal({detected: ['typescript']})
   })
 
   it('deduplicates when both tsconfig.json and package.json TS dep fire', async () => {
-    const fs = makeFileSystem(sb, {
+    const {fileSystem} = makeFileSystem(sb, {
       [join(CWD, 'package.json')]: JSON.stringify({dependencies: {typescript: '^5.0.0'}}),
       [join(CWD, 'tsconfig.json')]: '{}',
     })
-    const result = await detectProjectType(CWD, fs)
+    const result = await detectProjectType(CWD, fileSystem)
     expect(result).to.deep.equal({detected: ['typescript']})
   })
 
   // ── Additional safety checks beyond the 7 enumerated scenarios ──────────
 
   it('does not treat package.json without a typescript dep as a TypeScript signal', async () => {
-    const fs = makeFileSystem(sb, {
+    const {fileSystem} = makeFileSystem(sb, {
       [join(CWD, 'package.json')]: JSON.stringify({dependencies: {lodash: '^4.0.0'}}),
     })
-    const result = await detectProjectType(CWD, fs)
+    const result = await detectProjectType(CWD, fileSystem)
     expect(result).to.deep.equal({detected: ['generic']})
   })
 
   it('treats a corrupt package.json as no TypeScript signal (does not throw)', async () => {
-    const fs = makeFileSystem(sb, {[join(CWD, 'package.json')]: 'not valid json {{{'})
-    const result = await detectProjectType(CWD, fs)
+    const {fileSystem} = makeFileSystem(sb, {[join(CWD, 'package.json')]: 'not valid json {{{'})
+    const result = await detectProjectType(CWD, fileSystem)
     expect(result).to.deep.equal({detected: ['generic']})
   })
 
   it('runs filesystem probes in parallel', async () => {
-    // Verify via call count: every probe fires, regardless of early returns.
-    const fs = makeFileSystem(sb, {[join(CWD, 'tsconfig.json')]: '{}'})
-    await detectProjectType(CWD, fs)
+    const {fileSystem, readFileStub} = makeFileSystem(sb, {[join(CWD, 'tsconfig.json')]: '{}'})
+    await detectProjectType(CWD, fileSystem)
     // 5 parallel readFile calls: tsconfig, package.json, pyproject, setup.py, setup.cfg
-    const readFile = fs.readFile as unknown as {callCount: number}
-    expect(readFile.callCount).to.equal(5)
+    expect(readFileStub.callCount).to.equal(5)
   })
 })


### PR DESCRIPTION
## Summary

- **Problem**: Phase 4 `HarnessBootstrap` (Task 4.2) needs to know whether a project is TypeScript, Python, or generic before it can materialize the right v1 harness template. No such detector exists yet.
- **Why it matters**: Cold-start bootstrap must land a usable harness on the very first `(projectId, commandType)` visit; without detection it would have to either ask the user or ship only the generic template (losing the structural hints that make TS/Python templates useful).
- **What changed**: Ships a pure async `detectProjectType(cwd, fs): Promise<DetectResult>` function and its unit tests. Filesystem-based, 5 parallel probes, polyglot-aware (returns `readonly ProjectType[]`, length ≥ 1).
- **What did NOT change (scope boundary)**: No polyglot-winner picking, no `config.harness.language` override, no bootstrap orchestration, no walking up the directory tree. Those are Tasks 4.2 and 4.4. This task returns evidence only.

## Type of change

- [x] New feature

## Scope (select all touched areas)

- [x] Agent / Tools

## Linked issues

- Closes ENG-2246
- Related: ENG-2247 (Task 4.2 `HarnessBootstrap`, next consumer), ENG-2249 (Task 4.4 polyglot fallback)

## Root cause (bug fixes only, otherwise write `N/A`)

N/A

## Test plan

- Coverage added:
  - [x] Unit test
- Test file(s): `test/unit/agent/harness/project-detector.test.ts`
- Key scenario(s) covered:
  - The 7 scenarios enumerated in the task doc: tsconfig-only, pyproject-only, polyglot (both), neither → generic, setup.py-only, package.json TS dep without tsconfig, dedupe (tsconfig + package.json TS dep → single entry).
  - 3 additional safety checks: package.json without a TS dep does not fire, corrupt package.json does not throw, parallel-probe call-count.

## User-visible changes

None. Internal infrastructure consumed by Task 4.2.

## Evidence

- [x] Failing test/log before + passing after

```
$ npx mocha --forbid-only 'test/unit/agent/harness/project-detector.test.ts'
  detectProjectType
    ✔ returns [typescript] when only tsconfig.json is present
    ✔ returns [python] when only pyproject.toml is present
    ✔ returns [typescript, python] when both TS and Python signals fire (polyglot)
    ✔ returns [generic] when no signals fire
    ✔ returns [python] when only setup.py is present
    ✔ returns [typescript] when package.json declares typescript but tsconfig.json is absent
    ✔ deduplicates when both tsconfig.json and package.json TS dep fire
    ✔ does not treat package.json without a typescript dep as a TypeScript signal
    ✔ treats a corrupt package.json as no TypeScript signal (does not throw)
    ✔ runs filesystem probes in parallel

  10 passing

$ npx mocha --forbid-only 'test/unit/agent/harness/**/*.test.ts'
  155 passing (25s)
```

## Checklist

- [x] Tests added or updated and passing (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated (if applicable) — N/A, internal function
- [x] No breaking changes
- [x] Branch is up to date with `proj/autoharness-v2`

## Risks and mitigations

- **Risk**: Shallow `package.json` TS-dep check (presence of `dependencies.typescript` or `devDependencies.typescript`) could false-positive on a JS repo that only has `@types/node` in devDeps.
  - **Mitigation**: Worst case the user gets the TS template where a JS template would have been marginally better. JS support is post-v1.0, so "TS or generic" is the only real choice today. Accepted trade-off documented in task doc key design decisions.
- **Risk**: Detection is shallow — does not walk up the tree to find a parent project.
  - **Mitigation**: Explicit config override (`config.harness.language`) lands in Task 4.4 and is the escape hatch when `workingDirectory` is wrong.
- **Risk**: Corrupt `package.json` swallowed silently.
  - **Mitigation**: Treated as "no TS signal" rather than crashing the whole detector. Test pins this behavior so future contributors don't accidentally make it throw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)