### PR TITLE
feat: P6-Is 6.2 — Prompts + SDK documentation

### DIFF
--- a/src/agent/infra/harness/prompts/critic-prompt.ts
+++ b/src/agent/infra/harness/prompts/critic-prompt.ts
@@ -1,0 +1,112 @@
+/**
+ * AutoHarness V2 — Critic prompt builder.
+ *
+ * The Critic LLM call diagnoses why a harness version is
+ * underperforming by analyzing recent outcomes and evaluation
+ * scenarios. Its analysis feeds the Refiner, which produces
+ * a candidate replacement.
+ *
+ * The 8000-char ceiling keeps the prompt within weak models'
+ * context windows. If outcomes or parent code are too large,
+ * they are truncated with an explicit marker so the LLM knows
+ * content was omitted.
+ */
+
+import type {
+  CodeExecOutcome,
+  EvaluationScenario,
+} from '../../../core/domain/harness/types.js'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Maximum total prompt length. Prevents context-window overflow on weak models. */
+const MAX_PROMPT_LENGTH = 8000
+
+/** Maximum characters allocated to the parent code section. */
+const MAX_PARENT_CODE_LENGTH = 2000
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface CriticPromptContext {
+  readonly heuristic: number
+  readonly parentCode: string
+  readonly recentOutcomes: readonly CodeExecOutcome[]
+  readonly scenarios: readonly EvaluationScenario[]
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function truncate(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text
+  return text.slice(0, maxLength - 30) + '\n... [truncated for brevity]'
+}
+
+/**
+ * Format raw outcomes compactly — one line per outcome with key fields.
+ * Preserves all signals (commandType, stderr, executionTimeMs, usedHarness)
+ * so the Critic LLM can spot correlations the prompt author didn't anticipate.
+ * Overall prompt truncation handles budget; no per-section cap needed.
+ */
+function formatOutcomes(outcomes: readonly CodeExecOutcome[]): string {
+  const lines = outcomes.map((o) => {
+    const status = o.success ? 'OK' : 'FAIL'
+    const stderr = o.stderr ? ` err="${o.stderr}"` : ''
+    return `  [${status}] ${o.commandType} ${o.executionTimeMs.toFixed(0)}ms harness=${o.usedHarness}${stderr}`
+  })
+  return lines.join('\n')
+}
+
+function summarizeScenarios(scenarios: readonly EvaluationScenario[]): string {
+  return scenarios
+    .map((s, i) => `  ${i + 1}. [${s.commandType}] ${s.taskDescription} — expected: ${s.expectedBehavior}`)
+    .join('\n')
+}
+
+// ---------------------------------------------------------------------------
+// Builder
+// ---------------------------------------------------------------------------
+
+export function buildCriticPrompt(ctx: CriticPromptContext): string {
+  const parentCodeSection = truncate(ctx.parentCode, MAX_PARENT_CODE_LENGTH)
+  const outcomesSection = formatOutcomes(ctx.recentOutcomes)
+  const scenariosSection = summarizeScenarios(ctx.scenarios)
+
+  const prompt = `You are a harness quality critic. Analyze the following harness version and its recent execution outcomes to identify the root cause of failures.
+
+## Current harness code
+
+\`\`\`js
+${parentCodeSection}
+\`\`\`
+
+## Performance
+
+Current heuristic score (H): ${ctx.heuristic}
+Recent outcomes (${ctx.recentOutcomes.length} total):
+${outcomesSection}
+
+## Evaluation scenarios (${ctx.scenarios.length} total)
+
+${scenariosSection}
+
+## Your task
+
+Analyze the harness code, outcomes, and scenarios above. Identify:
+1. What failure pattern is most common
+2. What the root cause is in the harness code
+3. What structural change would fix it
+
+Respond in exactly this format:
+# Critic analysis
+- Failure pattern: <short description of the most common failure>
+- Root cause: <mechanism in the code causing failures>
+- Suggested change: <structural hint for the Refiner — what to change, not the full code>`
+
+  return truncate(prompt, MAX_PROMPT_LENGTH)
+}

--- a/src/agent/infra/harness/prompts/critic-prompt.ts
+++ b/src/agent/infra/harness/prompts/critic-prompt.ts
@@ -7,9 +7,9 @@
  * a candidate replacement.
  *
  * The 8000-char ceiling keeps the prompt within weak models'
- * context windows. If outcomes or parent code are too large,
- * they are truncated with an explicit marker so the LLM knows
- * content was omitted.
+ * context windows. Dynamic sections (outcomes, scenarios, parent
+ * code) are truncated independently so the static instruction
+ * block is never amputated.
  */
 
 import type {
@@ -26,6 +26,15 @@ const MAX_PROMPT_LENGTH = 8000
 
 /** Maximum characters allocated to the parent code section. */
 const MAX_PARENT_CODE_LENGTH = 2000
+
+/**
+ * Budget for dynamic sections (outcomes + scenarios). Derived from
+ * MAX_PROMPT_LENGTH minus the static scaffolding (~1200 chars) and
+ * the parent code cap. Outcomes get 70% of the remainder, scenarios 30%.
+ */
+const DYNAMIC_BUDGET = MAX_PROMPT_LENGTH - MAX_PARENT_CODE_LENGTH - 1200
+const MAX_OUTCOMES_LENGTH = Math.floor(DYNAMIC_BUDGET * 0.7)
+const MAX_SCENARIOS_LENGTH = Math.floor(DYNAMIC_BUDGET * 0.3)
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -51,21 +60,23 @@ function truncate(text: string, maxLength: number): string {
  * Format raw outcomes compactly — one line per outcome with key fields.
  * Preserves all signals (commandType, stderr, executionTimeMs, usedHarness)
  * so the Critic LLM can spot correlations the prompt author didn't anticipate.
- * Overall prompt truncation handles budget; no per-section cap needed.
  */
 function formatOutcomes(outcomes: readonly CodeExecOutcome[]): string {
   const lines = outcomes.map((o) => {
     const status = o.success ? 'OK' : 'FAIL'
-    const stderr = o.stderr ? ` err="${o.stderr}"` : ''
-    return `  [${status}] ${o.commandType} ${o.executionTimeMs.toFixed(0)}ms harness=${o.usedHarness}${stderr}`
+    const stderrSnippet = o.stderr
+      ? ` err="${o.stderr.slice(0, 80).replaceAll('"', "'")}"`
+      : ''
+    return `  [${status}] ${o.commandType} ${o.executionTimeMs.toFixed(0)}ms harness=${o.usedHarness}${stderrSnippet}`
   })
-  return lines.join('\n')
+  return truncate(lines.join('\n'), MAX_OUTCOMES_LENGTH)
 }
 
-function summarizeScenarios(scenarios: readonly EvaluationScenario[]): string {
-  return scenarios
+function formatScenarios(scenarios: readonly EvaluationScenario[]): string {
+  const text = scenarios
     .map((s, i) => `  ${i + 1}. [${s.commandType}] ${s.taskDescription} — expected: ${s.expectedBehavior}`)
     .join('\n')
+  return truncate(text, MAX_SCENARIOS_LENGTH)
 }
 
 // ---------------------------------------------------------------------------
@@ -75,9 +86,9 @@ function summarizeScenarios(scenarios: readonly EvaluationScenario[]): string {
 export function buildCriticPrompt(ctx: CriticPromptContext): string {
   const parentCodeSection = truncate(ctx.parentCode, MAX_PARENT_CODE_LENGTH)
   const outcomesSection = formatOutcomes(ctx.recentOutcomes)
-  const scenariosSection = summarizeScenarios(ctx.scenarios)
+  const scenariosSection = formatScenarios(ctx.scenarios)
 
-  const prompt = `You are a harness quality critic. Analyze the following harness version and its recent execution outcomes to identify the root cause of failures.
+  return `You are a harness quality critic. Analyze the following harness version and its recent execution outcomes to identify the root cause of failures.
 
 ## Current harness code
 
@@ -87,7 +98,7 @@ ${parentCodeSection}
 
 ## Performance
 
-Current heuristic score (H): ${ctx.heuristic}
+Current heuristic score (H): ${ctx.heuristic.toFixed(2)}
 Recent outcomes (${ctx.recentOutcomes.length} total):
 ${outcomesSection}
 
@@ -107,6 +118,4 @@ Respond in exactly this format:
 - Failure pattern: <short description of the most common failure>
 - Root cause: <mechanism in the code causing failures>
 - Suggested change: <structural hint for the Refiner — what to change, not the full code>`
-
-  return truncate(prompt, MAX_PROMPT_LENGTH)
 }

--- a/src/agent/infra/harness/prompts/refiner-prompt.ts
+++ b/src/agent/infra/harness/prompts/refiner-prompt.ts
@@ -10,9 +10,23 @@
  * module builder does not strip them. Weak models that still
  * emit fences are handled by a fallback in the Synthesizer
  * (not here).
+ *
+ * Dynamic sections (parentCode, criticAnalysis) are capped so
+ * the static scaffolding (SDK docs, output requirements) is
+ * never amputated on weak models with small context windows.
  */
 
 import type {ProjectType} from '../../../core/domain/harness/types.js'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Maximum characters for the parent code section. */
+const MAX_PARENT_CODE_LENGTH = 3000
+
+/** Maximum characters for the critic analysis section. */
+const MAX_CRITIC_ANALYSIS_LENGTH = 1000
 
 // ---------------------------------------------------------------------------
 // Project-type hints — language-aware guidance for the Refiner
@@ -22,6 +36,15 @@ const PROJECT_TYPE_HINTS: Record<ProjectType, string> = {
   generic: `The project type is "generic" (mixed or unknown language). The harness reads project files of any type — do not assume file extensions or language-specific patterns. Keep file-reading logic flexible.`,
   python: `The project type is "python". Source files typically use .py extensions. When reading project files with ctx.tools.readFile, expect Python source code, requirements.txt, pyproject.toml, and similar Python ecosystem files.`,
   typescript: `The project type is "typescript". Source files typically use .ts/.tsx extensions. When reading project files with ctx.tools.readFile, expect TypeScript source code, package.json, tsconfig.json, and similar Node.js ecosystem files.`,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function truncate(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text
+  return text.slice(0, maxLength - 30) + '\n... [truncated for brevity]'
 }
 
 // ---------------------------------------------------------------------------
@@ -40,6 +63,9 @@ export interface RefinerPromptContext {
 // ---------------------------------------------------------------------------
 
 export function buildRefinerPrompt(ctx: RefinerPromptContext): string {
+  const parentCodeSection = truncate(ctx.parentCode, MAX_PARENT_CODE_LENGTH)
+  const criticSection = truncate(ctx.criticAnalysis, MAX_CRITIC_ANALYSIS_LENGTH)
+
   return `You are a harness refiner. Your job is to produce an improved version of the harness code below, guided by the Critic's analysis and the available SDK tools.
 
 ## SDK tools reference
@@ -52,18 +78,18 @@ ${PROJECT_TYPE_HINTS[ctx.projectType]}
 
 ## Parent harness code (current version)
 
-${ctx.parentCode}
+${parentCodeSection}
 
 ## Critic's analysis (what to fix)
 
-${ctx.criticAnalysis}
+${criticSection}
 
 ## Output requirements
 
 Produce the COMPLETE replacement harness code as a single string. The code must:
 
 1. Export \`exports.meta\` as a function returning a HarnessMeta object
-2. Export \`exports.curate\` as an async function taking \`ctx\` and returning a CurateResult
+2. Export the appropriate handler function (\`exports.curate\` or \`exports.query\`) matching the harness's declared commandType
 3. Preserve \`version: 1\` in the meta return value (version bumps are handled externally)
 4. Only use \`ctx.tools.curate\` and \`ctx.tools.readFile\` — no other APIs
 5. Contain no \`require()\`, \`import\`, \`setTimeout\`, \`setInterval\`, or \`process\` calls

--- a/src/agent/infra/harness/prompts/refiner-prompt.ts
+++ b/src/agent/infra/harness/prompts/refiner-prompt.ts
@@ -1,0 +1,75 @@
+/**
+ * AutoHarness V2 — Refiner prompt builder.
+ *
+ * The Refiner LLM produces a complete replacement harness code
+ * string based on the Critic's analysis, the parent code, and
+ * the SDK documentation. Its output goes directly to
+ * `HarnessModuleBuilder.build` — no intermediate parsing.
+ *
+ * The prompt explicitly forbids markdown fences because the
+ * module builder does not strip them. Weak models that still
+ * emit fences are handled by a fallback in the Synthesizer
+ * (not here).
+ */
+
+import type {ProjectType} from '../../../core/domain/harness/types.js'
+
+// ---------------------------------------------------------------------------
+// Project-type hints — language-aware guidance for the Refiner
+// ---------------------------------------------------------------------------
+
+const PROJECT_TYPE_HINTS: Record<ProjectType, string> = {
+  generic: `The project type is "generic" (mixed or unknown language). The harness reads project files of any type — do not assume file extensions or language-specific patterns. Keep file-reading logic flexible.`,
+  python: `The project type is "python". Source files typically use .py extensions. When reading project files with ctx.tools.readFile, expect Python source code, requirements.txt, pyproject.toml, and similar Python ecosystem files.`,
+  typescript: `The project type is "typescript". Source files typically use .ts/.tsx extensions. When reading project files with ctx.tools.readFile, expect TypeScript source code, package.json, tsconfig.json, and similar Node.js ecosystem files.`,
+}
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface RefinerPromptContext {
+  readonly criticAnalysis: string
+  readonly parentCode: string
+  readonly projectType: ProjectType
+  readonly sdkDocumentation: string
+}
+
+// ---------------------------------------------------------------------------
+// Builder
+// ---------------------------------------------------------------------------
+
+export function buildRefinerPrompt(ctx: RefinerPromptContext): string {
+  return `You are a harness refiner. Your job is to produce an improved version of the harness code below, guided by the Critic's analysis and the available SDK tools.
+
+## SDK tools reference
+
+${ctx.sdkDocumentation}
+
+## Project context
+
+${PROJECT_TYPE_HINTS[ctx.projectType]}
+
+## Parent harness code (current version)
+
+${ctx.parentCode}
+
+## Critic's analysis (what to fix)
+
+${ctx.criticAnalysis}
+
+## Output requirements
+
+Produce the COMPLETE replacement harness code as a single string. The code must:
+
+1. Export \`exports.meta\` as a function returning a HarnessMeta object
+2. Export \`exports.curate\` as an async function taking \`ctx\` and returning a CurateResult
+3. Preserve \`version: 1\` in the meta return value (version bumps are handled externally)
+4. Only use \`ctx.tools.curate\` and \`ctx.tools.readFile\` — no other APIs
+5. Contain no \`require()\`, \`import\`, \`setTimeout\`, \`setInterval\`, or \`process\` calls
+6. Stay within the 50-operation cap on ctx.tools.* calls
+
+CRITICAL: Return ONLY the raw JavaScript code. Do NOT wrap it in markdown code fences (\`\`\`). Do NOT include any prose, explanation, or commentary before or after the code. The output is fed directly to a JavaScript parser — any non-code content will cause a syntax error.
+
+Begin your response with \`exports.meta\` — nothing else before it.`
+}

--- a/src/agent/infra/harness/prompts/sdk-documentation.ts
+++ b/src/agent/infra/harness/prompts/sdk-documentation.ts
@@ -40,7 +40,7 @@ The only tools available to the harness function are on the \`ctx.tools\` object
     Returns: FileContent — { content: string, formattedContent: string, lines: number, totalLines: number, size: number, truncated: boolean, encoding: string, message: string }
 
 Constraints:
-  * Must export exactly: exports.meta = function() { return HarnessMeta }; exports.curate = async function(ctx) { ... }
+  * Must export exports.meta = function() { return HarnessMeta } and the handler matching the commandType: exports.curate = async function(ctx) { ... } or exports.query = async function(ctx) { ... }
   * May only call ctx.tools.curate and ctx.tools.readFile — no other APIs
   * No async work except via ctx.tools.* calls
   * No setTimeout / setInterval / process / require / node: built-in modules

--- a/src/agent/infra/harness/prompts/sdk-documentation.ts
+++ b/src/agent/infra/harness/prompts/sdk-documentation.ts
@@ -1,0 +1,48 @@
+/**
+ * AutoHarness V2 — SDK documentation for harness refinement prompts.
+ *
+ * Hand-crafted description of the v1.0 `HarnessContextTools` surface.
+ * The Refiner LLM consumes this so it knows which tools are available
+ * inside the sandbox VM.
+ *
+ * This is a string constant, not auto-generated from types. LLMs
+ * understand natural-language docs better than JSON-schema output.
+ * Maintenance is manual: update this when `HarnessContextTools`
+ * (core/domain/harness/types.ts) changes.
+ */
+
+// Signatures reference HarnessContextTools in core/domain/harness/types.ts.
+// If a new tool is added to that interface, update this documentation.
+export const TOOLS_SDK_DOCUMENTATION = `You are refining a curate harness that runs inside a sandboxed VM.
+The only tools available to the harness function are on the \`ctx.tools\` object:
+
+  ctx.tools.curate(operations, options?)
+    Performs curate operations on the project's knowledge tree.
+    Parameters:
+      operations: CurateOperation[] — array of operations to apply.
+        Each operation has:
+          type: 'ADD' | 'UPDATE' | 'UPSERT' | 'MERGE' | 'DELETE'
+          path: string — domain/topic or domain/topic/subtopic
+          reason: string — why this operation is being performed
+          title?: string — title for the context file
+          content?: { narrative?: { highlights?, rules?, examples?, structure?, dependencies? }, rawConcept?: { task?, files?, changes?, flow?, patterns?, author?, timestamp? }, facts?: Array<{ statement, subject?, value?, category? }>, relations?: string[], snippets?: string[] }
+          summary?: string — one-line semantic summary
+          confidence?: 'high' | 'low'
+          impact?: 'high' | 'low'
+      options?: { basePath?: string }
+    Returns: CurateResult — { applied: CurateOperationResult[], summary: { added, deleted, failed, merged, updated } }
+
+  ctx.tools.readFile(filePath, options?)
+    Reads a file from the project's working directory.
+    Parameters:
+      filePath: string — path relative to the working directory
+      options?: { encoding?: BufferEncoding, offset?: number, limit?: number }
+    Returns: FileContent — { content: string, formattedContent: string, lines: number, totalLines: number, size: number, truncated: boolean, encoding: string, message: string }
+
+Constraints:
+  * Must export exactly: exports.meta = function() { return HarnessMeta }; exports.curate = async function(ctx) { ... }
+  * May only call ctx.tools.curate and ctx.tools.readFile — no other APIs
+  * No async work except via ctx.tools.* calls
+  * No setTimeout / setInterval / process / require / node: built-in modules
+  * Total calls to ctx.tools.* must not exceed 50 per invocation (ops cap enforced by the sandbox)
+  * The ctx.abort signal may fire at any time — long-running loops should check it`

--- a/test/unit/agent/harness/prompts.test.ts
+++ b/test/unit/agent/harness/prompts.test.ts
@@ -207,7 +207,31 @@ describe('Harness prompts — SDK documentation, Critic, and Refiner', () => {
     })
   })
 
+  // Test 8: Critic prompt truncates large parentCode without losing instructions
+  describe('truncation edge cases', () => {
+    it('truncates large parentCode but preserves the instruction block', () => {
+      const largeCode = 'exports.meta = function() {}\n' + 'x'.repeat(3000)
+      const prompt = buildCriticPrompt({
+        heuristic: 0.1,
+        parentCode: largeCode,
+        recentOutcomes: [makeOutcome({id: 'o-1', stderr: 'err', success: false})],
+        scenarios: [makeScenario({id: 's-1'})],
+      })
+
+      // Instruction block must survive — it's never in a truncated section
+      expect(prompt).to.include('Respond in exactly this format')
+      expect(prompt).to.include('# Critic analysis')
+      // parentCode was truncated
+      expect(prompt).to.include('[truncated for brevity]')
+      // Still within ceiling
+      expect(prompt.length).to.be.at.most(8000)
+    })
+  })
+
   // Test 6: Snapshot — pin exact output for fixed inputs
+  // To regenerate snapshots: run this test, copy the actual output from the
+  // failure diff, and replace the CRITIC_PROMPT_SNAPSHOT / REFINER_PROMPT_SNAPSHOT
+  // constants at the bottom of this file.
   describe('snapshot — exact output for fixed inputs', () => {
     // Use minimal deterministic fixtures for reproducible snapshots
     const snapshotParentCode = `exports.meta = function() { return { capabilities: ['curate'], commandType: 'curate', projectPatterns: [], version: 1 } }
@@ -301,7 +325,7 @@ exports.curate = async function(ctx) { return { applied: [], summary: { added: 0
 
 ## Performance
 
-Current heuristic score (H): 0.5
+Current heuristic score (H): 0.50
 Recent outcomes (2 total):
   [FAIL] curate 100ms harness=true err="Error: file not found"
   [OK] curate 50ms harness=true
@@ -354,7 +378,7 @@ The only tools available to the harness function are on the \`ctx.tools\` object
     Returns: FileContent — { content: string, formattedContent: string, lines: number, totalLines: number, size: number, truncated: boolean, encoding: string, message: string }
 
 Constraints:
-  * Must export exactly: exports.meta = function() { return HarnessMeta }; exports.curate = async function(ctx) { ... }
+  * Must export exports.meta = function() { return HarnessMeta } and the handler matching the commandType: exports.curate = async function(ctx) { ... } or exports.query = async function(ctx) { ... }
   * May only call ctx.tools.curate and ctx.tools.readFile — no other APIs
   * No async work except via ctx.tools.* calls
   * No setTimeout / setInterval / process / require / node: built-in modules
@@ -381,7 +405,7 @@ exports.curate = async function(ctx) { return { applied: [], summary: { added: 0
 Produce the COMPLETE replacement harness code as a single string. The code must:
 
 1. Export \`exports.meta\` as a function returning a HarnessMeta object
-2. Export \`exports.curate\` as an async function taking \`ctx\` and returning a CurateResult
+2. Export the appropriate handler function (\`exports.curate\` or \`exports.query\`) matching the harness's declared commandType
 3. Preserve \`version: 1\` in the meta return value (version bumps are handled externally)
 4. Only use \`ctx.tools.curate\` and \`ctx.tools.readFile\` — no other APIs
 5. Contain no \`require()\`, \`import\`, \`setTimeout\`, \`setInterval\`, or \`process\` calls

--- a/test/unit/agent/harness/prompts.test.ts
+++ b/test/unit/agent/harness/prompts.test.ts
@@ -1,0 +1,392 @@
+/**
+ * AutoHarness V2 — Prompt template tests.
+ *
+ * Snapshot-style tests that pin exact prompt output for fixed inputs
+ * (drift catchers) plus structural assertions that verify each prompt
+ * includes the required context sections. All in-memory; no LLM calls.
+ */
+
+import {expect} from 'chai'
+
+import type {
+  CodeExecOutcome,
+  EvaluationScenario,
+} from '../../../../src/agent/core/domain/harness/types.js'
+
+import {buildCriticPrompt} from '../../../../src/agent/infra/harness/prompts/critic-prompt.js'
+import {buildRefinerPrompt} from '../../../../src/agent/infra/harness/prompts/refiner-prompt.js'
+import {TOOLS_SDK_DOCUMENTATION} from '../../../../src/agent/infra/harness/prompts/sdk-documentation.js'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const PARENT_CODE = `exports.meta = function meta() {
+  return {
+    capabilities: ['curate'],
+    commandType: 'curate',
+    projectPatterns: ['*.ts'],
+    version: 1,
+  }
+}
+
+exports.curate = async function curate(ctx) {
+  const file = await ctx.tools.readFile('src/index.ts')
+  await ctx.tools.curate([{
+    path: 'project/overview',
+    type: 'UPSERT',
+    title: 'Overview',
+    reason: 'Initial curate',
+    content: { narrative: { highlights: file.content } },
+  }])
+  return { applied: [{ path: 'project/overview', status: 'success', type: 'UPSERT' }], summary: { added: 1, deleted: 0, failed: 0, merged: 0, updated: 0 } }
+}`
+
+function makeOutcome(overrides: Partial<CodeExecOutcome> = {}): CodeExecOutcome {
+  return {
+    code: 'exports.curate = async function() {}',
+    commandType: 'curate',
+    executionTimeMs: 120,
+    id: `outcome-${Math.random().toString(36).slice(2, 8)}`,
+    projectId: 'proj-1',
+    projectType: 'typescript',
+    sessionId: 'session-1',
+    success: true,
+    timestamp: Date.now(),
+    usedHarness: true,
+    ...overrides,
+  }
+}
+
+function makeScenario(overrides: Partial<EvaluationScenario> = {}): EvaluationScenario {
+  return {
+    code: 'exports.curate = async function(ctx) { await ctx.tools.curate([]) }',
+    commandType: 'curate',
+    expectedBehavior: 'Curates project files successfully',
+    id: `scenario-${Math.random().toString(36).slice(2, 8)}`,
+    projectId: 'proj-1',
+    projectType: 'typescript',
+    taskDescription: 'Curate the project overview',
+    ...overrides,
+  }
+}
+
+/** 50 outcomes: 30 success, 20 failed — realistic distribution for a struggling harness. */
+function makeRecentOutcomes(): CodeExecOutcome[] {
+  const outcomes: CodeExecOutcome[] = []
+  for (let i = 0; i < 30; i++) {
+    outcomes.push(makeOutcome({id: `outcome-s-${i}`, success: true}))
+  }
+
+  for (let i = 0; i < 20; i++) {
+    outcomes.push(makeOutcome({id: `outcome-f-${i}`, stderr: 'TypeError: Cannot read property', success: false}))
+  }
+
+  return outcomes
+}
+
+const CRITIC_ANALYSIS = `# Critic analysis
+- Failure pattern: TypeError when reading file content
+- Root cause: The harness assumes readFile always returns a non-empty content field, but some files are binary or empty
+- Suggested change: Add a guard checking file.content before passing to curate operations`
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Harness prompts — SDK documentation, Critic, and Refiner', () => {
+  // Test 1: SDK documentation mentions required tools and ops cap
+  describe('TOOLS_SDK_DOCUMENTATION', () => {
+    it('mentions ctx.tools.curate, ctx.tools.readFile, and 50-ops cap', () => {
+      expect(TOOLS_SDK_DOCUMENTATION).to.include('ctx.tools.curate')
+      expect(TOOLS_SDK_DOCUMENTATION).to.include('ctx.tools.readFile')
+      expect(TOOLS_SDK_DOCUMENTATION).to.include('50')
+      // Verify it's a non-trivial documentation string
+      expect(TOOLS_SDK_DOCUMENTATION.length).to.be.greaterThan(200)
+    })
+  })
+
+  // Test 2: Critic prompt includes all required context sections
+  describe('buildCriticPrompt', () => {
+    it('includes parent code, heuristic, scenario count, and failed outcomes', () => {
+      const outcomes = makeRecentOutcomes()
+      const scenarios = [makeScenario(), makeScenario({expectedBehavior: 'Should fail gracefully on missing files', id: 'scenario-neg'})]
+
+      const prompt = buildCriticPrompt({
+        heuristic: 0.42,
+        parentCode: PARENT_CODE,
+        recentOutcomes: outcomes,
+        scenarios,
+      })
+
+      // Parent code present
+      expect(prompt).to.include('exports.meta')
+      expect(prompt).to.include('exports.curate')
+      // Heuristic value
+      expect(prompt).to.include('0.42')
+      // Scenario count or scenario content present
+      expect(prompt).to.include('scenario')
+      // At least one failed outcome's stderr surfaced as raw data
+      expect(prompt).to.include('TypeError')
+      // Raw outcomes show OK/FAIL status per outcome
+      expect(prompt).to.include('[OK]')
+      expect(prompt).to.include('[FAIL]')
+    })
+
+    // Test 3: Critic prompt ceiling — 8000 chars on reference input
+    it('output does not exceed 8000 characters on reference input', () => {
+      const outcomes = makeRecentOutcomes()
+      const scenarios = [makeScenario(), makeScenario()]
+
+      const prompt = buildCriticPrompt({
+        heuristic: 0.42,
+        parentCode: PARENT_CODE,
+        recentOutcomes: outcomes,
+        scenarios,
+      })
+
+      expect(prompt.length).to.be.at.most(8000)
+    })
+  })
+
+  // Test 4: Refiner prompt includes all required context
+  describe('buildRefinerPrompt', () => {
+    it('includes parent code, critic analysis, and SDK docs', () => {
+      const prompt = buildRefinerPrompt({
+        criticAnalysis: CRITIC_ANALYSIS,
+        parentCode: PARENT_CODE,
+        projectType: 'typescript',
+        sdkDocumentation: TOOLS_SDK_DOCUMENTATION,
+      })
+
+      // Parent code present
+      expect(prompt).to.include('exports.meta')
+      // Critic analysis present
+      expect(prompt).to.include('Failure pattern')
+      expect(prompt).to.include('Root cause')
+      // SDK documentation present
+      expect(prompt).to.include('ctx.tools.curate')
+      expect(prompt).to.include('ctx.tools.readFile')
+    })
+
+    // Test 5: Refiner prompt explicitly forbids markdown fences
+    it('explicitly forbids markdown fences in instructions', () => {
+      const prompt = buildRefinerPrompt({
+        criticAnalysis: CRITIC_ANALYSIS,
+        parentCode: PARENT_CODE,
+        projectType: 'typescript',
+        sdkDocumentation: TOOLS_SDK_DOCUMENTATION,
+      })
+
+      // The prompt text itself must instruct the LLM not to use fences
+      const lowerPrompt = prompt.toLowerCase()
+      expect(lowerPrompt).to.match(/no\s+markdown|do\s+not.*markdown|without.*markdown|no.*```|do\s+not.*```|never.*```/)
+    })
+
+    // Test 7: Refiner prompt exercises each ProjectType
+    it('varies output per ProjectType (typescript, python, generic)', () => {
+      const baseCtx = {
+        criticAnalysis: CRITIC_ANALYSIS,
+        parentCode: PARENT_CODE,
+        sdkDocumentation: TOOLS_SDK_DOCUMENTATION,
+      }
+
+      const tsPrompt = buildRefinerPrompt({...baseCtx, projectType: 'typescript'})
+      const pyPrompt = buildRefinerPrompt({...baseCtx, projectType: 'python'})
+      const genPrompt = buildRefinerPrompt({...baseCtx, projectType: 'generic'})
+
+      // Each prompt should mention its project type
+      expect(tsPrompt.toLowerCase()).to.include('typescript')
+      expect(pyPrompt.toLowerCase()).to.include('python')
+      expect(genPrompt.toLowerCase()).to.include('generic')
+
+      // Prompts should differ from each other (project-type-aware)
+      expect(tsPrompt).to.not.equal(pyPrompt)
+      expect(tsPrompt).to.not.equal(genPrompt)
+      expect(pyPrompt).to.not.equal(genPrompt)
+    })
+  })
+
+  // Test 6: Snapshot — pin exact output for fixed inputs
+  describe('snapshot — exact output for fixed inputs', () => {
+    // Use minimal deterministic fixtures for reproducible snapshots
+    const snapshotParentCode = `exports.meta = function() { return { capabilities: ['curate'], commandType: 'curate', projectPatterns: [], version: 1 } }
+exports.curate = async function(ctx) { return { applied: [], summary: { added: 0, deleted: 0, failed: 0, merged: 0, updated: 0 } } }`
+
+    const snapshotOutcomes: CodeExecOutcome[] = [
+      {
+        code: 'test',
+        commandType: 'curate',
+        executionTimeMs: 100,
+        id: 'outcome-1',
+        projectId: 'proj-1',
+        projectType: 'typescript',
+        sessionId: 'session-1',
+        stderr: 'Error: file not found',
+        success: false,
+        timestamp: 1_700_000_000_000,
+        usedHarness: true,
+      },
+      {
+        code: 'test',
+        commandType: 'curate',
+        executionTimeMs: 50,
+        id: 'outcome-2',
+        projectId: 'proj-1',
+        projectType: 'typescript',
+        sessionId: 'session-1',
+        success: true,
+        timestamp: 1_700_000_000_000,
+        usedHarness: true,
+      },
+    ]
+
+    const snapshotScenarios: EvaluationScenario[] = [
+      {
+        code: 'test-code',
+        commandType: 'curate',
+        expectedBehavior: 'Curates successfully',
+        id: 'scenario-1',
+        projectId: 'proj-1',
+        projectType: 'typescript',
+        taskDescription: 'Curate project overview',
+      },
+    ]
+
+    it('buildCriticPrompt produces stable output for fixed input', () => {
+      const prompt = buildCriticPrompt({
+        heuristic: 0.5,
+        parentCode: snapshotParentCode,
+        recentOutcomes: snapshotOutcomes,
+        scenarios: snapshotScenarios,
+      })
+
+      // Snapshot will be pinned after implementation — initial run captures the output.
+      // For now, assert it's a non-empty string to confirm the function works.
+      expect(prompt).to.be.a('string').with.length.greaterThan(0)
+
+      // Pin the exact output (filled after first green run)
+      expect(prompt).to.equal(CRITIC_PROMPT_SNAPSHOT)
+    })
+
+    it('buildRefinerPrompt produces stable output for fixed input', () => {
+      const prompt = buildRefinerPrompt({
+        criticAnalysis: '- Failure pattern: file not found\n- Root cause: missing guard\n- Suggested change: add existence check',
+        parentCode: snapshotParentCode,
+        projectType: 'typescript',
+        sdkDocumentation: TOOLS_SDK_DOCUMENTATION,
+      })
+
+      expect(prompt).to.be.a('string').with.length.greaterThan(0)
+
+      // Pin the exact output (filled after first green run)
+      expect(prompt).to.equal(REFINER_PROMPT_SNAPSHOT)
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Snapshot constants — filled after first green implementation run.
+// Changing prompt wording requires updating these snapshots explicitly.
+// ---------------------------------------------------------------------------
+
+const CRITIC_PROMPT_SNAPSHOT = `You are a harness quality critic. Analyze the following harness version and its recent execution outcomes to identify the root cause of failures.
+
+## Current harness code
+
+\`\`\`js
+exports.meta = function() { return { capabilities: ['curate'], commandType: 'curate', projectPatterns: [], version: 1 } }
+exports.curate = async function(ctx) { return { applied: [], summary: { added: 0, deleted: 0, failed: 0, merged: 0, updated: 0 } } }
+\`\`\`
+
+## Performance
+
+Current heuristic score (H): 0.5
+Recent outcomes (2 total):
+  [FAIL] curate 100ms harness=true err="Error: file not found"
+  [OK] curate 50ms harness=true
+
+## Evaluation scenarios (1 total)
+
+  1. [curate] Curate project overview — expected: Curates successfully
+
+## Your task
+
+Analyze the harness code, outcomes, and scenarios above. Identify:
+1. What failure pattern is most common
+2. What the root cause is in the harness code
+3. What structural change would fix it
+
+Respond in exactly this format:
+# Critic analysis
+- Failure pattern: <short description of the most common failure>
+- Root cause: <mechanism in the code causing failures>
+- Suggested change: <structural hint for the Refiner — what to change, not the full code>`
+
+const REFINER_PROMPT_SNAPSHOT = `You are a harness refiner. Your job is to produce an improved version of the harness code below, guided by the Critic's analysis and the available SDK tools.
+
+## SDK tools reference
+
+You are refining a curate harness that runs inside a sandboxed VM.
+The only tools available to the harness function are on the \`ctx.tools\` object:
+
+  ctx.tools.curate(operations, options?)
+    Performs curate operations on the project's knowledge tree.
+    Parameters:
+      operations: CurateOperation[] — array of operations to apply.
+        Each operation has:
+          type: 'ADD' | 'UPDATE' | 'UPSERT' | 'MERGE' | 'DELETE'
+          path: string — domain/topic or domain/topic/subtopic
+          reason: string — why this operation is being performed
+          title?: string — title for the context file
+          content?: { narrative?: { highlights?, rules?, examples?, structure?, dependencies? }, rawConcept?: { task?, files?, changes?, flow?, patterns?, author?, timestamp? }, facts?: Array<{ statement, subject?, value?, category? }>, relations?: string[], snippets?: string[] }
+          summary?: string — one-line semantic summary
+          confidence?: 'high' | 'low'
+          impact?: 'high' | 'low'
+      options?: { basePath?: string }
+    Returns: CurateResult — { applied: CurateOperationResult[], summary: { added, deleted, failed, merged, updated } }
+
+  ctx.tools.readFile(filePath, options?)
+    Reads a file from the project's working directory.
+    Parameters:
+      filePath: string — path relative to the working directory
+      options?: { encoding?: BufferEncoding, offset?: number, limit?: number }
+    Returns: FileContent — { content: string, formattedContent: string, lines: number, totalLines: number, size: number, truncated: boolean, encoding: string, message: string }
+
+Constraints:
+  * Must export exactly: exports.meta = function() { return HarnessMeta }; exports.curate = async function(ctx) { ... }
+  * May only call ctx.tools.curate and ctx.tools.readFile — no other APIs
+  * No async work except via ctx.tools.* calls
+  * No setTimeout / setInterval / process / require / node: built-in modules
+  * Total calls to ctx.tools.* must not exceed 50 per invocation (ops cap enforced by the sandbox)
+  * The ctx.abort signal may fire at any time — long-running loops should check it
+
+## Project context
+
+The project type is "typescript". Source files typically use .ts/.tsx extensions. When reading project files with ctx.tools.readFile, expect TypeScript source code, package.json, tsconfig.json, and similar Node.js ecosystem files.
+
+## Parent harness code (current version)
+
+exports.meta = function() { return { capabilities: ['curate'], commandType: 'curate', projectPatterns: [], version: 1 } }
+exports.curate = async function(ctx) { return { applied: [], summary: { added: 0, deleted: 0, failed: 0, merged: 0, updated: 0 } } }
+
+## Critic's analysis (what to fix)
+
+- Failure pattern: file not found
+- Root cause: missing guard
+- Suggested change: add existence check
+
+## Output requirements
+
+Produce the COMPLETE replacement harness code as a single string. The code must:
+
+1. Export \`exports.meta\` as a function returning a HarnessMeta object
+2. Export \`exports.curate\` as an async function taking \`ctx\` and returning a CurateResult
+3. Preserve \`version: 1\` in the meta return value (version bumps are handled externally)
+4. Only use \`ctx.tools.curate\` and \`ctx.tools.readFile\` — no other APIs
+5. Contain no \`require()\`, \`import\`, \`setTimeout\`, \`setInterval\`, or \`process\` calls
+6. Stay within the 50-operation cap on ctx.tools.* calls
+
+CRITICAL: Return ONLY the raw JavaScript code. Do NOT wrap it in markdown code fences (\`\`\`). Do NOT include any prose, explanation, or commentary before or after the code. The output is fed directly to a JavaScript parser — any non-code content will cause a syntax error.
+
+Begin your response with \`exports.meta\` — nothing else before it.`


### PR DESCRIPTION
## Summary

- Add `TOOLS_SDK_DOCUMENTATION` constant describing the v1.0 `HarnessContextTools` surface (curate + readFile) with constraints and signatures
- Add `buildCriticPrompt()` — constructs the Critic LLM prompt from parent code, raw outcomes (compact one-line format), heuristic score, and evaluation scenarios. Overall 8000-char truncation prevents context-window overflow on weak models
- Add `buildRefinerPrompt()` — constructs the Refiner LLM prompt with parent code, Critic analysis, SDK docs, and project-type-aware hints. Explicitly forbids markdown fences in output instructions
- 8 unit tests: structural assertions (content inclusion, fence prohibition, ProjectType variation, 8000-char ceiling) + 2 snapshot tests pinning exact output for drift detection

## New files

| File | Description |
|------|-------------|
| `src/agent/infra/harness/prompts/sdk-documentation.ts` | `TOOLS_SDK_DOCUMENTATION` string constant |
| `src/agent/infra/harness/prompts/critic-prompt.ts` | `CriticPromptContext` + `buildCriticPrompt()` |
| `src/agent/infra/harness/prompts/refiner-prompt.ts` | `RefinerPromptContext` + `buildRefinerPrompt()` |
| `test/unit/agent/harness/prompts.test.ts` | 8 snapshot/structure tests |

## Test plan

- [x] `TOOLS_SDK_DOCUMENTATION` mentions `ctx.tools.curate`, `ctx.tools.readFile`, 50-ops cap
- [x] `buildCriticPrompt` includes parent code, heuristic, raw outcomes with OK/FAIL status, scenarios
- [x] Critic prompt output ≤ 8000 chars on 50-outcome reference input
- [x] `buildRefinerPrompt` includes parent code, critic analysis, SDK docs
- [x] Refiner prompt explicitly forbids markdown fences
- [x] Snapshot tests pin exact output for fixed inputs
- [x] Refiner prompt varies per ProjectType (typescript, python, generic)
- [x] `npm run typecheck` / `lint` / `test` / `build` all clean

Closes ENG-2260