### PR TITLE
feat: [ENG-2255] AutoHarness V2 prompt contributor

### DIFF
--- a/src/agent/infra/harness/harness-prompt-contributor.ts
+++ b/src/agent/infra/harness/harness-prompt-contributor.ts
@@ -18,8 +18,8 @@ const MODE_BODIES: Readonly<Record<HarnessMode, string>> = {
 
   filter: [
     'A `harness.curate(ctx)` function is available for curate tasks here.',
-    'When the task fits the harness, state your plan briefly and then invoke `harness.curate(ctx)`.',
-    'If the harness approach does not fit this task, write your own orchestration instead.',
+    'It has been validated on recent invocations and is a strong default for this request.',
+    'Review it against the task; invoke `harness.curate(ctx)` if suitable, or write your own orchestration only if you see a specific reason the harness does not fit.',
   ].join(' '),
 
   policy: [
@@ -27,6 +27,19 @@ const MODE_BODIES: Readonly<Record<HarnessMode, string>> = {
     'For this request, invoke `harness.curate(ctx)` directly.',
     'Do NOT write your own orchestration code — the harness handles this end to end.',
   ].join(' '),
+}
+
+// Version ids come from `randomUUID()` today (Phase 4 Task 4.2) and
+// contain only `[0-9a-f-]+`, so escaping is belt-and-braces. Included
+// anyway because downstream (Phase 7 CLI debug) parses these tags and
+// the cost of silent malformed output would be much higher than a few
+// string replacements.
+function escapeXmlAttribute(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
 }
 
 /**
@@ -40,5 +53,6 @@ export function contributeHarnessPrompt(ctx?: PromptContributionContext): string
   if (ctx === undefined) return ''
 
   const body = MODE_BODIES[ctx.mode]
-  return `<harness-v2 mode="${ctx.mode}" version="${ctx.version.id}">\n${body}\n</harness-v2>`
+  const safeVersionId = escapeXmlAttribute(ctx.version.id)
+  return `<harness-v2 mode="${ctx.mode}" version="${safeVersionId}">\n${body}\n</harness-v2>`
 }

--- a/src/agent/infra/harness/harness-prompt-contributor.ts
+++ b/src/agent/infra/harness/harness-prompt-contributor.ts
@@ -1,0 +1,44 @@
+import type {HarnessMode, HarnessVersion} from '../../core/domain/harness/types.js'
+
+export interface PromptContributionContext {
+  readonly mode: HarnessMode
+  readonly version: HarnessVersion
+}
+
+// Per-mode body text. Kept short on purpose — each block ≤ 400 chars
+// advisory, ≤ 600 hard ceiling in tests — because this text lands on
+// every turn's system prompt. Longer bodies burn context without
+// improving weak-model behavior.
+const MODE_BODIES: Readonly<Record<HarnessMode, string>> = {
+  assisted: [
+    'A learned `harness.curate(ctx)` function is available for curate tasks in this project.',
+    'It has been validated on recent invocations; call it when the task is a clean match for curate.',
+    'For tasks that don\'t fit, orchestrate with `tools.*` as usual.',
+  ].join(' '),
+
+  filter: [
+    'A `harness.curate(ctx)` function is available for curate tasks here.',
+    'When the task fits the harness, state your plan briefly and then invoke `harness.curate(ctx)`.',
+    'If the harness approach does not fit this task, write your own orchestration instead.',
+  ].join(' '),
+
+  policy: [
+    'This project has a proven `harness.curate(ctx)` for curate tasks.',
+    'For this request, invoke `harness.curate(ctx)` directly.',
+    'Do NOT write your own orchestration code — the harness handles this end to end.',
+  ].join(' '),
+}
+
+/**
+ * Render the mode-specific harness prompt block. Returns an empty
+ * string when `ctx` is `undefined` (harness disabled, below Mode A
+ * threshold, or no version in store). Block is wrapped in identifiable
+ * `<harness-v2 …>` tags so a downstream prompt assembler can locate or
+ * strip it.
+ */
+export function contributeHarnessPrompt(ctx?: PromptContributionContext): string {
+  if (ctx === undefined) return ''
+
+  const body = MODE_BODIES[ctx.mode]
+  return `<harness-v2 mode="${ctx.mode}" version="${ctx.version.id}">\n${body}\n</harness-v2>`
+}

--- a/src/agent/infra/harness/harness-prompt-contributor.ts
+++ b/src/agent/infra/harness/harness-prompt-contributor.ts
@@ -17,9 +17,9 @@ const MODE_BODIES: Readonly<Record<HarnessMode, string>> = {
   ].join(' '),
 
   filter: [
-    'A `harness.curate(ctx)` function is available for curate tasks here.',
-    'It has been validated on recent invocations and is a strong default for this request.',
-    'Review it against the task; invoke `harness.curate(ctx)` if suitable, or write your own orchestration only if you see a specific reason the harness does not fit.',
+    'A validated `harness.curate(ctx)` function is available for curate tasks here.',
+    'Invoke it to obtain the harness\'s proposed result, then review the returned value before treating it as final.',
+    'Prefer the harness\'s proposal unless you identify a specific issue with the output; only then adjust or replace it.',
   ].join(' '),
 
   policy: [
@@ -53,6 +53,9 @@ export function contributeHarnessPrompt(ctx?: PromptContributionContext): string
   if (ctx === undefined) return ''
 
   const body = MODE_BODIES[ctx.mode]
+  // `ctx.mode` is safe unescaped: `HarnessMode` is a Zod enum constrained
+  // to `'assisted' | 'filter' | 'policy'`, none of which contain XML
+  // specials. Version id is escaped as defense-in-depth — see below.
   const safeVersionId = escapeXmlAttribute(ctx.version.id)
   return `<harness-v2 mode="${ctx.mode}" version="${safeVersionId}">\n${body}\n</harness-v2>`
 }

--- a/test/unit/agent/harness/harness-prompt-contributor.test.ts
+++ b/test/unit/agent/harness/harness-prompt-contributor.test.ts
@@ -5,6 +5,7 @@ import type {
   HarnessVersion,
 } from '../../../../src/agent/core/domain/harness/types.js'
 
+import {HarnessModeSchema} from '../../../../src/agent/core/domain/harness/types.js'
 import {
   contributeHarnessPrompt,
   type PromptContributionContext,
@@ -44,7 +45,7 @@ A learned \`harness.curate(ctx)\` function is available for curate tasks in this
 </harness-v2>`
 
 const SNAPSHOT_FILTER = `<harness-v2 mode="filter" version="v-test-123">
-A \`harness.curate(ctx)\` function is available for curate tasks here. When the task fits the harness, state your plan briefly and then invoke \`harness.curate(ctx)\`. If the harness approach does not fit this task, write your own orchestration instead.
+A \`harness.curate(ctx)\` function is available for curate tasks here. It has been validated on recent invocations and is a strong default for this request. Review it against the task; invoke \`harness.curate(ctx)\` if suitable, or write your own orchestration only if you see a specific reason the harness does not fit.
 </harness-v2>`
 
 const SNAPSHOT_POLICY = `<harness-v2 mode="policy" version="v-test-123">
@@ -67,11 +68,15 @@ describe('contributeHarnessPrompt', () => {
     expect(out.length).to.be.at.most(600)
   })
 
-  it('3. Mode B mentions propose/plan workflow, ≤ 600 chars', () => {
+  it('3. Mode B positions harness as a reviewable default, ≤ 600 chars', () => {
+    // Per types.ts line 30: filter = "LLM reviews proposals from the
+    // harness". The body must position the harness as the proposal
+    // and the LLM as the reviewer — NOT the other way around.
     const out = contributeHarnessPrompt(makeCtx('filter'))
     expect(out).to.include('<harness-v2 mode="filter"')
-    expect(out).to.match(/plan|propose/i)
     expect(out).to.include('harness.curate(')
+    expect(out).to.match(/review/i)
+    expect(out).to.match(/default|strong/i)
     expect(out.length).to.be.at.most(600)
   })
 
@@ -87,8 +92,10 @@ describe('contributeHarnessPrompt', () => {
 
   // ── Version id attribute ──────────────────────────────────────────────────
 
-  it('5. version id appears in the opening tag for all three modes', () => {
-    for (const mode of ['assisted', 'filter', 'policy'] as const) {
+  it('5. version id appears in the opening tag for every HarnessMode', () => {
+    // Iterate over the schema's options rather than a hardcoded list
+    // so a new mode added to the enum is automatically covered.
+    for (const mode of HarnessModeSchema.options) {
       const out = contributeHarnessPrompt(makeCtx(mode))
       expect(out, `mode=${mode}`).to.include(`version="${TEST_VERSION_ID}"`)
     }
@@ -114,5 +121,21 @@ describe('contributeHarnessPrompt', () => {
     const first = contributeHarnessPrompt(makeCtx('assisted'))
     const second = contributeHarnessPrompt(makeCtx('assisted'))
     expect(first).to.equal(second)
+  })
+
+  // ── XML-attribute safety ─────────────────────────────────────────────────
+
+  it('8. version id with special characters is escaped in the tag', () => {
+    // Version ids are randomUUID() in production today (always safe)
+    // but this is defense-in-depth for a future where ids come from
+    // elsewhere. Phase 7 CLI will parse these tags; malformed XML
+    // would break silently without this escape.
+    const version = {...makeVersion(), id: 'v-"broken&<>'}
+    const out = contributeHarnessPrompt({mode: 'assisted', version})
+
+    // The raw specials must NOT appear in the emitted attribute.
+    expect(out).to.not.include('v-"broken')
+    // Expected encoded form:
+    expect(out).to.include('version="v-&quot;broken&amp;&lt;&gt;"')
   })
 })

--- a/test/unit/agent/harness/harness-prompt-contributor.test.ts
+++ b/test/unit/agent/harness/harness-prompt-contributor.test.ts
@@ -1,0 +1,118 @@
+import {expect} from 'chai'
+
+import type {
+  HarnessMode,
+  HarnessVersion,
+} from '../../../../src/agent/core/domain/harness/types.js'
+
+import {
+  contributeHarnessPrompt,
+  type PromptContributionContext,
+} from '../../../../src/agent/infra/harness/harness-prompt-contributor.js'
+
+const TEST_VERSION_ID = 'v-test-123'
+
+function makeVersion(): HarnessVersion {
+  return {
+    code: '/* placeholder */',
+    commandType: 'curate',
+    createdAt: 1_700_000_000_000,
+    heuristic: 0.45,
+    id: TEST_VERSION_ID,
+    metadata: {
+      capabilities: ['curate'],
+      commandType: 'curate',
+      projectPatterns: ['**/*.ts'],
+      version: 1,
+    },
+    projectId: 'p1',
+    projectType: 'typescript',
+    version: 1,
+  }
+}
+
+function makeCtx(mode: HarnessMode): PromptContributionContext {
+  return {mode, version: makeVersion()}
+}
+
+// Inline snapshot constants — avoids a new `chai-snapshot` devDep per
+// the repo's dependency-minimization policy. If any of these change,
+// the test fails with a clear diff and the reviewer must explicitly
+// accept the new wording.
+const SNAPSHOT_ASSISTED = `<harness-v2 mode="assisted" version="v-test-123">
+A learned \`harness.curate(ctx)\` function is available for curate tasks in this project. It has been validated on recent invocations; call it when the task is a clean match for curate. For tasks that don't fit, orchestrate with \`tools.*\` as usual.
+</harness-v2>`
+
+const SNAPSHOT_FILTER = `<harness-v2 mode="filter" version="v-test-123">
+A \`harness.curate(ctx)\` function is available for curate tasks here. When the task fits the harness, state your plan briefly and then invoke \`harness.curate(ctx)\`. If the harness approach does not fit this task, write your own orchestration instead.
+</harness-v2>`
+
+const SNAPSHOT_POLICY = `<harness-v2 mode="policy" version="v-test-123">
+This project has a proven \`harness.curate(ctx)\` for curate tasks. For this request, invoke \`harness.curate(ctx)\` directly. Do NOT write your own orchestration code — the harness handles this end to end.
+</harness-v2>`
+
+describe('contributeHarnessPrompt', () => {
+  // ── Empty path ────────────────────────────────────────────────────────────
+
+  it('1. undefined context returns empty string', () => {
+    expect(contributeHarnessPrompt()).to.equal('')
+  })
+
+  // ── Mode-specific structure ──────────────────────────────────────────────
+
+  it('2. Mode A contains assisted tag + harness.curate reference, ≤ 600 chars', () => {
+    const out = contributeHarnessPrompt(makeCtx('assisted'))
+    expect(out).to.include('<harness-v2 mode="assisted"')
+    expect(out).to.include('harness.curate(')
+    expect(out.length).to.be.at.most(600)
+  })
+
+  it('3. Mode B mentions propose/plan workflow, ≤ 600 chars', () => {
+    const out = contributeHarnessPrompt(makeCtx('filter'))
+    expect(out).to.include('<harness-v2 mode="filter"')
+    expect(out).to.match(/plan|propose/i)
+    expect(out).to.include('harness.curate(')
+    expect(out.length).to.be.at.most(600)
+  })
+
+  it('4. Mode C instructs autonomous call + forbids own orchestration, ≤ 600 chars', () => {
+    const out = contributeHarnessPrompt(makeCtx('policy'))
+    expect(out).to.include('<harness-v2 mode="policy"')
+    expect(out).to.include('harness.curate(')
+    // The "don't write your own" instruction is the load-bearing
+    // Mode C directive — weak models tend to ignore it; pin it here.
+    expect(out).to.match(/do not|don['’]t/i)
+    expect(out.length).to.be.at.most(600)
+  })
+
+  // ── Version id attribute ──────────────────────────────────────────────────
+
+  it('5. version id appears in the opening tag for all three modes', () => {
+    for (const mode of ['assisted', 'filter', 'policy'] as const) {
+      const out = contributeHarnessPrompt(makeCtx(mode))
+      expect(out, `mode=${mode}`).to.include(`version="${TEST_VERSION_ID}"`)
+    }
+  })
+
+  // ── Snapshot tests (drift catchers) ──────────────────────────────────────
+
+  it('6a. Mode A output matches snapshot', () => {
+    expect(contributeHarnessPrompt(makeCtx('assisted'))).to.equal(SNAPSHOT_ASSISTED)
+  })
+
+  it('6b. Mode B output matches snapshot', () => {
+    expect(contributeHarnessPrompt(makeCtx('filter'))).to.equal(SNAPSHOT_FILTER)
+  })
+
+  it('6c. Mode C output matches snapshot', () => {
+    expect(contributeHarnessPrompt(makeCtx('policy'))).to.equal(SNAPSHOT_POLICY)
+  })
+
+  // ── Stability ─────────────────────────────────────────────────────────────
+
+  it('7. Mode A output is stable across calls', () => {
+    const first = contributeHarnessPrompt(makeCtx('assisted'))
+    const second = contributeHarnessPrompt(makeCtx('assisted'))
+    expect(first).to.equal(second)
+  })
+})

--- a/test/unit/agent/harness/harness-prompt-contributor.test.ts
+++ b/test/unit/agent/harness/harness-prompt-contributor.test.ts
@@ -45,7 +45,7 @@ A learned \`harness.curate(ctx)\` function is available for curate tasks in this
 </harness-v2>`
 
 const SNAPSHOT_FILTER = `<harness-v2 mode="filter" version="v-test-123">
-A \`harness.curate(ctx)\` function is available for curate tasks here. It has been validated on recent invocations and is a strong default for this request. Review it against the task; invoke \`harness.curate(ctx)\` if suitable, or write your own orchestration only if you see a specific reason the harness does not fit.
+A validated \`harness.curate(ctx)\` function is available for curate tasks here. Invoke it to obtain the harness's proposed result, then review the returned value before treating it as final. Prefer the harness's proposal unless you identify a specific issue with the output; only then adjust or replace it.
 </harness-v2>`
 
 const SNAPSHOT_POLICY = `<harness-v2 mode="policy" version="v-test-123">
@@ -68,15 +68,20 @@ describe('contributeHarnessPrompt', () => {
     expect(out.length).to.be.at.most(600)
   })
 
-  it('3. Mode B positions harness as a reviewable default, ≤ 600 chars', () => {
-    // Per types.ts line 30: filter = "LLM reviews proposals from the
-    // harness". The body must position the harness as the proposal
-    // and the LLM as the reviewer — NOT the other way around.
+  it('3. Mode B frames harness output as the proposal and LLM as reviewer, ≤ 600 chars', () => {
+    // Authoritative source: v1-design-decisions.md §2.2 and types.ts
+    // line 30 both say filter = "LLM reviews harness proposals". The
+    // harness is PROPOSING; the LLM is REVIEWING the output. Pin the
+    // harness-first framing to catch any drift back to LLM-first.
     const out = contributeHarnessPrompt(makeCtx('filter'))
     expect(out).to.include('<harness-v2 mode="filter"')
     expect(out).to.include('harness.curate(')
+    // Harness-first: "invoke…obtain…" directs the LLM to call first.
+    expect(out).to.match(/invoke|obtain|call/i)
+    // Review-after semantics: reviewing must apply to the RETURNED
+    // VALUE / RESULT / PROPOSAL, not to the task upfront.
+    expect(out).to.match(/result|proposal|returned/i)
     expect(out).to.match(/review/i)
-    expect(out).to.match(/default|strong/i)
     expect(out.length).to.be.at.most(600)
   })
 


### PR DESCRIPTION
## Summary

- **Problem**: Task 5.1 picks a mode, but nothing yet renders a prompt block that tells the LLM what to do with that mode. Without mode-specific prompting, the LLM can't differentiate "call the harness as helper" (Mode A) from "just call the harness" (Mode C).
- **Why it matters**: The system-prompt block is the primary behavior lever — weak models in particular follow the prompt more than they inspect the harness module. Mode-awareness at the prompt layer is what makes Mode C autonomous in practice.
- **What changed**: Ships `contributeHarnessPrompt(ctx?): string` — pure function that returns the mode-specific body wrapped in `<harness-v2 mode="..." version="...">` tags, or an empty string when harness is absent/disabled.
- **What did NOT change (scope boundary)**: No prompt-assembly wiring into `AgentLLMService` (Task 5.4). No mode selection (Task 5.1, already merged). No Mode C caps (Task 5.3). No event emission.

## Type of change

- [x] New feature

## Scope (select all touched areas)

- [x] Agent / Tools

## Linked issues

- Closes ENG-2255
- Related: ENG-2254 (Task 5.1 mode selector — merged, provides `HarnessMode`), ENG-2256 (Task 5.3 Mode C caps), ENG-2257 (Task 5.4 agent wiring — consumes this)

## Root cause (bug fixes only, otherwise write `N/A`)

N/A

## Test plan

- Coverage added:
  - [x] Unit test
- Test file(s): `test/unit/agent/harness/harness-prompt-contributor.test.ts`
- Key scenario(s) covered (9 tests):
  1. `undefined` → empty string
  2. Mode A: contains `<harness-v2 mode="assisted"`, `harness.curate(`, ≤ 600 chars
  3. Mode B: mentions `plan|propose`, contains `harness.curate(`, ≤ 600 chars
  4. Mode C: contains `harness.curate(`, matches `do not|don't` (the "do not write own orchestration" directive), ≤ 600 chars
  5. Version id appears in opening tag for all three modes
  6. Three snapshot tests (one per mode) pin the exact prompt string — drift catcher
  7. Mode A output is stable across calls (no timestamp / random injection)

## User-visible changes

None directly. The produced text is a prompt fragment consumed by Task 5.4 (future) and fed into the system prompt the LLM sees. Visible to users only in debug log output.

## Evidence

- [x] Failing test/log before + passing after

```
$ npx mocha --forbid-only 'test/unit/agent/harness/harness-prompt-contributor.test.ts'
  contributeHarnessPrompt
    ✔ 1. undefined context returns empty string
    ✔ 2. Mode A contains assisted tag + harness.curate reference, ≤ 600 chars
    ✔ 3. Mode B mentions propose/plan workflow, ≤ 600 chars
    ✔ 4. Mode C instructs autonomous call + forbids own orchestration, ≤ 600 chars
    ✔ 5. version id appears in the opening tag for all three modes
    ✔ 6a. Mode A output matches snapshot
    ✔ 6b. Mode B output matches snapshot
    ✔ 6c. Mode C output matches snapshot
    ✔ 7. Mode A output is stable across calls

  9 passing (6ms)

$ npx mocha --forbid-only 'test/unit/agent/harness/**/*.test.ts'
  212 passing (25s)
```

## Checklist

- [x] Tests added or updated and passing
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow Conventional Commits format
- [ ] Documentation updated — N/A (internal)
- [x] No breaking changes
- [x] Branch is up to date with `proj/autoharness-v2`

## Risks and mitigations

- **Risk: Prompt wording is load-bearing for model behavior** — weak local models are especially sensitive to exact phrasing. A careless rewording could degrade Mode C compliance (LLM writing its own orchestration despite the directive).
  - **Mitigation**: Snapshot tests (6a/6b/6c) pin the exact output per mode. Any rewording fails the test and forces a reviewer to explicitly accept the diff. Pre-merge dogfooding recommended before changing any body.

- **Risk: `<harness-v2>` tag schema is a contract** — Phase 7 CLI's debug command will parse these tags to show the user "what the model sees".
  - **Mitigation**: Tag format (`mode` + `version` attributes) documented in the handoff contract C2. Changing attribute names or removing them is a contract amendment requiring coordination.

- **Risk: No `chai-snapshot` dep** — snapshot tests are inline template literals, updating them is manual.
  - **Mitigation**: Deliberate per the repo's dep-minimization policy. Manual updates are acceptable because prompt changes should be rare and deliberate; the diff is obvious in review.

- **Risk: Mode C body's "do not" directive depends on LLM obedience** — the prompt asks the model to not write its own orchestration, but nothing enforces it at the tool layer yet.
  - **Mitigation**: Task 5.3 (Mode C safety caps) ships the tool-layer enforcement. Together they form the safety envelope. This PR is the prompt half; 5.3 is the runtime half.