### PR TITLE
feat: [ENG-2256] AutoHarness V2 Mode C safety caps

### DIFF
--- a/src/agent/infra/harness/harness-mode-c-errors.ts
+++ b/src/agent/infra/harness/harness-mode-c-errors.ts
@@ -1,0 +1,18 @@
+/**
+ * Errors surfaced when a harness invocation trips a Mode C safety cap.
+ * Carry a machine-readable `code` + structured `details` so observability
+ * (Phase 7 CLI debug, metrics) can distinguish cap types without
+ * string-parsing.
+ */
+export type HarnessModeCErrorCode = 'OPS_CAP_EXCEEDED' | 'RATE_CAP_THROTTLED'
+
+export class HarnessModeCError extends Error {
+  constructor(
+    message: string,
+    public readonly code: HarnessModeCErrorCode,
+    public readonly details: Readonly<Record<string, unknown>>,
+  ) {
+    super(message)
+    this.name = 'HarnessModeCError'
+  }
+}

--- a/src/agent/infra/harness/ops-counter.ts
+++ b/src/agent/infra/harness/ops-counter.ts
@@ -1,0 +1,39 @@
+import {HarnessModeCError} from './harness-mode-c-errors.js'
+
+/**
+ * Per-outer-invocation counter for harness-initiated `ctx.tools.*` calls.
+ * The cap is the Tier 1 X1 brutal-review gate — 50 ops per
+ * `harness.curate()` / `harness.query()` call, regardless of mode.
+ *
+ * Scope is per-construction: every `SandboxService.buildHarnessTools()`
+ * call creates a fresh counter, so the reset boundary is the outer
+ * harness invocation. No explicit `.reset()` method — callers replace
+ * the instance, not its state.
+ */
+export const MODE_C_OPS_CAP = 50
+
+export class OpsCounter {
+  private readonly cap: number
+  private count = 0
+
+  constructor(cap: number = MODE_C_OPS_CAP) {
+    this.cap = cap
+  }
+
+  /**
+   * Increment the counter. Throws `HarnessModeCError` with code
+   * `'OPS_CAP_EXCEEDED'` on the `cap + 1`-th call. Caller is
+   * responsible for invoking this BEFORE delegating to the real
+   * tool — so a cap hit prevents the side effect from landing.
+   */
+  increment(): void {
+    this.count++
+    if (this.count > this.cap) {
+      throw new HarnessModeCError(
+        `Harness Mode C ops cap exceeded: ${this.count} > ${this.cap} tool calls in a single harness.curate() invocation`,
+        'OPS_CAP_EXCEEDED',
+        {cap: this.cap, count: this.count},
+      )
+    }
+  }
+}

--- a/src/agent/infra/harness/rate-limiter.ts
+++ b/src/agent/infra/harness/rate-limiter.ts
@@ -13,6 +13,16 @@ import {HarnessModeCError} from './harness-mode-c-errors.js'
 export const RATE_CAP_DEFAULT = 30
 export const RATE_WINDOW_MS_DEFAULT = 60_000
 
