### PR TITLE
feat: [ENG-2250] AutoHarness V2 cold-start integration test

### DIFF
--- a/test/integration/agent/harness/cold-start.test.ts
+++ b/test/integration/agent/harness/cold-start.test.ts
@@ -144,16 +144,26 @@ describe('AutoHarness V2 — cold-start integration (Phase 3 + Phase 4)', functi
 
   let tempDir: string
   let sb: SinonSandbox
+  let activeSandboxService: SandboxService | undefined
 
   beforeEach(() => {
     // `realpathSync` unwraps macOS `/var` → `/private/var` symlink so path
     // comparisons (e.g. warn-once keying on workingDirectory) stay stable.
     tempDir = realpathSync(mkdtempSync(join(tmpdir(), 'brv-cold-start-')))
     sb = createSandbox()
+    activeSandboxService = undefined
     _clearPolyglotWarningState()
   })
 
-  afterEach(() => {
+  afterEach(async () => {
+    // Mirror service-initializer's shutdown contract: clears session state
+    // and stops any background timers in the recorder. Benign for the
+    // current recorder but guards against future changes that hold live
+    // resources.
+    if (activeSandboxService !== undefined) {
+      await activeSandboxService.cleanup()
+    }
+
     sb.restore()
     rmSync(tempDir, {force: true, recursive: true})
   })
@@ -169,6 +179,7 @@ describe('AutoHarness V2 — cold-start integration (Phase 3 + Phase 4)', functi
       makeHarnessConfig(),
       new NoOpLogger(),
     )
+    activeSandboxService = sandboxService
 
     await bootstrap.bootstrapIfNeeded(PROJECT_ID, 'curate', tempDir)
 
@@ -194,11 +205,20 @@ describe('AutoHarness V2 — cold-start integration (Phase 3 + Phase 4)', functi
     )
     expect(exec.returnValue).to.equal(true)
 
-    // The recorder is fire-and-forget — wait for the background write.
-    await new Promise((resolve) => {
-      setTimeout(resolve, 500)
-    })
-    const outcomes = await harnessStore.listOutcomes(PROJECT_ID, 'curate', 10)
+    // The recorder is fire-and-forget — poll until the outcome lands
+    // rather than a flat sleep, so the test stays fast when the write
+    // completes in <50ms but doesn't false-negative on slow CI.
+    const deadline = Date.now() + 2000
+    let outcomes = await harnessStore.listOutcomes(PROJECT_ID, 'curate', 10)
+    while (outcomes.length === 0 && Date.now() < deadline) {
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise((r) => {
+        setTimeout(r, 50)
+      })
+      // eslint-disable-next-line no-await-in-loop
+      outcomes = await harnessStore.listOutcomes(PROJECT_ID, 'curate', 10)
+    }
+
     expect(outcomes.length).to.be.greaterThan(0)
   })
 
@@ -207,12 +227,13 @@ describe('AutoHarness V2 — cold-start integration (Phase 3 + Phase 4)', functi
   it('2. 100 parallel bootstrapIfNeeded on same pair → exactly 1 v1', async () => {
     writeFileSync(join(tempDir, 'tsconfig.json'), '{}')
 
-    const {bootstrap, harnessStore} = await createColdStartStack(
+    const {bootstrap, harnessStore, sandboxService} = await createColdStartStack(
       PROJECT_ID,
       tempDir,
       makeHarnessConfig(),
       new NoOpLogger(),
     )
+    activeSandboxService = sandboxService
 
     const calls: Array<Promise<void>> = []
     for (let i = 0; i < 100; i++) {
@@ -223,7 +244,9 @@ describe('AutoHarness V2 — cold-start integration (Phase 3 + Phase 4)', functi
 
     const versions = await harnessStore.listVersions(PROJECT_ID, 'curate')
     expect(versions.length).to.equal(1)
-    expect(versions[0].version).to.equal(1)
+    const [only] = versions
+    if (only === undefined) throw new Error('unreachable: length asserted above')
+    expect(only.version).to.equal(1)
   })
 
   // ── Scenario 3: polyglot → generic + warn-once ───────────────────────────
@@ -233,17 +256,20 @@ describe('AutoHarness V2 — cold-start integration (Phase 3 + Phase 4)', functi
     writeFileSync(join(tempDir, 'pyproject.toml'), '[project]\nname="x"\n')
 
     const spyLogger = makeSpyLogger(sb)
-    const {bootstrap, harnessStore} = await createColdStartStack(
+    const {bootstrap, harnessStore, sandboxService} = await createColdStartStack(
       PROJECT_ID,
       tempDir,
       makeHarnessConfig(),
       spyLogger,
     )
+    activeSandboxService = sandboxService
 
     await bootstrap.bootstrapIfNeeded(PROJECT_ID, 'curate', tempDir)
 
     const v1 = await harnessStore.getLatest(PROJECT_ID, 'curate')
-    expect(v1?.projectType).to.equal('generic')
+    expect(v1, 'bootstrap must have written v1').to.not.equal(undefined)
+    if (v1 === undefined) throw new Error('unreachable: chai asserted above')
+    expect(v1.projectType).to.equal('generic')
 
     // Warn fired exactly once with types listed + override path.
     const polyglotWarnCalls = spyLogger.warn.getCalls().filter((call) => {
@@ -251,10 +277,14 @@ describe('AutoHarness V2 — cold-start integration (Phase 3 + Phase 4)', functi
       return typeof msg === 'string' && /polyglot/i.test(msg)
     })
     expect(polyglotWarnCalls.length).to.equal(1)
-    const [warnMessage] = polyglotWarnCalls[0].args as [string]
-    expect(warnMessage).to.include('typescript')
-    expect(warnMessage).to.include('python')
-    expect(warnMessage).to.include('config.harness.language')
+    const rawMsg = polyglotWarnCalls[0].args[0]
+    if (typeof rawMsg !== 'string') {
+      throw new TypeError('expected warn message to be a string')
+    }
+
+    expect(rawMsg).to.include('typescript')
+    expect(rawMsg).to.include('python')
+    expect(rawMsg).to.include('config.harness.language')
 
     // Warn-once: second call on the same path should NOT re-warn.
     // Use a fresh bootstrap call but note that `getLatest` now returns v1
@@ -272,16 +302,19 @@ describe('AutoHarness V2 — cold-start integration (Phase 3 + Phase 4)', functi
     // be 'python'. The typescript value below proves override precedence.
     writeFileSync(join(tempDir, 'pyproject.toml'), '[project]\nname="x"\n')
 
-    const {bootstrap, harnessStore} = await createColdStartStack(
+    const {bootstrap, harnessStore, sandboxService} = await createColdStartStack(
       PROJECT_ID,
       tempDir,
       makeHarnessConfig({language: 'typescript'}),
       new NoOpLogger(),
     )
+    activeSandboxService = sandboxService
 
     await bootstrap.bootstrapIfNeeded(PROJECT_ID, 'curate', tempDir)
 
     const v1 = await harnessStore.getLatest(PROJECT_ID, 'curate')
-    expect(v1?.projectType).to.equal('typescript')
+    expect(v1, 'bootstrap must have written v1').to.not.equal(undefined)
+    if (v1 === undefined) throw new Error('unreachable: chai asserted above')
+    expect(v1.projectType).to.equal('typescript')
   })
 })

--- a/test/integration/agent/harness/cold-start.test.ts
+++ b/test/integration/agent/harness/cold-start.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Integration test — Phase 4 cold-start flow.
+ *
+ * Exercises Phase 3 + Phase 4 end to end with real components: fresh
+ * tmpdir → bootstrap fires → v1 lands in store → Phase 3 loader injects
+ * `harness.curate` → `executeCode` runs → outcome recorded by the
+ * recorder. Four scenarios:
+ *
+ *   1. First code_exec in a fresh TypeScript project.
+ *   2. 100 parallel bootstrapIfNeeded on the same pair → exactly one v1.
+ *   3. Polyglot project (tsconfig + pyproject) → generic + warn-once.
+ *   4. `config.language: 'typescript'` override beats a python-only repo.
+ *
+ * No stubs of harness internals: real `HarnessModuleBuilder`, real
+ * `HarnessStore` (`FileKeyStorage({inMemory: true})`), real
+ * `HarnessBootstrap`, real `SandboxService`. Only `ILogger` is stubbed
+ * in scenario 3 so warn messages can be inspected.
+ */
+
+import {expect} from 'chai'
+import {mkdtempSync, realpathSync, rmSync, writeFileSync} from 'node:fs'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+import {createSandbox, type SinonSandbox, type SinonStub} from 'sinon'
+
+import type {EnvironmentContext} from '../../../../src/agent/core/domain/environment/types.js'
+import type {ILogger} from '../../../../src/agent/core/interfaces/i-logger.js'
+import type {ValidatedHarnessConfig} from '../../../../src/agent/infra/agent/agent-schemas.js'
+
+import {NoOpLogger} from '../../../../src/agent/core/interfaces/i-logger.js'
+import {SessionEventBus} from '../../../../src/agent/infra/events/event-emitter.js'
+import {FileSystemService} from '../../../../src/agent/infra/file-system/file-system-service.js'
+import {_clearPolyglotWarningState} from '../../../../src/agent/infra/harness/detect-and-pick-template.js'
+import {
+  HarnessBootstrap,
+  HarnessModuleBuilder,
+  HarnessOutcomeRecorder,
+  HarnessStore,
+} from '../../../../src/agent/infra/harness/index.js'
+import {SandboxService} from '../../../../src/agent/infra/sandbox/sandbox-service.js'
+import {FileKeyStorage} from '../../../../src/agent/infra/storage/file-key-storage.js'
+
+const SESSION_ID = 'sess-1'
+
+// `FileKeyStorage` rejects path separators in key segments, so `projectId`
+// must be a slug. In production the recorder derives projectId from
+// `environmentContext.workingDirectory` — that path-to-key incompatibility
+// is a known gap tracked in outcome-collection.test.ts:32. For this test,
+// we set `workingDirectory = PROJECT_ID` (slug) on the EnvironmentContext
+// so recorder writes and bootstrap writes land in the same partition, and
+// pass the real tempDir as the DETECTION workingDirectory to
+// `bootstrap.bootstrapIfNeeded`. Once the slug/path gap is resolved, both
+// can unify on the real path.
+const PROJECT_ID = 'cold-start-test'
+
+function makeHarnessConfig(overrides?: Partial<ValidatedHarnessConfig>): ValidatedHarnessConfig {
+  return {
+    autoLearn: true,
+    enabled: true,
+    language: 'auto',
+    maxVersions: 20,
+    ...overrides,
+  }
+}
+
+function makeEnvironmentContext(workingDirectory: string): EnvironmentContext {
+  return {
+    brvStructure: '',
+    fileTree: '',
+    isGitRepository: false,
+    nodeVersion: process.version,
+    osVersion: 'test',
+    platform: process.platform,
+    workingDirectory,
+  }
+}
+
+function makeSpyLogger(sb: SinonSandbox): ILogger & {
+  debug: SinonStub
+  error: SinonStub
+  info: SinonStub
+  warn: SinonStub
+} {
+  return {
+    debug: sb.stub(),
+    error: sb.stub(),
+    info: sb.stub(),
+    warn: sb.stub(),
+  }
+}
+
+/**
+ * Wires the same component graph `service-initializer.ts` builds for
+ * the harness subsystem: FileSystemService → HarnessStore → builder →
+ * bootstrap → recorder → SandboxService. Real components throughout.
+ */
+async function createColdStartStack(
+  projectId: string,
+  detectionCwd: string,
+  config: ValidatedHarnessConfig,
+  logger: ILogger,
+): Promise<{
+  bootstrap: HarnessBootstrap
+  fileSystem: FileSystemService
+  harnessStore: HarnessStore
+  sandboxService: SandboxService
+}> {
+  const fileSystem = new FileSystemService({
+    allowedPaths: [detectionCwd],
+    workingDirectory: detectionCwd,
+  })
+  await fileSystem.initialize()
+
+  const keyStorage = new FileKeyStorage({inMemory: true})
+  await keyStorage.initialize()
+
+  const harnessStore = new HarnessStore(keyStorage, logger)
+  const builder = new HarnessModuleBuilder(logger)
+  const bootstrap = new HarnessBootstrap(harnessStore, fileSystem, config, logger)
+
+  const sandboxService = new SandboxService()
+  sandboxService.setHarnessConfig(config)
+  // EnvironmentContext.workingDirectory feeds `projectId` into the recorder
+  // (sandbox-service.ts:222). Use the slug so store keys are valid; the
+  // real tempDir stays on FileSystemService for detection.
+  sandboxService.setEnvironmentContext(makeEnvironmentContext(projectId))
+  sandboxService.setHarnessStore(harnessStore)
+  sandboxService.setHarnessModuleBuilder(builder)
+  sandboxService.setFileSystem(fileSystem)
+
+  const recorder = new HarnessOutcomeRecorder(
+    harnessStore,
+    new SessionEventBus(),
+    logger,
+    config,
+  )
+  sandboxService.setHarnessOutcomeRecorder(recorder, logger)
+
+  return {bootstrap, fileSystem, harnessStore, sandboxService}
+}
+
+describe('AutoHarness V2 — cold-start integration (Phase 3 + Phase 4)', function () {
+  this.timeout(15_000)
+
+  let tempDir: string
+  let sb: SinonSandbox
+
+  beforeEach(() => {
+    // `realpathSync` unwraps macOS `/var` → `/private/var` symlink so path
+    // comparisons (e.g. warn-once keying on workingDirectory) stay stable.
+    tempDir = realpathSync(mkdtempSync(join(tmpdir(), 'brv-cold-start-')))
+    sb = createSandbox()
+    _clearPolyglotWarningState()
+  })
+
+  afterEach(() => {
+    sb.restore()
+    rmSync(tempDir, {force: true, recursive: true})
+  })
+
+  // ── Scenario 1: fresh TS project — full cold-start flow ──────────────────
+
+  it('1. fresh TypeScript project: bootstrap → loadHarness → executeCode → outcome recorded', async () => {
+    writeFileSync(join(tempDir, 'tsconfig.json'), '{}')
+
+    const {bootstrap, harnessStore, sandboxService} = await createColdStartStack(
+      PROJECT_ID,
+      tempDir,
+      makeHarnessConfig(),
+      new NoOpLogger(),
+    )
+
+    await bootstrap.bootstrapIfNeeded(PROJECT_ID, 'curate', tempDir)
+
+    // v1 landed
+    const v1 = await harnessStore.getLatest(PROJECT_ID, 'curate')
+    expect(v1, 'bootstrap must have written v1').to.not.equal(undefined)
+    if (v1 === undefined) throw new Error('unreachable: chai asserted above')
+    expect(v1.projectType).to.equal('typescript')
+    expect(v1.version).to.equal(1)
+    // The typescript curate template declares the ts-specific patterns;
+    // the generic template uses ['**/*']. This check discriminates.
+    expect(v1.metadata.projectPatterns).to.include('tsconfig.json')
+
+    // Phase 3 loader sees the newly-written v1
+    const loadResult = await sandboxService.loadHarness(SESSION_ID, PROJECT_ID, 'curate')
+    expect(loadResult.loaded).to.equal(true)
+
+    // executeCode runs against the injected harness namespace
+    const exec = await sandboxService.executeCode(
+      `typeof harness !== 'undefined' && typeof harness.curate === 'function'`,
+      SESSION_ID,
+      {commandType: 'curate', taskDescription: 'cold-start-smoke'},
+    )
+    expect(exec.returnValue).to.equal(true)
+
+    // The recorder is fire-and-forget — wait for the background write.
+    await new Promise((resolve) => {
+      setTimeout(resolve, 500)
+    })
+    const outcomes = await harnessStore.listOutcomes(PROJECT_ID, 'curate', 10)
+    expect(outcomes.length).to.be.greaterThan(0)
+  })
+
+  // ── Scenario 2: idempotent bootstrap under 100-way concurrency ───────────
+
+  it('2. 100 parallel bootstrapIfNeeded on same pair → exactly 1 v1', async () => {
+    writeFileSync(join(tempDir, 'tsconfig.json'), '{}')
+
+    const {bootstrap, harnessStore} = await createColdStartStack(
+      PROJECT_ID,
+      tempDir,
+      makeHarnessConfig(),
+      new NoOpLogger(),
+    )
+
+    const calls: Array<Promise<void>> = []
+    for (let i = 0; i < 100; i++) {
+      calls.push(bootstrap.bootstrapIfNeeded(PROJECT_ID, 'curate', tempDir))
+    }
+
+    await Promise.all(calls)
+
+    const versions = await harnessStore.listVersions(PROJECT_ID, 'curate')
+    expect(versions.length).to.equal(1)
+    expect(versions[0].version).to.equal(1)
+  })
+
+  // ── Scenario 3: polyglot → generic + warn-once ───────────────────────────
+
+  it('3. polyglot repo: projectType=generic + warn-once with both types listed', async () => {
+    writeFileSync(join(tempDir, 'tsconfig.json'), '{}')
+    writeFileSync(join(tempDir, 'pyproject.toml'), '[project]\nname="x"\n')
+
+    const spyLogger = makeSpyLogger(sb)
+    const {bootstrap, harnessStore} = await createColdStartStack(
+      PROJECT_ID,
+      tempDir,
+      makeHarnessConfig(),
+      spyLogger,
+    )
+
+    await bootstrap.bootstrapIfNeeded(PROJECT_ID, 'curate', tempDir)
+
+    const v1 = await harnessStore.getLatest(PROJECT_ID, 'curate')
+    expect(v1?.projectType).to.equal('generic')
+
+    // Warn fired exactly once with types listed + override path.
+    const polyglotWarnCalls = spyLogger.warn.getCalls().filter((call) => {
+      const [msg] = call.args
+      return typeof msg === 'string' && /polyglot/i.test(msg)
+    })
+    expect(polyglotWarnCalls.length).to.equal(1)
+    const [warnMessage] = polyglotWarnCalls[0].args as [string]
+    expect(warnMessage).to.include('typescript')
+    expect(warnMessage).to.include('python')
+    expect(warnMessage).to.include('config.harness.language')
+
+    // Warn-once: second call on the same path should NOT re-warn.
+    // Use a fresh bootstrap call but note that `getLatest` now returns v1
+    // (idempotence short-circuits before reaching detection), so we need
+    // to exercise detection directly. The warn-once invariant is
+    // orthogonally tested in the Task 4.4 unit tests; here we confirm
+    // that ONE bootstrap call produces ONE warn, not multiple.
+  })
+
+  // ── Scenario 4: `config.language` override beats python-only detection ───
+
+  it('4. config.language=typescript beats python-only project detection', async () => {
+    // Fixture has ONLY pyproject.toml — detector would return ['python'].
+    // If the override is broken and detection runs, v1.projectType would
+    // be 'python'. The typescript value below proves override precedence.
+    writeFileSync(join(tempDir, 'pyproject.toml'), '[project]\nname="x"\n')
+
+    const {bootstrap, harnessStore} = await createColdStartStack(
+      PROJECT_ID,
+      tempDir,
+      makeHarnessConfig({language: 'typescript'}),
+      new NoOpLogger(),
+    )
+
+    await bootstrap.bootstrapIfNeeded(PROJECT_ID, 'curate', tempDir)
+
+    const v1 = await harnessStore.getLatest(PROJECT_ID, 'curate')
+    expect(v1?.projectType).to.equal('typescript')
+  })
+})


### PR DESCRIPTION
## Summary

- **Problem**: Unit tests cover each Phase 3 + Phase 4 seam in isolation but nothing has verified the full cold-start flow end to end. A contract mismatch between the bootstrap, the module builder, and the loader could hide behind green unit tests.
- **Why it matters**: The Phase 4 ship gate. Unlike Phase 3 where isolation tests guard security (`isolation.test.ts`), this test guards the "feature actually works end to end" invariant. A failure here almost certainly points at a seam — either `service-initializer.ts` wiring or a Phase 3 ↔ Phase 4 contract drift.
- **What changed**: Adds `test/integration/agent/harness/cold-start.test.ts` with 4 scenarios using real components throughout (real `HarnessStore` / `HarnessModuleBuilder` / `HarnessBootstrap` / `SandboxService`, `FileSystemService` + `FileKeyStorage({inMemory: true})`).
- **What did NOT change (scope boundary)**: No source code changes. No refinement-triggering logic (Phase 6). No mode selection (Phase 5). No Phase 5 wiring of bootstrap into the agent flow — the test calls `bootstrap.bootstrapIfNeeded(...)` explicitly, which is what Phase 5 will eventually do automatically.

## Type of change

- [x] Test

## Scope (select all touched areas)

- [x] Agent / Tools

## Linked issues

- Closes ENG-2250
- Depends on (all merged): ENG-2238/2239/2240/2241/2243 (Phase 3), ENG-2246 (Task 4.1), ENG-2247 (Task 4.3), ENG-2248 (Task 4.4), ENG-2249 (Task 4.2)
- **Closes Phase 4.** Phase 5 (mode selector + prompt) is the next ship.

## Root cause (bug fixes only, otherwise write `N/A`)

N/A

## Test plan

- Coverage added:
  - [x] Integration test
- Test file(s): `test/integration/agent/harness/cold-start.test.ts`
- Key scenario(s) covered:
  1. **Fresh TypeScript project** — touch `tsconfig.json` → `bootstrap.bootstrapIfNeeded` → v1 lands with `projectType: 'typescript'` and ts-specific `projectPatterns` → `sandboxService.loadHarness` returns `{loaded: true}` → `executeCode` sees injected `harness.curate` → recorder lands an outcome in `listOutcomes`.
  2. **100 parallel bootstraps on same pair** → exactly 1 v1 in store. Uses real `HarnessStore` + `FileKeyStorage({inMemory: true})` — proves the single-flight invariant from Task 4.2 holds against the real store.
  3. **Polyglot repo** (both `tsconfig.json` + `pyproject.toml`) → `projectType: 'generic'` + a warn whose message contains both `'typescript'`, `'python'`, and the override path text `config.harness.language`. Uses a spied `ILogger` to inspect warn calls.
  4. **Override precedence** — fixture has ONLY `pyproject.toml` (detector would say Python). Config sets `language: 'typescript'`. Final v1 has `projectType: 'typescript'`. If the override path accidentally ran detection and used its result, test 4 would fail loudly.

## User-visible changes

None. Test-only.

## Evidence

- [x] Failing test/log before + passing after

```
$ npx mocha --forbid-only 'test/integration/agent/harness/cold-start.test.ts'
  AutoHarness V2 — cold-start integration (Phase 3 + Phase 4)
    ✔ 1. fresh TypeScript project: bootstrap → loadHarness → executeCode → outcome recorded (551ms)
    ✔ 2. 100 parallel bootstrapIfNeeded on same pair → exactly 1 v1
    ✔ 3. polyglot repo: projectType=generic + warn-once with both types listed
    ✔ 4. config.language=typescript beats python-only project detection

  4 passing (559ms)

$ npx mocha --forbid-only 'test/unit/agent/harness/**/*.test.ts' 'test/integration/agent/harness/**/*.test.ts'
  205 passing (29s)
```

**Runtime: 559ms** (spec budget: <5s).

## Checklist

- [x] Tests added or updated and passing
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow Conventional Commits format
- [ ] Documentation updated — N/A (test-only)
- [x] No breaking changes
- [x] Branch is up to date with `proj/autoharness-v2`

## Risks and mitigations

- **Risk: Slug/path gap workaround surfaces in the test** — `FileKeyStorage` rejects path separators in key segments, but the recorder derives `projectId` from `environmentContext.workingDirectory` (sandbox-service.ts:222), which is a full filesystem path. Direct use of `tempDir` as both projectId AND workingDirectory fails key validation.
  - **Mitigation**: Decoupled in the test helper — `projectId` is a slug (`'cold-start-test'`) set as `workingDirectory` on the `EnvironmentContext` for recorder compatibility, while the real tempDir is passed as the DETECTION working directory on `FileSystemService` and `bootstrap.bootstrapIfNeeded`. Mirrors the existing workaround in `outcome-collection.test.ts:32`. Resolving the slug/path gap is out of scope; when it lands, both can unify on the real path.

- **Risk: Warn-once invariant only partially exercised here** — after Task 4.2's guard reorder (PR #506 review fix), `getLatest` short-circuits before reaching detection on the second `bootstrapIfNeeded` call on the same pair. So a bootstrap-level warn-once test can only verify "one bootstrap → one warn".
  - **Mitigation**: Documented inline in test 3. Task 4.4 unit tests 6 and 7 cover the cross-call warn-once invariant by calling `detectAndPickTemplate` directly, bypassing the bootstrap guard. Sufficient coverage across layers.

- **Risk: Phase 5 wiring of bootstrap into the agent flow doesn't exist yet** — the test calls `bootstrap.bootstrapIfNeeded(...)` explicitly, but the production call site will live in `AgentLLMService` (Phase 5).
  - **Mitigation**: The explicit call in the test still exercises every seam from bootstrap to outcome. Phase 5 wiring is the remaining work, tracked separately; this test is sufficient as Phase 4's ship gate.

- **Risk: Integration test adds ~560ms to CI** — modest, but non-zero.
  - **Mitigation**: Well under the 5s budget. `FileKeyStorage({inMemory: true})` keeps disk I/O out of the critical path. If CI time becomes an issue, scenarios 2-4 could be split into a separate file run in parallel.