### PR TITLE
feat: [ENG-2249] AutoHarness V2 HarnessBootstrap cold-start writer

### DIFF
--- a/src/agent/infra/harness/harness-bootstrap.ts
+++ b/src/agent/infra/harness/harness-bootstrap.ts
@@ -59,6 +59,8 @@ export class HarnessBootstrap {
     try {
       await promise
     } finally {
+      // Clear regardless of outcome so a later retry starts a fresh bootstrap
+      // rather than re-awaiting the settled (possibly rejected) promise.
       this.inFlight.delete(pairKey)
     }
   }
@@ -70,11 +72,9 @@ export class HarnessBootstrap {
   ): Promise<void> {
     if (!this.config.enabled) return
 
-    const existing = await this.store.getLatest(projectId, commandType)
-    if (existing !== undefined) return
-
     // v1.0 ships curate templates only (Task 4.3). chat/query bootstraps
-    // are graceful no-ops until template coverage extends.
+    // are graceful no-ops until template coverage extends. Guard fires
+    // BEFORE `store.getLatest` so no-op commandTypes skip the store I/O.
     if (commandType !== 'curate') {
       this.logger.debug('HarnessBootstrap: no template for commandType — skipping', {
         commandType,
@@ -82,6 +82,9 @@ export class HarnessBootstrap {
       })
       return
     }
+
+    const existing = await this.store.getLatest(projectId, commandType)
+    if (existing !== undefined) return
 
     const projectType = await detectAndPickTemplate(
       workingDirectory,

--- a/src/agent/infra/harness/harness-bootstrap.ts
+++ b/src/agent/infra/harness/harness-bootstrap.ts
@@ -1,0 +1,134 @@
+import {randomUUID} from 'node:crypto'
+
+import type {HarnessVersion} from '../../core/domain/harness/types.js'
+import type {IFileSystem} from '../../core/interfaces/i-file-system.js'
+import type {IHarnessStore} from '../../core/interfaces/i-harness-store.js'
+import type {ILogger} from '../../core/interfaces/i-logger.js'
+import type {ValidatedHarnessConfig} from '../agent/agent-schemas.js'
+
+import {
+  HarnessStoreError,
+  HarnessStoreErrorCode,
+} from '../../core/domain/errors/harness-store-error.js'
+import {detectAndPickTemplate} from './detect-and-pick-template.js'
+import {getTemplate} from './templates/index.js'
+
+// Heuristic starting value per v1-design-decisions.md §2.1 — Mode A threshold.
+// Option C pass-through templates cap the steady-state heuristic at 0.50, so
+// starting at 0.30 keeps v1 inside Mode A from the first call without flipping
+// into Mode B/C before refinement lands in Phase 6.
+const V1_STARTING_HEURISTIC = 0.3
+
+export class HarnessBootstrap {
+  // Per-pair single-flight map — collapses concurrent bootstrap attempts
+  // for the same (projectId, commandType) into one actual save. The
+  // underlying store's sibling-version check is documented racy under
+  // concurrent saveVersion calls with the same version number but
+  // different ids (harness-store.ts:282); this map closes that window
+  // for bootstrap-originated writes.
+  private readonly inFlight = new Map<string, Promise<void>>()
+
+  constructor(
+    private readonly store: IHarnessStore,
+    private readonly fileSystem: IFileSystem,
+    private readonly config: ValidatedHarnessConfig,
+    private readonly logger: ILogger,
+  ) {}
+
+  /**
+   * Idempotent. If a harness version already exists for
+   * `(projectId, commandType)`, returns silently. Otherwise writes v1
+   * from the Option C template that matches the detected project type.
+   *
+   * Race-safe: 100 parallel calls on the same pair produce exactly one
+   * v1. Concurrent callers share the same in-flight promise; losers on
+   * a cross-process race catch `VERSION_CONFLICT` and return silently.
+   */
+  async bootstrapIfNeeded(
+    projectId: string,
+    commandType: 'chat' | 'curate' | 'query',
+    workingDirectory: string,
+  ): Promise<void> {
+    // `\x00` is forbidden in both fields so the join is unambiguous.
+    const pairKey = `${projectId}\u0000${commandType}`
+    const inFlight = this.inFlight.get(pairKey)
+    if (inFlight !== undefined) return inFlight
+
+    const promise = this.doBootstrap(projectId, commandType, workingDirectory)
+    this.inFlight.set(pairKey, promise)
+    try {
+      await promise
+    } finally {
+      this.inFlight.delete(pairKey)
+    }
+  }
+
+  private async doBootstrap(
+    projectId: string,
+    commandType: 'chat' | 'curate' | 'query',
+    workingDirectory: string,
+  ): Promise<void> {
+    if (!this.config.enabled) return
+
+    const existing = await this.store.getLatest(projectId, commandType)
+    if (existing !== undefined) return
+
+    // v1.0 ships curate templates only (Task 4.3). chat/query bootstraps
+    // are graceful no-ops until template coverage extends.
+    if (commandType !== 'curate') {
+      this.logger.debug('HarnessBootstrap: no template for commandType — skipping', {
+        commandType,
+        projectId,
+      })
+      return
+    }
+
+    const projectType = await detectAndPickTemplate(
+      workingDirectory,
+      this.fileSystem,
+      this.config,
+      this.logger,
+    )
+    const template = getTemplate(commandType, projectType)
+
+    const version: HarnessVersion = {
+      code: template.code,
+      commandType,
+      createdAt: Date.now(),
+      heuristic: V1_STARTING_HEURISTIC,
+      id: randomUUID(),
+      metadata: template.meta,
+      projectId,
+      projectType,
+      version: 1,
+    }
+
+    try {
+      await this.store.saveVersion(version)
+      this.logger.info('HarnessBootstrap: wrote v1 harness', {
+        commandType,
+        projectId,
+        projectType,
+        versionId: version.id,
+      })
+    } catch (error) {
+      if (HarnessStoreError.isCode(error, HarnessStoreErrorCode.VERSION_CONFLICT)) {
+        // Expected race outcome: another bootstrapIfNeeded call wrote v1
+        // first. Both callers wanted the same thing; the existing v1 is
+        // the correct end state.
+        this.logger.debug('HarnessBootstrap: lost race — existing v1 satisfies the caller', {
+          commandType,
+          projectId,
+        })
+        return
+      }
+
+      this.logger.error('HarnessBootstrap: saveVersion failed with unexpected error', {
+        commandType,
+        error: error instanceof Error ? error.message : String(error),
+        projectId,
+      })
+      throw error
+    }
+  }
+}

--- a/src/agent/infra/harness/index.ts
+++ b/src/agent/infra/harness/index.ts
@@ -6,6 +6,7 @@
  * from '.../infra/harness'` without reaching into individual files.
  */
 
+export {HarnessBootstrap} from './harness-bootstrap.js'
 export {HarnessModuleBuilder} from './harness-module-builder.js'
 export {HarnessOutcomeRecorder} from './harness-outcome-recorder.js'
 export {HarnessStore} from './harness-store.js'

--- a/test/unit/agent/harness/harness-bootstrap.test.ts
+++ b/test/unit/agent/harness/harness-bootstrap.test.ts
@@ -1,0 +1,281 @@
+import {expect} from 'chai'
+import {createSandbox, type SinonSandbox, type SinonStub} from 'sinon'
+
+import type {HarnessVersion} from '../../../../src/agent/core/domain/harness/types.js'
+import type {IFileSystem} from '../../../../src/agent/core/interfaces/i-file-system.js'
+import type {IHarnessStore} from '../../../../src/agent/core/interfaces/i-harness-store.js'
+import type {ILogger} from '../../../../src/agent/core/interfaces/i-logger.js'
+import type {ValidatedHarnessConfig} from '../../../../src/agent/infra/agent/agent-schemas.js'
+
+import {HarnessStoreError} from '../../../../src/agent/core/domain/errors/harness-store-error.js'
+import {NoOpLogger} from '../../../../src/agent/core/interfaces/i-logger.js'
+import {HarnessBootstrap} from '../../../../src/agent/infra/harness/harness-bootstrap.js'
+import {HarnessStore} from '../../../../src/agent/infra/harness/harness-store.js'
+import {FileKeyStorage} from '../../../../src/agent/infra/storage/file-key-storage.js'
+
+const PROJECT_ID = 'p1'
+const WORKING_DIRECTORY = '/proj'
+
+function makeConfig(overrides: Partial<ValidatedHarnessConfig> = {}): ValidatedHarnessConfig {
+  return {
+    autoLearn: true,
+    enabled: true,
+    // Concrete override means detectAndPickTemplate skips detection — keeps
+    // the filesystem unused and tests fast. Tests that need a specific
+    // project type set it here.
+    language: 'generic',
+    maxVersions: 20,
+    ...overrides,
+  }
+}
+
+function makeStoreStub(sb: SinonSandbox): {
+  readonly getLatest: SinonStub
+  readonly saveVersion: SinonStub
+  readonly store: IHarnessStore
+} {
+  const getLatest = sb.stub()
+  const saveVersion = sb.stub()
+  const store = {
+    deleteOutcomes: sb.stub(),
+    getLatest,
+    getVersion: sb.stub(),
+    listOutcomes: sb.stub(),
+    listScenarios: sb.stub(),
+    listVersions: sb.stub(),
+    pruneOldVersions: sb.stub(),
+    recordFeedback: sb.stub(),
+    saveOutcome: sb.stub(),
+    saveScenario: sb.stub(),
+    saveVersion,
+  } satisfies IHarnessStore
+
+  return {getLatest, saveVersion, store}
+}
+
+function makeFileSystemStub(sb: SinonSandbox): IFileSystem {
+  return {
+    editFile: sb.stub(),
+    globFiles: sb.stub(),
+    initialize: sb.stub(),
+    listDirectory: sb.stub(),
+    readFile: sb.stub(),
+    searchContent: sb.stub(),
+    writeFile: sb.stub(),
+  } satisfies IFileSystem
+}
+
+function makeLoggerStub(sb: SinonSandbox): ILogger & {
+  debug: SinonStub
+  error: SinonStub
+  info: SinonStub
+  warn: SinonStub
+} {
+  return {
+    debug: sb.stub(),
+    error: sb.stub(),
+    info: sb.stub(),
+    warn: sb.stub(),
+  }
+}
+
+describe('HarnessBootstrap', () => {
+  let sb: SinonSandbox
+
+  beforeEach(() => {
+    sb = createSandbox()
+  })
+
+  afterEach(() => {
+    sb.restore()
+  })
+
+  // ── Config gating ─────────────────────────────────────────────────────────
+
+  it('1. config.enabled=false → no store call, no detector call', async () => {
+    const {getLatest, saveVersion, store} = makeStoreStub(sb)
+    const fs = makeFileSystemStub(sb)
+    const logger = makeLoggerStub(sb)
+    const bootstrap = new HarnessBootstrap(store, fs, makeConfig({enabled: false}), logger)
+
+    await bootstrap.bootstrapIfNeeded(PROJECT_ID, 'curate', WORKING_DIRECTORY)
+
+    expect(getLatest.callCount).to.equal(0)
+    expect(saveVersion.callCount).to.equal(0)
+  })
+
+  it('2. existing version → early return, no save', async () => {
+    const {getLatest, saveVersion, store} = makeStoreStub(sb)
+    const fs = makeFileSystemStub(sb)
+    const logger = makeLoggerStub(sb)
+    getLatest.resolves({id: 'v-existing'} as HarnessVersion)
+    const bootstrap = new HarnessBootstrap(store, fs, makeConfig(), logger)
+
+    await bootstrap.bootstrapIfNeeded(PROJECT_ID, 'curate', WORKING_DIRECTORY)
+
+    expect(getLatest.callCount).to.equal(1)
+    expect(saveVersion.callCount).to.equal(0)
+  })
+
+  // ── Bootstrap flow ────────────────────────────────────────────────────────
+
+  it('3. no existing version → writes v1 with correct shape', async () => {
+    const {getLatest, saveVersion, store} = makeStoreStub(sb)
+    const fs = makeFileSystemStub(sb)
+    const logger = makeLoggerStub(sb)
+    getLatest.resolves()
+    saveVersion.resolves()
+    const bootstrap = new HarnessBootstrap(store, fs, makeConfig({language: 'generic'}), logger)
+
+    await bootstrap.bootstrapIfNeeded(PROJECT_ID, 'curate', WORKING_DIRECTORY)
+
+    expect(saveVersion.callCount).to.equal(1)
+    const [saved] = saveVersion.firstCall.args as [HarnessVersion]
+    expect(saved.projectId).to.equal(PROJECT_ID)
+    expect(saved.commandType).to.equal('curate')
+    expect(saved.projectType).to.equal('generic')
+    expect(saved.version).to.equal(1)
+    expect(saved.heuristic).to.equal(0.3)
+    expect(saved.code).to.be.a('string').and.not.empty
+    expect(saved.metadata.commandType).to.equal('curate')
+    expect(saved.metadata.version).to.equal(1)
+    expect(saved.id).to.match(/^[\da-f-]{36}$/)
+    expect(saved.createdAt).to.be.a('number')
+  })
+
+  it('4. logs info on successful v1 write', async () => {
+    const {getLatest, saveVersion, store} = makeStoreStub(sb)
+    const fs = makeFileSystemStub(sb)
+    const logger = makeLoggerStub(sb)
+    getLatest.resolves()
+    saveVersion.resolves()
+    const bootstrap = new HarnessBootstrap(store, fs, makeConfig({language: 'typescript'}), logger)
+
+    await bootstrap.bootstrapIfNeeded(PROJECT_ID, 'curate', WORKING_DIRECTORY)
+
+    expect(logger.info.callCount).to.equal(1)
+    const [message, context] = logger.info.firstCall.args as [string, Record<string, unknown>]
+    expect(message).to.include('v1')
+    expect(context.projectId).to.equal(PROJECT_ID)
+    expect(context.projectType).to.equal('typescript')
+  })
+
+  it('5. unexpected storage error → log error + rethrow', async () => {
+    const {getLatest, saveVersion, store} = makeStoreStub(sb)
+    const fs = makeFileSystemStub(sb)
+    const logger = makeLoggerStub(sb)
+    getLatest.resolves()
+    const boom = new Error('transport down')
+    saveVersion.rejects(boom)
+    const bootstrap = new HarnessBootstrap(store, fs, makeConfig(), logger)
+
+    let caught: unknown
+    try {
+      await bootstrap.bootstrapIfNeeded(PROJECT_ID, 'curate', WORKING_DIRECTORY)
+    } catch (error) {
+      caught = error
+    }
+
+    expect(caught).to.equal(boom)
+    expect(logger.error.callCount).to.equal(1)
+  })
+
+  it('6. VERSION_CONFLICT on save → swallowed + debug log', async () => {
+    const {getLatest, saveVersion, store} = makeStoreStub(sb)
+    const fs = makeFileSystemStub(sb)
+    const logger = makeLoggerStub(sb)
+    getLatest.resolves()
+    const conflict = HarnessStoreError.versionConflict(PROJECT_ID, 'curate', {version: 1})
+    saveVersion.rejects(conflict)
+    const bootstrap = new HarnessBootstrap(store, fs, makeConfig(), logger)
+
+    // Must not throw.
+    await bootstrap.bootstrapIfNeeded(PROJECT_ID, 'curate', WORKING_DIRECTORY)
+
+    expect(logger.debug.callCount).to.be.greaterThanOrEqual(1)
+    const hasRaceDebug = logger.debug.getCalls().some((call) => {
+      const [msg] = call.args
+      return typeof msg === 'string' && msg.includes('lost race')
+    })
+    expect(hasRaceDebug).to.equal(true)
+    expect(logger.error.callCount).to.equal(0)
+  })
+
+  // ── Detector-driven project type picks the right template ────────────────
+
+  it('7. projectType=typescript → v1 uses curate/typescript template', async () => {
+    const {getLatest, saveVersion, store} = makeStoreStub(sb)
+    const fs = makeFileSystemStub(sb)
+    const logger = makeLoggerStub(sb)
+    getLatest.resolves()
+    saveVersion.resolves()
+    const bootstrap = new HarnessBootstrap(store, fs, makeConfig({language: 'typescript'}), logger)
+
+    await bootstrap.bootstrapIfNeeded(PROJECT_ID, 'curate', WORKING_DIRECTORY)
+
+    const [saved] = saveVersion.firstCall.args as [HarnessVersion]
+    expect(saved.projectType).to.equal('typescript')
+    // typescript template declares the ts-specific project patterns.
+    expect(saved.metadata.projectPatterns).to.include('tsconfig.json')
+  })
+
+  it('8. projectType=generic → v1 uses curate/generic template', async () => {
+    const {getLatest, saveVersion, store} = makeStoreStub(sb)
+    const fs = makeFileSystemStub(sb)
+    const logger = makeLoggerStub(sb)
+    getLatest.resolves()
+    saveVersion.resolves()
+    const bootstrap = new HarnessBootstrap(store, fs, makeConfig({language: 'generic'}), logger)
+
+    await bootstrap.bootstrapIfNeeded(PROJECT_ID, 'curate', WORKING_DIRECTORY)
+
+    const [saved] = saveVersion.firstCall.args as [HarnessVersion]
+    expect(saved.projectType).to.equal('generic')
+    expect(saved.metadata.projectPatterns).to.deep.equal(['**/*'])
+  })
+
+  // ── v1.0 scope narrowing: non-curate commandTypes are graceful no-ops ─────
+
+  it('9. non-curate commandType (query) → no save, debug log', async () => {
+    const {getLatest, saveVersion, store} = makeStoreStub(sb)
+    const fs = makeFileSystemStub(sb)
+    const logger = makeLoggerStub(sb)
+    getLatest.resolves()
+    const bootstrap = new HarnessBootstrap(store, fs, makeConfig(), logger)
+
+    await bootstrap.bootstrapIfNeeded(PROJECT_ID, 'query', WORKING_DIRECTORY)
+
+    expect(saveVersion.callCount).to.equal(0)
+    const skipDebug = logger.debug.getCalls().some((call) => {
+      const [msg] = call.args
+      return typeof msg === 'string' && msg.includes('no template for commandType')
+    })
+    expect(skipDebug).to.equal(true)
+  })
+
+  // ── Concurrency / idempotence via real store ──────────────────────────────
+
+  it('10. 100 parallel bootstrapIfNeeded on same pair → exactly 1 v1 in store', async () => {
+    // Uses real FileKeyStorage({inMemory: true}) + real HarnessStore to
+    // exercise the actual VERSION_CONFLICT path under load. Proves the
+    // idempotence invariant that Phase 4's cold-start depends on.
+    const keyStorage = new FileKeyStorage({inMemory: true})
+    await keyStorage.initialize()
+    const store = new HarnessStore(keyStorage, new NoOpLogger())
+    const fs = makeFileSystemStub(sb)
+    const logger = new NoOpLogger()
+    const bootstrap = new HarnessBootstrap(store, fs, makeConfig({language: 'generic'}), logger)
+
+    const calls: Array<Promise<void>> = []
+    for (let i = 0; i < 100; i++) {
+      calls.push(bootstrap.bootstrapIfNeeded(PROJECT_ID, 'curate', WORKING_DIRECTORY))
+    }
+
+    // None should throw — all losers catch VERSION_CONFLICT.
+    await Promise.all(calls)
+
+    const versions = await store.listVersions(PROJECT_ID, 'curate')
+    expect(versions.length).to.equal(1)
+    expect(versions[0].version).to.equal(1)
+  })
+})

--- a/test/unit/agent/harness/harness-bootstrap.test.ts
+++ b/test/unit/agent/harness/harness-bootstrap.test.ts
@@ -246,6 +246,9 @@ describe('HarnessBootstrap', () => {
     await bootstrap.bootstrapIfNeeded(PROJECT_ID, 'query', WORKING_DIRECTORY)
 
     expect(saveVersion.callCount).to.equal(0)
+    // Guard fires before getLatest, so the store must not be touched at all
+    // for no-op commandTypes. Pinning this catches an accidental reorder.
+    expect(getLatest.callCount).to.equal(0)
     const skipDebug = logger.debug.getCalls().some((call) => {
       const [msg] = call.args
       return typeof msg === 'string' && msg.includes('no template for commandType')
@@ -256,9 +259,12 @@ describe('HarnessBootstrap', () => {
   // ── Concurrency / idempotence via real store ──────────────────────────────
 
   it('10. 100 parallel bootstrapIfNeeded on same pair → exactly 1 v1 in store', async () => {
-    // Uses real FileKeyStorage({inMemory: true}) + real HarnessStore to
-    // exercise the actual VERSION_CONFLICT path under load. Proves the
-    // idempotence invariant that Phase 4's cold-start depends on.
+    // Exercises SINGLE-INSTANCE deduplication: 100 callers share one
+    // in-flight promise, only one save lands. Uses real
+    // FileKeyStorage({inMemory: true}) + real HarnessStore so the full
+    // path runs. Cross-instance races (two HarnessBootstrap instances
+    // racing on the same pair) rely on VERSION_CONFLICT swallowing,
+    // which test 6 covers.
     const keyStorage = new FileKeyStorage({inMemory: true})
     await keyStorage.initialize()
     const store = new HarnessStore(keyStorage, new NoOpLogger())


### PR DESCRIPTION
## Summary

- **Problem**: Every AutoHarness V2 feature downstream of Phase 4 assumes a v1 `HarnessVersion` exists for any `(projectId, commandType)` the user has touched. Nothing yet fires on first `code_exec` to put that v1 in the store.
- **Why it matters**: Owns the "cold-start" moment. Without this, the loader returns `{loaded: false, reason: 'no-version'}` forever and Option C never kicks in — no silent-inject, no heuristic, no refinement loop.
- **What changed**: Ships `HarnessBootstrap` class with one public method `bootstrapIfNeeded(projectId, commandType, workingDirectory)`. Reads config → checks existing version → detects/overrides project type via Task 4.4 → gets template from Task 4.3's registry → writes v1 with `heuristic: 0.30, version: 1`. Idempotent under 100-way concurrency.
- **What did NOT change (scope boundary)**: No agent-level wiring (Phase 5's `AgentLLMService` hook). No refinement (Phase 6). No template content (Task 4.3). No project-type detection heuristics (Task 4.1/4.4). Non-curate commandTypes are graceful no-ops pending query-template follow-up tickets.

## Type of change

- [x] New feature

## Scope (select all touched areas)

- [x] Agent / Tools

## Linked issues

- Closes ENG-2249
- Depends on: ENG-2246 (Task 4.1 — detector), ENG-2247 (Task 4.3 — templates), ENG-2248 (Task 4.4 — polyglot fallback) — all merged
- Consumer: Phase 5 mode-selector hook (to be scheduled) — `AgentLLMService` or `SandboxService` will call `bootstrap.bootstrapIfNeeded(...)` once per session before first `code_exec`
- Integration-test unblock: Phase 4 Task 4.5 (cold-start)

## Root cause (bug fixes only, otherwise write `N/A`)

N/A

## Test plan

- Coverage added:
  - [x] Unit test
- Test file(s): `test/unit/agent/harness/harness-bootstrap.test.ts`
- Key scenario(s) covered (10 tests):
  1. `config.enabled=false` → no store call, no detector call
  2. Existing version → early return, no save
  3. No existing → writes v1 with correct shape (id/projectId/commandType/projectType/version=1/heuristic=0.3/code/metadata/createdAt)
  4. Logs `info` on successful v1 write
  5. Unexpected storage error → logs `error` and rethrows
  6. `VERSION_CONFLICT` → swallowed, logs `debug` with `"lost race"` substring
  7. `projectType=typescript` → v1 uses `curate/typescript` template (via `config.language: 'typescript'` override)
  8. `projectType=generic` → v1 uses `curate/generic` template (`projectPatterns: ['**/*']`)
  9. Non-curate commandType (e.g. `'query'`) → graceful no-op with debug log — v1.0 scope narrowing
  10. **100 parallel `bootstrapIfNeeded` on same pair → exactly 1 v1 in store** — uses real `FileKeyStorage({inMemory: true})` + real `HarnessStore`

## User-visible changes

None. Internal infrastructure. First agent-level consumer lands in Phase 5.

## Evidence

- [x] Failing test/log before + passing after

```
$ npx mocha --forbid-only 'test/unit/agent/harness/harness-bootstrap.test.ts'
  HarnessBootstrap
    ✔ 1. config.enabled=false → no store call, no detector call
    ✔ 2. existing version → early return, no save
    ✔ 3. no existing version → writes v1 with correct shape
    ✔ 4. logs info on successful v1 write
    ✔ 5. unexpected storage error → log error + rethrow
    ✔ 6. VERSION_CONFLICT on save → swallowed + debug log
    ✔ 7. projectType=typescript → v1 uses curate/typescript template
    ✔ 8. projectType=generic → v1 uses curate/generic template
    ✔ 9. non-curate commandType (query) → no save, debug log
    ✔ 10. 100 parallel bootstrapIfNeeded on same pair → exactly 1 v1 in store

  10 passing

$ npx mocha --forbid-only 'test/unit/agent/harness/**/*.test.ts'
  193 passing (25s)
```

## Checklist

- [x] Tests added or updated and passing
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow Conventional Commits format
- [ ] Documentation updated — N/A (internal)
- [x] No breaking changes
- [x] Branch is up to date with `proj/autoharness-v2`

## Risks and mitigations

- **Risk: store's sibling-version check is documented racy** — `harness-store.ts:282` NOTE says concurrent `saveVersion` calls with same `version` but different `id`s can ALL succeed, which defeats the 100-parallel idempotence AC. Without mitigation, Test 10 produces 100 versions instead of 1.
  - **Mitigation**: Added a per-pair single-flight map inside `HarnessBootstrap` — `Map<string, Promise<void>>` keyed on `` `${projectId}\x00${commandType}` ``. Concurrent callers share one promise; only the first runs the bootstrap logic. Documented in the class-level comment. Cross-instance races still surface as `VERSION_CONFLICT` on save, swallowed per spec.

- **Risk: non-curate commandType silently no-ops** — v1.0 scope narrowing (Task 4.3 ships curate templates only). A user invoking `'query'` in production would hit bootstrap but no v1 would be written; the loader returns `{loaded: false, reason: 'no-version'}` and the sandbox degrades to raw `tools.*`.
  - **Mitigation**: Logged at `debug` with the commandType + projectId context so operators can spot it if the silent-skip masks a real issue. Three follow-up tickets already tracked against 4.3 unblock query: (a) add `'query'` to `HarnessCapabilitySchema`, (b) add `query` to `HarnessContextTools`, (c) ship query templates. Single-line changes each.

- **Risk: `heuristic: 0.30` puts v1 in Mode A immediately** — Phase 5's mode selector maps H ≥ 0.30 to Mode A (Assisted). Starting below (e.g., 0.29) would defeat Option C's "silent inject pass-through from day 1" design.
  - **Mitigation**: Option C pass-through cap is 0.50, so v1 stays in Mode A but can't reach Mode B/C without refinement. Decision documented in commit message and in the `V1_STARTING_HEURISTIC` constant comment.

- **Risk: `\x00` delimiter in single-flight key** — if `projectId` or `commandType` ever contains a null byte, key collisions are possible.
  - **Mitigation**: Null byte isn't a valid character in either field (Zod schemas enforce `min(1)` non-empty strings; real IDs are UUIDs / enum values). Documented in a comment. If a future schema ever allows null bytes, the join should switch to a multi-byte separator or structured key.