### PR TITLE
feat: [ENG-2254] AutoHarness V2 mode selector

### DIFF
--- a/src/agent/infra/harness/harness-mode-selector.ts
+++ b/src/agent/infra/harness/harness-mode-selector.ts
@@ -1,0 +1,33 @@
+import type {HarnessMode} from '../../core/domain/harness/types.js'
+import type {ValidatedHarnessConfig} from '../agent/agent-schemas.js'
+
+export interface ModeSelection {
+  readonly mode: HarnessMode
+  readonly source: 'heuristic' | 'override'
+}
+
+// Thresholds per v1-design-decisions.md §2.2. Inclusive at the floor —
+// matches the heuristic helper's inclusive semantics for realHarnessRate.
+const MODE_C_FLOOR = 0.85
+const MODE_B_FLOOR = 0.6
+const MODE_A_FLOOR = 0.3
+
+/**
+ * Select the harness mode from a heuristic value and config. Returns
+ * `undefined` when heuristic is below Mode A's floor AND no override
+ * is set — callers should then leave the harness uninjected.
+ */
+export function selectHarnessMode(
+  heuristic: number,
+  config: ValidatedHarnessConfig,
+): ModeSelection | undefined {
+  if (config.modeOverride !== undefined) {
+    return {mode: config.modeOverride, source: 'override'}
+  }
+
+  if (heuristic >= MODE_C_FLOOR) return {mode: 'policy', source: 'heuristic'}
+  if (heuristic >= MODE_B_FLOOR) return {mode: 'filter', source: 'heuristic'}
+  if (heuristic >= MODE_A_FLOOR) return {mode: 'assisted', source: 'heuristic'}
+
+  return undefined
+}

