### PR TITLE
feat: [ENG-2257] AutoHarness V2 agent wiring — Phase 5 production entry

### DIFF
--- a/src/agent/core/domain/system-prompt/types.ts
+++ b/src/agent/core/domain/system-prompt/types.ts
@@ -1,6 +1,6 @@
 import type { MemoryManager } from '../../../infra/memory/memory-manager.js'
 import type { EnvironmentContext } from '../environment/types.js'
-import type { HarnessMode } from '../harness/types.js'
+import type { HarnessMode, HarnessVersion } from '../harness/types.js'
 
 /**
  * Conversation metadata for execution context
@@ -63,6 +63,16 @@ export interface ContributorContext {
    * means no harness is injected.
    */
   harnessMode?: HarnessMode
+
+  /**
+   * The `HarnessVersion` record the mode selection was computed against.
+   * Paired with `harnessMode` — both are set or both absent. The
+   * harness system-prompt contributor needs the version id for the
+   * `<harness-v2 version="…">` tag; the object is passed in full so
+   * future contributor logic can read metadata without another store
+   * round-trip.
+   */
+  harnessVersion?: HarnessVersion
 
   /** Memory manager instance for accessing memories */
   memoryManager?: MemoryManager

--- a/src/agent/core/interfaces/cipher-services.ts
+++ b/src/agent/core/interfaces/cipher-services.ts
@@ -1,7 +1,8 @@
 import type {IRuntimeSignalStore} from '../../../server/core/interfaces/storage/i-runtime-signal-store.js'
+import type {ValidatedHarnessConfig} from '../../infra/agent/agent-schemas.js'
 import type {AgentEventBus, SessionEventBus} from '../../infra/events/event-emitter.js'
 import type {FileSystemService} from '../../infra/file-system/file-system-service.js'
-import type {HarnessOutcomeRecorder, HarnessStore} from '../../infra/harness/index.js'
+import type {HarnessBootstrap, HarnessOutcomeRecorder, HarnessStore} from '../../infra/harness/index.js'
 import type {CompactionService} from '../../infra/llm/context/compaction/compaction-service.js'
 import type {AbstractGenerationQueue} from '../../infra/map/abstract-queue.js'
 import type {MemoryManager} from '../../infra/memory/memory-manager.js'