+/**
+ * Symbol-keyed reset method. Tests must explicitly import this
+ * symbol to clear limiter state, which prevents accidental
+ * production calls: a stray string-named `_resetForTests()` in
+ * production code would silently discard rate history, hiding
+ * runaway harness behavior. The symbol can only be reached by
+ * code that imports it.
+ */
+export const TEST_ONLY_RESET: unique symbol = Symbol('TEST_ONLY_RESET')
+
 export class RateLimiter {
   private readonly cap: number
   private readonly timestamps: number[] = []
@@ -24,17 +34,6 @@ export class RateLimiter {
   }
 
   /**
-   * Test-only helper — clears the in-flight window so tests don't
-   * leak rate state between cases. Production code must not call
-   * this; the `_` prefix flags it as internal.
-   *
-   * @internal
-   */
-  _resetForTests(): void {
-    this.timestamps.length = 0
-  }
-
-  /**
    * Record one call against the limit. Throws `HarnessModeCError`
    * with code `'RATE_CAP_THROTTLED'` if the `cap + 1`-th call would
    * land inside the current rolling window.
@@ -43,7 +42,12 @@ export class RateLimiter {
     const now = Date.now()
     const cutoff = now - this.windowMs
     // Expire stale entries. At cap = 30, shift cost is negligible.
-    while (this.timestamps.length > 0 && this.timestamps[0] !== undefined && this.timestamps[0] < cutoff) {
+    // `timestamps[0]` is guaranteed defined while `length > 0` (array
+    // only populated via push), but `noUncheckedIndexedAccess` still
+    // narrows to `number | undefined`, so we bind + guard once.
+    while (this.timestamps.length > 0) {
+      const head = this.timestamps[0]
+      if (head === undefined || head >= cutoff) break
       this.timestamps.shift()
     }
 
@@ -56,6 +60,12 @@ export class RateLimiter {
     }
 
     this.timestamps.push(now)
+  }
+
+  // Test-only reset, keyed by the TEST_ONLY_RESET symbol so production
+  // code has no string-name surface to call accidentally.
+  [TEST_ONLY_RESET](): void {
+    this.timestamps.length = 0
   }
 }
 

--- a/src/agent/infra/harness/rate-limiter.ts
+++ b/src/agent/infra/harness/rate-limiter.ts
@@ -1,0 +1,69 @@
+import {HarnessModeCError} from './harness-mode-c-errors.js'
+
+/**
+ * Sliding-window rate limiter. Process-wide — a runaway harness
+ * spawning sessions cannot bypass a per-session cap, so the right
+ * scope is the daemon process.
+ *
+ * Current v1.0 consumer: reserved for `tools.curation.mapExtract()`
+ * when that surface lands on `HarnessContextTools` (out of scope for
+ * v1.0 per Phase 4 Task 4.3 scope narrowing). Shipped now so the
+ * wiring is a one-liner when mapExtract joins the surface.
+ */
+export const RATE_CAP_DEFAULT = 30
+export const RATE_WINDOW_MS_DEFAULT = 60_000
+
+export class RateLimiter {
+  private readonly cap: number
+  private readonly timestamps: number[] = []
+  private readonly windowMs: number
+
+  constructor(cap: number = RATE_CAP_DEFAULT, windowMs: number = RATE_WINDOW_MS_DEFAULT) {
+    this.cap = cap
+    this.windowMs = windowMs
+  }
+
+  /**
+   * Test-only helper — clears the in-flight window so tests don't
+   * leak rate state between cases. Production code must not call
+   * this; the `_` prefix flags it as internal.
+   *
+   * @internal
+   */
+  _resetForTests(): void {
+    this.timestamps.length = 0
+  }
+
+  /**
+   * Record one call against the limit. Throws `HarnessModeCError`
+   * with code `'RATE_CAP_THROTTLED'` if the `cap + 1`-th call would
+   * land inside the current rolling window.
+   */
+  checkAndRecord(): void {
+    const now = Date.now()
+    const cutoff = now - this.windowMs
+    // Expire stale entries. At cap = 30, shift cost is negligible.
+    while (this.timestamps.length > 0 && this.timestamps[0] !== undefined && this.timestamps[0] < cutoff) {
+      this.timestamps.shift()
+    }
+
+    if (this.timestamps.length >= this.cap) {
+      throw new HarnessModeCError(
+        `Harness Mode C rate cap throttled: ${this.timestamps.length + 1} > ${this.cap} calls in ${this.windowMs}ms`,
+        'RATE_CAP_THROTTLED',
+        {cap: this.cap, count: this.timestamps.length + 1, windowMs: this.windowMs},
+      )
+    }
+
+    this.timestamps.push(now)
+  }
+}
+
+/**
+ * Process-wide singleton. Imported by `SandboxService` when the
+ * rate-limited tool surface comes online. Tests exercise the class
+ * directly; this singleton exists so production wiring can be added
+ * as a single `GLOBAL_RATE_LIMITER.checkAndRecord()` call at the
+ * wrapper site.
+ */
+export const GLOBAL_RATE_LIMITER = new RateLimiter()

--- a/src/agent/infra/sandbox/sandbox-service.ts
+++ b/src/agent/infra/sandbox/sandbox-service.ts
@@ -521,19 +521,21 @@ export class SandboxService implements ISandboxService {
     const opsCounter = new OpsCounter()
     return {
       async curate(operations, options) {
-        opsCounter.increment()
+        // Service-wired check FIRST — a misconfiguration error never
+        // reaches the real tool, so it shouldn't consume op budget.
         if (curateService === undefined) {
           throw new Error('harness.ctx.tools.curate: no curate service wired')
         }
 
+        opsCounter.increment()
         return curateService.curate(operations, options)
       },
       async readFile(filePath, options) {
-        opsCounter.increment()
         if (fileSystem === undefined) {
           throw new Error('harness.ctx.tools.readFile: no file system wired')
         }
 
+        opsCounter.increment()
         return fileSystem.readFile(filePath, options)
       },
     }

--- a/src/agent/infra/sandbox/sandbox-service.ts
+++ b/src/agent/infra/sandbox/sandbox-service.ts
@@ -21,6 +21,7 @@ import type { SessionManager } from '../session/session-manager.js'
 import type { ISearchKnowledgeService, ToolsSDK } from './tools-sdk.js'
 
 import { ProjectTypeSchema } from '../../core/domain/harness/types.js'
+import { OpsCounter } from '../harness/ops-counter.js'
 import {CurateResultCollector} from './curate-result-collector.js'
 import { LocalSandbox } from './local-sandbox.js'
 import { createToolsSDK } from './tools-sdk.js'
@@ -508,8 +509,19 @@ export class SandboxService implements ISandboxService {
   private buildHarnessTools(): HarnessContext['tools'] {
     const {curateService} = this
     const {fileSystem} = this
+    // Fresh counter per outer harness invocation. The `buildCtx` helper
+    // calls `buildHarnessTools()` each time `harness.curate()` /
+    // `harness.query()` fires, so the counter's scope is naturally one
+    // outer call — no explicit reset needed.
+    //
+    // Tier 1 X1 safety gate: caps apply unconditionally (all modes).
+    // Mode A / B almost never approach 50 ops; Mode C is where they
+    // bite. Always-on enforcement prevents a "mode not set yet"
+    // bypass window.
+    const opsCounter = new OpsCounter()
     return {
       async curate(operations, options) {
+        opsCounter.increment()
         if (curateService === undefined) {
           throw new Error('harness.ctx.tools.curate: no curate service wired')
         }
@@ -517,6 +529,7 @@ export class SandboxService implements ISandboxService {
         return curateService.curate(operations, options)
       },
       async readFile(filePath, options) {
+        opsCounter.increment()
         if (fileSystem === undefined) {
           throw new Error('harness.ctx.tools.readFile: no file system wired')
         }

--- a/test/unit/agent/harness/mode-c-caps.test.ts
+++ b/test/unit/agent/harness/mode-c-caps.test.ts
@@ -1,0 +1,141 @@
+import {expect} from 'chai'
+import {createSandbox, type SinonSandbox} from 'sinon'
+
+import {
+  HarnessModeCError,
+  type HarnessModeCErrorCode,
+} from '../../../../src/agent/infra/harness/harness-mode-c-errors.js'
+import {MODE_C_OPS_CAP, OpsCounter} from '../../../../src/agent/infra/harness/ops-counter.js'
+import {
+  GLOBAL_RATE_LIMITER,
+  RATE_CAP_DEFAULT,
+  RATE_WINDOW_MS_DEFAULT,
+  RateLimiter,
+} from '../../../../src/agent/infra/harness/rate-limiter.js'
+
+function expectModeCError(
+  fn: () => void,
+  expectedCode: HarnessModeCErrorCode,
+): HarnessModeCError {
+  try {
+    fn()
+    throw new Error('expected HarnessModeCError to be thrown')
+  } catch (error) {
+    expect(error).to.be.instanceOf(HarnessModeCError)
+    const err = error as HarnessModeCError
+    expect(err.code).to.equal(expectedCode)
+    return err
+  }
+}
+
+describe('Mode C safety caps', () => {
+  describe('OpsCounter', () => {
+    it('1. cap default is 50 ops per outer invocation', () => {
+      expect(MODE_C_OPS_CAP).to.equal(50)
+    })
+
+    it('2. 50 increments succeed', () => {
+      const counter = new OpsCounter()
+      for (let i = 0; i < 50; i++) counter.increment()
+      // no throw
+    })
+
+    it('3. 51st increment throws HarnessModeCError(OPS_CAP_EXCEEDED)', () => {
+      const counter = new OpsCounter()
+      for (let i = 0; i < 50; i++) counter.increment()
+      const err = expectModeCError(() => counter.increment(), 'OPS_CAP_EXCEEDED')
+      expect(err.details).to.deep.equal({cap: 50, count: 51})
+    })
+
+    it('4. new OpsCounter instance has fresh state (reset per outer call)', () => {
+      const first = new OpsCounter()
+      for (let i = 0; i < 50; i++) first.increment()
+
+      const second = new OpsCounter()
+      // 50 fresh increments succeed — second instance is unaffected by first's state.
+      for (let i = 0; i < 50; i++) second.increment()
+    })
+
+    it('5. error message mentions the cap and the actual count', () => {
+      const counter = new OpsCounter()
+      for (let i = 0; i < 50; i++) counter.increment()
+      const err = expectModeCError(() => counter.increment(), 'OPS_CAP_EXCEEDED')
+      expect(err.message).to.include('51')
+      expect(err.message).to.include('50')
+    })
+  })
+
+  describe('RateLimiter', () => {
+    let sb: SinonSandbox
+    let clock: ReturnType<SinonSandbox['useFakeTimers']>
+    let limiter: RateLimiter
+
+    beforeEach(() => {
+      sb = createSandbox()
+      clock = sb.useFakeTimers({now: 1_700_000_000_000})
+      limiter = new RateLimiter()
+    })
+
+    afterEach(() => {
+      sb.restore()
+    })
+
+    it('6. defaults are 30 calls per 60_000 ms', () => {
+      expect(RATE_CAP_DEFAULT).to.equal(30)
+      expect(RATE_WINDOW_MS_DEFAULT).to.equal(60_000)
+    })
+
+    it('7. 30 calls within the window succeed', () => {
+      for (let i = 0; i < 30; i++) limiter.checkAndRecord()
+      // no throw
+    })
+
+    it('8. 31st call within the window throws HarnessModeCError(RATE_CAP_THROTTLED)', () => {
+      for (let i = 0; i < 30; i++) limiter.checkAndRecord()
+      const err = expectModeCError(() => limiter.checkAndRecord(), 'RATE_CAP_THROTTLED')
+      expect(err.details).to.deep.equal({cap: 30, count: 31, windowMs: 60_000})
+    })
+
+    it('9. window slides — calls older than windowMs expire', () => {
+      // Fill the window at T = 0
+      for (let i = 0; i < 30; i++) limiter.checkAndRecord()
+
+      // Advance past the window. Every recorded timestamp is now stale.
+      clock.tick(RATE_WINDOW_MS_DEFAULT + 1)
+
+      // 30 fresh calls succeed at the new now()
+      for (let i = 0; i < 30; i++) limiter.checkAndRecord()
+    })
+
+    it('10. error message mentions the cap, count, and window', () => {
+      for (let i = 0; i < 30; i++) limiter.checkAndRecord()
+      const err = expectModeCError(() => limiter.checkAndRecord(), 'RATE_CAP_THROTTLED')
+      expect(err.message).to.include('31')
+      expect(err.message).to.include('30')
+      expect(err.message).to.include('60000')
+    })
+
+    it('11. GLOBAL_RATE_LIMITER is process-wide (shared across imports)', () => {
+      // Two different "sessions" would both reach for GLOBAL_RATE_LIMITER.
+      // Verify that hits against it accumulate rather than per-reference.
+      GLOBAL_RATE_LIMITER._resetForTests()
+      for (let i = 0; i < 30; i++) GLOBAL_RATE_LIMITER.checkAndRecord()
+      expectModeCError(
+        () => GLOBAL_RATE_LIMITER.checkAndRecord(),
+        'RATE_CAP_THROTTLED',
+      )
+      GLOBAL_RATE_LIMITER._resetForTests()
+    })
+  })
+
+  describe('HarnessModeCError shape', () => {
+    it('12. carries code + details + preserves Error semantics', () => {
+      const err = new HarnessModeCError('test', 'OPS_CAP_EXCEEDED', {a: 1})
+      expect(err).to.be.instanceOf(Error)
+      expect(err).to.be.instanceOf(HarnessModeCError)
+      expect(err.name).to.equal('HarnessModeCError')
+      expect(err.code).to.equal('OPS_CAP_EXCEEDED')
+      expect(err.details).to.deep.equal({a: 1})
+    })
+  })
+})

--- a/test/unit/agent/harness/mode-c-caps.test.ts
+++ b/test/unit/agent/harness/mode-c-caps.test.ts
@@ -11,6 +11,7 @@ import {
   RATE_CAP_DEFAULT,
   RATE_WINDOW_MS_DEFAULT,
   RateLimiter,
+  TEST_ONLY_RESET,
 } from '../../../../src/agent/infra/harness/rate-limiter.js'
 
 function expectModeCError(
@@ -118,13 +119,18 @@ describe('Mode C safety caps', () => {
     it('11. GLOBAL_RATE_LIMITER is process-wide (shared across imports)', () => {
       // Two different "sessions" would both reach for GLOBAL_RATE_LIMITER.
       // Verify that hits against it accumulate rather than per-reference.
-      GLOBAL_RATE_LIMITER._resetForTests()
-      for (let i = 0; i < 30; i++) GLOBAL_RATE_LIMITER.checkAndRecord()
-      expectModeCError(
-        () => GLOBAL_RATE_LIMITER.checkAndRecord(),
-        'RATE_CAP_THROTTLED',
-      )
-      GLOBAL_RATE_LIMITER._resetForTests()
+      // `try/finally` so a mid-test throw doesn't leak global state into
+      // subsequent tests.
+      GLOBAL_RATE_LIMITER[TEST_ONLY_RESET]()
+      try {
+        for (let i = 0; i < 30; i++) GLOBAL_RATE_LIMITER.checkAndRecord()
+        expectModeCError(
+          () => GLOBAL_RATE_LIMITER.checkAndRecord(),
+          'RATE_CAP_THROTTLED',
+        )
+      } finally {
+        GLOBAL_RATE_LIMITER[TEST_ONLY_RESET]()
+      }
     })
   })
 


### PR DESCRIPTION
## Summary

- **Problem**: Phase 5's mode selector can now put a harness into Mode C (autonomous execution), but nothing enforces the safety caps that make autonomous execution acceptable. A runaway harness could burst thousands of `ctx.tools.curate` calls with no ceiling.
- **Why it matters**: HARD GATE for Tier 1 X1 brutal-review item. Mode C without caps is unshippable to internal beta — this PR closes the gate so Task 5.4 (agent wiring) can safely activate Mode C selection in production.
- **What changed**: Ships `HarnessModeCError`, `OpsCounter` (50 ops/outer-invocation), and `RateLimiter` (30 calls/60s, process-wide). Wires `OpsCounter` into `SandboxService.buildHarnessTools()` so every `ctx.tools.*` call increments. Caps apply unconditionally — no mode-gating, because "mode not set yet" must never be a bypass window.
- **What did NOT change (scope boundary)**: No agent wiring (Task 5.4). No mode-specific enforcement policy — caps are always-on. No wiring of `RateLimiter` to a tool surface — `HarnessContextTools` doesn't expose `curation.mapExtract` in v1.0 (Phase 4 scope narrowing). RateLimiter shipped as a ready-to-wire singleton so a future mapExtract addition is a one-liner at the wrapper site.

## Type of change

- [x] New feature

## Scope (select all touched areas)

- [x] Agent / Tools

## Linked issues

- Closes ENG-2256
- Closes brutal-review item Tier 1 X1 (Mode C safety caps — HARD GATE)
- Related: ENG-2254 (mode selector, merged), ENG-2255 (prompt contributor, merged), ENG-2257 (Task 5.4 agent wiring — soft-depends on this for shippability)

## Root cause (bug fixes only, otherwise write `N/A`)

N/A

## Test plan

- Coverage added:
  - [x] Unit test
- Test file(s): `test/unit/agent/harness/mode-c-caps.test.ts`
- Key scenario(s) covered (12 tests):
  - **OpsCounter**: default cap is 50; 50 increments succeed; 51st throws `OPS_CAP_EXCEEDED`; new instance is fresh (reset per outer call); error message carries actual count.
  - **RateLimiter**: defaults 30/60_000ms; 30 calls succeed; 31st throws `RATE_CAP_THROTTLED`; window slides via fake timers (after 60_001ms tick, 30 fresh calls succeed); error message carries cap, count, window; `GLOBAL_RATE_LIMITER` singleton is shared across imports.
  - **HarnessModeCError**: instanceof Error + HarnessModeCError; name/code/details preserved.

## User-visible changes

None directly. The caps activate whenever `ctx.tools.*` is called from inside harness code. A user wouldn't notice unless a harness tries >50 ops in a single call, in which case they'd see a `HarnessModeCError` wrapped by Phase 3's error normalization as `harness curate() failed: ... ops cap exceeded ...`.

## Evidence

- [x] Failing test/log before + passing after

```
$ npx mocha --forbid-only 'test/unit/agent/harness/mode-c-caps.test.ts'
  Mode C safety caps
    OpsCounter
      ✔ 1. cap default is 50 ops per outer invocation
      ✔ 2. 50 increments succeed
      ✔ 3. 51st increment throws HarnessModeCError(OPS_CAP_EXCEEDED)
      ✔ 4. new OpsCounter instance has fresh state (reset per outer call)
      ✔ 5. error message mentions the cap and the actual count
    RateLimiter
      ✔ 6. defaults are 30 calls per 60_000 ms
      ✔ 7. 30 calls within the window succeed
      ✔ 8. 31st call within the window throws HarnessModeCError(RATE_CAP_THROTTLED)
      ✔ 9. window slides — calls older than windowMs expire
      ✔ 10. error message mentions the cap, count, and window
      ✔ 11. GLOBAL_RATE_LIMITER is process-wide (shared across imports)
    HarnessModeCError shape
      ✔ 12. carries code + details + preserves Error semantics

  12 passing

$ npx mocha --forbid-only 'test/unit/agent/harness/**/*.test.ts'
  225 passing (25s)
```

## Checklist

- [x] Tests added or updated and passing
- [x] Lint passes (one pre-existing `executeCode` complexity warning is unchanged by this PR)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow Conventional Commits format
- [ ] Documentation updated — N/A (internal)
- [x] No breaking changes
- [x] Branch is up to date with `proj/autoharness-v2`

## Risks and mitigations

- **Risk: design divergence from task doc** — the original task doc (`tasks/phase_5/task_03-mode-c-safety-caps.md`) described a reset hook in `harness-module-builder.wrapInvocation`. I took a simpler path: fresh `OpsCounter` per `buildHarnessTools()` closure. `buildCtx()` calls `buildHarnessTools()` per outer invocation, so the counter's scope is already per-outer-call without touching the module builder.
  - **Mitigation**: Test 4 pins the per-instance-is-fresh invariant. The upside is less cross-module coupling. If a future design needs access to the counter across call boundaries, the module-builder hook can be added then.

- **Risk: always-on caps could reject legitimate Mode A/B flows** — a Mode A curate that happens to need 55 ops would now fail.
  - **Mitigation**: 50 is generous for real curate flows (typically 1-10 ops). If dogfooding shows false positives, the cap raises without touching the mode enum. Making caps mode-gated would reintroduce the "mode not set yet" bypass window — rejected as less safe.

- **Risk: `RateLimiter` is shipped unwired** — production code doesn't call it yet.
  - **Mitigation**: Unit-tested directly; the singleton exists so the wiring PR (whenever `curation.mapExtract()` joins `HarnessContextTools`) is a one-line `GLOBAL_RATE_LIMITER.checkAndRecord()` at the wrapper site.

- **Risk: Process-wide rate cap** — a busy daemon handling many sessions could exhaust the 30/min budget faster than expected.
  - **Mitigation**: Per-session caps were considered and rejected — a malicious/buggy harness could spawn sessions to bypass. Process-wide is the right scope. If dogfood data shows legitimate traffic hitting the cap, raising the default (or making it config-driven) is additive; both paths keep the safety invariant intact.