### PR TITLE
feat: [ENG-2247] AutoHarness V2 curate template files + registry

### DIFF
--- a/src/agent/infra/harness/templates/curate/generic.ts
+++ b/src/agent/infra/harness/templates/curate/generic.ts
@@ -1,4 +1,5 @@
 // CommonJS-in-string template body per phase_3_4_handoff.md §C7.
+// v1.0 placeholder: `ctx.tools.curate(ctx.env)` — real adapter shape decided by Task 4.2.
 import type {HarnessMeta} from '../../../../core/domain/harness/types.js'
 
 export const TEMPLATE_CODE = `

--- a/src/agent/infra/harness/templates/curate/generic.ts
+++ b/src/agent/infra/harness/templates/curate/generic.ts
@@ -1,0 +1,24 @@
+// CommonJS-in-string template body per phase_3_4_handoff.md §C7.
+import type {HarnessMeta} from '../../../../core/domain/harness/types.js'
+
+export const TEMPLATE_CODE = `
+exports.meta = function meta() {
+  return {
+    capabilities: ['curate'],
+    commandType: 'curate',
+    projectPatterns: ['**/*'],
+    version: 1,
+  }
+}
+
+exports.curate = async function curate(ctx) {
+  return ctx.tools.curate(ctx.env)
+}
+`
+
+export const TEMPLATE_META: HarnessMeta = {
+  capabilities: ['curate'],
+  commandType: 'curate',
+  projectPatterns: ['**/*'],
+  version: 1,
+}

--- a/src/agent/infra/harness/templates/curate/python.ts
+++ b/src/agent/infra/harness/templates/curate/python.ts
@@ -1,4 +1,5 @@
 // CommonJS-in-string template body per phase_3_4_handoff.md §C7.
+// v1.0 placeholder: `ctx.tools.curate(ctx.env)` — real adapter shape decided by Task 4.2.
 import type {HarnessMeta} from '../../../../core/domain/harness/types.js'
 
 export const TEMPLATE_CODE = `

--- a/src/agent/infra/harness/templates/curate/python.ts
+++ b/src/agent/infra/harness/templates/curate/python.ts
@@ -1,0 +1,24 @@
+// CommonJS-in-string template body per phase_3_4_handoff.md §C7.
+import type {HarnessMeta} from '../../../../core/domain/harness/types.js'
+
+export const TEMPLATE_CODE = `
+exports.meta = function meta() {
+  return {
+    capabilities: ['curate'],
+    commandType: 'curate',
+    projectPatterns: ['**/*.py', 'pyproject.toml', 'setup.py'],
+    version: 1,
+  }
+}
+
+exports.curate = async function curate(ctx) {
+  return ctx.tools.curate(ctx.env)
+}
+`
+
+export const TEMPLATE_META: HarnessMeta = {
+  capabilities: ['curate'],
+  commandType: 'curate',
+  projectPatterns: ['**/*.py', 'pyproject.toml', 'setup.py'],
+  version: 1,
+}

--- a/src/agent/infra/harness/templates/curate/typescript.ts
+++ b/src/agent/infra/harness/templates/curate/typescript.ts
@@ -1,0 +1,24 @@
+// CommonJS-in-string template body per phase_3_4_handoff.md §C7.
+import type {HarnessMeta} from '../../../../core/domain/harness/types.js'
+
+export const TEMPLATE_CODE = `
+exports.meta = function meta() {
+  return {
+    capabilities: ['curate'],
+    commandType: 'curate',
+    projectPatterns: ['**/*.ts', '**/*.tsx', 'tsconfig.json'],
+    version: 1,
+  }
+}
+
+exports.curate = async function curate(ctx) {
+  return ctx.tools.curate(ctx.env)
+}
+`
+
+export const TEMPLATE_META: HarnessMeta = {
+  capabilities: ['curate'],
+  commandType: 'curate',
+  projectPatterns: ['**/*.ts', '**/*.tsx', 'tsconfig.json'],
+  version: 1,
+}