--- a/test/unit/agent/harness/harness-mode-selector.test.ts
+++ b/test/unit/agent/harness/harness-mode-selector.test.ts
@@ -1,0 +1,109 @@
+import {expect} from 'chai'
+
+import type {ValidatedHarnessConfig} from '../../../../src/agent/infra/agent/agent-schemas.js'
+
+import {selectHarnessMode} from '../../../../src/agent/infra/harness/harness-mode-selector.js'
+
+function makeConfig(overrides: Partial<ValidatedHarnessConfig> = {}): ValidatedHarnessConfig {
+  return {
+    autoLearn: true,
+    enabled: true,
+    language: 'auto',
+    maxVersions: 20,
+    ...overrides,
+  }
+}
+
+// Deterministic LCG used by the property test — keeps the seed stable
+// across runs so a drift in the threshold table fails identically on
+// every machine. Constants from Numerical Recipes.
+function lcg(seed: number): () => number {
+  let state = seed
+  return () => {
+    state = (state * 1_664_525 + 1_013_904_223) % 2 ** 32
+    return state / 2 ** 32
+  }
+}
+
+describe('selectHarnessMode', () => {
+  // ── Heuristic-driven threshold boundaries ────────────────────────────────
+
+  it('1. heuristic=0.29 (just below Mode A) returns undefined', () => {
+    expect(selectHarnessMode(0.29, makeConfig())).to.equal(undefined)
+  })
+
+  it('2. heuristic=0.30 (Mode A floor) returns assisted', () => {
+    expect(selectHarnessMode(0.3, makeConfig())).to.deep.equal({
+      mode: 'assisted',
+      source: 'heuristic',
+    })
+  })
+
+  it('3. heuristic=0.59 (just below Mode B) returns assisted', () => {
+    expect(selectHarnessMode(0.59, makeConfig())).to.deep.equal({
+      mode: 'assisted',
+      source: 'heuristic',
+    })
+  })
+
+  it('4. heuristic=0.60 (Mode B floor) returns filter', () => {
+    expect(selectHarnessMode(0.6, makeConfig())).to.deep.equal({
+      mode: 'filter',
+      source: 'heuristic',
+    })
+  })
+
+  it('5. heuristic=0.84 (just below Mode C) returns filter', () => {
+    expect(selectHarnessMode(0.84, makeConfig())).to.deep.equal({
+      mode: 'filter',
+      source: 'heuristic',
+    })
+  })
+
+  it('6. heuristic=0.85 (Mode C floor) returns policy', () => {
+    expect(selectHarnessMode(0.85, makeConfig())).to.deep.equal({
+      mode: 'policy',
+      source: 'heuristic',
+    })
+  })
+
+  it('7. heuristic=1.00 (top) returns policy', () => {
+    expect(selectHarnessMode(1, makeConfig())).to.deep.equal({
+      mode: 'policy',
+      source: 'heuristic',
+    })
+  })
+
+  // ── Override semantics ──────────────────────────────────────────────────
+
+  it('8. modeOverride=policy + heuristic=0.05 returns policy/override', () => {
+    expect(
+      selectHarnessMode(0.05, makeConfig({modeOverride: 'policy'})),
+    ).to.deep.equal({mode: 'policy', source: 'override'})
+  })
+
+  it('9. modeOverride=assisted + heuristic=0.95 returns assisted/override', () => {
+    expect(
+      selectHarnessMode(0.95, makeConfig({modeOverride: 'assisted'})),
+    ).to.deep.equal({mode: 'assisted', source: 'override'})
+  })
+
+  // ── Property test (drift guard) ─────────────────────────────────────────
+
+  it('10. property test: 100 random heuristics honor the threshold table', () => {
+    const rand = lcg(42) // stable seed — reproducible across runs
+    for (let i = 0; i < 100; i++) {
+      const h = rand()
+      const result = selectHarnessMode(h, makeConfig())
+      if (h < 0.3) {
+        expect(result, `h=${h}`).to.equal(undefined)
+      } else if (h < 0.6) {
+        expect(result, `h=${h}`).to.deep.equal({mode: 'assisted', source: 'heuristic'})
+      } else if (h < 0.85) {
+        expect(result, `h=${h}`).to.deep.equal({mode: 'filter', source: 'heuristic'})
+      } else {
+        expect(result, `h=${h}`).to.deep.equal({mode: 'policy', source: 'heuristic'})
+      }
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- **Problem**: Phase 4 landed the cold-start flow, but the sandbox still can't choose *how* the LLM + harness should collaborate. Every session currently runs the same injection regardless of the learned harness's trustworthiness.
- **Why it matters**: Foundational seam for Phase 5. Task 5.2 (prompt contributor), Task 5.4 (agent wiring), and Phase 6 Evaluator all depend on `HarnessMode` being selectable from the heuristic.
- **What changed**: Ships `selectHarnessMode(heuristic, config): ModeSelection | undefined` — a pure function that maps H to `'assisted' | 'filter' | 'policy'` per the v1-design-decisions §2.2 threshold table. `config.modeOverride` wins over H.
- **What did NOT change (scope boundary)**: No agent wiring (Task 5.4). No prompt generation (Task 5.2). No safety caps (Task 5.3). No event emission. No persistence. Just the pure threshold mapping.

## Type of change

- [x] New feature

## Scope (select all touched areas)

- [x] Agent / Tools

## Linked issues

- Closes ENG-2254
- Related: ENG-2255 (Task 5.2 prompt contributor), ENG-2256 (Task 5.3 Mode C caps), ENG-2257 (Task 5.4 agent wiring)

## Root cause (bug fixes only, otherwise write `N/A`)

N/A

## Test plan

- Coverage added:
  - [x] Unit test
- Test file(s): `test/unit/agent/harness/harness-mode-selector.test.ts`
- Key scenario(s) covered (10 tests):
  1. `heuristic=0.29` (just below Mode A) → `undefined`
  2. `heuristic=0.30` (Mode A floor) → `assisted`
  3. `heuristic=0.59` (just below Mode B) → `assisted`
  4. `heuristic=0.60` (Mode B floor) → `filter`
  5. `heuristic=0.84` (just below Mode C) → `filter`
  6. `heuristic=0.85` (Mode C floor) → `policy`
  7. `heuristic=1.00` (top) → `policy`
  8. `modeOverride=policy` + low H → `policy/override`
  9. `modeOverride=assisted` + high H → `assisted/override`
  10. Property test — 100 LCG-seeded random heuristics honor the threshold table

## User-visible changes

None. Internal building block consumed by downstream Phase 5 tasks.

## Evidence

- [x] Failing test/log before + passing after

```
$ npx mocha --forbid-only 'test/unit/agent/harness/harness-mode-selector.test.ts'
  selectHarnessMode
    ✔ 1. heuristic=0.29 (just below Mode A) returns undefined
    ✔ 2. heuristic=0.30 (Mode A floor) returns assisted
    ✔ 3. heuristic=0.59 (just below Mode B) returns assisted
    ✔ 4. heuristic=0.60 (Mode B floor) returns filter
    ✔ 5. heuristic=0.84 (just below Mode C) returns filter
    ✔ 6. heuristic=0.85 (Mode C floor) returns policy
    ✔ 7. heuristic=1.00 (top) returns policy
    ✔ 8. modeOverride=policy + heuristic=0.05 returns policy/override
    ✔ 9. modeOverride=assisted + heuristic=0.95 returns assisted/override
    ✔ 10. property test: 100 random heuristics honor the threshold table

  10 passing (8ms)
```

## Checklist

- [x] Tests added or updated and passing
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow Conventional Commits format
- [ ] Documentation updated — N/A (internal)
- [x] No breaking changes
- [x] Branch is up to date with `proj/autoharness-v2`

## Risks and mitigations

- **Risk: Threshold values are load-bearing constants** — flipping any to strict inequality or to a different floor changes the mode boundary for every user.
  - **Mitigation**: Tests 1-7 pin the exact boundary behavior (both just-below and at-floor). Test 10 is a property test with a stable LCG seed — any drift in the threshold table fails identically on every machine. Reviewers should reject any threshold nudge without a paper-trail design doc update.

- **Risk: `ModeSelection | undefined` return type is unusual** — some readers may expect a default mode instead of `undefined`.
  - **Mitigation**: The task doc explains why: below-threshold H is a legitimate "don't inject harness" signal, not an error. Task 5.4 (wiring) explicitly handles the `undefined` path.

- **Risk: Override path doesn't validate the override value** — trusting `config.modeOverride` as-is.
  - **Mitigation**: `HarnessConfigSchema.modeOverride` (Phase 0) already validates against the enum at config-load time. Re-validating here would be a layering violation.