### PR TITLE
feat: [ENG-2263] HarnessSynthesizer

### DIFF
--- a/src/agent/infra/harness/harness-refiner-client.ts
+++ b/src/agent/infra/harness/harness-refiner-client.ts
@@ -1,0 +1,42 @@
+/**
+ * AutoHarness V2 — Thin wrapper around the LLM provider for
+ * Critic and Refiner completions.
+ *
+ * The synthesizer depends on `IRefinerClient` (not `ILLMService`
+ * directly) so unit tests can stub prompt→response without wiring
+ * the full agentic loop.
+ */
+
+import type {ILLMService} from '../../core/interfaces/i-llm-service.js'
+
+// ---------------------------------------------------------------------------
+// Interface
+// ---------------------------------------------------------------------------
+
+export interface IRefinerClient {
+  /** Send the Critic prompt and return the analysis string. */
+  completeCritic(prompt: string): Promise<string>
+  /** Send the Refiner prompt and return the candidate code string. */
+  completeRefiner(prompt: string): Promise<string>
+  /** The model ID used for refinement (for logging and weak-model checks). */
+  readonly modelId: string
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+export class RefinerClient implements IRefinerClient {
+  constructor(
+    private readonly llmService: ILLMService,
+    public readonly modelId: string,
+  ) {}
+
+  async completeCritic(prompt: string): Promise<string> {
+    return this.llmService.completeTask(prompt)
+  }
+
+  async completeRefiner(prompt: string): Promise<string> {
+    return this.llmService.completeTask(prompt)
+  }
+}

--- a/src/agent/infra/harness/harness-synthesizer.ts
+++ b/src/agent/infra/harness/harness-synthesizer.ts
@@ -48,8 +48,8 @@ const OUTCOMES_WINDOW = 50
 
 /**
  * Skip refinement when baseline H is at or above this threshold
- *  AND all scenarios are passing — the harness is already performing
- *  well enough that LLM calls would be wasted.
+ * AND all scenarios are passing — the harness is already performing
+ * well enough that LLM calls would be wasted.
  */
 const SKIP_REFINEMENT_THRESHOLD = 0.85
 
@@ -57,8 +57,9 @@ const SKIP_REFINEMENT_THRESHOLD = 0.85
  * Strip a single leading/trailing markdown fence pair from LLM output.
  * Weak models add fences despite prompt instructions; one fallback
  * layer is sufficient — further stripping invites complexity.
+ * Trailing `\s*` tolerates models that append a trailing newline.
  */
-const MARKDOWN_FENCE_RE = /^```(?:\w*)\n([\s\S]*?)\n```$/
+const MARKDOWN_FENCE_RE = /^```(?:\w*)\n([\s\S]*?)\n```\s*$/
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -99,8 +100,8 @@ export class HarnessSynthesizer {
 
   /**
    * Clear per-session state. Called by the session-end trigger
-   *  between sessions so weak-model warnings fire once per session,
-   *  not once per synthesizer lifetime.
+   * between sessions so weak-model warnings fire once per session,
+   * not once per synthesizer lifetime.
    */
   cleanup(): void {
     this.weakModelWarned.clear()
@@ -153,14 +154,18 @@ export class HarnessSynthesizer {
 
   // ── private ─────────────────────────────────────────────────────────────────
 
-  private async acceptCandidate(
-    candidateCode: string,
-    parent: HarnessVersion,
-    deltaH: number,
-    candidateHeuristic: number,
-  ): Promise<SynthesisResult> {
-    // Build candidate to extract metadata safely
-    const candidateVersion: HarnessVersion = {
+  private async acceptCandidate(opts: {
+    candidateCode: string
+    candidateHeuristic: number
+    deltaH: number
+    parent: HarnessVersion
+  }): Promise<SynthesisResult> {
+    const {candidateCode, candidateHeuristic, deltaH, parent} = opts
+
+    // Build candidate to extract metadata safely — compute metadata
+    // before constructing the final version so the object is fully
+    // formed in one place without post-construction mutation.
+    const protoVersion: HarnessVersion = {
       code: candidateCode,
       commandType: parent.commandType,
       createdAt: Date.now(),
@@ -172,11 +177,10 @@ export class HarnessSynthesizer {
       projectType: parent.projectType,
       version: parent.version + 1,
     }
-
-    // Try to extract metadata from the candidate's meta() export
-    const buildResult = this.moduleBuilder.build(candidateVersion)
-    if (buildResult.loaded) {
-      candidateVersion.metadata = buildResult.module.meta()
+    const buildResult = this.moduleBuilder.build(protoVersion)
+    const candidateVersion: HarnessVersion = {
+      ...protoVersion,
+      metadata: buildResult.loaded ? buildResult.module.meta() : parent.metadata,
     }
 
     try {
@@ -268,7 +272,7 @@ export class HarnessSynthesizer {
     })
     const criticAnalysis = await this.refinerClient.completeCritic(criticPrompt)
 
-    // 7. Refiner call
+    // 8. Refiner call
     const refinerPrompt = buildRefinerPrompt({
       criticAnalysis,
       parentCode: parent.code,
@@ -277,19 +281,24 @@ export class HarnessSynthesizer {
     })
     let candidateCode = await this.refinerClient.completeRefiner(refinerPrompt)
 
-    // 8. Markdown-fence fallback strip
+    // 9. Markdown-fence fallback strip
     const fenceMatch = MARKDOWN_FENCE_RE.exec(candidateCode)
     if (fenceMatch) {
       candidateCode = fenceMatch[1]
       this.logger.debug('HarnessSynthesizer: stripped markdown fences from refiner output')
     }
 
-    // 9. Evaluate
+    // 10. Evaluate
     const evalResult = await this.evaluator.evaluate(candidateCode, parent, scenarios)
 
-    // 10. Accept / reject
+    // 11. Accept / reject
     if (evalResult.accepted) {
-      return this.acceptCandidate(candidateCode, parent, evalResult.deltaH, evalResult.candidateHeuristic)
+      return this.acceptCandidate({
+        candidateCode,
+        candidateHeuristic: evalResult.candidateHeuristic,
+        deltaH: evalResult.deltaH,
+        parent,
+      })
     }
 
     return this.rejectCandidate(parent, evalResult.deltaH)
@@ -306,7 +315,7 @@ export class HarnessSynthesizer {
   }
 
   private rejectCandidate(parent: HarnessVersion, deltaH: number): SynthesisResult {
-    const reason = `delta H = ${deltaH.toFixed(2)} below 0.05`
+    const reason = `delta H was ${deltaH.toFixed(2)}, below acceptance threshold`
 
     this.logger.info('HarnessSynthesizer: rejected candidate', {
       commandType: parent.commandType,

--- a/src/agent/infra/harness/harness-synthesizer.ts
+++ b/src/agent/infra/harness/harness-synthesizer.ts
@@ -1,0 +1,327 @@
+/**
+ * AutoHarness V2 — HarnessSynthesizer.
+ *
+ * Orchestrates the Critic → Refiner → Evaluator pipeline into one
+ * `refineIfNeeded(projectId, commandType)` entry point. Called from
+ * the session-end trigger or manually.
+ *
+ * Responsibilities:
+ *   - Per-pair single-flight gate (log-and-drop on contention)
+ *   - Weak-model refinement skip (Tier 1 X2)
+ *   - Critic LLM call → analysis string
+ *   - Refiner LLM call → candidate code (with markdown-fence fallback)
+ *   - Evaluation via HarnessEvaluator
+ *   - Accept: save new version, emit event
+ *   - Reject: log reason, emit event
+ *   - VERSION_CONFLICT on concurrent cross-instance race: treat as
+ *     "accepted by someone else"
+ */
+
+import {randomUUID} from 'node:crypto'
+
+import type {HarnessVersion} from '../../core/domain/harness/types.js'
+import type {IHarnessStore} from '../../core/interfaces/i-harness-store.js'
+import type {ILogger} from '../../core/interfaces/i-logger.js'
+import type {ValidatedHarnessConfig} from '../agent/agent-schemas.js'
+import type {AgentEventBus} from '../events/event-emitter.js'
+import type {HarnessEvaluator} from './harness-evaluator.js'
+import type {IRefinerClient} from './harness-refiner-client.js'
+import type {HarnessScenarioCapture} from './harness-scenario-capture.js'
+
+import {
+  HarnessStoreError,
+  HarnessStoreErrorCode,
+} from '../../core/domain/errors/harness-store-error.js'
+import {computeHeuristic} from '../../core/domain/harness/heuristic.js'
+import {HarnessModuleBuilder} from './harness-module-builder.js'
+import {isBlocklistedForRefinement} from './model-policy.js'
+import {buildCriticPrompt} from './prompts/critic-prompt.js'
+import {buildRefinerPrompt} from './prompts/refiner-prompt.js'
+import {TOOLS_SDK_DOCUMENTATION} from './prompts/sdk-documentation.js'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Outcomes window for baseline heuristic + critic context. */
+const OUTCOMES_WINDOW = 50
+
+/**
+ * Skip refinement when baseline H is at or above this threshold
+ *  AND all scenarios are passing — the harness is already performing
+ *  well enough that LLM calls would be wasted.
+ */
+const SKIP_REFINEMENT_THRESHOLD = 0.85
+
+/**
+ * Strip a single leading/trailing markdown fence pair from LLM output.
+ * Weak models add fences despite prompt instructions; one fallback
+ * layer is sufficient — further stripping invites complexity.
+ */
+const MARKDOWN_FENCE_RE = /^```(?:\w*)\n([\s\S]*?)\n```$/
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface SynthesisResult {
+  readonly accepted: boolean
+  readonly deltaH?: number
+  readonly fromVersionId: string
+  readonly reason?: string
+  readonly toVersionId?: string
+}
+
+// ---------------------------------------------------------------------------
+// HarnessSynthesizer
+// ---------------------------------------------------------------------------
+
+export class HarnessSynthesizer {
+  private readonly inFlight = new Map<string, Promise<SynthesisResult | undefined>>()
+  private readonly moduleBuilder: HarnessModuleBuilder
+  private readonly weakModelWarned = new Set<string>()
+
+  constructor(
+    private readonly harnessStore: IHarnessStore,
+    private readonly evaluator: HarnessEvaluator,
+    // Held for session-end trigger wiring — the trigger needs
+    // scenarioCapture available alongside the synthesizer. Scenario
+    // listing goes through harnessStore.listScenarios() directly
+    // because HarnessScenarioCapture has no list method.
+    private readonly _scenarioCapture: HarnessScenarioCapture,
+    private readonly refinerClient: IRefinerClient,
+    private readonly eventBus: AgentEventBus,
+    private readonly config: ValidatedHarnessConfig,
+    private readonly logger: ILogger,
+  ) {
+    this.moduleBuilder = new HarnessModuleBuilder(logger)
+  }
+
+  /**
+   * Clear per-session state. Called by the session-end trigger
+   *  between sessions so weak-model warnings fire once per session,
+   *  not once per synthesizer lifetime.
+   */
+  cleanup(): void {
+    this.weakModelWarned.clear()
+  }
+
+  /**
+   * Run the Critic → Refiner → Evaluator pipeline for a single
+   * `(projectId, commandType)` pair. Returns `undefined` when
+   * refinement was skipped (no parent, weak model, in-flight
+   * contention, or nothing to refine).
+   */
+  async refineIfNeeded(
+    projectId: string,
+    commandType: 'chat' | 'curate' | 'query',
+  ): Promise<SynthesisResult | undefined> {
+    // 1. Weak-model skip (before single-flight gate — cheap check)
+    if (this.config.refinementModel === undefined && isBlocklistedForRefinement(this.refinerClient.modelId)) {
+      const warnKey = `${projectId}\0${commandType}`
+      if (!this.weakModelWarned.has(warnKey)) {
+        this.weakModelWarned.add(warnKey)
+        this.logger.warn('HarnessSynthesizer: skipping refinement — runtime model is blocklisted', {
+          commandType,
+          modelId: this.refinerClient.modelId,
+          projectId,
+        })
+      }
+
+      return undefined
+    }
+
+    // 2. Per-pair single-flight gate
+    const pairKey = `${projectId}\0${commandType}`
+    const existing = this.inFlight.get(pairKey)
+    if (existing !== undefined) {
+      this.logger.info('HarnessSynthesizer: refinement already in flight, dropping', {
+        commandType,
+        projectId,
+      })
+      return undefined
+    }
+
+    const promise = this.doRefine(projectId, commandType)
+    this.inFlight.set(pairKey, promise)
+    try {
+      return await promise
+    } finally {
+      this.inFlight.delete(pairKey)
+    }
+  }
+
+  // ── private ─────────────────────────────────────────────────────────────────
+
+  private async acceptCandidate(
+    candidateCode: string,
+    parent: HarnessVersion,
+    deltaH: number,
+    candidateHeuristic: number,
+  ): Promise<SynthesisResult> {
+    // Build candidate to extract metadata safely
+    const candidateVersion: HarnessVersion = {
+      code: candidateCode,
+      commandType: parent.commandType,
+      createdAt: Date.now(),
+      heuristic: candidateHeuristic,
+      id: randomUUID(),
+      metadata: parent.metadata,
+      parentId: parent.id,
+      projectId: parent.projectId,
+      projectType: parent.projectType,
+      version: parent.version + 1,
+    }
+
+    // Try to extract metadata from the candidate's meta() export
+    const buildResult = this.moduleBuilder.build(candidateVersion)
+    if (buildResult.loaded) {
+      candidateVersion.metadata = buildResult.module.meta()
+    }
+
+    try {
+      await this.harnessStore.saveVersion(candidateVersion)
+    } catch (error) {
+      if (HarnessStoreError.isCode(error, HarnessStoreErrorCode.VERSION_CONFLICT)) {
+        this.logger.debug('HarnessSynthesizer: VERSION_CONFLICT — lost race to concurrent refinement', {
+          commandType: parent.commandType,
+          projectId: parent.projectId,
+        })
+        this.emitRejected(parent, 'lost race to concurrent refinement')
+        return {
+          accepted: false,
+          fromVersionId: parent.id,
+          reason: 'lost race to concurrent refinement',
+        }
+      }
+
+      throw error
+    }
+
+    this.logger.info('HarnessSynthesizer: accepted candidate', {
+      commandType: parent.commandType,
+      deltaH,
+      fromVersion: parent.version,
+      projectId: parent.projectId,
+      toVersion: candidateVersion.version,
+    })
+
+    this.eventBus.emit('harness:refinement-completed', {
+      accepted: true,
+      commandType: parent.commandType,
+      fromVersion: parent.version,
+      projectId: parent.projectId,
+      toVersion: candidateVersion.version,
+    })
+
+    return {
+      accepted: true,
+      deltaH,
+      fromVersionId: parent.id,
+      toVersionId: candidateVersion.id,
+    }
+  }
+
+  private async doRefine(
+    projectId: string,
+    commandType: 'chat' | 'curate' | 'query',
+  ): Promise<SynthesisResult | undefined> {
+    // 3. Fetch parent version
+    const parent = await this.harnessStore.getLatest(projectId, commandType)
+    if (parent === undefined) {
+      this.logger.debug('HarnessSynthesizer: no parent version, skipping', {commandType, projectId})
+      return undefined
+    }
+
+    // 4. Fetch outcomes and scenarios
+    const [outcomes, scenarios] = await Promise.all([
+      this.harnessStore.listOutcomes(projectId, commandType, OUTCOMES_WINDOW),
+      this.harnessStore.listScenarios(projectId, commandType),
+    ])
+
+    // 5. Compute baseline H
+    const baselineH = computeHeuristic(outcomes, Date.now())
+
+    // 6. Skip if not worth refining — high baseline with no failure
+    // scenarios means the harness is performing well and the Critic +
+    // Refiner LLM calls would be wasted.
+    if (baselineH !== null && baselineH >= SKIP_REFINEMENT_THRESHOLD) {
+      const hasFailingScenarios = scenarios.some(
+        (s) => s.expectedBehavior !== 'Succeeds without errors',
+      )
+      if (!hasFailingScenarios) {
+        this.logger.debug('HarnessSynthesizer: baseline H high and all scenarios passing, skipping', {
+          baselineH,
+          commandType,
+          projectId,
+        })
+        return undefined
+      }
+    }
+
+    // 7. Critic call
+    const criticPrompt = buildCriticPrompt({
+      heuristic: baselineH ?? parent.heuristic,
+      parentCode: parent.code,
+      recentOutcomes: outcomes,
+      scenarios,
+    })
+    const criticAnalysis = await this.refinerClient.completeCritic(criticPrompt)
+
+    // 7. Refiner call
+    const refinerPrompt = buildRefinerPrompt({
+      criticAnalysis,
+      parentCode: parent.code,
+      projectType: parent.projectType,
+      sdkDocumentation: TOOLS_SDK_DOCUMENTATION,
+    })
+    let candidateCode = await this.refinerClient.completeRefiner(refinerPrompt)
+
+    // 8. Markdown-fence fallback strip
+    const fenceMatch = MARKDOWN_FENCE_RE.exec(candidateCode)
+    if (fenceMatch) {
+      candidateCode = fenceMatch[1]
+      this.logger.debug('HarnessSynthesizer: stripped markdown fences from refiner output')
+    }
+
+    // 9. Evaluate
+    const evalResult = await this.evaluator.evaluate(candidateCode, parent, scenarios)
+
+    // 10. Accept / reject
+    if (evalResult.accepted) {
+      return this.acceptCandidate(candidateCode, parent, evalResult.deltaH, evalResult.candidateHeuristic)
+    }
+
+    return this.rejectCandidate(parent, evalResult.deltaH)
+  }
+
+  private emitRejected(parent: HarnessVersion, reason: string): void {
+    this.eventBus.emit('harness:refinement-completed', {
+      accepted: false,
+      commandType: parent.commandType,
+      fromVersion: parent.version,
+      projectId: parent.projectId,
+      reason,
+    })
+  }
+
+  private rejectCandidate(parent: HarnessVersion, deltaH: number): SynthesisResult {
+    const reason = `delta H = ${deltaH.toFixed(2)} below 0.05`
+
+    this.logger.info('HarnessSynthesizer: rejected candidate', {
+      commandType: parent.commandType,
+      deltaH,
+      projectId: parent.projectId,
+      reason,
+    })
+
+    this.emitRejected(parent, reason)
+
+    return {
+      accepted: false,
+      deltaH,
+      fromVersionId: parent.id,
+      reason,
+    }
+  }
+}

--- a/src/agent/infra/harness/model-policy.ts
+++ b/src/agent/infra/harness/model-policy.ts
@@ -1,0 +1,31 @@
+/**
+ * AutoHarness V2 — Weak-model refinement block-list.
+ *
+ * Models <10B parameters are skipped for refinement — they produce
+ * too many syntactically-invalid Refiner outputs to be worth the
+ * cost in v1.0. Users can override via `config.harness.refinementModel`.
+ *
+ * See `v1-design-decisions.md §2.6` for the full list with rationale.
+ */
+
+/**
+ * Models known to produce low-quality refiner output.
+ * Substring-matched against the runtime model ID (case-insensitive).
+ */
+export const REFINEMENT_MODEL_BLOCKLIST: readonly string[] = [
+  'gemma-2-9b-it',
+  'llama-3.1-8b-instruct',
+  'mistral-7b-instruct',
+  'phi-3-mini',
+  'qwen-2.5-7b-instruct',
+] as const
+
+/**
+ * Returns `true` when `modelId` matches any entry in the blocklist.
+ * Comparison is case-insensitive substring match so provider-specific
+ * prefixes (e.g., `together/llama-3.1-8b-instruct`) are handled.
+ */
+export function isBlocklistedForRefinement(modelId: string): boolean {
+  const lower = modelId.toLowerCase()
+  return REFINEMENT_MODEL_BLOCKLIST.some((blocked) => lower.includes(blocked))
+}

--- a/test/unit/agent/harness/harness-synthesizer.test.ts
+++ b/test/unit/agent/harness/harness-synthesizer.test.ts
@@ -1,0 +1,471 @@
+/**
+ * AutoHarness V2 — HarnessSynthesizer tests.
+ *
+ * Validates the orchestration logic: single-flight per-pair gate,
+ * weak-model skip, Critic→Refiner→Evaluator pipeline, markdown-fence
+ * fallback, accept/reject paths, and concurrent-pair parallelism.
+ *
+ * Uses stubbed Evaluator, RefinerClient, and store — the real
+ * integration path is exercised in the learning-loop integration test.
+ */
+
+import {expect} from 'chai'
+import {randomUUID} from 'node:crypto'
+import sinon, {type SinonSandbox, type SinonStub} from 'sinon'
+
+import type {
+  CodeExecOutcome,
+  HarnessVersion,
+  ValidatedEvaluationScenario,
+} from '../../../../src/agent/core/domain/harness/types.js'
+import type {IHarnessStore} from '../../../../src/agent/core/interfaces/i-harness-store.js'
+import type {ILogger} from '../../../../src/agent/core/interfaces/i-logger.js'
+import type {ValidatedHarnessConfig} from '../../../../src/agent/infra/agent/agent-schemas.js'
+import type {EvaluationResult, HarnessEvaluator} from '../../../../src/agent/infra/harness/harness-evaluator.js'
+import type {IRefinerClient} from '../../../../src/agent/infra/harness/harness-refiner-client.js'
+import type {HarnessScenarioCapture} from '../../../../src/agent/infra/harness/harness-scenario-capture.js'
+
+import {NoOpLogger} from '../../../../src/agent/core/interfaces/i-logger.js'
+import {AgentEventBus} from '../../../../src/agent/infra/events/event-emitter.js'
+import {HarnessSynthesizer} from '../../../../src/agent/infra/harness/harness-synthesizer.js'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeParentVersion(overrides: Partial<HarnessVersion> = {}): HarnessVersion {
+  return {
+    code: 'exports.meta = () => ({capabilities:["curate"],commandType:"curate",projectPatterns:["**/*.ts"],version:1}); exports.curate = async (ctx) => {};',
+    commandType: 'curate',
+    createdAt: Date.now(),
+    heuristic: 0.5,
+    id: `v-${randomUUID().slice(0, 8)}`,
+    metadata: {capabilities: ['curate'], commandType: 'curate', projectPatterns: ['**/*.ts'], version: 1},
+    projectId: 'proj-1',
+    projectType: 'typescript',
+    version: 1,
+    ...overrides,
+  }
+}
+
+function makeOutcomes(count: number): CodeExecOutcome[] {
+  return Array.from({length: count}, (_, i) => ({
+    code: `code-${i}`,
+    commandType: 'curate',
+    executionTimeMs: 100,
+    id: `outcome-${i}`,
+    projectId: 'proj-1',
+    projectType: 'typescript' as const,
+    sessionId: 'session-1',
+    stderr: i % 2 === 1 ? 'TypeError: something' : undefined,
+    success: i % 2 === 0,
+    timestamp: Date.now() - i * 1000,
+    usedHarness: true,
+  }))
+}
+
+function makeScenarios(count: number): ValidatedEvaluationScenario[] {
+  return Array.from({length: count}, (_, i) => ({
+    code: `scenario-code-${i}`,
+    commandType: 'curate' as const,
+    createdAt: Date.now() - i * 1000,
+    expectedBehavior: i < Math.floor(count / 2) ? 'Succeeds without errors' : 'Returns error without corrupting state',
+    id: `scenario-${i}`,
+    projectId: 'proj-1',
+    projectType: 'typescript' as const,
+    taskDescription: `Task ${i}`,
+  }))
+}
+
+function makeConfig(overrides: Partial<ValidatedHarnessConfig> = {}): ValidatedHarnessConfig {
+  return {
+    autoLearn: true,
+    enabled: true,
+    language: 'auto',
+    maxVersions: 20,
+    ...overrides,
+  }
+}
+
+function makeAcceptedResult(deltaH = 0.1): EvaluationResult {
+  return {
+    accepted: true,
+    baselineHeuristic: 0.5,
+    candidateHeuristic: 0.5 + deltaH,
+    deltaH,
+    details: [],
+  }
+}
+
+function makeRejectedResult(deltaH = 0.03): EvaluationResult {
+  return {
+    accepted: false,
+    baselineHeuristic: 0.5,
+    candidateHeuristic: 0.5 + deltaH,
+    deltaH,
+    details: [],
+  }
+}
+
+function makeCandidateLoadFailedResult(): EvaluationResult {
+  return {
+    accepted: false,
+    baselineHeuristic: 0.5,
+    candidateHeuristic: 0,
+    deltaH: -0.5,
+    details: [],
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Stubs
+// ---------------------------------------------------------------------------
+
+interface StubSet {
+  completeCritic: SinonStub
+  completeRefiner: SinonStub
+  config: ValidatedHarnessConfig
+  evaluate: SinonStub
+  eventBus: AgentEventBus
+  getLatest: SinonStub
+  listOutcomes: SinonStub
+  listScenarios: SinonStub
+  logger: ILogger
+  refinerClient: IRefinerClient
+  saveVersion: SinonStub
+  store: IHarnessStore
+}
+
+function makeStubs(sb: SinonSandbox, configOverrides?: Partial<ValidatedHarnessConfig>): StubSet {
+  const getLatest = sb.stub()
+  const listOutcomes = sb.stub()
+  const listScenarios = sb.stub()
+  const saveVersion = sb.stub()
+
+  const store = {
+    deleteOutcomes: sb.stub(),
+    deleteScenario: sb.stub(),
+    getLatest,
+    getVersion: sb.stub(),
+    listOutcomes,
+    listScenarios,
+    listVersions: sb.stub(),
+    pruneOldVersions: sb.stub(),
+    recordFeedback: sb.stub(),
+    saveOutcome: sb.stub(),
+    saveScenario: sb.stub(),
+    saveVersion,
+  } as unknown as IHarnessStore
+
+  const completeCritic = sb.stub()
+  const completeRefiner = sb.stub()
+  const refinerClient: IRefinerClient = {
+    completeCritic,
+    completeRefiner,
+    modelId: 'claude-sonnet-4-20250514',
+  }
+
+  const evaluate = sb.stub()
+  const eventBus = new AgentEventBus()
+  const config = makeConfig(configOverrides)
+
+  return {
+    completeCritic,
+    completeRefiner,
+    config,
+    evaluate,
+    eventBus,
+    getLatest,
+    listOutcomes,
+    listScenarios,
+    logger: new NoOpLogger(),
+    refinerClient,
+    saveVersion,
+    store,
+  }
+}
+
+function makeSynthesizer(stubs: StubSet): HarnessSynthesizer {
+  const evaluator = {evaluate: stubs.evaluate} as unknown as HarnessEvaluator
+  const scenarioCapture = {} as unknown as HarnessScenarioCapture
+  return new HarnessSynthesizer(
+    stubs.store,
+    evaluator,
+    scenarioCapture,
+    stubs.refinerClient,
+    stubs.eventBus,
+    stubs.config,
+    stubs.logger,
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('HarnessSynthesizer', () => {
+  let sb: SinonSandbox
+
+  beforeEach(() => {
+    sb = sinon.createSandbox()
+  })
+
+  afterEach(() => {
+    sb.restore()
+  })
+
+  // Test 1: Pair has no parent version → no refinement
+  it('returns undefined when pair has no parent version', async () => {
+    const stubs = makeStubs(sb)
+    stubs.getLatest.resolves()
+    const synth = makeSynthesizer(stubs)
+
+    const result = await synth.refineIfNeeded('proj-1', 'curate')
+
+    expect(result).to.equal(undefined)
+    expect(stubs.completeCritic.callCount).to.equal(0)
+    expect(stubs.completeRefiner.callCount).to.equal(0)
+  })
+
+  // Test 2: 100 parallel refineIfNeeded on same pair → only one runs
+  it('single-flights concurrent calls on the same pair (log-and-drop)', async () => {
+    const stubs = makeStubs(sb)
+    const parent = makeParentVersion()
+    stubs.getLatest.resolves(parent)
+    stubs.listOutcomes.resolves(makeOutcomes(50))
+    stubs.listScenarios.resolves(makeScenarios(10))
+    stubs.completeCritic.resolves('Failure pattern: null pointer')
+    stubs.completeRefiner.resolves('exports.meta = () => ({capabilities:["curate"],commandType:"curate",projectPatterns:["**/*.ts"],version:2}); exports.curate = async (ctx) => { if (!ctx) return; };')
+    stubs.evaluate.resolves(makeAcceptedResult())
+    stubs.saveVersion.resolves()
+
+    const synth = makeSynthesizer(stubs)
+
+    const promises = Array.from({length: 100}, () => synth.refineIfNeeded('proj-1', 'curate'))
+    const results = await Promise.all(promises)
+
+    // Only one should have actually run (non-undefined result)
+    const ran = results.filter((r): r is NonNullable<typeof r> => r !== undefined)
+    expect(ran).to.have.lengthOf(1)
+    // Critic + Refiner each called exactly once
+    expect(stubs.completeCritic.callCount).to.equal(1)
+    expect(stubs.completeRefiner.callCount).to.equal(1)
+  })
+
+  // Test 3: Weak-model skip
+  it('skips refinement when runtime model is blocklisted and no refinementModel override', async () => {
+    const stubs = makeStubs(sb)
+    // Override refiner client to use a blocklisted model
+    stubs.refinerClient = {
+      completeCritic: stubs.completeCritic,
+      completeRefiner: stubs.completeRefiner,
+      modelId: 'llama-3.1-8b-instruct',
+    }
+    const synth = makeSynthesizer(stubs)
+
+    const result = await synth.refineIfNeeded('proj-1', 'curate')
+
+    expect(result).to.equal(undefined)
+    expect(stubs.completeCritic.callCount).to.equal(0)
+    expect(stubs.completeRefiner.callCount).to.equal(0)
+    expect(stubs.getLatest.callCount).to.equal(0)
+  })
+
+  // Test 4: Happy path — accepted
+  it('accepts candidate when delta H exceeds threshold', async () => {
+    const stubs = makeStubs(sb)
+    const parent = makeParentVersion()
+    stubs.getLatest.resolves(parent)
+    stubs.listOutcomes.resolves(makeOutcomes(50))
+    stubs.listScenarios.resolves(makeScenarios(10))
+    stubs.completeCritic.resolves('Failure pattern: null pointer. Root cause: missing check.')
+    stubs.completeRefiner.resolves('exports.meta = () => ({capabilities:["curate"],commandType:"curate",projectPatterns:["**/*.ts"],version:2}); exports.curate = async (ctx) => { if (!ctx) return; };')
+    stubs.evaluate.resolves(makeAcceptedResult(0.1))
+    stubs.saveVersion.resolves()
+
+    const eventPayloads: unknown[] = []
+    stubs.eventBus.on('harness:refinement-completed', (payload) => eventPayloads.push(payload))
+
+    const synth = makeSynthesizer(stubs)
+    const result = await synth.refineIfNeeded('proj-1', 'curate')
+
+    expect(result).to.not.equal(undefined)
+    expect(result!.accepted).to.equal(true)
+    expect(result!.deltaH).to.equal(0.1)
+    expect(result!.fromVersionId).to.equal(parent.id)
+    expect(result!.toVersionId).to.be.a('string')
+
+    // saveVersion called with version = parent.version + 1
+    expect(stubs.saveVersion.callCount).to.equal(1)
+    const savedVersion = stubs.saveVersion.firstCall.args[0] as HarnessVersion
+    expect(savedVersion.version).to.equal(parent.version + 1)
+    expect(savedVersion.parentId).to.equal(parent.id)
+
+    // Event emitted
+    expect(eventPayloads).to.have.lengthOf(1)
+    const event = eventPayloads[0] as {accepted: true; toVersion: number}
+    expect(event.accepted).to.equal(true)
+    expect(event.toVersion).to.equal(parent.version + 1)
+  })
+
+  // Test 5: Markdown-fence fallback
+  it('strips leading/trailing markdown fences from refiner output', async () => {
+    const stubs = makeStubs(sb)
+    const parent = makeParentVersion()
+    stubs.getLatest.resolves(parent)
+    stubs.listOutcomes.resolves(makeOutcomes(50))
+    stubs.listScenarios.resolves(makeScenarios(10))
+    stubs.completeCritic.resolves('Analysis here')
+    // Refiner wraps code in markdown fences
+    stubs.completeRefiner.resolves('```javascript\nexports.meta = () => ({capabilities:["curate"],commandType:"curate",projectPatterns:["**/*.ts"],version:2}); exports.curate = async (ctx) => {};\n```')
+    stubs.evaluate.resolves(makeAcceptedResult())
+    stubs.saveVersion.resolves()
+
+    const synth = makeSynthesizer(stubs)
+    await synth.refineIfNeeded('proj-1', 'curate')
+
+    // The evaluate call should receive code WITHOUT fences
+    expect(stubs.evaluate.callCount).to.equal(1)
+    const candidateCode = stubs.evaluate.firstCall.args[0] as string
+    expect(candidateCode).to.not.include('```')
+    expect(candidateCode).to.include('exports.meta')
+  })
+
+  // Test 6: Syntactically-invalid refiner output → evaluator rejects
+  it('rejects when evaluator returns candidate load failed', async () => {
+    const stubs = makeStubs(sb)
+    const parent = makeParentVersion()
+    stubs.getLatest.resolves(parent)
+    stubs.listOutcomes.resolves(makeOutcomes(50))
+    stubs.listScenarios.resolves(makeScenarios(10))
+    stubs.completeCritic.resolves('Analysis')
+    stubs.completeRefiner.resolves('const { x = broken JS')
+    stubs.evaluate.resolves(makeCandidateLoadFailedResult())
+
+    const eventPayloads: unknown[] = []
+    stubs.eventBus.on('harness:refinement-completed', (payload) => eventPayloads.push(payload))
+
+    const synth = makeSynthesizer(stubs)
+    const result = await synth.refineIfNeeded('proj-1', 'curate')
+
+    expect(result).to.not.equal(undefined)
+    expect(result!.accepted).to.equal(false)
+    expect(result!.reason).to.be.a('string')
+
+    // No version saved
+    expect(stubs.saveVersion.callCount).to.equal(0)
+
+    // Event emitted with accepted: false
+    expect(eventPayloads).to.have.lengthOf(1)
+    const event = eventPayloads[0] as {accepted: false; reason: string}
+    expect(event.accepted).to.equal(false)
+    expect(event.reason).to.be.a('string')
+  })
+
+  // Test 7: delta H below threshold → rejected
+  it('rejects when delta H is below 0.05 threshold', async () => {
+    const stubs = makeStubs(sb)
+    const parent = makeParentVersion()
+    stubs.getLatest.resolves(parent)
+    stubs.listOutcomes.resolves(makeOutcomes(50))
+    stubs.listScenarios.resolves(makeScenarios(10))
+    stubs.completeCritic.resolves('Analysis')
+    stubs.completeRefiner.resolves('exports.meta = () => ({capabilities:["curate"],commandType:"curate",projectPatterns:["**/*.ts"],version:2}); exports.curate = async (ctx) => {};')
+    stubs.evaluate.resolves(makeRejectedResult(0.03))
+
+    const eventPayloads: unknown[] = []
+    stubs.eventBus.on('harness:refinement-completed', (payload) => eventPayloads.push(payload))
+
+    const synth = makeSynthesizer(stubs)
+    const result = await synth.refineIfNeeded('proj-1', 'curate')
+
+    expect(result).to.not.equal(undefined)
+    expect(result!.accepted).to.equal(false)
+    expect(result!.reason).to.include('0.03')
+
+    // No version saved
+    expect(stubs.saveVersion.callCount).to.equal(0)
+
+    // Event emitted with accepted: false
+    expect(eventPayloads).to.have.lengthOf(1)
+    const event = eventPayloads[0] as {accepted: false; reason: string}
+    expect(event.accepted).to.equal(false)
+  })
+
+  // Test 8: Concurrent refinements on DIFFERENT pairs → both run
+  it('allows concurrent refinements on different pairs', async () => {
+    const stubs = makeStubs(sb)
+
+    const parentCurate = makeParentVersion({commandType: 'curate', projectId: 'proj-1'})
+    const parentQuery = makeParentVersion({commandType: 'query', projectId: 'proj-1'})
+
+    stubs.getLatest.withArgs('proj-1', 'curate').resolves(parentCurate)
+    stubs.getLatest.withArgs('proj-1', 'query').resolves(parentQuery)
+    stubs.listOutcomes.resolves(makeOutcomes(50))
+    stubs.listScenarios.resolves(makeScenarios(10))
+    stubs.completeCritic.resolves('Analysis')
+    stubs.completeRefiner.resolves('exports.meta = () => ({capabilities:["curate"],commandType:"curate",projectPatterns:["**/*.ts"],version:2}); exports.curate = async (ctx) => {};')
+    stubs.evaluate.resolves(makeAcceptedResult())
+    stubs.saveVersion.resolves()
+
+    const synth = makeSynthesizer(stubs)
+
+    const [resultCurate, resultQuery] = await Promise.all([
+      synth.refineIfNeeded('proj-1', 'curate'),
+      synth.refineIfNeeded('proj-1', 'query'),
+    ])
+
+    // Both should have run (neither dropped)
+    expect(resultCurate).to.not.equal(undefined)
+    expect(resultQuery).to.not.equal(undefined)
+    expect(resultCurate!.accepted).to.equal(true)
+    expect(resultQuery!.accepted).to.equal(true)
+
+    // Critic + Refiner each called twice (once per pair)
+    expect(stubs.completeCritic.callCount).to.equal(2)
+    expect(stubs.completeRefiner.callCount).to.equal(2)
+  })
+
+  // Test 9: Skip when baseline H >= 0.85 and all scenarios passing
+  it('skips refinement when baseline H is high and all scenarios are passing', async () => {
+    const stubs = makeStubs(sb)
+    const parent = makeParentVersion({heuristic: 0.9})
+    stubs.getLatest.resolves(parent)
+
+    // Outcomes that produce a high heuristic (all successful, all using harness)
+    const highOutcomes = Array.from({length: 50}, (_, i) => ({
+      code: `code-${i}`,
+      commandType: 'curate',
+      delegated: false,
+      executionTimeMs: 100,
+      id: `outcome-${i}`,
+      projectId: 'proj-1',
+      projectType: 'typescript' as const,
+      sessionId: 'session-1',
+      success: true,
+      timestamp: Date.now() - i * 1000,
+      usedHarness: true,
+    }))
+    stubs.listOutcomes.resolves(highOutcomes)
+
+    // All-passing scenarios
+    const passingScenarios = Array.from({length: 5}, (_, i) => ({
+      code: `scenario-code-${i}`,
+      commandType: 'curate' as const,
+      createdAt: Date.now() - i * 1000,
+      expectedBehavior: 'Succeeds without errors',
+      id: `scenario-${i}`,
+      projectId: 'proj-1',
+      projectType: 'typescript' as const,
+      taskDescription: `Task ${i}`,
+    }))
+    stubs.listScenarios.resolves(passingScenarios)
+
+    const synth = makeSynthesizer(stubs)
+    const result = await synth.refineIfNeeded('proj-1', 'curate')
+
+    expect(result).to.equal(undefined)
+    expect(stubs.completeCritic.callCount).to.equal(0)
+    expect(stubs.completeRefiner.callCount).to.equal(0)
+  })
+})

--- a/test/unit/agent/harness/harness-synthesizer.test.ts
+++ b/test/unit/agent/harness/harness-synthesizer.test.ts
@@ -2,7 +2,7 @@
  * AutoHarness V2 — HarnessSynthesizer tests.
  *
  * Validates the orchestration logic: single-flight per-pair gate,
- * weak-model skip, Critic→Refiner→Evaluator pipeline, markdown-fence
+ * weak-model skip, Critic->Refiner->Evaluator pipeline, markdown-fence
  * fallback, accept/reject paths, and concurrent-pair parallelism.
  *
  * Uses stubbed Evaluator, RefinerClient, and store — the real
@@ -25,6 +25,7 @@ import type {EvaluationResult, HarnessEvaluator} from '../../../../src/agent/inf
 import type {IRefinerClient} from '../../../../src/agent/infra/harness/harness-refiner-client.js'
 import type {HarnessScenarioCapture} from '../../../../src/agent/infra/harness/harness-scenario-capture.js'
 
+import {HarnessStoreError} from '../../../../src/agent/core/domain/errors/harness-store-error.js'
 import {NoOpLogger} from '../../../../src/agent/core/interfaces/i-logger.js'
 import {AgentEventBus} from '../../../../src/agent/infra/events/event-emitter.js'
 import {HarnessSynthesizer} from '../../../../src/agent/infra/harness/harness-synthesizer.js'
@@ -117,6 +118,11 @@ function makeCandidateLoadFailedResult(): EvaluationResult {
   }
 }
 
+/** Guard that narrows result and throws with a clear message on miss. */
+function assertDefined<T>(value: T | undefined, label: string): asserts value is T {
+  if (value === undefined) throw new Error(`expected ${label} to be defined`)
+}
+
 // ---------------------------------------------------------------------------
 // Stubs
 // ---------------------------------------------------------------------------
@@ -199,6 +205,17 @@ function makeSynthesizer(stubs: StubSet): HarnessSynthesizer {
   )
 }
 
+/** Wire stubs for a standard happy-path refinement (Critic + Refiner + Evaluate). */
+function wireHappyPath(stubs: StubSet, parent: HarnessVersion, evalResult: EvaluationResult): void {
+  stubs.getLatest.resolves(parent)
+  stubs.listOutcomes.resolves(makeOutcomes(50))
+  stubs.listScenarios.resolves(makeScenarios(10))
+  stubs.completeCritic.resolves('Failure pattern: null pointer. Root cause: missing check.')
+  stubs.completeRefiner.resolves('exports.meta = () => ({capabilities:["curate"],commandType:"curate",projectPatterns:["**/*.ts"],version:2}); exports.curate = async (ctx) => { if (!ctx) return; };')
+  stubs.evaluate.resolves(evalResult)
+  stubs.saveVersion.resolves()
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -214,7 +231,7 @@ describe('HarnessSynthesizer', () => {
     sb.restore()
   })
 
-  // Test 1: Pair has no parent version → no refinement
+  // Test 1: Pair has no parent version -> no refinement
   it('returns undefined when pair has no parent version', async () => {
     const stubs = makeStubs(sb)
     stubs.getLatest.resolves()
@@ -227,27 +244,19 @@ describe('HarnessSynthesizer', () => {
     expect(stubs.completeRefiner.callCount).to.equal(0)
   })
 
-  // Test 2: 100 parallel refineIfNeeded on same pair → only one runs
+  // Test 2: 100 parallel refineIfNeeded on same pair -> only one runs
   it('single-flights concurrent calls on the same pair (log-and-drop)', async () => {
     const stubs = makeStubs(sb)
     const parent = makeParentVersion()
-    stubs.getLatest.resolves(parent)
-    stubs.listOutcomes.resolves(makeOutcomes(50))
-    stubs.listScenarios.resolves(makeScenarios(10))
-    stubs.completeCritic.resolves('Failure pattern: null pointer')
-    stubs.completeRefiner.resolves('exports.meta = () => ({capabilities:["curate"],commandType:"curate",projectPatterns:["**/*.ts"],version:2}); exports.curate = async (ctx) => { if (!ctx) return; };')
-    stubs.evaluate.resolves(makeAcceptedResult())
-    stubs.saveVersion.resolves()
+    wireHappyPath(stubs, parent, makeAcceptedResult())
 
     const synth = makeSynthesizer(stubs)
 
     const promises = Array.from({length: 100}, () => synth.refineIfNeeded('proj-1', 'curate'))
     const results = await Promise.all(promises)
 
-    // Only one should have actually run (non-undefined result)
     const ran = results.filter((r): r is NonNullable<typeof r> => r !== undefined)
     expect(ran).to.have.lengthOf(1)
-    // Critic + Refiner each called exactly once
     expect(stubs.completeCritic.callCount).to.equal(1)
     expect(stubs.completeRefiner.callCount).to.equal(1)
   })
@@ -255,7 +264,6 @@ describe('HarnessSynthesizer', () => {
   // Test 3: Weak-model skip
   it('skips refinement when runtime model is blocklisted and no refinementModel override', async () => {
     const stubs = makeStubs(sb)
-    // Override refiner client to use a blocklisted model
     stubs.refinerClient = {
       completeCritic: stubs.completeCritic,
       completeRefiner: stubs.completeRefiner,
@@ -275,13 +283,7 @@ describe('HarnessSynthesizer', () => {
   it('accepts candidate when delta H exceeds threshold', async () => {
     const stubs = makeStubs(sb)
     const parent = makeParentVersion()
-    stubs.getLatest.resolves(parent)
-    stubs.listOutcomes.resolves(makeOutcomes(50))
-    stubs.listScenarios.resolves(makeScenarios(10))
-    stubs.completeCritic.resolves('Failure pattern: null pointer. Root cause: missing check.')
-    stubs.completeRefiner.resolves('exports.meta = () => ({capabilities:["curate"],commandType:"curate",projectPatterns:["**/*.ts"],version:2}); exports.curate = async (ctx) => { if (!ctx) return; };')
-    stubs.evaluate.resolves(makeAcceptedResult(0.1))
-    stubs.saveVersion.resolves()
+    wireHappyPath(stubs, parent, makeAcceptedResult(0.1))
 
     const eventPayloads: unknown[] = []
     stubs.eventBus.on('harness:refinement-completed', (payload) => eventPayloads.push(payload))
@@ -289,11 +291,11 @@ describe('HarnessSynthesizer', () => {
     const synth = makeSynthesizer(stubs)
     const result = await synth.refineIfNeeded('proj-1', 'curate')
 
-    expect(result).to.not.equal(undefined)
-    expect(result!.accepted).to.equal(true)
-    expect(result!.deltaH).to.equal(0.1)
-    expect(result!.fromVersionId).to.equal(parent.id)
-    expect(result!.toVersionId).to.be.a('string')
+    assertDefined(result, 'result')
+    expect(result.accepted).to.equal(true)
+    expect(result.deltaH).to.equal(0.1)
+    expect(result.fromVersionId).to.equal(parent.id)
+    expect(result.toVersionId).to.be.a('string')
 
     // saveVersion called with version = parent.version + 1
     expect(stubs.saveVersion.callCount).to.equal(1)
@@ -316,7 +318,6 @@ describe('HarnessSynthesizer', () => {
     stubs.listOutcomes.resolves(makeOutcomes(50))
     stubs.listScenarios.resolves(makeScenarios(10))
     stubs.completeCritic.resolves('Analysis here')
-    // Refiner wraps code in markdown fences
     stubs.completeRefiner.resolves('```javascript\nexports.meta = () => ({capabilities:["curate"],commandType:"curate",projectPatterns:["**/*.ts"],version:2}); exports.curate = async (ctx) => {};\n```')
     stubs.evaluate.resolves(makeAcceptedResult())
     stubs.saveVersion.resolves()
@@ -324,23 +325,18 @@ describe('HarnessSynthesizer', () => {
     const synth = makeSynthesizer(stubs)
     await synth.refineIfNeeded('proj-1', 'curate')
 
-    // The evaluate call should receive code WITHOUT fences
     expect(stubs.evaluate.callCount).to.equal(1)
     const candidateCode = stubs.evaluate.firstCall.args[0] as string
     expect(candidateCode).to.not.include('```')
     expect(candidateCode).to.include('exports.meta')
   })
 
-  // Test 6: Syntactically-invalid refiner output → evaluator rejects
+  // Test 6: Syntactically-invalid refiner output -> evaluator rejects
   it('rejects when evaluator returns candidate load failed', async () => {
     const stubs = makeStubs(sb)
     const parent = makeParentVersion()
-    stubs.getLatest.resolves(parent)
-    stubs.listOutcomes.resolves(makeOutcomes(50))
-    stubs.listScenarios.resolves(makeScenarios(10))
-    stubs.completeCritic.resolves('Analysis')
+    wireHappyPath(stubs, parent, makeCandidateLoadFailedResult())
     stubs.completeRefiner.resolves('const { x = broken JS')
-    stubs.evaluate.resolves(makeCandidateLoadFailedResult())
 
     const eventPayloads: unknown[] = []
     stubs.eventBus.on('harness:refinement-completed', (payload) => eventPayloads.push(payload))
@@ -348,30 +344,23 @@ describe('HarnessSynthesizer', () => {
     const synth = makeSynthesizer(stubs)
     const result = await synth.refineIfNeeded('proj-1', 'curate')
 
-    expect(result).to.not.equal(undefined)
-    expect(result!.accepted).to.equal(false)
-    expect(result!.reason).to.be.a('string')
+    assertDefined(result, 'result')
+    expect(result.accepted).to.equal(false)
+    expect(result.reason).to.be.a('string')
 
-    // No version saved
     expect(stubs.saveVersion.callCount).to.equal(0)
 
-    // Event emitted with accepted: false
     expect(eventPayloads).to.have.lengthOf(1)
     const event = eventPayloads[0] as {accepted: false; reason: string}
     expect(event.accepted).to.equal(false)
     expect(event.reason).to.be.a('string')
   })
 
-  // Test 7: delta H below threshold → rejected
-  it('rejects when delta H is below 0.05 threshold', async () => {
+  // Test 7: delta H below threshold -> rejected
+  it('rejects when delta H is below acceptance threshold', async () => {
     const stubs = makeStubs(sb)
     const parent = makeParentVersion()
-    stubs.getLatest.resolves(parent)
-    stubs.listOutcomes.resolves(makeOutcomes(50))
-    stubs.listScenarios.resolves(makeScenarios(10))
-    stubs.completeCritic.resolves('Analysis')
-    stubs.completeRefiner.resolves('exports.meta = () => ({capabilities:["curate"],commandType:"curate",projectPatterns:["**/*.ts"],version:2}); exports.curate = async (ctx) => {};')
-    stubs.evaluate.resolves(makeRejectedResult(0.03))
+    wireHappyPath(stubs, parent, makeRejectedResult(0.03))
 
     const eventPayloads: unknown[] = []
     stubs.eventBus.on('harness:refinement-completed', (payload) => eventPayloads.push(payload))
@@ -379,20 +368,18 @@ describe('HarnessSynthesizer', () => {
     const synth = makeSynthesizer(stubs)
     const result = await synth.refineIfNeeded('proj-1', 'curate')
 
-    expect(result).to.not.equal(undefined)
-    expect(result!.accepted).to.equal(false)
-    expect(result!.reason).to.include('0.03')
+    assertDefined(result, 'result')
+    expect(result.accepted).to.equal(false)
+    expect(result.reason).to.include('0.03')
 
-    // No version saved
     expect(stubs.saveVersion.callCount).to.equal(0)
 
-    // Event emitted with accepted: false
     expect(eventPayloads).to.have.lengthOf(1)
     const event = eventPayloads[0] as {accepted: false; reason: string}
     expect(event.accepted).to.equal(false)
   })
 
-  // Test 8: Concurrent refinements on DIFFERENT pairs → both run
+  // Test 8: Concurrent refinements on DIFFERENT pairs -> both run
   it('allows concurrent refinements on different pairs', async () => {
     const stubs = makeStubs(sb)
 
@@ -415,13 +402,11 @@ describe('HarnessSynthesizer', () => {
       synth.refineIfNeeded('proj-1', 'query'),
     ])
 
-    // Both should have run (neither dropped)
-    expect(resultCurate).to.not.equal(undefined)
-    expect(resultQuery).to.not.equal(undefined)
-    expect(resultCurate!.accepted).to.equal(true)
-    expect(resultQuery!.accepted).to.equal(true)
+    assertDefined(resultCurate, 'resultCurate')
+    assertDefined(resultQuery, 'resultQuery')
+    expect(resultCurate.accepted).to.equal(true)
+    expect(resultQuery.accepted).to.equal(true)
 
-    // Critic + Refiner each called twice (once per pair)
     expect(stubs.completeCritic.callCount).to.equal(2)
     expect(stubs.completeRefiner.callCount).to.equal(2)
   })
@@ -432,7 +417,6 @@ describe('HarnessSynthesizer', () => {
     const parent = makeParentVersion({heuristic: 0.9})
     stubs.getLatest.resolves(parent)
 
-    // Outcomes that produce a high heuristic (all successful, all using harness)
     const highOutcomes = Array.from({length: 50}, (_, i) => ({
       code: `code-${i}`,
       commandType: 'curate',
@@ -448,7 +432,6 @@ describe('HarnessSynthesizer', () => {
     }))
     stubs.listOutcomes.resolves(highOutcomes)
 
-    // All-passing scenarios
     const passingScenarios = Array.from({length: 5}, (_, i) => ({
       code: `scenario-code-${i}`,
       commandType: 'curate' as const,
@@ -467,5 +450,30 @@ describe('HarnessSynthesizer', () => {
     expect(result).to.equal(undefined)
     expect(stubs.completeCritic.callCount).to.equal(0)
     expect(stubs.completeRefiner.callCount).to.equal(0)
+  })
+
+  // Test 10: VERSION_CONFLICT on concurrent cross-instance race
+  it('treats VERSION_CONFLICT as lost race and emits rejected event', async () => {
+    const stubs = makeStubs(sb)
+    const parent = makeParentVersion()
+    wireHappyPath(stubs, parent, makeAcceptedResult())
+    stubs.saveVersion.rejects(
+      HarnessStoreError.versionConflict('proj-1', 'curate', {version: 2}),
+    )
+
+    const eventPayloads: unknown[] = []
+    stubs.eventBus.on('harness:refinement-completed', (payload) => eventPayloads.push(payload))
+
+    const synth = makeSynthesizer(stubs)
+    const result = await synth.refineIfNeeded('proj-1', 'curate')
+
+    assertDefined(result, 'result')
+    expect(result.accepted).to.equal(false)
+    expect(result.reason).to.include('lost race')
+
+    expect(eventPayloads).to.have.lengthOf(1)
+    const event = eventPayloads[0] as {accepted: false; reason: string}
+    expect(event.accepted).to.equal(false)
+    expect(event.reason).to.include('lost race')
   })
 })


### PR DESCRIPTION
## Summary

- Adds `HarnessSynthesizer` orchestrating the Critic → Refiner → Evaluator pipeline via `refineIfNeeded(projectId, commandType)`
- Adds `IRefinerClient` interface + `RefinerClient` class wrapping `ILLMService` for testable LLM calls
- Adds `model-policy.ts` with `REFINEMENT_MODEL_BLOCKLIST` and `isBlocklistedForRefinement()` per v1-design-decisions §2.6
- 9 unit tests covering all 8 spec scenarios + step-6 skip behavior

### Key behaviors
- **Per-pair single-flight**: `inFlight` Map with try/finally cleanup; concurrent calls on same pair log-and-drop
- **Weak-model skip**: blocklist check before single-flight gate; session-scoped via `cleanup()` lifecycle method
- **Skip if not worth refining**: baseline H >= 0.85 AND all scenarios passing → no LLM calls
- **Markdown-fence fallback**: single-layer regex strip for weak models that add fences despite prompt instructions
- **Accept path**: save version with `parent.version + 1`, emit `harness:refinement-completed` with `accepted: true`
- **Reject path**: log reason, emit event with `accepted: false` and reason string
- **VERSION_CONFLICT**: caught on concurrent cross-instance race, treated as "lost race" rejection

### Implementation decisions
- Uses `AgentEventBus` (not `SessionEventBus`) because `harness:refinement-completed` is on `AgentEventMap` — using `SessionEventBus` would be a type error
- `weakModelWarned` keyed by pair with `cleanup()` for per-session reset — `refineIfNeeded` has no `sessionId` param per spec
- `_scenarioCapture` held in constructor for session-end trigger wiring; scenario listing uses `harnessStore.listScenarios()` directly since `HarnessScenarioCapture` has no list method

Closes ENG-2263

## Test plan

- [ ] `npx mocha --forbid-only "test/unit/agent/harness/harness-synthesizer.test.ts"` — 9/9 pass
- [ ] `npm run typecheck` clean
- [ ] `npm run lint` clean
- [ ] `npm run build` clean
- [ ] `npm test` — 6857 passing, 0 failing