--- a/src/agent/infra/harness/templates/curate/typescript.ts
+++ b/src/agent/infra/harness/templates/curate/typescript.ts
@@ -1,4 +1,5 @@
 // CommonJS-in-string template body per phase_3_4_handoff.md §C7.
+// v1.0 placeholder: `ctx.tools.curate(ctx.env)` — real adapter shape decided by Task 4.2.
 import type {HarnessMeta} from '../../../../core/domain/harness/types.js'
 
 export const TEMPLATE_CODE = `

--- a/src/agent/infra/harness/templates/index.ts
+++ b/src/agent/infra/harness/templates/index.ts
@@ -1,0 +1,31 @@
+import type {HarnessMeta, ProjectType} from '../../../core/domain/harness/types.js'
+
+import * as CurateGeneric from './curate/generic.js'
+import * as CuratePython from './curate/python.js'
+import * as CurateTypescript from './curate/typescript.js'
+
+export interface Template {
+  readonly code: string
+  readonly meta: HarnessMeta
+}
+
+// Scope note: v1.0 ships `curate` templates only. `query` templates are
+// parked until (a) `HarnessCapabilitySchema` gains `'query'` and
+// (b) `HarnessContextTools` exposes a `query` method. Follow-up tickets
+// will extend the registry additively; no existing key changes.
+export type SupportedCommandType = 'curate'
+
+const REGISTRY: Record<SupportedCommandType, Record<ProjectType, Template>> = {
+  curate: {
+    generic: {code: CurateGeneric.TEMPLATE_CODE, meta: CurateGeneric.TEMPLATE_META},
+    python: {code: CuratePython.TEMPLATE_CODE, meta: CuratePython.TEMPLATE_META},
+    typescript: {code: CurateTypescript.TEMPLATE_CODE, meta: CurateTypescript.TEMPLATE_META},
+  },
+}
+
+export function getTemplate(
+  commandType: SupportedCommandType,
+  projectType: ProjectType,
+): Template {
+  return REGISTRY[commandType][projectType]
+}

--- a/src/agent/infra/harness/templates/index.ts
+++ b/src/agent/infra/harness/templates/index.ts
@@ -27,5 +27,13 @@ export function getTemplate(
   commandType: SupportedCommandType,
   projectType: ProjectType,
 ): Template {
-  return REGISTRY[commandType][projectType]
+  const template = REGISTRY[commandType][projectType]
+  if (template === undefined) {
+    // Unreachable under the current type signature, but guards against
+    // silent `undefined` when `SupportedCommandType` widens ahead of a
+    // new template landing.
+    throw new Error(`no template registered for commandType=${commandType}, projectType=${projectType}`)
+  }
+
+  return template
 }

--- a/test/unit/agent/harness/templates.test.ts
+++ b/test/unit/agent/harness/templates.test.ts
@@ -1,0 +1,138 @@
+import {expect} from 'chai'
+import {createSandbox, type SinonSandbox} from 'sinon'
+
+import type {
+  HarnessContext,
+  HarnessMeta,
+  HarnessVersion,
+} from '../../../../src/agent/core/domain/harness/types.js'
+
+import {
+  HarnessMetaSchema,
+  ProjectTypeSchema,
+} from '../../../../src/agent/core/domain/harness/types.js'
+import {NoOpLogger} from '../../../../src/agent/core/interfaces/i-logger.js'
+import {HarnessModuleBuilder} from '../../../../src/agent/infra/harness/harness-module-builder.js'
+import {
+  getTemplate,
+  type SupportedCommandType,
+} from '../../../../src/agent/infra/harness/templates/index.js'
+
+const SUPPORTED_COMMANDS: readonly SupportedCommandType[] = ['curate']
+
+function makeVersion(commandType: SupportedCommandType, projectType: 'generic' | 'python' | 'typescript'): HarnessVersion {
+  const template = getTemplate(commandType, projectType)
+  return {
+    code: template.code,
+    commandType,
+    createdAt: 1_700_000_000_000,
+    heuristic: 0.3,
+    id: `v-${commandType}-${projectType}`,
+    metadata: template.meta,
+    projectId: 'p',
+    projectType,
+    version: 1,
+  }
+}
+
+describe('harness template registry (curate templates, v1.0)', () => {
+  const builder = new HarnessModuleBuilder(new NoOpLogger())
+  let sb: SinonSandbox
+
+  beforeEach(() => {
+    sb = createSandbox()
+  })
+
+  afterEach(() => {
+    sb.restore()
+  })
+
+  describe('Test 1 — TEMPLATE_META passes HarnessMetaSchema.parse', () => {
+    for (const cmd of SUPPORTED_COMMANDS) {
+      for (const project of ProjectTypeSchema.options) {
+        it(`${cmd}/${project} meta round-trips HarnessMetaSchema`, () => {
+          const {meta} = getTemplate(cmd, project)
+          expect(() => HarnessMetaSchema.parse(meta)).to.not.throw()
+        })
+      }
+    }
+  })
+
+  describe('Test 2 — TEMPLATE_CODE loads via HarnessModuleBuilder.build', () => {
+    for (const cmd of SUPPORTED_COMMANDS) {
+      for (const project of ProjectTypeSchema.options) {
+        it(`${cmd}/${project} code loads successfully`, () => {
+          const result = builder.build(makeVersion(cmd, project))
+          expect(result.loaded).to.equal(true)
+          if (!result.loaded) return // unreachable: chai asserts above
+          expect(typeof result.module.meta).to.equal('function')
+          expect(typeof result.module.curate).to.equal('function')
+        })
+      }
+    }
+  })
+
+  describe('Test 3 — embedded meta() equals external TEMPLATE_META', () => {
+    for (const cmd of SUPPORTED_COMMANDS) {
+      for (const project of ProjectTypeSchema.options) {
+        it(`${cmd}/${project} embedded meta() matches TEMPLATE_META`, () => {
+          const template = getTemplate(cmd, project)
+          const result = builder.build(makeVersion(cmd, project))
+          expect(result.loaded).to.equal(true)
+          if (!result.loaded) return
+          const embedded = result.module.meta()
+          expect(embedded).to.deep.equal(template.meta as HarnessMeta)
+        })
+      }
+    }
+  })
+
+  describe('Test 4 — pass-through: curate(ctx) invokes ctx.tools.curate once with ctx.env', () => {
+    for (const project of ProjectTypeSchema.options) {
+      it(`curate/${project} forwards ctx.env to ctx.tools.curate`, async () => {
+        const result = builder.build(makeVersion('curate', project))
+        expect(result.loaded).to.equal(true)
+        if (!result.loaded) return
+        if (result.module.curate === undefined) throw new Error('curate must be defined')
+
+        const curateStub = sb.stub().resolves({})
+        const readFileStub = sb.stub().resolves({})
+        const ctx: HarnessContext = {
+          abort: new AbortController().signal,
+          env: {commandType: 'curate', projectType: project, workingDirectory: '/proj'},
+          tools: {curate: curateStub, readFile: readFileStub},
+        }
+
+        await result.module.curate(ctx)
+
+        expect(curateStub.callCount).to.equal(1)
+        expect(curateStub.firstCall.firstArg).to.deep.equal(ctx.env)
+      })
+    }
+  })
+
+  describe('Test 5 — registry exhaustiveness for curate', () => {
+    for (const project of ProjectTypeSchema.options) {
+      it(`getTemplate('curate', '${project}') returns a defined template`, () => {
+        const t = getTemplate('curate', project)
+        expect(t.code).to.be.a('string').and.not.empty
+        expect(t.meta).to.be.an('object')
+        expect(t.meta.commandType).to.equal('curate')
+      })
+    }
+  })
+
+  describe('Test 6 — template body is a minimal pass-through', () => {
+    // Until Phase 2's delegated-detection regex lands, verify the
+    // templates STRUCTURALLY match a pass-through shape. Any reasonable
+    // regex the recorder lands should match this shape; drift here
+    // should fail the test before it hides in the recorder.
+    const PASS_THROUGH_SHAPE = /return\s+ctx\.tools\.\w+\(/
+    for (const project of ProjectTypeSchema.options) {
+      it(`curate/${project} body contains a bare ctx.tools.* forward`, () => {
+        const {code} = getTemplate('curate', project)
+        expect(code).to.match(PASS_THROUGH_SHAPE)
+      })
+    }
+  })
+})

--- a/test/unit/agent/harness/templates.test.ts
+++ b/test/unit/agent/harness/templates.test.ts
@@ -3,7 +3,6 @@ import {createSandbox, type SinonSandbox} from 'sinon'
 
 import type {
   HarnessContext,
-  HarnessMeta,
   HarnessVersion,
 } from '../../../../src/agent/core/domain/harness/types.js'
 
@@ -81,7 +80,7 @@ describe('harness template registry (curate templates, v1.0)', () => {
           expect(result.loaded).to.equal(true)
           if (!result.loaded) return
           const embedded = result.module.meta()
-          expect(embedded).to.deep.equal(template.meta as HarnessMeta)
+          expect(embedded).to.deep.equal(template.meta)
         })
       }
     }
@@ -107,6 +106,8 @@ describe('harness template registry (curate templates, v1.0)', () => {
 
         expect(curateStub.callCount).to.equal(1)
         expect(curateStub.firstCall.firstArg).to.deep.equal(ctx.env)
+        // v1 templates must not touch the filesystem — pins the pass-through invariant.
+        expect(readFileStub.callCount).to.equal(0)
       })
     }
   })


### PR DESCRIPTION
## Summary

- **Problem**: Phase 4 `HarnessBootstrap` (Task 4.2) needs template strings to write as v1 `HarnessVersion.code` on first `code_exec`. Without the template registry, bootstrap has nothing to materialize.
- **Why it matters**: Templates are Option C's concrete form — every bootstrapped v1 harness starts from one of these files. They're the "silent inject" design decision made concrete, capping H at 0.50 (pass-through cap) until Phase 6 refinement lands.
- **What changed**: Ships 3 curate templates (`typescript.ts` / `python.ts` / `generic.ts`) + `getTemplate(commandType, projectType)` registry. Each template is 3 lines of pass-through: `return ctx.tools.curate(ctx.env)`. `TEMPLATE_META` is declared externally from `TEMPLATE_CODE` so bootstrap can build `HarnessVersion` records without running the code.
- **What did NOT change (scope boundary)**: **Scope narrowed from 6 templates to 3.** Query templates (`query/{typescript,python,generic}.ts`) are parked pending two follow-up tickets — see "Risks and mitigations" for the details. No bootstrap orchestration, no refinement, no delegated-detection regex (regex lives in the recorder and hasn't landed yet).

## Type of change

- [x] New feature

## Scope (select all touched areas)

- [x] Agent / Tools

## Linked issues

- Closes ENG-2247
- Related: ENG-2248 (Task 4.4 — polyglot fallback, next), ENG-2249 (Task 4.2 — `HarnessBootstrap`, will consume this registry)
- Follow-ups (query parking):
  - Add `'query'` to `HarnessCapabilitySchema` enum (core/domain/harness/types.ts:40)
  - Add `query` to `HarnessContextTools` (core/domain/harness/types.ts:220)
  - Ship 3 query templates + widen `SupportedCommandType` to `'curate' | 'query'`

## Root cause (bug fixes only, otherwise write `N/A`)

N/A

## Test plan

- Coverage added:
  - [x] Unit test
- Test file(s): `test/unit/agent/harness/templates.test.ts`
- Key scenario(s) covered (18 tests, parametrized over 3 project types):
  1. Every `TEMPLATE_META` round-trips `HarnessMetaSchema.parse`
  2. Every `TEMPLATE_CODE` loads via the real `HarnessModuleBuilder.build` (not stubbed — we want to verify templates actually parse against the evaluator)
  3. Embedded `meta()` return equals external `TEMPLATE_META` — pins the store-layer invariant (ENG-2226) statically
  4. Pass-through behavior: `curate(ctx)` invokes `ctx.tools.curate` exactly once with `ctx.env`
  5. Registry exhaustiveness: `getTemplate('curate', projectType)` is defined for every `ProjectType`
  6. Structural shape: each template body matches `/return\s+ctx\.tools\.\w+\(/` — any reasonable delegated-detection regex the Phase 2 recorder lands will match this

## User-visible changes

None. Internal infrastructure consumed by Task 4.2.

## Evidence

- [x] Failing test/log before + passing after

```
$ npx mocha --forbid-only 'test/unit/agent/harness/templates.test.ts'
  harness template registry (curate templates, v1.0)
    Test 1 — TEMPLATE_META passes HarnessMetaSchema.parse
      ✔ curate/typescript meta round-trips HarnessMetaSchema
      ✔ curate/python meta round-trips HarnessMetaSchema
      ✔ curate/generic meta round-trips HarnessMetaSchema
    Test 2 — TEMPLATE_CODE loads via HarnessModuleBuilder.build
      ✔ curate/typescript code loads successfully
      ✔ curate/python code loads successfully
      ✔ curate/generic code loads successfully
    Test 3 — embedded meta() equals external TEMPLATE_META
      ✔ curate/typescript embedded meta() matches TEMPLATE_META
      ✔ curate/python embedded meta() matches TEMPLATE_META
      ✔ curate/generic embedded meta() matches TEMPLATE_META
    Test 4 — pass-through: curate(ctx) invokes ctx.tools.curate once with ctx.env
      ✔ curate/typescript forwards ctx.env to ctx.tools.curate
      ✔ curate/python forwards ctx.env to ctx.tools.curate
      ✔ curate/generic forwards ctx.env to ctx.tools.curate
    Test 5 — registry exhaustiveness for curate
      ✔ getTemplate('curate', 'typescript') returns a defined template
      ✔ getTemplate('curate', 'python') returns a defined template
      ✔ getTemplate('curate', 'generic') returns a defined template
    Test 6 — template body is a minimal pass-through
      ✔ curate/typescript body contains a bare ctx.tools.* forward
      ✔ curate/python body contains a bare ctx.tools.* forward
      ✔ curate/generic body contains a bare ctx.tools.* forward

  18 passing

$ npx mocha --forbid-only 'test/unit/agent/harness/**/*.test.ts'
  174 passing (25s)
```

## Checklist

- [x] Tests added or updated and passing
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow Conventional Commits format
- [ ] Documentation updated — N/A (internal)
- [x] No breaking changes
- [x] Branch is up to date with `proj/autoharness-v2`

## Risks and mitigations

- **Risk: Scope narrowed from 6 to 3 templates** — query templates parked. `HarnessBootstrap` (Task 4.2) will only support `commandType === 'curate'` at ship time; query bootstraps return `{loaded: false, reason: 'no-version'}` until query templates land.
  - **Mitigation**: `SupportedCommandType = 'curate'` narrows the public API at the type level. Expanding to `'curate' | 'query'` is additive — no existing call site breaks. Two blockers spelled out above under "Follow-ups" are single-line changes each; total parking cost is a <1hr follow-up ticket.

- **Risk: `delegated: true` AC deferred** — the recorder's delegation-detection regex lives as `// placeholder — real detection lives in §C1` in `harness-outcome-recorder.ts:235`. Can't assert templates match a regex that doesn't exist yet.
  - **Mitigation**: Test 6 pins the template body STRUCTURALLY to `/return\s+ctx\.tools\.\w+\(/`. When Phase 2 lands the real regex, either the templates match it (desired) or Test 6 reveals drift (template body evolved beyond bare pass-through). Either way, the drift is caught at the template side before it can hide under the recorder.

- **Risk: Template `TEMPLATE_META` and embedded `meta()` could drift** — someone edits the code string but forgets the external constant.
  - **Mitigation**: Test 3 pins the invariant statically per template — parse the code via the real builder, call `meta()`, deep-equal against `TEMPLATE_META`. The store-layer invariant check (ENG-2226) would also catch it at runtime, but static is better.

- **Risk: CommonJS-in-string format surprise** — a contributor opens `curate/typescript.ts` expecting normal TS code and sees a string literal with `exports.meta = ...` syntax.
  - **Mitigation**: One-line comment at the top of each template pointing at `phase_3_4_handoff.md §C7`.