### PR TITLE
feat: [ENG-2248] AutoHarness V2 polyglot fallback + config override

### DIFF
--- a/src/agent/infra/harness/detect-and-pick-template.ts
+++ b/src/agent/infra/harness/detect-and-pick-template.ts
@@ -26,13 +26,22 @@ export async function detectAndPickTemplate(
   const {detected} = await detectProjectType(workingDirectory, fileSystem)
 
   if (detected.length === 0) {
+    // Unreachable under Task 4.1's contract (always returns ≥1), kept as a
+    // defense-in-depth guard so a future contract change can't produce a
+    // silent `undefined` + malformed warn message. Logs loudly so the
+    // contract breakage is visible.
     logger.error('Project detector returned empty array — falling back to generic', {
       workingDirectory,
     })
     return 'generic'
   }
 
-  if (detected.length === 1) return detected[0]
+  if (detected.length === 1) {
+    // Destructure rather than index so TS narrows `single` to `ProjectType`
+    // under stricter tsconfig options (e.g. `noUncheckedIndexedAccess`).
+    const [single] = detected
+    return single
+  }
 
   const overrideOptions = detected.map((t) => `'${t}'`).join(' | ')
   const message = `Polyglot repo detected (${detected.join(', ')}). Defaulting to 'generic' harness templates. Override with \`config.harness.language: ${overrideOptions}\` in your config.`

--- a/src/agent/infra/harness/detect-and-pick-template.ts
+++ b/src/agent/infra/harness/detect-and-pick-template.ts
@@ -1,0 +1,55 @@
+import type {ProjectType} from '../../core/domain/harness/types.js'
+import type {IFileSystem} from '../../core/interfaces/i-file-system.js'
+import type {ILogger} from '../../core/interfaces/i-logger.js'
+import type {ValidatedHarnessConfig} from '../agent/agent-schemas.js'
+
+import {detectProjectType} from './project-detector.js'
+
+// Module-level set keeps the polyglot warning to once per workingDirectory
+// per process. Resets on daemon restart — intentional.
+const polyglotWarnedPaths = new Set<string>()
+
+export async function detectAndPickTemplate(
+  workingDirectory: string,
+  fileSystem: IFileSystem,
+  config: ValidatedHarnessConfig,
+  logger: ILogger,
+): Promise<ProjectType> {
+  if (config.language !== 'auto') {
+    logger.debug('Harness language override applied', {
+      language: config.language,
+      workingDirectory,
+    })
+    return config.language
+  }
+
+  const {detected} = await detectProjectType(workingDirectory, fileSystem)
+
+  if (detected.length === 0) {
+    logger.error('Project detector returned empty array — falling back to generic', {
+      workingDirectory,
+    })
+    return 'generic'
+  }
+
+  if (detected.length === 1) return detected[0]
+
+  const overrideOptions = detected.map((t) => `'${t}'`).join(' | ')
+  const message = `Polyglot repo detected (${detected.join(', ')}). Defaulting to 'generic' harness templates. Override with \`config.harness.language: ${overrideOptions}\` in your config.`
+  const context = {detected, workingDirectory}
+
+  if (polyglotWarnedPaths.has(workingDirectory)) {
+    logger.debug(message, context)
+  } else {
+    polyglotWarnedPaths.add(workingDirectory)
+    logger.warn(message, context)
+  }
+
+  return 'generic'
+}
+
+// @internal — test-only. Resets warn-once state so tests stay isolated
+// without having to use distinct workingDirectory paths per case.
+export function _clearPolyglotWarningState(): void {
+  polyglotWarnedPaths.clear()
+}

--- a/test/unit/agent/harness/detect-and-pick-template.test.ts
+++ b/test/unit/agent/harness/detect-and-pick-template.test.ts
@@ -105,7 +105,6 @@ describe('detectAndPickTemplate', () => {
 
   afterEach(() => {
     sb.restore()
-    _clearPolyglotWarningState()
   })
 
   // ── Override branch: config.language wins, no detection runs ──────────────
@@ -190,9 +189,14 @@ describe('detectAndPickTemplate', () => {
     await detectAndPickTemplate(CWD_A, fileSystem, makeConfig(), logger)
 
     expect(logger.warn.callCount).to.equal(1)
-    // Second hit logs debug instead of warn. Other debug calls (e.g. from
-    // the override branch) don't apply because we're in the auto branch.
-    expect(logger.debug.callCount).to.equal(1)
+    // Second hit logs debug with the polyglot message. Asserting on
+    // message content rather than raw call count keeps the test precise
+    // if debug-log volume elsewhere grows.
+    const polyglotDebug = logger.debug.getCalls().find((call) => {
+      const [msg] = call.args
+      return typeof msg === 'string' && msg.includes('Polyglot repo')
+    })
+    expect(polyglotDebug, 'expected a polyglot debug log on second call').to.not.equal(undefined)
   })
 
   it('7. warn fires again for a different workingDirectory', async () => {

--- a/test/unit/agent/harness/detect-and-pick-template.test.ts
+++ b/test/unit/agent/harness/detect-and-pick-template.test.ts
@@ -1,0 +1,214 @@
+import {expect} from 'chai'
+import {join} from 'node:path'
+import {createSandbox, type SinonSandbox, type SinonStub} from 'sinon'
+
+import type {FileContent} from '../../../../src/agent/core/domain/file-system/types.js'
+import type {IFileSystem} from '../../../../src/agent/core/interfaces/i-file-system.js'
+import type {ILogger} from '../../../../src/agent/core/interfaces/i-logger.js'
+import type {ValidatedHarnessConfig} from '../../../../src/agent/infra/agent/agent-schemas.js'
+
+import {
+  _clearPolyglotWarningState,
+  detectAndPickTemplate,
+} from '../../../../src/agent/infra/harness/detect-and-pick-template.js'
+
+type FilePresence = {
+  readonly [filename: string]: string | undefined
+}
+
+function makeFileSystem(
+  sb: SinonSandbox,
+  files: FilePresence,
+): {readonly fileSystem: IFileSystem; readonly readFileStub: SinonStub} {
+  const readFileStub = sb.stub()
+  readFileStub.callsFake(async (filePath: string): Promise<FileContent> => {
+    const content = files[filePath]
+    if (content === undefined) throw new Error(`ENOENT: ${filePath}`)
+    return {
+      content,
+      encoding: 'utf8',
+      formattedContent: content,
+      lines: 1,
+      message: '',
+      size: content.length,
+      totalLines: 1,
+      truncated: false,
+    }
+  })
+
+  const fileSystem = {
+    editFile: sb.stub(),
+    globFiles: sb.stub(),
+    initialize: sb.stub(),
+    listDirectory: sb.stub(),
+    readFile: readFileStub,
+    searchContent: sb.stub(),
+    writeFile: sb.stub(),
+  } satisfies IFileSystem
+
+  return {fileSystem, readFileStub}
+}
+
+function makeLogger(sb: SinonSandbox): ILogger & {
+  readonly debug: SinonStub
+  readonly error: SinonStub
+  readonly info: SinonStub
+  readonly warn: SinonStub
+} {
+  return {
+    debug: sb.stub(),
+    error: sb.stub(),
+    info: sb.stub(),
+    warn: sb.stub(),
+  }
+}
+
+function makeConfig(overrides: Partial<ValidatedHarnessConfig> = {}): ValidatedHarnessConfig {
+  return {
+    autoLearn: true,
+    enabled: true,
+    language: 'auto',
+    maxVersions: 20,
+    ...overrides,
+  }
+}
+
+// A filesystem whose `readFile` throws if invoked — used to prove the
+// override path does NOT call the detector. Guards against a future
+// "detect anyway for telemetry" refactor slipping in silently.
+function makeExplodingFileSystem(sb: SinonSandbox): IFileSystem {
+  const readFileStub = sb.stub()
+  readFileStub.callsFake(() => {
+    throw new Error('detector must NOT be called when config.language is a concrete override')
+  })
+  return {
+    editFile: sb.stub(),
+    globFiles: sb.stub(),
+    initialize: sb.stub(),
+    listDirectory: sb.stub(),
+    readFile: readFileStub,
+    searchContent: sb.stub(),
+    writeFile: sb.stub(),
+  } satisfies IFileSystem
+}
+
+const CWD_A = '/proj-a'
+const CWD_B = '/proj-b'
+
+describe('detectAndPickTemplate', () => {
+  let sb: SinonSandbox
+
+  beforeEach(() => {
+    sb = createSandbox()
+    _clearPolyglotWarningState()
+  })
+
+  afterEach(() => {
+    sb.restore()
+    _clearPolyglotWarningState()
+  })
+
+  // ── Override branch: config.language wins, no detection runs ──────────────
+
+  it('1. config.language=typescript → returns typescript without calling detector', async () => {
+    const fs = makeExplodingFileSystem(sb)
+    const logger = makeLogger(sb)
+    const result = await detectAndPickTemplate(CWD_A, fs, makeConfig({language: 'typescript'}), logger)
+    expect(result).to.equal('typescript')
+    expect(logger.warn.callCount).to.equal(0)
+  })
+
+  it('2. config.language=generic → returns generic without calling detector', async () => {
+    const fs = makeExplodingFileSystem(sb)
+    const logger = makeLogger(sb)
+    const result = await detectAndPickTemplate(CWD_A, fs, makeConfig({language: 'generic'}), logger)
+    expect(result).to.equal('generic')
+    expect(logger.warn.callCount).to.equal(0)
+  })
+
+  it('9. config.language=python overrides tsconfig-only repo', async () => {
+    const fs = makeExplodingFileSystem(sb)
+    const logger = makeLogger(sb)
+    // The fs is exploding — the test passes only if the detector is never called.
+    const result = await detectAndPickTemplate(CWD_A, fs, makeConfig({language: 'python'}), logger)
+    expect(result).to.equal('python')
+  })
+
+  // ── Auto branch: single-detection pass-through ────────────────────────────
+
+  it('3. auto + [typescript] → returns typescript', async () => {
+    const {fileSystem} = makeFileSystem(sb, {[join(CWD_A, 'tsconfig.json')]: '{}'})
+    const logger = makeLogger(sb)
+    const result = await detectAndPickTemplate(CWD_A, fileSystem, makeConfig(), logger)
+    expect(result).to.equal('typescript')
+    expect(logger.warn.callCount).to.equal(0)
+  })
+
+  it('4. auto + [python] → returns python', async () => {
+    const {fileSystem} = makeFileSystem(sb, {[join(CWD_A, 'pyproject.toml')]: '[project]\n'})
+    const logger = makeLogger(sb)
+    const result = await detectAndPickTemplate(CWD_A, fileSystem, makeConfig(), logger)
+    expect(result).to.equal('python')
+    expect(logger.warn.callCount).to.equal(0)
+  })
+
+  it('8. auto + [generic] → returns generic with no warning', async () => {
+    const {fileSystem} = makeFileSystem(sb, {})
+    const logger = makeLogger(sb)
+    const result = await detectAndPickTemplate(CWD_A, fileSystem, makeConfig(), logger)
+    expect(result).to.equal('generic')
+    expect(logger.warn.callCount).to.equal(0)
+  })
+
+  // ── Auto branch: polyglot → generic + warn-once ───────────────────────────
+
+  it('5. auto + polyglot [typescript, python] → returns generic with warn containing both types', async () => {
+    const {fileSystem} = makeFileSystem(sb, {
+      [join(CWD_A, 'pyproject.toml')]: '[project]\n',
+      [join(CWD_A, 'tsconfig.json')]: '{}',
+    })
+    const logger = makeLogger(sb)
+    const result = await detectAndPickTemplate(CWD_A, fileSystem, makeConfig(), logger)
+    expect(result).to.equal('generic')
+    expect(logger.warn.callCount).to.equal(1)
+    const [message] = logger.warn.firstCall.args
+    expect(message).to.include('typescript')
+    expect(message).to.include('python')
+    // Warn message must spell out the override path — the user has no other
+    // discoverable way to silence it.
+    expect(message).to.include('config.harness.language')
+  })
+
+  it('6. warn fires once per workingDirectory; second call logs debug', async () => {
+    const {fileSystem} = makeFileSystem(sb, {
+      [join(CWD_A, 'pyproject.toml')]: '[project]\n',
+      [join(CWD_A, 'tsconfig.json')]: '{}',
+    })
+    const logger = makeLogger(sb)
+
+    await detectAndPickTemplate(CWD_A, fileSystem, makeConfig(), logger)
+    await detectAndPickTemplate(CWD_A, fileSystem, makeConfig(), logger)
+
+    expect(logger.warn.callCount).to.equal(1)
+    // Second hit logs debug instead of warn. Other debug calls (e.g. from
+    // the override branch) don't apply because we're in the auto branch.
+    expect(logger.debug.callCount).to.equal(1)
+  })
+
+  it('7. warn fires again for a different workingDirectory', async () => {
+    const fsA = makeFileSystem(sb, {
+      [join(CWD_A, 'pyproject.toml')]: '[project]\n',
+      [join(CWD_A, 'tsconfig.json')]: '{}',
+    })
+    const fsB = makeFileSystem(sb, {
+      [join(CWD_B, 'pyproject.toml')]: '[project]\n',
+      [join(CWD_B, 'tsconfig.json')]: '{}',
+    })
+    const logger = makeLogger(sb)
+
+    await detectAndPickTemplate(CWD_A, fsA.fileSystem, makeConfig(), logger)
+    await detectAndPickTemplate(CWD_B, fsB.fileSystem, makeConfig(), logger)
+
+    expect(logger.warn.callCount).to.equal(2)
+  })
+})


### PR DESCRIPTION
## Summary

- **Problem**: Task 4.1's `detectProjectType` returns `readonly ProjectType[]` — may be length 1 (clean) or length 2 (polyglot). Task 4.2's `HarnessBootstrap` needs a single concrete `ProjectType` to pick a template. Something in the middle has to disambiguate, handle the user's config override, and warn intelligibly when a repo is polyglot.
- **Why it matters**: Closes brutal-review Tier 3 S4 (polyglot-aware project detection). Without this wrapper, a mixed TS+Python repo would either crash the bootstrap or silently pick an arbitrary language. The warning makes the default discoverable — the user learns exactly which config key to flip to override it.
- **What changed**: Ships `detectAndPickTemplate(workingDirectory, fileSystem, config, logger): Promise<ProjectType>`. Three branches: concrete `config.language` → return verbatim (no detection call); `'auto'` + single-detection → pass-through; `'auto'` + polyglot → `'generic'` with a warn-once per `workingDirectory`.
- **What did NOT change (scope boundary)**: No fuzzy/content-based detection heuristics beyond Task 4.1. No per-command-type overrides (future v1.1 additive extension). No bootstrap orchestration — Task 4.2 consumes this.

## Type of change

- [x] New feature

## Scope (select all touched areas)

- [x] Agent / Tools

## Linked issues

- Closes ENG-2248
- Depends on: ENG-2246 (Task 4.1 — detector, merged)
- Consumer: ENG-2249 (Task 4.2 — `HarnessBootstrap`, next)
- Brutal-review item closed: Tier 3 S4 (polyglot-aware project detection)

## Root cause (bug fixes only, otherwise write `N/A`)

N/A

## Test plan

- Coverage added:
  - [x] Unit test
- Test file(s): `test/unit/agent/harness/detect-and-pick-template.test.ts`
- Key scenario(s) covered (9 tests — the enumerated AC scenarios):
  1. `config.language: 'typescript'` → returns `'typescript'`, no detection call
  2. `config.language: 'generic'` → returns `'generic'`, no detection call
  3. `auto` + detector `['typescript']` → `'typescript'`
  4. `auto` + detector `['python']` → `'python'`
  5. `auto` + polyglot `['typescript', 'python']` → `'generic'` + warn containing both types AND override path
  6. Polyglot warn fires ONCE per `workingDirectory` (second call logs `debug`)
  7. Polyglot warn FIRES AGAIN for a different `workingDirectory`
  8. `auto` + `['generic']` → `'generic'` with NO warning
  9. `config.language: 'python'` override beats `tsconfig.json`-only repo

**Notable test design**: tests 1/2/9 use a `makeExplodingFileSystem` helper whose `readFile` throws if called. If a future refactor sneaks a "detect anyway for telemetry" call into the override branch, those three tests fail loudly with the message *"detector must NOT be called when config.language is a concrete override"*.

## User-visible changes

**Polyglot warning log** — when a repo has both TypeScript and Python signals AND the user has not set `config.harness.language`, the daemon emits a WARN on first encounter per `workingDirectory`:

> *Polyglot repo detected (typescript, python). Defaulting to 'generic' harness templates. Override with `config.harness.language: 'typescript' | 'python'` in your config.*

Subsequent invocations for the same `workingDirectory` in the same process log at `debug` instead.

## Evidence

- [x] Failing test/log before + passing after

```
$ npx mocha --forbid-only 'test/unit/agent/harness/detect-and-pick-template.test.ts'
  detectAndPickTemplate
    ✔ 1. config.language=typescript → returns typescript without calling detector
    ✔ 2. config.language=generic → returns generic without calling detector
    ✔ 9. config.language=python overrides tsconfig-only repo
    ✔ 3. auto + [typescript] → returns typescript
    ✔ 4. auto + [python] → returns python
    ✔ 8. auto + [generic] → returns generic with no warning
    ✔ 5. auto + polyglot [typescript, python] → returns generic with warn containing both types
    ✔ 6. warn fires once per workingDirectory; second call logs debug
    ✔ 7. warn fires again for a different workingDirectory

  9 passing

$ npx mocha --forbid-only 'test/unit/agent/harness/**/*.test.ts'
  183 passing (25s)
```

## Checklist

- [x] Tests added or updated and passing
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow Conventional Commits format
- [ ] Documentation updated — N/A (internal)
- [x] No breaking changes
- [x] Branch is up to date with `proj/autoharness-v2`

## Risks and mitigations

- **Risk: Module-level `Set<string>` state** — warn-once cache is process-scoped global state. Test isolation depends on clearing it; production code has no way to clear it (by design).
  - **Mitigation**: `_clearPolyglotWarningState()` exported with `@internal` label for tests. Production state resets on daemon restart — intentional per the task doc. Alternative (DI'd cache) was considered and rejected because every consumer would thread a cache they don't care about.

- **Risk: False-positive polyglot warnings on repos with stray files** — e.g., a TS repo with a `setup.py` for a build tool would get classified as polyglot.
  - **Mitigation**: The warn message names the exact config override the user can set. One-time annoyance per working directory per process; no functional impact (bootstrap proceeds with `'generic'` template).

- **Risk: Warn message is a long single line** — could be split across log lines but kept single-line for log grep-ability.
  - **Mitigation**: Tested that the message contains the key substrings (types + `config.harness.language`). Formatting tweaks are non-breaking since the assertion is substring-based.