### PR TITLE
feat: [ENG-2261] HarnessScenarioCapture

### DIFF
--- a/src/agent/core/domain/harness/types.ts
+++ b/src/agent/core/domain/harness/types.ts
@@ -170,7 +170,7 @@ export const EvaluationScenarioSchema = z
   .object({
     code: z.string().min(1),
     commandType: z.enum(['chat', 'curate', 'query']),
-    createdAt: z.number(),
+    createdAt: z.number().int().nonnegative(),
     expectedBehavior: z.string().min(1),
     id: z.string().min(1),
     projectId: z.string().min(1),

--- a/src/agent/core/domain/harness/types.ts
+++ b/src/agent/core/domain/harness/types.ts
@@ -170,6 +170,7 @@ export const EvaluationScenarioSchema = z
   .object({
     code: z.string().min(1),
     commandType: z.enum(['chat', 'curate', 'query']),
+    createdAt: z.number(),
     expectedBehavior: z.string().min(1),
     id: z.string().min(1),
     projectId: z.string().min(1),

--- a/src/agent/core/interfaces/i-harness-store.ts
+++ b/src/agent/core/interfaces/i-harness-store.ts
@@ -54,6 +54,18 @@ export interface IHarnessStore {
   deleteOutcomes(projectId: string, commandType: string): Promise<number>
 
   /**
+   * Delete a single scenario by its `(projectId, commandType, scenarioId)` key.
+   * Returns `true` when the scenario existed and was deleted; `false` on miss.
+   * Used by `HarnessScenarioCapture` for LRU eviction when the per-pair cap
+   * is exceeded.
+   */
+  deleteScenario(
+    projectId: string,
+    commandType: string,
+    scenarioId: string,
+  ): Promise<boolean>
+
+  /**
    * Return the most-recently-written version for a `(projectId, commandType)`
    * pair — ranked by the stored `version` number, not by `heuristic`. This
    * is "newest" semantics, not "best" semantics. Phase 7's pinned-version

--- a/src/agent/infra/harness/harness-scenario-capture.ts
+++ b/src/agent/infra/harness/harness-scenario-capture.ts
@@ -1,0 +1,283 @@
+/**
+ * AutoHarness V2 — Scenario capture from real sessions.
+ *
+ * Captures `EvaluationScenario` records from both successful AND failed
+ * sessions so the Evaluator has real test cases to score candidate
+ * harness versions against. Negative scenarios prevent the Refiner
+ * from "improving" into a harness that succeeds by damaging data.
+ *
+ * Called in-line after outcome recording — not out-of-band — so a
+ * scenario can't be captured for an outcome that didn't persist.
+ * The call site (outcome recorder or session-end hook) is wired
+ * separately.
+ *
+ * Concurrent-capture safety is achieved via per-pair promise chaining:
+ * the list→dedup→evict→save sequence serializes for each
+ * `(projectId, commandType)` pair, so the 20-scenario cap holds even
+ * under parallel captures.
+ */
+
+import {randomUUID} from 'node:crypto'
+
+import type {CodeExecOutcome, ProjectType} from '../../core/domain/harness/types.js'
+import type {IHarnessStore} from '../../core/interfaces/i-harness-store.js'
+import type {ILogger} from '../../core/interfaces/i-logger.js'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Maximum scenarios per `(projectId, commandType)` pair. */
+const MAX_SCENARIOS_PER_PAIR = 20
+
+/**
+ * Structural failure pattern for negative capture selection.
+ * Matches common JavaScript/Python error class names in stderr.
+ */
+const STRUCTURAL_FAILURE_PATTERN = /Error|Exception|Failed|Rejected/
+
+/** Minimum query confidence score for positive query capture. */
+const MIN_QUERY_TOP_SCORE = 0.7
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface CaptureContext {
+  readonly code: string
+  /** Matches EvaluationScenarioSchema.commandType (core/domain/harness/types.ts). */
+  readonly commandType: 'chat' | 'curate' | 'query'
+  readonly outcome: CodeExecOutcome
+  readonly projectId: string
+  readonly projectType: ProjectType
+  readonly taskDescription: string
+}
+
+// ---------------------------------------------------------------------------
+// Type guards for unknown outcome fields
+// ---------------------------------------------------------------------------
+
+/**
+ * Checks whether `curateResult` contains at least one applied operation.
+ * `CodeExecOutcome.curateResult` is `z.unknown()` — populated from
+ * `REPLResult.curateResults` (an array of curate call results).
+ */
+function hasAppliedCurateOps(curateResult: unknown): boolean {
+  return Array.isArray(curateResult) && curateResult.length > 0
+}
+
+/**
+ * Extracts the `topScore` from an unknown `queryResult`, returning
+ * `undefined` when the shape doesn't match. Avoids `as Type` casts
+ * by using `in` narrowing (TS 4.9+).
+ */
+function getQueryTopScore(queryResult: unknown): number | undefined {
+  if (typeof queryResult !== 'object' || queryResult === null) return undefined
+  if (!('topScore' in queryResult)) return undefined
+  return typeof queryResult.topScore === 'number' ? queryResult.topScore : undefined
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+type CaptureType = 'negative' | 'positive'
+
+export class HarnessScenarioCapture {
+  /** Tracks `${sessionId}\0${commandType}` keys for rate-limiting negative captures. */
+  private readonly negativeCaptured = new Set<string>()
+  /**
+   * Per-pair promise chain for serializing concurrent captures.
+   * Each `(projectId, commandType)` pair chains its list→dedup→evict→save
+   * sequence so the 20-scenario cap holds under parallel calls.
+   */
+  private readonly pairLocks = new Map<string, Promise<void>>()
+
+  constructor(
+    private readonly harnessStore: IHarnessStore,
+    private readonly logger: ILogger,
+  ) {}
+
+  /**
+   * Capture policy — called once per interesting outcome.
+   *
+   * Determines whether the outcome is worth capturing as a scenario,
+   * deduplicates against existing scenarios, enforces the per-pair cap
+   * via LRU eviction, and rate-limits negative captures to one per
+   * session per commandType.
+   */
+  async captureIfInteresting(ctx: CaptureContext): Promise<void> {
+    if (ctx.commandType === 'chat') return
+
+    const captureType = this.classifyCapture(ctx)
+    if (captureType === undefined) return
+
+    // Negative rate-limit pre-check: fast path avoids entering the lock when
+    // a negative for this session+commandType was already captured. The
+    // authoritative check is inside the lock (below) to close the race where
+    // two concurrent negatives both pass this line before either adds to the
+    // Set. This outer check is a performance optimization only.
+    if (captureType === 'negative') {
+      const rateKey = `${ctx.outcome.sessionId}\0${ctx.commandType}`
+      if (this.negativeCaptured.has(rateKey)) return
+    }
+
+    await this.withPairLock(ctx.projectId, ctx.commandType, async () => {
+      // Authoritative negative rate-limit check inside the lock. Concurrent
+      // calls serialize here, so the Set reflects all prior captures.
+      if (captureType === 'negative') {
+        const rateKey = `${ctx.outcome.sessionId}\0${ctx.commandType}`
+        if (this.negativeCaptured.has(rateKey)) return
+      }
+
+      const existing = await this.harnessStore.listScenarios(ctx.projectId, ctx.commandType)
+
+      // Dedup: skip if an identical (taskDescription, code) scenario exists
+      const isDuplicate = existing.some(
+        (s) => s.taskDescription === ctx.taskDescription && s.code === ctx.code,
+      )
+      if (isDuplicate) {
+        this.logger.debug('HarnessScenarioCapture: skipping duplicate scenario', {
+          commandType: ctx.commandType,
+          projectId: ctx.projectId,
+        })
+        return
+      }
+
+      // LRU eviction: delete the oldest (first in insertion order) when at cap
+      if (existing.length >= MAX_SCENARIOS_PER_PAIR) {
+        const oldest = existing[0]
+        await this.harnessStore.deleteScenario(ctx.projectId, ctx.commandType, oldest.id)
+        this.logger.debug('HarnessScenarioCapture: evicted oldest scenario for LRU cap', {
+          commandType: ctx.commandType,
+          evictedId: oldest.id,
+          projectId: ctx.projectId,
+        })
+      }
+
+      await this.harnessStore.saveScenario({
+        code: ctx.code,
+        commandType: ctx.commandType,
+        expectedBehavior: this.deriveExpectedBehavior(captureType, ctx),
+        id: randomUUID(),
+        projectId: ctx.projectId,
+        projectType: ctx.projectType,
+        taskDescription: ctx.taskDescription,
+      })
+
+      // Mark negative capture for session rate-limiting (after successful save)
+      if (captureType === 'negative') {
+        this.negativeCaptured.add(`${ctx.outcome.sessionId}\0${ctx.commandType}`)
+      }
+
+      this.logger.debug('HarnessScenarioCapture: captured scenario', {
+        captureType,
+        commandType: ctx.commandType,
+        projectId: ctx.projectId,
+      })
+    })
+  }
+
+  /** Clear all per-session state. */
+  cleanup(): void {
+    this.negativeCaptured.clear()
+    this.pairLocks.clear()
+  }
+
+  /** Remove negative-capture tracking for a session. */
+  clearSession(sessionId: string): void {
+    for (const key of this.negativeCaptured) {
+      if (key.startsWith(`${sessionId}\0`)) {
+        this.negativeCaptured.delete(key)
+      }
+    }
+  }
+
+  // ── private ─────────────────────────────────────────────────────────────────
+
+  /**
+   * Classify whether an outcome is interesting enough to capture.
+   *
+   * Returns 'positive', 'negative', or `undefined` (skip).
+   *
+   * Selection rules from the spec:
+   *   - Positive curate: success AND curateResult has applied ops
+   *   - Positive query: success AND queryResult.topScore >= 0.7
+   *   - Negative: !success AND stderr matches structural failure pattern
+   *   - Chat: never captured (filtered upstream in captureIfInteresting)
+   */
+  private classifyCapture(ctx: CaptureContext): CaptureType | undefined {
+    const {outcome} = ctx
+
+    // Negative capture: structural failure in stderr
+    if (!outcome.success) {
+      if (outcome.stderr && STRUCTURAL_FAILURE_PATTERN.test(outcome.stderr)) {
+        return 'negative'
+      }
+
+      return undefined
+    }
+
+    // Positive capture by commandType
+    switch (ctx.commandType) {
+      case 'curate': {
+        return hasAppliedCurateOps(outcome.curateResult) ? 'positive' : undefined
+      }
+
+      case 'query': {
+        const topScore = getQueryTopScore(outcome.queryResult)
+        return topScore !== undefined && topScore >= MIN_QUERY_TOP_SCORE ? 'positive' : undefined
+      }
+
+      default: {
+        return undefined
+      }
+    }
+  }
+
+  /**
+   * Derive `expectedBehavior` wording based on capture type.
+   *
+   * For v1.0, `expectedBehavior` is a short string logged by the evaluator,
+   * not used for pass/fail assertion. When LLM-as-judge scoring lands
+   * (v1.x), the wording becomes load-bearing.
+   *
+   * Negative wording heuristic: 'Rejects malformed input' when stderr
+   * suggests rejection; 'Returns error without corrupting state' otherwise.
+   */
+  private deriveExpectedBehavior(captureType: CaptureType, ctx: CaptureContext): string {
+    if (captureType === 'positive') {
+      return 'Succeeds without errors'
+    }
+
+    // Negative: distinguish rejection from generic error
+    if (ctx.outcome.stderr && /Rejected/.test(ctx.outcome.stderr)) {
+      return 'Rejects malformed input'
+    }
+
+    return 'Returns error without corrupting state'
+  }
+
+  /**
+   * Serialize operations per `(projectId, commandType)` pair.
+   *
+   * Chains promises so that concurrent `captureIfInteresting` calls
+   * for the same pair execute their list→dedup→evict→save sequence
+   * one at a time. Different pairs run in parallel.
+   */
+  private withPairLock(
+    projectId: string,
+    commandType: string,
+    fn: () => Promise<void>,
+  ): Promise<void> {
+    const key = `${projectId}\0${commandType}`
+    const previous = this.pairLocks.get(key) ?? Promise.resolve()
+    // Chain: run fn after previous completes. Previous errors are isolated
+    // (swallowed in the stored chain) so one failed capture doesn't block
+    // subsequent captures for the same pair.
+    const current = previous.then(fn, fn)
+    // Store a never-rejecting version for chaining
+    this.pairLocks.set(key, current.then(() => {}, () => {}))
+    return current
+  }
+}

--- a/src/agent/infra/harness/harness-scenario-capture.ts
+++ b/src/agent/infra/harness/harness-scenario-capture.ts
@@ -277,12 +277,18 @@ export class HarnessScenarioCapture {
   ): Promise<void> {
     const key = `${projectId}\0${commandType}`
     const previous = this.pairLocks.get(key) ?? Promise.resolve()
-    // Chain: run fn after previous completes. Previous errors are isolated
-    // (swallowed in the stored chain) so one failed capture doesn't block
-    // subsequent captures for the same pair.
-    const current = previous.then(fn, fn)
-    // Store a never-rejecting version for chaining
-    this.pairLocks.set(key, current.then(() => {}, () => {}))
+    // Chain: swallow previous errors so one failed capture doesn't block
+    // subsequent captures for the same pair, then run fn.
+    const current = previous.catch(() => {}).then(fn)
+    // Store a never-rejecting version for chaining; clean up the entry
+    // once settled so pairLocks doesn't grow unbounded across projects.
+    const stored = current.then(() => {}, () => {})
+    this.pairLocks.set(key, stored)
+    stored.finally(() => {
+      if (this.pairLocks.get(key) === stored) {
+        this.pairLocks.delete(key)
+      }
+    })
     return current
   }
 }

--- a/src/agent/infra/harness/harness-scenario-capture.ts
+++ b/src/agent/infra/harness/harness-scenario-capture.ts
@@ -144,9 +144,13 @@ export class HarnessScenarioCapture {
         return
       }
 
-      // LRU eviction: delete the oldest (first in insertion order) when at cap
+      // LRU eviction: delete the oldest by createdAt when at cap.
+      // Sort explicitly — listScenarios ordering is store-dependent
+      // (InMemoryHarnessStore preserves insertion order; FileKeyStorage
+      // orders lexicographically by key, which may not match createdAt).
       if (existing.length >= MAX_SCENARIOS_PER_PAIR) {
-        const oldest = existing[0]
+        const sorted = [...existing].sort((a, b) => a.createdAt - b.createdAt)
+        const oldest = sorted[0]
         await this.harnessStore.deleteScenario(ctx.projectId, ctx.commandType, oldest.id)
         this.logger.debug('HarnessScenarioCapture: evicted oldest scenario for LRU cap', {
           commandType: ctx.commandType,
@@ -158,6 +162,7 @@ export class HarnessScenarioCapture {
       await this.harnessStore.saveScenario({
         code: ctx.code,
         commandType: ctx.commandType,
+        createdAt: Date.now(),
         expectedBehavior: this.deriveExpectedBehavior(captureType, ctx),
         id: randomUUID(),
         projectId: ctx.projectId,

--- a/src/agent/infra/harness/harness-store.ts
+++ b/src/agent/infra/harness/harness-store.ts
@@ -99,6 +99,10 @@ export class HarnessStore implements IHarnessStore {
       // eslint-disable-next-line no-await-in-loop
       const exists = await this.keyStorage.exists(key)
       if (exists) {
+        // keyStorage.delete is idempotent on missing keys, so the narrow
+        // TOCTOU window between exists() and delete() is harmless — a
+        // concurrent deleteOutcomes could remove the key in between, but
+        // the delete call simply no-ops.
         // eslint-disable-next-line no-await-in-loop
         await this.keyStorage.delete(key)
         this.logger.debug('HarnessStore.deleteScenario removed entry', {

--- a/src/agent/infra/harness/harness-store.ts
+++ b/src/agent/infra/harness/harness-store.ts
@@ -87,6 +87,32 @@ export class HarnessStore implements IHarnessStore {
     return keys.length
   }
 
+  // ── scenarios ─────────────────────────────────────────────────────────────
+
+  async deleteScenario(
+    projectId: string,
+    commandType: string,
+    scenarioId: string,
+  ): Promise<boolean> {
+    for (const projectType of ProjectTypeSchema.options) {
+      const key = this.scenarioKey(projectType, projectId, commandType, scenarioId)
+      // eslint-disable-next-line no-await-in-loop
+      const exists = await this.keyStorage.exists(key)
+      if (exists) {
+        // eslint-disable-next-line no-await-in-loop
+        await this.keyStorage.delete(key)
+        this.logger.debug('HarnessStore.deleteScenario removed entry', {
+          commandType,
+          projectId,
+          scenarioId,
+        })
+        return true
+      }
+    }
+
+    return false
+  }
+
   // ── versions ───────────────────────────────────────────────────────────────
 
   async getLatest(projectId: string, commandType: string): Promise<HarnessVersion | undefined> {

--- a/test/helpers/in-memory-harness-store.test.ts
+++ b/test/helpers/in-memory-harness-store.test.ts
@@ -52,6 +52,7 @@ function makeScenario(overrides: Partial<EvaluationScenario> = {}): EvaluationSc
   return {
     code: 'tools.search("x")',
     commandType: 'curate',
+    createdAt: Date.now(),
     expectedBehavior: 'returns results',
     id: 's-default',
     projectId: 'p',

--- a/test/helpers/in-memory-harness-store.ts
+++ b/test/helpers/in-memory-harness-store.ts
@@ -45,7 +45,7 @@ function partitionKey(projectId: string, commandType: string): string {
   return `${projectId}\u0000${commandType}`
 }
 
-function versionKey(projectId: string, commandType: string, versionId: string): string {
+function compositeKey(projectId: string, commandType: string, versionId: string): string {
   return `${partitionKey(projectId, commandType)}\u0000${versionId}`
 }
 
@@ -72,7 +72,7 @@ export class InMemoryHarnessStore implements IHarnessStore {
     commandType: string,
     scenarioId: string,
   ): Promise<boolean> {
-    const key = versionKey(projectId, commandType, scenarioId)
+    const key = compositeKey(projectId, commandType, scenarioId)
     return this.scenarios.delete(key)
   }
 
@@ -93,7 +93,7 @@ export class InMemoryHarnessStore implements IHarnessStore {
     commandType: string,
     versionId: string,
   ): Promise<HarnessVersion | undefined> {
-    const hit = this.versions.get(versionKey(projectId, commandType, versionId))
+    const hit = this.versions.get(compositeKey(projectId, commandType, versionId))
     return hit ? structuredClone(hit) : undefined
   }
 
@@ -139,7 +139,7 @@ export class InMemoryHarnessStore implements IHarnessStore {
     const sorted = [...matches].sort((a, b) => b.version - a.version)
     const toDelete = sorted.slice(keep)
     for (const v of toDelete) {
-      this.versions.delete(versionKey(v.projectId, v.commandType, v.id))
+      this.versions.delete(compositeKey(v.projectId, v.commandType, v.id))
     }
 
     return toDelete.length
@@ -165,17 +165,17 @@ export class InMemoryHarnessStore implements IHarnessStore {
   }
 
   async saveOutcome(outcome: CodeExecOutcome): Promise<void> {
-    const key = versionKey(outcome.projectId, outcome.commandType, outcome.id)
+    const key = compositeKey(outcome.projectId, outcome.commandType, outcome.id)
     this.outcomes.set(key, structuredClone(outcome))
   }
 
   async saveScenario(scenario: EvaluationScenario): Promise<void> {
-    const key = versionKey(scenario.projectId, scenario.commandType, scenario.id)
+    const key = compositeKey(scenario.projectId, scenario.commandType, scenario.id)
     this.scenarios.set(key, structuredClone(scenario))
   }
 
   async saveVersion(version: HarnessVersion): Promise<void> {
-    const key = versionKey(version.projectId, version.commandType, version.id)
+    const key = compositeKey(version.projectId, version.commandType, version.id)
     if (this.versions.has(key)) {
       throw HarnessStoreError.versionConflict(version.projectId, version.commandType, {
         id: version.id,

--- a/test/helpers/in-memory-harness-store.ts
+++ b/test/helpers/in-memory-harness-store.ts
@@ -67,6 +67,15 @@ export class InMemoryHarnessStore implements IHarnessStore {
     return deleted
   }
 
+  async deleteScenario(
+    projectId: string,
+    commandType: string,
+    scenarioId: string,
+  ): Promise<boolean> {
+    const key = versionKey(projectId, commandType, scenarioId)
+    return this.scenarios.delete(key)
+  }
+
   async getLatest(projectId: string, commandType: string): Promise<HarnessVersion | undefined> {
     const matches = this.versionsForPartition(projectId, commandType)
     if (matches.length === 0) return undefined

--- a/test/unit/agent/harness/harness-bootstrap.test.ts
+++ b/test/unit/agent/harness/harness-bootstrap.test.ts
@@ -38,6 +38,7 @@ function makeStoreStub(sb: SinonSandbox): {
   const saveVersion = sb.stub()
   const store = {
     deleteOutcomes: sb.stub(),
+    deleteScenario: sb.stub(),
     getLatest,
     getVersion: sb.stub(),
     listOutcomes: sb.stub(),

--- a/test/unit/agent/harness/harness-evaluator.test.ts
+++ b/test/unit/agent/harness/harness-evaluator.test.ts
@@ -131,6 +131,7 @@ function makeScenario(overrides?: Partial<ValidatedEvaluationScenario>): Validat
   return {
     code: 'tools.curate([])',
     commandType: 'curate',
+    createdAt: Date.now(),
     expectedBehavior: 'Succeeds without errors',
     id: 'scenario-1',
     projectId: 'proj-eval',

--- a/test/unit/agent/harness/harness-evaluator.test.ts
+++ b/test/unit/agent/harness/harness-evaluator.test.ts
@@ -186,6 +186,7 @@ function makeStoreStub(sb: SinonSandbox): {
   const listOutcomes = sb.stub()
   const store = {
     deleteOutcomes: sb.stub(),
+    deleteScenario: sb.stub(),
     getLatest: sb.stub(),
     getVersion: sb.stub(),
     listOutcomes,

--- a/test/unit/agent/harness/harness-scenario-capture.test.ts
+++ b/test/unit/agent/harness/harness-scenario-capture.test.ts
@@ -1,0 +1,373 @@
+/**
+ * AutoHarness V2 — HarnessScenarioCapture tests.
+ *
+ * Validates the scenario capture policy: positive/negative selection
+ * rules, deduplication, per-pair LRU eviction (20-scenario cap),
+ * and concurrent-capture safety. Uses a real `InMemoryHarnessStore`
+ * for speed — the real `HarnessStore` is tested via Task 6.6.
+ */
+
+import {expect} from 'chai'
+import {randomUUID} from 'node:crypto'
+
+import type {CodeExecOutcome} from '../../../../src/agent/core/domain/harness/types.js'
+import type {ILogger} from '../../../../src/agent/core/interfaces/i-logger.js'
+import type {CaptureContext} from '../../../../src/agent/infra/harness/harness-scenario-capture.js'
+
+import {NoOpLogger} from '../../../../src/agent/core/interfaces/i-logger.js'
+import {HarnessScenarioCapture} from '../../../../src/agent/infra/harness/harness-scenario-capture.js'
+import {InMemoryHarnessStore} from '../../../helpers/in-memory-harness-store.js'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeOutcome(overrides: Partial<CodeExecOutcome> = {}): CodeExecOutcome {
+  return {
+    code: 'exports.curate = async function(ctx) {}',
+    commandType: 'curate',
+    executionTimeMs: 100,
+    id: `outcome-${randomUUID().slice(0, 8)}`,
+    projectId: 'proj-1',
+    projectType: 'typescript',
+    sessionId: 'session-1',
+    success: true,
+    timestamp: Date.now(),
+    usedHarness: true,
+    ...overrides,
+  }
+}
+
+function makeCaptureContext(overrides: Partial<CaptureContext> = {}): CaptureContext {
+  return {
+    code: 'const result = await tools.curate(ops)',
+    commandType: 'curate',
+    outcome: makeOutcome({
+      curateResult: [{applied: [{path: 'project/overview', status: 'success', type: 'UPSERT'}], summary: {added: 1, deleted: 0, failed: 0, merged: 0, updated: 0}}],
+    }),
+    projectId: 'proj-1',
+    projectType: 'typescript',
+    taskDescription: 'Curate the project overview',
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('HarnessScenarioCapture', () => {
+  let store: InMemoryHarnessStore
+  let logger: ILogger
+  let capture: HarnessScenarioCapture
+
+  beforeEach(() => {
+    store = new InMemoryHarnessStore()
+    logger = new NoOpLogger()
+    capture = new HarnessScenarioCapture(store, logger)
+  })
+
+  // Test 1: Positive curate outcome → scenario saved
+  it('captures positive curate outcome with non-empty curateResult', async () => {
+    const ctx = makeCaptureContext()
+
+    await capture.captureIfInteresting(ctx)
+
+    const scenarios = await store.listScenarios('proj-1', 'curate')
+    expect(scenarios).to.have.lengthOf(1)
+    expect(scenarios[0].expectedBehavior).to.equal('Succeeds without errors')
+    expect(scenarios[0].commandType).to.equal('curate')
+    expect(scenarios[0].code).to.equal(ctx.code)
+    expect(scenarios[0].taskDescription).to.equal(ctx.taskDescription)
+    expect(scenarios[0].projectId).to.equal('proj-1')
+    expect(scenarios[0].projectType).to.equal('typescript')
+  })
+
+  // Test 2: Positive query outcome with topScore 0.9 → scenario saved
+  it('captures positive query outcome with topScore >= 0.7', async () => {
+    const ctx = makeCaptureContext({
+      commandType: 'query',
+      outcome: makeOutcome({
+        commandType: 'query',
+        queryResult: {topScore: 0.9},
+        success: true,
+      }),
+    })
+
+    await capture.captureIfInteresting(ctx)
+
+    const scenarios = await store.listScenarios('proj-1', 'query')
+    expect(scenarios).to.have.lengthOf(1)
+    expect(scenarios[0].expectedBehavior).to.equal('Succeeds without errors')
+  })
+
+  // Test 3: Positive query outcome with topScore 0.3 → NOT captured
+  it('skips positive query outcome with topScore below 0.7', async () => {
+    const ctx = makeCaptureContext({
+      commandType: 'query',
+      outcome: makeOutcome({
+        commandType: 'query',
+        queryResult: {topScore: 0.3},
+        success: true,
+      }),
+    })
+
+    await capture.captureIfInteresting(ctx)
+
+    const scenarios = await store.listScenarios('proj-1', 'query')
+    expect(scenarios).to.have.lengthOf(0)
+  })
+
+  // Test 4: Negative outcome with structural stderr → scenario saved
+  it('captures negative outcome with structural failure stderr', async () => {
+    const ctx = makeCaptureContext({
+      outcome: makeOutcome({
+        stderr: 'TypeError: Cannot read property of undefined',
+        success: false,
+      }),
+    })
+
+    await capture.captureIfInteresting(ctx)
+
+    const scenarios = await store.listScenarios('proj-1', 'curate')
+    expect(scenarios).to.have.lengthOf(1)
+    expect(scenarios[0].expectedBehavior).to.satisfy(
+      (s: string) => s === 'Rejects malformed input' || s === 'Returns error without corrupting state',
+    )
+  })
+
+  // Test 5: Chat outcome (success or fail) → NOT captured
+  it('does not capture chat outcomes regardless of success', async () => {
+    const successCtx = makeCaptureContext({
+      commandType: 'chat',
+      outcome: makeOutcome({commandType: 'chat', success: true}),
+    })
+    const failCtx = makeCaptureContext({
+      commandType: 'chat',
+      outcome: makeOutcome({commandType: 'chat', stderr: 'Error: something', success: false}),
+      taskDescription: 'Chat about code',
+    })
+
+    await capture.captureIfInteresting(successCtx)
+    await capture.captureIfInteresting(failCtx)
+
+    const scenarios = await store.listScenarios('proj-1', 'chat')
+    expect(scenarios).to.have.lengthOf(0)
+  })
+
+  // Test 6: Identical (taskDescription, code) → deduplicated
+  it('deduplicates identical (taskDescription, code) pairs', async () => {
+    const ctx = makeCaptureContext()
+
+    await capture.captureIfInteresting(ctx)
+    await capture.captureIfInteresting(ctx)
+    await capture.captureIfInteresting(ctx)
+
+    const scenarios = await store.listScenarios('proj-1', 'curate')
+    expect(scenarios).to.have.lengthOf(1)
+  })
+
+  // Test 7: 21st scenario for a pair → oldest deleted, total stays at 20
+  it('evicts oldest scenario when per-pair cap of 20 is exceeded', async () => {
+    // Seed 20 distinct scenarios
+    for (let i = 0; i < 20; i++) {
+      const ctx = makeCaptureContext({
+        outcome: makeOutcome({
+          curateResult: [{applied: [{path: `p/${i}`, status: 'success', type: 'UPSERT'}], summary: {added: 1, deleted: 0, failed: 0, merged: 0, updated: 0}}],
+        }),
+        taskDescription: `Task ${i}`,
+      })
+      // eslint-disable-next-line no-await-in-loop
+      await capture.captureIfInteresting(ctx)
+    }
+
+    let scenarios = await store.listScenarios('proj-1', 'curate')
+    expect(scenarios).to.have.lengthOf(20)
+
+    // The first scenario's taskDescription
+    const oldestDescription = scenarios[0].taskDescription
+
+    // 21st scenario triggers eviction
+    const ctx21 = makeCaptureContext({
+      outcome: makeOutcome({
+        curateResult: [{applied: [{path: 'p/new', status: 'success', type: 'UPSERT'}], summary: {added: 1, deleted: 0, failed: 0, merged: 0, updated: 0}}],
+      }),
+      taskDescription: 'Task NEW',
+    })
+    await capture.captureIfInteresting(ctx21)
+
+    scenarios = await store.listScenarios('proj-1', 'curate')
+    expect(scenarios).to.have.lengthOf(20)
+
+    // Oldest should be gone
+    const descriptions = scenarios.map((s) => s.taskDescription)
+    expect(descriptions).to.not.include(oldestDescription)
+    expect(descriptions).to.include('Task NEW')
+  })
+
+  // Test 8: Concurrent captures → no more than 20 end up in store
+  it('maintains per-pair cap under concurrent captures', async () => {
+    const promises: Array<Promise<void>> = []
+
+    for (let i = 0; i < 25; i++) {
+      const ctx = makeCaptureContext({
+        outcome: makeOutcome({
+          curateResult: [{applied: [{path: `p/${i}`, status: 'success', type: 'UPSERT'}], summary: {added: 1, deleted: 0, failed: 0, merged: 0, updated: 0}}],
+        }),
+        taskDescription: `Concurrent task ${i}`,
+      })
+      promises.push(capture.captureIfInteresting(ctx))
+    }
+
+    await Promise.all(promises)
+
+    const scenarios = await store.listScenarios('proj-1', 'curate')
+    expect(scenarios).to.have.lengthOf(20)
+  })
+
+  // Additional: Negative captures rate-limited to one per session per commandType
+  it('rate-limits negative captures to one per session per commandType', async () => {
+    const ctx1 = makeCaptureContext({
+      outcome: makeOutcome({
+        sessionId: 'session-A',
+        stderr: 'TypeError: first error',
+        success: false,
+      }),
+      taskDescription: 'Task A',
+    })
+    const ctx2 = makeCaptureContext({
+      code: 'different code',
+      outcome: makeOutcome({
+        sessionId: 'session-A',
+        stderr: 'RangeError: second error',
+        success: false,
+      }),
+      taskDescription: 'Task B',
+    })
+
+    await capture.captureIfInteresting(ctx1)
+    await capture.captureIfInteresting(ctx2)
+
+    const scenarios = await store.listScenarios('proj-1', 'curate')
+    expect(scenarios).to.have.lengthOf(1)
+  })
+
+  // Concurrent negative captures for same session → only one saved
+  it('rate-limits concurrent negative captures for the same session', async () => {
+    const promises: Array<Promise<void>> = []
+    for (let i = 0; i < 5; i++) {
+      const ctx = makeCaptureContext({
+        code: `code-${i}`,
+        outcome: makeOutcome({
+          sessionId: 'session-concurrent',
+          stderr: `TypeError: error ${i}`,
+          success: false,
+        }),
+        taskDescription: `Negative task ${i}`,
+      })
+      promises.push(capture.captureIfInteresting(ctx))
+    }
+
+    await Promise.all(promises)
+
+    const scenarios = await store.listScenarios('proj-1', 'curate')
+    expect(scenarios).to.have.lengthOf(1)
+  })
+
+  // Additional: Positive curate with empty curateResult → NOT captured
+  it('skips positive curate outcome with empty curateResult', async () => {
+    const ctx = makeCaptureContext({
+      outcome: makeOutcome({
+        curateResult: [],
+        success: true,
+      }),
+    })
+
+    await capture.captureIfInteresting(ctx)
+
+    const scenarios = await store.listScenarios('proj-1', 'curate')
+    expect(scenarios).to.have.lengthOf(0)
+  })
+
+  // Additional: Negative outcome with soft failure (no structural pattern) → NOT captured
+  it('skips negative outcome without structural failure pattern in stderr', async () => {
+    const ctx = makeCaptureContext({
+      outcome: makeOutcome({
+        stderr: 'no results found',
+        success: false,
+      }),
+    })
+
+    await capture.captureIfInteresting(ctx)
+
+    const scenarios = await store.listScenarios('proj-1', 'curate')
+    expect(scenarios).to.have.lengthOf(0)
+  })
+
+  // expectedBehavior derivation: 'Rejects malformed input' when stderr contains Rejected
+  it('derives "Rejects malformed input" for negative outcomes with Rejected in stderr', async () => {
+    const ctx = makeCaptureContext({
+      outcome: makeOutcome({
+        stderr: 'Rejected: input validation failed',
+        success: false,
+      }),
+    })
+
+    await capture.captureIfInteresting(ctx)
+
+    const scenarios = await store.listScenarios('proj-1', 'curate')
+    expect(scenarios).to.have.lengthOf(1)
+    expect(scenarios[0].expectedBehavior).to.equal('Rejects malformed input')
+  })
+
+  // expectedBehavior derivation: generic error gets 'Returns error without corrupting state'
+  it('derives "Returns error without corrupting state" for non-rejection negative outcomes', async () => {
+    const ctx = makeCaptureContext({
+      outcome: makeOutcome({
+        stderr: 'TypeError: Cannot read property of undefined',
+        success: false,
+      }),
+    })
+
+    await capture.captureIfInteresting(ctx)
+
+    const scenarios = await store.listScenarios('proj-1', 'curate')
+    expect(scenarios).to.have.lengthOf(1)
+    expect(scenarios[0].expectedBehavior).to.equal('Returns error without corrupting state')
+  })
+
+  // Lifecycle: clearSession removes negative-capture tracking for that session
+  it('clearSession allows new negative captures for the same session', async () => {
+    const ctx1 = makeCaptureContext({
+      outcome: makeOutcome({
+        sessionId: 'session-X',
+        stderr: 'Error: first',
+        success: false,
+      }),
+      taskDescription: 'Task 1',
+    })
+
+    await capture.captureIfInteresting(ctx1)
+
+    let scenarios = await store.listScenarios('proj-1', 'curate')
+    expect(scenarios).to.have.lengthOf(1)
+
+    // Clear session tracking
+    capture.clearSession('session-X')
+
+    const ctx2 = makeCaptureContext({
+      code: 'different code',
+      outcome: makeOutcome({
+        sessionId: 'session-X',
+        stderr: 'Exception: second',
+        success: false,
+      }),
+      taskDescription: 'Task 2',
+    })
+
+    await capture.captureIfInteresting(ctx2)
+
+    scenarios = await store.listScenarios('proj-1', 'curate')
+    expect(scenarios).to.have.lengthOf(2)
+  })
+})

--- a/test/unit/agent/harness/harness-scenario-capture.test.ts
+++ b/test/unit/agent/harness/harness-scenario-capture.test.ts
@@ -370,4 +370,39 @@ describe('HarnessScenarioCapture', () => {
     scenarios = await store.listScenarios('proj-1', 'curate')
     expect(scenarios).to.have.lengthOf(2)
   })
+
+  // cleanup() clears all session state (negative rate-limits + pair locks)
+  it('cleanup clears all session state so captures resume normally', async () => {
+    const ctx1 = makeCaptureContext({
+      outcome: makeOutcome({
+        sessionId: 'session-Z',
+        stderr: 'Error: first',
+        success: false,
+      }),
+      taskDescription: 'Task 1',
+    })
+
+    await capture.captureIfInteresting(ctx1)
+
+    let scenarios = await store.listScenarios('proj-1', 'curate')
+    expect(scenarios).to.have.lengthOf(1)
+
+    capture.cleanup()
+
+    // Same session should now be capturable again (rate-limit reset)
+    const ctx2 = makeCaptureContext({
+      code: 'different code',
+      outcome: makeOutcome({
+        sessionId: 'session-Z',
+        stderr: 'Exception: second',
+        success: false,
+      }),
+      taskDescription: 'Task 2',
+    })
+
+    await capture.captureIfInteresting(ctx2)
+
+    scenarios = await store.listScenarios('proj-1', 'curate')
+    expect(scenarios).to.have.lengthOf(2)
+  })
 })

--- a/test/unit/agent/harness/harness-store-outcomes.test.ts
+++ b/test/unit/agent/harness/harness-store-outcomes.test.ts
@@ -33,6 +33,7 @@ function makeScenario(overrides: Partial<EvaluationScenario> = {}): EvaluationSc
   return {
     code: 'tools.search("x")',
     commandType: 'curate',
+    createdAt: Date.now(),
     expectedBehavior: 'returns results',
     id: 's-default',
     projectId: 'p',

--- a/test/unit/agent/harness/prompts.test.ts
+++ b/test/unit/agent/harness/prompts.test.ts
@@ -62,6 +62,7 @@ function makeScenario(overrides: Partial<EvaluationScenario> = {}): EvaluationSc
   return {
     code: 'exports.curate = async function(ctx) { await ctx.tools.curate([]) }',
     commandType: 'curate',
+    createdAt: Date.now(),
     expectedBehavior: 'Curates project files successfully',
     id: `scenario-${Math.random().toString(36).slice(2, 8)}`,
     projectId: 'proj-1',
@@ -269,6 +270,7 @@ exports.curate = async function(ctx) { return { applied: [], summary: { added: 0
       {
         code: 'test-code',
         commandType: 'curate',
+        createdAt: 1_700_000_000_000,
         expectedBehavior: 'Curates successfully',
         id: 'scenario-1',
         projectId: 'proj-1',

--- a/test/unit/agent/harness/types.test.ts
+++ b/test/unit/agent/harness/types.test.ts
@@ -262,6 +262,7 @@ describe('autoharness-v2 types and schemas', () => {
     const valid = {
       code: 'await tools.curate([])',
       commandType: 'curate',
+      createdAt: Date.now(),
       expectedBehavior: 'Produces 5 curate operations',
       id: 'scen-1',
       projectId: 'proj-1',


### PR DESCRIPTION
## Summary

- Adds `HarnessScenarioCapture` class that captures `EvaluationScenario` records from real sessions (both positive and negative outcomes) for the Evaluator to score candidate harness versions against
- Adds `deleteScenario` to `IHarnessStore` interface + both implementations (`HarnessStore`, `InMemoryHarnessStore`) for LRU eviction
- 14 unit tests covering all 8 spec scenarios plus edge cases (rate-limiting, expectedBehavior derivation, clearSession lifecycle)

### Key behaviors
- **Positive capture**: curate (non-empty curateResult), query (topScore >= 0.7); chat never captured
- **Negative capture**: structural failure in stderr (`Error|Exception|Failed|Rejected`), rate-limited to one per session per commandType
- **Dedup**: identical `(taskDescription, code)` pairs skipped
- **LRU eviction**: 20-scenario per-pair cap, oldest by `createdAt` evicted
- **Concurrency**: per-pair promise chaining serializes list→dedup→evict→save

### Note for Task 6.6
Unit tests use `InMemoryHarnessStore` where Map insertion order = `createdAt` order, so LRU is trivially correct. The real `HarnessStore`'s key-space ordering may differ — ENG-2266 updated with an implementation note to explicitly verify the 20-scenario cap with the real store.

Closes ENG-2261

## Test plan

- [ ] `npx mocha --forbid-only "test/unit/agent/harness/harness-scenario-capture.test.ts"` — all 14 tests pass
- [ ] `npm run typecheck` clean
- [ ] `npm run lint` clean
- [ ] `npm run build` clean