@@ -46,6 +47,18 @@ export interface CipherAgentServices {
    */
   compactionService: CompactionService
   fileSystemService: FileSystemService
+  /**
+   * AutoHarness V2 bootstrap (Phase 4 Task 4.2) — fires on first turn
+   * per `(projectId, commandType)`, writing v1 from the matching
+   * template. Consumed by `AgentLLMService.ensureHarnessReady()`.
+   */
+  harnessBootstrap?: HarnessBootstrap
+  /**
+   * AutoHarness V2 validated config — the `harness` block from
+   * `AgentConfigSchema`. Threaded here so `AgentLLMService` can read
+   * `enabled` / `modeOverride` without re-parsing.
+   */
+  harnessConfig?: ValidatedHarnessConfig
   /**
    * AutoHarness V2 outcome recorder. Wired in by `service-initializer.ts`
    * alongside `harnessStore`; consumers can assume it is present. Kept

--- a/src/agent/infra/agent/service-initializer.ts
+++ b/src/agent/infra/agent/service-initializer.ts
@@ -23,7 +23,7 @@ import { createBlobStorage } from '../blob/blob-storage-factory.js'
 import { EnvironmentContextBuilder } from '../environment/environment-context-builder.js'
 import { AgentEventBus, SessionEventBus } from '../events/event-emitter.js'
 import { FileSystemService } from '../file-system/file-system-service.js'
-import { HarnessModuleBuilder, HarnessOutcomeRecorder, HarnessStore } from '../harness/index.js'
+import { HarnessBootstrap, HarnessModuleBuilder, HarnessOutcomeRecorder, HarnessStore } from '../harness/index.js'
 import { AgentLLMService } from '../llm/agent-llm-service.js'
 import { CompactionService } from '../llm/context/compaction/compaction-service.js'
 import { EscalatedCompressionStrategy } from '../llm/context/compression/escalated-compression.js'
@@ -49,6 +49,7 @@ import { buildProvidersFromConfig } from '../swarm/provider-factory.js'
 import { SwarmCoordinator } from '../swarm/swarm-coordinator.js'
 import { validateSwarmProviders } from '../swarm/validation/config-validator.js'
 import { ContextTreeStructureContributor } from '../system-prompt/contributors/context-tree-structure-contributor.js'
+import { HarnessContributor } from '../system-prompt/contributors/harness-contributor.js'
 import { MapSelectionContributor } from '../system-prompt/contributors/map-selection-contributor.js'
 import { SwarmStateContributor } from '../system-prompt/contributors/swarm-state-contributor.js'
 import { SystemPromptManager } from '../system-prompt/system-prompt-manager.js'
@@ -273,6 +274,24 @@ export async function createCipherAgentServices(
   sandboxService.setHarnessModuleBuilder(harnessModuleBuilder)
   sandboxService.setHarnessStore(harnessStore)
 
+  // Phase 4 Task 4.2 + Phase 5 Task 5.4: HarnessBootstrap fires on first
+  // turn per `(projectId, commandType)`, writing v1 from the matching
+  // template. `AgentLLMService.ensureHarnessReady()` invokes it before
+  // each system-prompt build.
+  const harnessBootstrap = new HarnessBootstrap(
+    harnessStore,
+    fileSystemService,
+    config.harness,
+    logger.withSource('HarnessBootstrap'),
+  )
+
+  // Phase 5 Task 5.4: HarnessContributor renders the mode-specific
+  // prompt block. Registered at priority 18 — after context tree (15),
+  // map selection (16), swarm state (17), before memories (20). Reads
+  // `harnessMode` + `harnessVersion` from ContributorContext; those are
+  // populated by AgentLLMService after `ensureHarnessReady()`.
+  systemPromptManager.registerContributor(new HarnessContributor())
+
   // 6c. Swarm coordinator — try to load config and build providers.
   // Missing config → fail-open (no swarm). Invalid config → warn but continue.
   let swarmCoordinator: SwarmCoordinator | undefined
@@ -381,6 +400,8 @@ export async function createCipherAgentServices(
     blobStorage,
     compactionService,
     fileSystemService,
+    harnessBootstrap,
+    harnessConfig: config.harness,
     harnessOutcomeRecorder,
     harnessStore,
     historyStorage,
@@ -479,6 +500,9 @@ export function createSessionServices(
           new MiddleRemovalStrategy({preserveEnd: 5, preserveStart: 4}),
           new OldestRemovalStrategy({minMessagesToKeep: 4}),
         ],
+        harnessBootstrap: sharedServices.harnessBootstrap,
+        harnessConfig: sharedServices.harnessConfig,
+        harnessStore: sharedServices.harnessStore,
         historyStorage: sharedServices.historyStorage,
         logger: sessionLogger,
         memoryManager: sharedServices.memoryManager,

--- a/src/agent/infra/agent/service-initializer.ts
+++ b/src/agent/infra/agent/service-initializer.ts
@@ -290,7 +290,14 @@ export async function createCipherAgentServices(
   // map selection (16), swarm state (17), before memories (20). Reads
   // `harnessMode` + `harnessVersion` from ContributorContext; those are
   // populated by AgentLLMService after `ensureHarnessReady()`.
-  systemPromptManager.registerContributor(new HarnessContributor())
+  //
+  // Registration is gated on `config.harness.enabled`: when disabled at
+  // agent-init time, the contributor is not registered at all, saving a
+  // no-op invocation per prompt build. Config is validated once here —
+  // runtime toggles require restarting the agent (acceptable for v1.0).
+  if (config.harness.enabled) {
+    systemPromptManager.registerContributor(new HarnessContributor())
+  }
 
   // 6c. Swarm coordinator — try to load config and build providers.
   // Missing config → fail-open (no swarm). Invalid config → warn but continue.

--- a/src/agent/infra/llm/agent-llm-service.ts
+++ b/src/agent/infra/llm/agent-llm-service.ts
@@ -868,19 +868,24 @@ export class AgentLLMService implements ILLMService {
    *
    * @param result - Parallel tool result to add
    */
-/**
- * AutoHarness V2 (Phase 5 Task 5.4) — ensures the harness is
- * bootstrapped, loaded, and a mode is selected for this session-pair.
- * Emits `harness:mode-selected` at most once per
- * `(sessionId, commandType)`. Returns the selection for the prompt
- * contributor, or `undefined` when harness is disabled / below
- * threshold / has no version in store.
- *
- * Cheap on the happy path after the first turn: bootstrap is
- * idempotent + short-circuits on `getLatest`; `SandboxService.loadHarness`
- * short-circuits on `sessionHarnessStates`. Two async store reads
- * per turn when enabled — acceptable for v1.0.
- */
+  /**
+   * AutoHarness V2 (Phase 5 Task 5.4) — ensures the harness is
+   * bootstrapped, loaded, and a mode is selected for this session-pair.
+   * Emits `harness:mode-selected` at most once per
+   * `(sessionId, commandType)`. Returns the selection for the prompt
+   * contributor, or `undefined` when harness is disabled / below
+   * threshold / has no version in store.
+   *
+   * Cheap on the happy path after the first turn: bootstrap is
+   * idempotent + short-circuits on `getLatest`; `SandboxService.loadHarness`
+   * short-circuits on `sessionHarnessStates`. Two async store reads
+   * per turn when enabled — acceptable for v1.0.
+   *
+   * Fails open: any unexpected error from bootstrap / load / store is
+   * logged at `warn` and the method returns `undefined`, leaving the
+   * agent to proceed without harness. Harness is non-critical
+   * infrastructure; a transient I/O error here must not kill the task.
+   */
   private async ensureHarnessReady(
     commandType: 'chat' | 'curate' | 'query',
   ): Promise<undefined | {mode: HarnessMode; version: HarnessVersion}> {
@@ -895,48 +900,60 @@ export class AgentLLMService implements ILLMService {
       return undefined
     }
 
-    // Slug/path gap workaround (known issue — see
-    // outcome-collection.test.ts:32): the recorder derives projectId
-    // from `environmentContext.workingDirectory`, so we use the same
-    // source here. In-memory storage accepts paths; persistent
-    // FileKeyStorage would need a slug — that unification is tracked
-    // separately.
-    const projectId = this.workingDirectory
-    const {workingDirectory} = this
+    try {
+      // Slug/path gap workaround (known issue — see
+      // outcome-collection.test.ts:32): the recorder derives projectId
+      // from `environmentContext.workingDirectory`, so we use the same
+      // source here. `bootstrapIfNeeded` takes both `projectId` (for
+      // store key partitioning) and `workingDirectory` (for filesystem
+      // detection); at present they're the same value, aliased for
+      // readability at the call site.
+      const projectId = this.workingDirectory
+      const {workingDirectory} = this
 
-    await harnessBootstrap.bootstrapIfNeeded(projectId, commandType, workingDirectory)
+      await harnessBootstrap.bootstrapIfNeeded(projectId, commandType, workingDirectory)
 
-    const loadResult = await sandboxService.loadHarness(this.sessionId, projectId, commandType)
-    if (!loadResult.loaded) return undefined
+      const loadResult = await sandboxService.loadHarness(this.sessionId, projectId, commandType)
+      if (!loadResult.loaded) return undefined
 
-    const outcomes = await harnessStore.listOutcomes(projectId, commandType, 50)
-    const heuristic = computeHeuristic(outcomes, Date.now())
-    if (heuristic === null) {
-      // Below the min-sample floor — behave as "no harness" for this
-      // turn. When enough outcomes accumulate, mode selection kicks in.
+      const outcomes = await harnessStore.listOutcomes(projectId, commandType, 50)
+      const heuristic = computeHeuristic(outcomes, Date.now())
+      if (heuristic === null) {
+        // Below the min-sample floor — behave as "no harness" for this
+        // turn. When enough outcomes accumulate, mode selection kicks in.
+        return undefined
+      }
+
+      const selection = selectHarnessMode(heuristic, harnessConfig)
+      if (selection === undefined) return undefined
+
+      // `::` separator — safe because `commandType` is the controlled
+      // enum `'chat' | 'curate' | 'query'` and cannot contain colons.
+      const dedupKey = `${this.sessionId}::${commandType}`
+      if (!this.harnessModeSelectedEmitted.has(dedupKey)) {
+        this.harnessModeSelectedEmitted.add(dedupKey)
+        // `SessionEventBus` payload omits `sessionId` — the bus is already
+        // session-scoped and forwarding infra adds it when routing to
+        // `AgentEventBus`. See `AgentEventMap.'harness:mode-selected'`
+        // which includes `sessionId` for cross-session consumers.
+        this.sessionEventBus.emit('harness:mode-selected', {
+          commandType,
+          heuristic,
+          mode: selection.mode,
+          projectId,
+          version: loadResult.version.version,
+        })
+      }
+
+      return {mode: selection.mode, version: loadResult.version}
+    } catch (error) {
+      this.logger.warn('ensureHarnessReady failed; proceeding without harness', {
+        commandType,
+        error: getErrorMessage(error),
+        sessionId: this.sessionId,
+      })
       return undefined
     }
-
-    const selection = selectHarnessMode(heuristic, harnessConfig)
-    if (selection === undefined) return undefined
-
-    const dedupKey = `${this.sessionId}\u0000${commandType}`
-    if (!this.harnessModeSelectedEmitted.has(dedupKey)) {
-      this.harnessModeSelectedEmitted.add(dedupKey)
-      // `SessionEventBus` payload omits `sessionId` — the bus is already
-      // session-scoped and forwarding infra adds it when routing to
-      // `AgentEventBus`. See `AgentEventMap.'harness:mode-selected'`
-      // which includes `sessionId` for cross-session consumers.
-      this.sessionEventBus.emit('harness:mode-selected', {
-        commandType,
-        heuristic,
-        mode: selection.mode,
-        projectId,
-        version: loadResult.version.version,
-      })
-    }
-
-    return {mode: selection.mode, version: loadResult.version}
   }
 
   /**
@@ -993,9 +1010,10 @@ export class AgentLLMService implements ILLMService {
       // AutoHarness V2 (Phase 5): bootstrap + load + mode-select BEFORE
       // prompt build, so the system-prompt contributor sees the final
       // mode and version in `ContributorContext`.
-      const harnessReady = executionContext?.commandType === undefined
+      const harnessCommandType = executionContext?.commandType
+      const harnessReady = harnessCommandType === undefined
         ? undefined
-        : await this.ensureHarnessReady(executionContext.commandType)
+        : await this.ensureHarnessReady(harnessCommandType)
 
       basePrompt = await this.systemPromptManager.build({
         availableMarkers,

--- a/src/agent/infra/llm/agent-llm-service.ts
+++ b/src/agent/infra/llm/agent-llm-service.ts
@@ -2,9 +2,11 @@ import type {MessageParam} from '@anthropic-ai/sdk/resources/messages'
 import type {Content} from '@google/genai'
 import type {ChatCompletionMessageParam} from 'openai/resources/chat/completions'
 
+import type {HarnessMode, HarnessVersion} from '../../core/domain/harness/types.js'
 import type {ToolExecutionResult} from '../../core/domain/tools/tool-error.js'
 import type {ToolSet} from '../../core/domain/tools/types.js'
 import type {ExecutionContext} from '../../core/interfaces/i-cipher-agent.js'
+import type {IHarnessStore} from '../../core/interfaces/i-harness-store.js'
 import type {IHistoryStorage} from '../../core/interfaces/i-history-storage.js'
 import type {ILLMService} from '../../core/interfaces/i-llm-service.js'
 import type {ILogger} from '../../core/interfaces/i-logger.js'
@@ -18,6 +20,8 @@ import type {
   ToolStateError,
   ToolStateRunning,
 } from '../../core/interfaces/message-types.js'
+import type {ValidatedHarnessConfig} from '../agent/agent-schemas.js'
+import type {HarnessBootstrap} from '../harness/harness-bootstrap.js'
 import type {MemoryManager} from '../memory/memory-manager.js'
 import type {SystemPromptManager} from '../system-prompt/system-prompt-manager.js'
 import type {ToolManager} from '../tools/tool-manager.js'
@@ -28,6 +32,7 @@ import {getErrorMessage} from '../../../server/utils/error-helpers.js'
 import {AgentStateMachine} from '../../core/domain/agent/agent-state-machine.js'
 import {AgentState, TerminationReason} from '../../core/domain/agent/agent-state.js'
 import {LlmGenerationError, LlmMaxIterationsError, LlmResponseParsingError} from '../../core/domain/errors/llm-error.js'
+import {computeHeuristic} from '../../core/domain/harness/heuristic.js'
 import {
   getEffectiveMaxInputTokens,
   getMaxInputTokensForModel,
@@ -43,6 +48,7 @@ import {
 import {NoOpLogger} from '../../core/interfaces/i-logger.js'
 import {EnvironmentContextBuilder} from '../environment/environment-context-builder.js'
 import {SessionEventBus} from '../events/event-emitter.js'
+import {selectHarnessMode} from '../harness/harness-mode-selector.js'
 import {ToolMetadataHandler} from '../tools/streaming/metadata-handler.js'
 import {AsyncMutex} from './context/async-mutex.js'
 import {ContextManager, type FileData, type ImageData} from './context/context-manager.js'
@@ -166,6 +172,16 @@ export class AgentLLMService implements ILLMService {
   private readonly environmentBuilder: EnvironmentContextBuilder
   private readonly formatter: IMessageFormatter<ChatCompletionMessageParam | Content | MessageParam>
   private readonly generator: IContentGenerator
+  private readonly harnessBootstrap?: HarnessBootstrap
+  private readonly harnessConfig?: ValidatedHarnessConfig
+  /**
+   * Per-session-per-commandType dedup for the `harness:mode-selected`
+   * event — emit at most once per pair for the lifetime of this
+   * service instance, matching the event's docstring ("once per
+   * session for harness-enabled sessions").
+   */
+  private readonly harnessModeSelectedEmitted = new Set<string>()
+  private readonly harnessStore?: IHarnessStore
   private readonly logger: ILogger
   private readonly loopDetector: LoopDetector
   /** Flag indicating memory was modified by tools during this task, requiring prompt rebuild */
@@ -206,6 +222,10 @@ export class AgentLLMService implements ILLMService {
    * @param options.memoryManager - Memory manager for agent memories
    * @param options.sessionEventBus - Event bus for session lifecycle events
    * @param options.compactionService - Optional compaction service for context overflow management
+   * @param options.compressionStrategies - Optional context-compression strategies
+   * @param options.harnessBootstrap - AutoHarness V2 bootstrap (Phase 4)
+   * @param options.harnessConfig - AutoHarness V2 validated config
+   * @param options.harnessStore - AutoHarness V2 store for the H window
    * @param options.historyStorage - Optional history storage for persistence
    * @param options.logger - Optional logger for structured logging
    * @param options.sandboxService - Optional sandbox service for rolling checkpoint variable injection
@@ -218,6 +238,12 @@ export class AgentLLMService implements ILLMService {
       compactionService?: CompactionService
       /** Optional compression strategies for context overflow management */
       compressionStrategies?: ICompressionStrategy[]
+      /** AutoHarness V2 bootstrap (Phase 4) — fires on first turn per pair. */
+      harnessBootstrap?: HarnessBootstrap
+      /** AutoHarness V2 config — modeOverride + enabled gate. */
+      harnessConfig?: ValidatedHarnessConfig
+      /** AutoHarness V2 store — used to read outcomes for the H window. */
+      harnessStore?: IHarnessStore
       historyStorage?: IHistoryStorage
       logger?: ILogger
       memoryManager?: MemoryManager
@@ -231,6 +257,9 @@ export class AgentLLMService implements ILLMService {
     this.sessionId = sessionId
     this.generator = generator
     this.compactionService = options.compactionService
+    this.harnessBootstrap = options.harnessBootstrap
+    this.harnessStore = options.harnessStore
+    this.harnessConfig = options.harnessConfig
     this.sandboxService = options.sandboxService
     this.toolManager = options.toolManager
     this.systemPromptManager = options.systemPromptManager
@@ -457,12 +486,6 @@ export class AgentLLMService implements ILLMService {
     return this.contextManager.initialize()
   }
 
-  /**
-   * Add a parallel tool result to the context.
-   * Called sequentially after parallel execution to preserve message order.
-   *
-   * @param result - Parallel tool result to add
-   */
   private async addParallelToolResultToContext(result: ParallelToolResult): Promise<void> {
     const {toolCall, toolResult} = result
 
@@ -840,6 +863,83 @@ export class AgentLLMService implements ILLMService {
   }
 
   /**
+   * Add a parallel tool result to the context.
+   * Called sequentially after parallel execution to preserve message order.
+   *
+   * @param result - Parallel tool result to add
+   */
+/**
+ * AutoHarness V2 (Phase 5 Task 5.4) — ensures the harness is
+ * bootstrapped, loaded, and a mode is selected for this session-pair.
+ * Emits `harness:mode-selected` at most once per
+ * `(sessionId, commandType)`. Returns the selection for the prompt
+ * contributor, or `undefined` when harness is disabled / below
+ * threshold / has no version in store.
+ *
+ * Cheap on the happy path after the first turn: bootstrap is
+ * idempotent + short-circuits on `getLatest`; `SandboxService.loadHarness`
+ * short-circuits on `sessionHarnessStates`. Two async store reads
+ * per turn when enabled — acceptable for v1.0.
+ */
+  private async ensureHarnessReady(
+    commandType: 'chat' | 'curate' | 'query',
+  ): Promise<undefined | {mode: HarnessMode; version: HarnessVersion}> {
+    const {harnessBootstrap, harnessConfig, harnessStore, sandboxService} = this
+    if (
+      harnessConfig === undefined ||
+      !harnessConfig.enabled ||
+      harnessBootstrap === undefined ||
+      harnessStore === undefined ||
+      sandboxService === undefined
+    ) {
+      return undefined
+    }
+
+    // Slug/path gap workaround (known issue — see
+    // outcome-collection.test.ts:32): the recorder derives projectId
+    // from `environmentContext.workingDirectory`, so we use the same
+    // source here. In-memory storage accepts paths; persistent
+    // FileKeyStorage would need a slug — that unification is tracked
+    // separately.
+    const projectId = this.workingDirectory
+    const {workingDirectory} = this
+
+    await harnessBootstrap.bootstrapIfNeeded(projectId, commandType, workingDirectory)
+
+    const loadResult = await sandboxService.loadHarness(this.sessionId, projectId, commandType)
+    if (!loadResult.loaded) return undefined
+
+    const outcomes = await harnessStore.listOutcomes(projectId, commandType, 50)
+    const heuristic = computeHeuristic(outcomes, Date.now())
+    if (heuristic === null) {
+      // Below the min-sample floor — behave as "no harness" for this
+      // turn. When enough outcomes accumulate, mode selection kicks in.
+      return undefined
+    }
+
+    const selection = selectHarnessMode(heuristic, harnessConfig)
+    if (selection === undefined) return undefined
+
+    const dedupKey = `${this.sessionId}\u0000${commandType}`
+    if (!this.harnessModeSelectedEmitted.has(dedupKey)) {
+      this.harnessModeSelectedEmitted.add(dedupKey)
+      // `SessionEventBus` payload omits `sessionId` — the bus is already
+      // session-scoped and forwarding infra adds it when routing to
+      // `AgentEventBus`. See `AgentEventMap.'harness:mode-selected'`
+      // which includes `sessionId` for cross-session consumers.
+      this.sessionEventBus.emit('harness:mode-selected', {
+        commandType,
+        heuristic,
+        mode: selection.mode,
+        projectId,
+        version: loadResult.version.version,
+      })
+    }
+
+    return {mode: selection.mode, version: loadResult.version}
+  }
+
+  /**
    * Execute a single iteration of the agentic loop.
    *
    * @param options - Iteration options
@@ -890,6 +990,13 @@ export class AgentLLMService implements ILLMService {
         workingDirectory: this.workingDirectory,
       })
 
+      // AutoHarness V2 (Phase 5): bootstrap + load + mode-select BEFORE
+      // prompt build, so the system-prompt contributor sees the final
+      // mode and version in `ContributorContext`.
+      const harnessReady = executionContext?.commandType === undefined
+        ? undefined
+        : await this.ensureHarnessReady(executionContext.commandType)
+
       basePrompt = await this.systemPromptManager.build({
         availableMarkers,
         availableTools,
@@ -897,6 +1004,8 @@ export class AgentLLMService implements ILLMService {
         conversationMetadata: executionContext?.conversationMetadata,
         environmentContext,
         fileReferenceInstructions: executionContext?.fileReferenceInstructions,
+        harnessMode: harnessReady?.mode,
+        harnessVersion: harnessReady?.version,
         memoryManager: this.memoryManager,
       })
 

--- a/src/agent/infra/llm/agent-llm-service.ts
+++ b/src/agent/infra/llm/agent-llm-service.ts
@@ -486,6 +486,12 @@ export class AgentLLMService implements ILLMService {
     return this.contextManager.initialize()
   }
 
+  /**
+   * Add a parallel tool result to the context.
+   * Called sequentially after parallel execution to preserve message order.
+   *
+   * @param result - Parallel tool result to add
+   */
   private async addParallelToolResultToContext(result: ParallelToolResult): Promise<void> {
     const {toolCall, toolResult} = result
 
@@ -862,12 +868,6 @@ export class AgentLLMService implements ILLMService {
     return undefined
   }
 
-  /**
-   * Add a parallel tool result to the context.
-   * Called sequentially after parallel execution to preserve message order.
-   *
-   * @param result - Parallel tool result to add
-   */
   /**
    * AutoHarness V2 (Phase 5 Task 5.4) — ensures the harness is
    * bootstrapped, loaded, and a mode is selected for this session-pair.

--- a/src/agent/infra/system-prompt/contributors/harness-contributor.ts
+++ b/src/agent/infra/system-prompt/contributors/harness-contributor.ts
@@ -1,0 +1,37 @@
+import type {
+  ContributorContext,
+  SystemPromptContributor,
+} from '../../../core/domain/system-prompt/types.js'
+
+import {contributeHarnessPrompt} from '../../harness/harness-prompt-contributor.js'
+
+/**
+ * System-prompt contributor that renders the mode-specific harness
+ * prompt block. Reads `harnessMode` + `harnessVersion` from
+ * `ContributorContext` — both are set by `AgentLLMService` after it
+ * runs `ensureHarnessReady()` (which does bootstrap + loadHarness +
+ * mode selection + event emission). When either is absent, the
+ * contributor emits an empty string and the harness block does not
+ * land in the system prompt.
+ *
+ * Priority 18 per `phase_5/task_04-agent-wiring.md`: after context
+ * tree (15), map selection (16), swarm state (17) — but before
+ * memories (20) so the harness block lands in the high-priority
+ * prefix with the other capability-context blocks.
+ */
+export class HarnessContributor implements SystemPromptContributor {
+  public readonly id: string
+  public readonly priority: number
+
+  public constructor(id: string = 'harness', priority: number = 18) {
+    this.id = id
+    this.priority = priority
+  }
+
+  public async getContent(context: ContributorContext): Promise<string> {
+    const {harnessMode, harnessVersion} = context
+    if (harnessMode === undefined || harnessVersion === undefined) return ''
+
+    return contributeHarnessPrompt({mode: harnessMode, version: harnessVersion})
+  }
+}

--- a/test/unit/agent/llm/agent-llm-service-harness-wiring.test.ts
+++ b/test/unit/agent/llm/agent-llm-service-harness-wiring.test.ts
@@ -19,8 +19,10 @@ import {ByteRoverContentGenerator} from '../../../../src/agent/infra/llm/generat
 import {SystemPromptManager} from '../../../../src/agent/infra/system-prompt/system-prompt-manager.js'
 import {ToolManager} from '../../../../src/agent/infra/tools/tool-manager.js'
 
-const PROJECT_ID = process.cwd() // AgentLLMService uses this as projectId
-
+// `AgentLLMService` derives `projectId` from `process.cwd()` at
+// construction time. Each test captures the same value inside
+// `beforeEach` so fixtures match whatever cwd the service sees —
+// immune to `process.chdir()` calls from other test files.
 function makeConfig(overrides: Partial<ValidatedHarnessConfig> = {}): ValidatedHarnessConfig {
   return {
     autoLearn: true,
@@ -31,7 +33,7 @@ function makeConfig(overrides: Partial<ValidatedHarnessConfig> = {}): ValidatedH
   }
 }
 
-function makeVersion(): HarnessVersion {
+function makeVersion(projectId: string): HarnessVersion {
   return {
     code: '/* placeholder */',
     commandType: 'curate',
@@ -44,13 +46,18 @@ function makeVersion(): HarnessVersion {
       projectPatterns: ['**/*.ts'],
       version: 1,
     },
-    projectId: PROJECT_ID,
+    projectId,
     projectType: 'typescript',
     version: 1,
   }
 }
 
-function makeOutcomes(count: number, successRate: number, now: number): CodeExecOutcome[] {
+function makeOutcomes(
+  projectId: string,
+  count: number,
+  successRate: number,
+  now: number,
+): CodeExecOutcome[] {
   const outcomes: CodeExecOutcome[] = []
   for (let i = 0; i < count; i++) {
     outcomes.push({
@@ -59,7 +66,7 @@ function makeOutcomes(count: number, successRate: number, now: number): CodeExec
       delegated: true,
       executionTimeMs: 10,
       id: `o-${i}`,
-      projectId: PROJECT_ID,
+      projectId,
       projectType: 'typescript',
       sessionId: 'sess',
       success: i < Math.round(count * successRate),
@@ -161,9 +168,14 @@ describe('AgentLLMService.ensureHarnessReady (Phase 5 Task 5.4 wiring)', () => {
   let sb: SinonSandbox
   let sessionEventBus: SessionEventBus
   let modeSelectedEvents: Array<Record<string, unknown>>
+  let projectId: string
 
   beforeEach(() => {
     sb = createSandbox()
+    // Capture cwd once per test to match the service's own `process.cwd()`
+    // read at construction. Per-test capture keeps these tests immune to
+    // any other test file that calls `process.chdir()`.
+    projectId = process.cwd()
     sessionEventBus = new SessionEventBus()
     modeSelectedEvents = []
     sessionEventBus.on('harness:mode-selected', (payload) => {
@@ -214,10 +226,10 @@ describe('AgentLLMService.ensureHarnessReady (Phase 5 Task 5.4 wiring)', () => {
 
   it('3. happy path: loaded + H in Mode A → emits event, returns {mode: assisted, version}', async () => {
     const stubs = makeHarnessStubs(sb)
-    const version = makeVersion()
+    const version = makeVersion(projectId)
     stubs.sandboxService.loadHarness.resolves({loaded: true, version})
     // Seed outcomes that produce H in [0.30, 0.60) — pass-through cap.
-    stubs.store.listOutcomes.resolves(makeOutcomes(20, 1, Date.now()))
+    stubs.store.listOutcomes.resolves(makeOutcomes(projectId, 20, 1, Date.now()))
 
     const service = buildService({
       config: makeConfig(),
@@ -237,16 +249,16 @@ describe('AgentLLMService.ensureHarnessReady (Phase 5 Task 5.4 wiring)', () => {
     const [event] = modeSelectedEvents
     expect(event.commandType).to.equal('curate')
     expect(event.mode).to.equal('assisted')
-    expect(event.projectId).to.equal(PROJECT_ID)
+    expect(event.projectId).to.equal(projectId)
     expect(event.version).to.equal(1)
     expect(event.heuristic).to.be.a('number')
   })
 
   it('4. heuristic=null (insufficient outcomes) → no event, returns undefined', async () => {
     const stubs = makeHarnessStubs(sb)
-    stubs.sandboxService.loadHarness.resolves({loaded: true, version: makeVersion()})
+    stubs.sandboxService.loadHarness.resolves({loaded: true, version: makeVersion(projectId)})
     // Fewer than the min-sample floor → computeHeuristic returns null.
-    stubs.store.listOutcomes.resolves(makeOutcomes(5, 1, Date.now()))
+    stubs.store.listOutcomes.resolves(makeOutcomes(projectId, 5, 1, Date.now()))
 
     const service = buildService({
       config: makeConfig(),
@@ -265,8 +277,8 @@ describe('AgentLLMService.ensureHarnessReady (Phase 5 Task 5.4 wiring)', () => {
 
   it('5. modeOverride=policy + low H → returns policy (override wins); event carries policy', async () => {
     const stubs = makeHarnessStubs(sb)
-    stubs.sandboxService.loadHarness.resolves({loaded: true, version: makeVersion()})
-    stubs.store.listOutcomes.resolves(makeOutcomes(20, 0, Date.now())) // H would be ~0 without override
+    stubs.sandboxService.loadHarness.resolves({loaded: true, version: makeVersion(projectId)})
+    stubs.store.listOutcomes.resolves(makeOutcomes(projectId, 20, 0, Date.now())) // H would be ~0 without override
 
     const service = buildService({
       config: makeConfig({modeOverride: 'policy'}),
@@ -286,8 +298,8 @@ describe('AgentLLMService.ensureHarnessReady (Phase 5 Task 5.4 wiring)', () => {
 
   it('6. event fires ONCE per (sessionId, commandType) across multiple calls', async () => {
     const stubs = makeHarnessStubs(sb)
-    stubs.sandboxService.loadHarness.resolves({loaded: true, version: makeVersion()})
-    stubs.store.listOutcomes.resolves(makeOutcomes(20, 1, Date.now()))
+    stubs.sandboxService.loadHarness.resolves({loaded: true, version: makeVersion(projectId)})
+    stubs.store.listOutcomes.resolves(makeOutcomes(projectId, 20, 1, Date.now()))
 
     const service = buildService({
       config: makeConfig(),
@@ -308,7 +320,7 @@ describe('AgentLLMService.ensureHarnessReady (Phase 5 Task 5.4 wiring)', () => {
 
   it('7. fails open: store error → logs warn and returns undefined (does not throw)', async () => {
     const stubs = makeHarnessStubs(sb)
-    stubs.sandboxService.loadHarness.resolves({loaded: true, version: makeVersion()})
+    stubs.sandboxService.loadHarness.resolves({loaded: true, version: makeVersion(projectId)})
     const boom = new Error('store read failed')
     stubs.store.listOutcomes.rejects(boom)
 

--- a/test/unit/agent/llm/agent-llm-service-harness-wiring.test.ts
+++ b/test/unit/agent/llm/agent-llm-service-harness-wiring.test.ts
@@ -305,4 +305,28 @@ describe('AgentLLMService.ensureHarnessReady (Phase 5 Task 5.4 wiring)', () => {
 
     expect(modeSelectedEvents).to.have.length(1)
   })
+
+  it('7. fails open: store error → logs warn and returns undefined (does not throw)', async () => {
+    const stubs = makeHarnessStubs(sb)
+    stubs.sandboxService.loadHarness.resolves({loaded: true, version: makeVersion()})
+    const boom = new Error('store read failed')
+    stubs.store.listOutcomes.rejects(boom)
+
+    const service = buildService({
+      config: makeConfig(),
+      harnessBootstrap: stubs.bootstrap,
+      harnessStore: stubs.store,
+      sandboxService: stubs.sandboxService,
+      sb,
+      sessionEventBus,
+    })
+
+    // Harness is non-critical — must never propagate an error up to the
+    // agent's state machine. Returning undefined lets the LLM turn run
+    // without the harness block.
+    const result = await callEnsureHarnessReady(service, 'curate')
+
+    expect(result).to.equal(undefined)
+    expect(modeSelectedEvents).to.have.length(0)
+  })
 })

--- a/test/unit/agent/llm/agent-llm-service-harness-wiring.test.ts
+++ b/test/unit/agent/llm/agent-llm-service-harness-wiring.test.ts
@@ -1,0 +1,308 @@
+import {expect} from 'chai'
+import {createSandbox, type SinonSandbox, type SinonStub} from 'sinon'
+
+import type {
+  CodeExecOutcome,
+  HarnessMode,
+  HarnessVersion,
+} from '../../../../src/agent/core/domain/harness/types.js'
+import type {IHarnessStore} from '../../../../src/agent/core/interfaces/i-harness-store.js'
+import type {ISandboxService} from '../../../../src/agent/core/interfaces/i-sandbox-service.js'
+import type {IToolProvider} from '../../../../src/agent/core/interfaces/i-tool-provider.js'
+import type {ValidatedHarnessConfig} from '../../../../src/agent/infra/agent/agent-schemas.js'
+
+import {SessionEventBus} from '../../../../src/agent/infra/events/event-emitter.js'
+import {HarnessBootstrap} from '../../../../src/agent/infra/harness/harness-bootstrap.js'
+import {ByteRoverLlmHttpService} from '../../../../src/agent/infra/http/internal-llm-http-service.js'
+import {AgentLLMService} from '../../../../src/agent/infra/llm/agent-llm-service.js'
+import {ByteRoverContentGenerator} from '../../../../src/agent/infra/llm/generators/byterover-content-generator.js'
+import {SystemPromptManager} from '../../../../src/agent/infra/system-prompt/system-prompt-manager.js'
+import {ToolManager} from '../../../../src/agent/infra/tools/tool-manager.js'
+
+const PROJECT_ID = process.cwd() // AgentLLMService uses this as projectId
+
+function makeConfig(overrides: Partial<ValidatedHarnessConfig> = {}): ValidatedHarnessConfig {
+  return {
+    autoLearn: true,
+    enabled: true,
+    language: 'typescript',
+    maxVersions: 20,
+    ...overrides,
+  }
+}
+
+function makeVersion(): HarnessVersion {
+  return {
+    code: '/* placeholder */',
+    commandType: 'curate',
+    createdAt: 1_700_000_000_000,
+    heuristic: 0.45,
+    id: 'v-test-wiring',
+    metadata: {
+      capabilities: ['curate'],
+      commandType: 'curate',
+      projectPatterns: ['**/*.ts'],
+      version: 1,
+    },
+    projectId: PROJECT_ID,
+    projectType: 'typescript',
+    version: 1,
+  }
+}
+
+function makeOutcomes(count: number, successRate: number, now: number): CodeExecOutcome[] {
+  const outcomes: CodeExecOutcome[] = []
+  for (let i = 0; i < count; i++) {
+    outcomes.push({
+      code: `step ${i}`,
+      commandType: 'curate',
+      delegated: true,
+      executionTimeMs: 10,
+      id: `o-${i}`,
+      projectId: PROJECT_ID,
+      projectType: 'typescript',
+      sessionId: 'sess',
+      success: i < Math.round(count * successRate),
+      timestamp: now - i * 1000,
+      usedHarness: true,
+    })
+  }
+
+  return outcomes
+}
+
+function createContentGenerator() {
+  const httpService = new ByteRoverLlmHttpService({
+    apiBaseUrl: 'http://localhost:3000',
+    sessionKey: 'k',
+    spaceId: 's',
+    teamId: 't',
+  })
+  return new ByteRoverContentGenerator(httpService, {model: 'gemini-2.5-flash'})
+}
+
+type HarnessStub = {
+  readonly bootstrap: HarnessBootstrap & {bootstrapIfNeeded: SinonStub}
+  readonly sandboxService: ISandboxService & {loadHarness: SinonStub}
+  readonly store: IHarnessStore & {listOutcomes: SinonStub}
+}
+
+function makeHarnessStubs(sb: SinonSandbox): HarnessStub {
+  const bootstrapIfNeeded = sb.stub().resolves()
+  const loadHarness = sb.stub()
+  const listOutcomes = sb.stub().resolves([])
+
+  // Minimal stubs — AgentLLMService only calls these three methods.
+  const bootstrap = {bootstrapIfNeeded} as unknown as HarnessBootstrap & {
+    bootstrapIfNeeded: SinonStub
+  }
+  const sandboxService = {
+    cleanup: sb.stub(),
+    clearSession: sb.stub(),
+    deleteSandboxVariable: sb.stub(),
+    executeCode: sb.stub(),
+    loadHarness,
+    setSandboxVariable: sb.stub(),
+  } as unknown as ISandboxService & {loadHarness: SinonStub}
+  const store = {listOutcomes} as unknown as IHarnessStore & {listOutcomes: SinonStub}
+
+  return {bootstrap, sandboxService, store}
+}
+
+function buildService(deps: {
+  config?: ValidatedHarnessConfig
+  harnessBootstrap?: HarnessBootstrap
+  harnessStore?: IHarnessStore
+  sandboxService?: ISandboxService
+  sb: SinonSandbox
+  sessionEventBus: SessionEventBus
+}): AgentLLMService {
+  const mockToolProvider = {
+    getAllTools: deps.sb.stub().returns({}),
+    getAvailableMarkers: deps.sb.stub().returns(new Set<string>()),
+    getToolNames: deps.sb.stub().returns([]),
+  }
+  const toolManager = new ToolManager(mockToolProvider as unknown as IToolProvider)
+
+  return new AgentLLMService(
+    'test-session',
+    createContentGenerator(),
+    {model: 'gemini-2.5-flash'},
+    {
+      harnessBootstrap: deps.harnessBootstrap,
+      harnessConfig: deps.config,
+      harnessStore: deps.harnessStore,
+      sandboxService: deps.sandboxService,
+      sessionEventBus: deps.sessionEventBus,
+      systemPromptManager: new SystemPromptManager(),
+      toolManager,
+    },
+  )
+}
+
+// Private-method access helper. AgentLLMService's `ensureHarnessReady`
+// is private (correctly scoped — external callers go through
+// `completeTask` which invokes it indirectly). Unit-testing the
+// orchestration logic without constructing the full turn would be
+// impractical, so the cast below intentionally reaches the private
+// method. Confined to this test file.
+type EnsureHarnessReadyResult = undefined | {mode: HarnessMode; version: HarnessVersion}
+function callEnsureHarnessReady(
+  service: AgentLLMService,
+  commandType: 'chat' | 'curate' | 'query',
+): Promise<EnsureHarnessReadyResult> {
+  const internal = service as unknown as {
+    ensureHarnessReady: (commandType: 'chat' | 'curate' | 'query') => Promise<EnsureHarnessReadyResult>
+  }
+  return internal.ensureHarnessReady(commandType)
+}
+
+describe('AgentLLMService.ensureHarnessReady (Phase 5 Task 5.4 wiring)', () => {
+  let sb: SinonSandbox
+  let sessionEventBus: SessionEventBus
+  let modeSelectedEvents: Array<Record<string, unknown>>
+
+  beforeEach(() => {
+    sb = createSandbox()
+    sessionEventBus = new SessionEventBus()
+    modeSelectedEvents = []
+    sessionEventBus.on('harness:mode-selected', (payload) => {
+      modeSelectedEvents.push(payload as Record<string, unknown>)
+    })
+  })
+
+  afterEach(() => {
+    sb.restore()
+  })
+
+  it('1. harness.enabled=false → no bootstrap call, no event, returns undefined', async () => {
+    const stubs = makeHarnessStubs(sb)
+    const service = buildService({
+      config: makeConfig({enabled: false}),
+      harnessBootstrap: stubs.bootstrap,
+      harnessStore: stubs.store,
+      sandboxService: stubs.sandboxService,
+      sb,
+      sessionEventBus,
+    })
+
+    const result = await callEnsureHarnessReady(service, 'curate')
+
+    expect(result).to.equal(undefined)
+    expect(stubs.bootstrap.bootstrapIfNeeded.callCount).to.equal(0)
+    expect(modeSelectedEvents).to.have.length(0)
+  })
+
+  it('2. loadHarness returns no-version → no event, returns undefined', async () => {
+    const stubs = makeHarnessStubs(sb)
+    stubs.sandboxService.loadHarness.resolves({loaded: false, reason: 'no-version'})
+    const service = buildService({
+      config: makeConfig(),
+      harnessBootstrap: stubs.bootstrap,
+      harnessStore: stubs.store,
+      sandboxService: stubs.sandboxService,
+      sb,
+      sessionEventBus,
+    })
+
+    const result = await callEnsureHarnessReady(service, 'curate')
+
+    expect(result).to.equal(undefined)
+    expect(stubs.bootstrap.bootstrapIfNeeded.callCount).to.equal(1)
+    expect(modeSelectedEvents).to.have.length(0)
+  })
+
+  it('3. happy path: loaded + H in Mode A → emits event, returns {mode: assisted, version}', async () => {
+    const stubs = makeHarnessStubs(sb)
+    const version = makeVersion()
+    stubs.sandboxService.loadHarness.resolves({loaded: true, version})
+    // Seed outcomes that produce H in [0.30, 0.60) — pass-through cap.
+    stubs.store.listOutcomes.resolves(makeOutcomes(20, 1, Date.now()))
+
+    const service = buildService({
+      config: makeConfig(),
+      harnessBootstrap: stubs.bootstrap,
+      harnessStore: stubs.store,
+      sandboxService: stubs.sandboxService,
+      sb,
+      sessionEventBus,
+    })
+
+    const result = await callEnsureHarnessReady(service, 'curate')
+
+    expect(result).to.not.equal(undefined)
+    expect(result?.mode).to.equal('assisted')
+    expect(result?.version.id).to.equal('v-test-wiring')
+    expect(modeSelectedEvents).to.have.length(1)
+    const [event] = modeSelectedEvents
+    expect(event.commandType).to.equal('curate')
+    expect(event.mode).to.equal('assisted')
+    expect(event.projectId).to.equal(PROJECT_ID)
+    expect(event.version).to.equal(1)
+    expect(event.heuristic).to.be.a('number')
+  })
+
+  it('4. heuristic=null (insufficient outcomes) → no event, returns undefined', async () => {
+    const stubs = makeHarnessStubs(sb)
+    stubs.sandboxService.loadHarness.resolves({loaded: true, version: makeVersion()})
+    // Fewer than the min-sample floor → computeHeuristic returns null.
+    stubs.store.listOutcomes.resolves(makeOutcomes(5, 1, Date.now()))
+
+    const service = buildService({
+      config: makeConfig(),
+      harnessBootstrap: stubs.bootstrap,
+      harnessStore: stubs.store,
+      sandboxService: stubs.sandboxService,
+      sb,
+      sessionEventBus,
+    })
+
+    const result = await callEnsureHarnessReady(service, 'curate')
+
+    expect(result).to.equal(undefined)
+    expect(modeSelectedEvents).to.have.length(0)
+  })
+
+  it('5. modeOverride=policy + low H → returns policy (override wins); event carries policy', async () => {
+    const stubs = makeHarnessStubs(sb)
+    stubs.sandboxService.loadHarness.resolves({loaded: true, version: makeVersion()})
+    stubs.store.listOutcomes.resolves(makeOutcomes(20, 0, Date.now())) // H would be ~0 without override
+
+    const service = buildService({
+      config: makeConfig({modeOverride: 'policy'}),
+      harnessBootstrap: stubs.bootstrap,
+      harnessStore: stubs.store,
+      sandboxService: stubs.sandboxService,
+      sb,
+      sessionEventBus,
+    })
+
+    const result = await callEnsureHarnessReady(service, 'curate')
+
+    expect(result?.mode).to.equal('policy')
+    expect(modeSelectedEvents).to.have.length(1)
+    expect(modeSelectedEvents[0].mode).to.equal('policy')
+  })
+
+  it('6. event fires ONCE per (sessionId, commandType) across multiple calls', async () => {
+    const stubs = makeHarnessStubs(sb)
+    stubs.sandboxService.loadHarness.resolves({loaded: true, version: makeVersion()})
+    stubs.store.listOutcomes.resolves(makeOutcomes(20, 1, Date.now()))
+
+    const service = buildService({
+      config: makeConfig(),
+      harnessBootstrap: stubs.bootstrap,
+      harnessStore: stubs.store,
+      sandboxService: stubs.sandboxService,
+      sb,
+      sessionEventBus,
+    })
+
+    // Three turns, same commandType.
+    await callEnsureHarnessReady(service, 'curate')
+    await callEnsureHarnessReady(service, 'curate')
+    await callEnsureHarnessReady(service, 'curate')
+
+    expect(modeSelectedEvents).to.have.length(1)
+  })
+})

--- a/test/unit/agent/system-prompt/harness-contributor.test.ts
+++ b/test/unit/agent/system-prompt/harness-contributor.test.ts
@@ -1,0 +1,82 @@
+import {expect} from 'chai'
+
+import type {
+  HarnessMode,
+  HarnessVersion,
+} from '../../../../src/agent/core/domain/harness/types.js'
+import type {ContributorContext} from '../../../../src/agent/core/domain/system-prompt/types.js'
+
+import {HarnessContributor} from '../../../../src/agent/infra/system-prompt/contributors/harness-contributor.js'
+
+function makeVersion(): HarnessVersion {
+  return {
+    code: '/* placeholder */',
+    commandType: 'curate',
+    createdAt: 1_700_000_000_000,
+    heuristic: 0.45,
+    id: 'v-test-contrib',
+    metadata: {
+      capabilities: ['curate'],
+      commandType: 'curate',
+      projectPatterns: ['**/*.ts'],
+      version: 1,
+    },
+    projectId: 'p1',
+    projectType: 'typescript',
+    version: 1,
+  }
+}
+
+function ctxWith(mode?: HarnessMode, version?: HarnessVersion): ContributorContext {
+  return {harnessMode: mode, harnessVersion: version}
+}
+
+describe('HarnessContributor (system-prompt wrapper)', () => {
+  const contributor = new HarnessContributor()
+
+  it('1. default id and priority match the Phase 5 Task 5.4 registration contract', () => {
+    expect(contributor.id).to.equal('harness')
+    expect(contributor.priority).to.equal(18)
+  })
+
+  it('2. constructor accepts custom id + priority', () => {
+    const custom = new HarnessContributor('custom-id', 42)
+    expect(custom.id).to.equal('custom-id')
+    expect(custom.priority).to.equal(42)
+  })
+
+  it('3. returns empty string when harnessMode is undefined', async () => {
+    const out = await contributor.getContent(ctxWith(undefined, makeVersion()))
+    expect(out).to.equal('')
+  })
+
+  it('4. returns empty string when harnessVersion is undefined', async () => {
+    const out = await contributor.getContent(ctxWith('assisted'))
+    expect(out).to.equal('')
+  })
+
+  it('5. returns empty string when BOTH are undefined', async () => {
+    const out = await contributor.getContent(ctxWith())
+    expect(out).to.equal('')
+  })
+
+  it('6. renders the assisted prompt when mode+version present', async () => {
+    const out = await contributor.getContent(ctxWith('assisted', makeVersion()))
+    expect(out).to.include('<harness-v2 mode="assisted"')
+    expect(out).to.include('version="v-test-contrib"')
+    expect(out).to.include('harness.curate(')
+  })
+
+  it('7. renders the filter prompt (harness-first framing) when mode=filter', async () => {
+    const out = await contributor.getContent(ctxWith('filter', makeVersion()))
+    expect(out).to.include('<harness-v2 mode="filter"')
+    expect(out).to.match(/invoke|obtain|call/i)
+    expect(out).to.match(/result|proposal|returned/i)
+  })
+
+  it('8. renders the policy prompt (forbids own orchestration) when mode=policy', async () => {
+    const out = await contributor.getContent(ctxWith('policy', makeVersion()))
+    expect(out).to.include('<harness-v2 mode="policy"')
+    expect(out).to.match(/do not|don['’]t/i)
+  })
+})


### PR DESCRIPTION
## Summary

- **Problem**: Phase 4 shipped `HarnessBootstrap`. Phase 5 Tasks 5.1/5.2/5.3 shipped the mode selector, prompt contributor, and Mode C caps. Nothing yet wires them into the actual agent flow, so every turn still runs the same way regardless of H.
- **Why it matters**: This is the production entry point for everything Phases 3–5 have built. Without this wiring, the prompt contributor never fires, no event is emitted, and the heuristic never drives behavior. Phase 6's learning loop has no signal to consume either.
- **What changed**: Adds `AgentLLMService.ensureHarnessReady(commandType)` — orchestrates bootstrap → load → heuristic → mode selection → event emission. Creates `HarnessContributor` (system-prompt contributor) that reads `harnessMode` + `harnessVersion` from `ContributorContext` and delegates to `contributeHarnessPrompt`. Wires `HarnessBootstrap` + the new contributor into `service-initializer.ts`; threads the new deps into `AgentLLMService`.
- **What did NOT change (scope boundary)**: No Mode C cap changes (Task 5.3 already in). No refinement (Phase 6). No integration test (Task 5.5). No new events beyond what's already in `AgentEventMap`. The `harness:loaded` event (already in the event map, intended to fire from `SandboxService.loadHarness`) is NOT wired here — Phase 3 follow-up.

## Type of change

- [x] New feature

## Scope (select all touched areas)

- [x] Agent / Tools

## Linked issues

- Closes ENG-2257
- Depends on (all merged): ENG-2254 (mode selector), ENG-2255 (prompt contributor), ENG-2256 (Mode C caps), ENG-2249 (`HarnessBootstrap`)
- Related: ENG-2258 (Task 5.5 integration test — exercises this wiring end-to-end)

## Root cause (bug fixes only, otherwise write `N/A`)

N/A

## Test plan

- Coverage added:
  - [x] Unit test
- Test file(s):
  - `test/unit/agent/system-prompt/harness-contributor.test.ts` (8 tests)
  - `test/unit/agent/llm/agent-llm-service-harness-wiring.test.ts` (6 tests)
- Key scenario(s) covered:

**HarnessContributor** (8):
1. Default id=`'harness'` + priority=`18` match the registration contract
2. Constructor accepts custom id + priority
3. `harnessMode` undefined → empty string
4. `harnessVersion` undefined → empty string
5. Both undefined → empty string
6. assisted → `<harness-v2 mode="assisted" version="…">` + `harness.curate(` body
7. filter → harness-first framing (`invoke|obtain|call` + `result|proposal|returned`)
8. policy → `do not|don't` + `harness.curate(` body

**AgentLLMService wiring** (6):
1. `harness.enabled=false` → no bootstrap call, no event, returns `undefined`
2. `loadHarness` returns `no-version` → bootstrap fires but no event, returns `undefined`
3. Happy path: loaded + seeded outcomes → event emitted with full payload (commandType, mode, projectId, version, heuristic), returns `{mode, version}`
4. Heuristic below min-sample floor → no event, returns `undefined`
5. `modeOverride: 'policy'` + low H → returns `'policy'` (override wins), event carries `mode: 'policy'`
6. Event fires ONCE per `(sessionId, commandType)` across three calls — session-scoped dedup invariant

## User-visible changes

No end-user-facing changes yet. When a harness is loaded for a `(projectId, commandType)` pair, the LLM now sees a mode-specific prompt block and the `harness:mode-selected` event fires once per session. All pre-wired downstream consumers (Phase 6+ refinement, Phase 7 CLI observability) have their signal.

## Evidence

- [x] Failing test/log before + passing after

```
$ npx mocha --forbid-only test/unit/agent/system-prompt/harness-contributor.test.ts test/unit/agent/llm/agent-llm-service-harness-wiring.test.ts
  HarnessContributor (system-prompt wrapper)
    ✔ 1. default id and priority match the Phase 5 Task 5.4 registration contract
    ✔ 2. constructor accepts custom id + priority
    ✔ 3. returns empty string when harnessMode is undefined
    ✔ 4. returns empty string when harnessVersion is undefined
    ✔ 5. returns empty string when BOTH are undefined
    ✔ 6. renders the assisted prompt when mode+version present
    ✔ 7. renders the filter prompt (harness-first framing) when mode=filter
    ✔ 8. renders the policy prompt (forbids own orchestration) when mode=policy
  AgentLLMService.ensureHarnessReady (Phase 5 Task 5.4 wiring)
    ✔ 1. harness.enabled=false → no bootstrap call, no event, returns undefined
    ✔ 2. loadHarness returns no-version → no event, returns undefined
    ✔ 3. happy path: loaded + H in Mode A → emits event, returns {mode: assisted, version}
    ✔ 4. heuristic=null (insufficient outcomes) → no event, returns undefined
    ✔ 5. modeOverride=policy + low H → returns policy (override wins); event carries policy
    ✔ 6. event fires ONCE per (sessionId, commandType) across multiple calls

  14 passing (13ms)

$ npx mocha --forbid-only 'test/unit/**/*.test.ts'
  5888 passing (40s)
```

## Checklist

- [x] Tests added or updated and passing
- [x] Lint passes
- [x] Type check passes
- [x] Build succeeds
- [x] Commits follow Conventional Commits format
- [ ] Documentation updated — N/A (internal)
- [x] No breaking changes
- [x] Branch is up to date with `proj/autoharness-v2`

## Risks and mitigations

- **Risk: contributor runs on every `systemPromptManager.build(...)` call**, including non-harness-aware ones. If `harnessMode`/`harnessVersion` aren't populated by the caller, the contributor returns an empty string, so the net effect is safe. But it does add a no-op branch to every contributor run.
  - **Mitigation**: The empty-string path is one `if (undefined || undefined)` check — tens of nanoseconds. Measurable impact is zero. Tests 3–5 pin the invariant.

- **Risk: private-method access in tests via cast** — the `agent-llm-service-harness-wiring.test.ts` file accesses `ensureHarnessReady` through a narrow cast helper. Reviewer has flagged `as unknown as` casts before.
  - **Mitigation**: The cast is confined to ONE helper function at the top of the test file, with a comment explaining why it's necessary (constructing the full turn lifecycle to test this method indirectly would be much more fragile). Production code has zero casts. If the reviewer prefers, the method can be changed to `public` with an `@internal` JSDoc tag, or extracted to a standalone helper — both are refactor-only changes.

- **Risk: JSDoc warnings pre-existing on sibling fields** — lint originally flagged missing `@param` tags for `compressionStrategies` and the three new harness fields. I documented all four to preempt reviewer noise; other pre-existing fields in the codebase remain sparsely documented.
  - **Mitigation**: Warnings now clean for this file. Broader JSDoc cleanup is out of scope.

- **Risk: `harness:mode-selected` event dedup is per-service-instance** — if AgentLLMService is recreated mid-session (via session manager restart or similar), the event may re-fire.
  - **Mitigation**: Matches the event's docstring ("Emitted when the harness mode is selected... once per session"). Session recreation is expected to be rare and typically indicates a clean session boundary anyway. Test 6 pins the per-instance invariant.