### PR TITLE
feat: [ENG-2330] graceful-degradation regression at integration level

### DIFF
--- a/test/integration/agent/harness/graceful-degradation-regression.test.ts
+++ b/test/integration/agent/harness/graceful-degradation-regression.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Integration regression test for Phase 3 Task 3.4's graceful-
+ * degradation invariants, exercised through the full Phase 3 + 4 + 5
+ * stack.
+ *
+ * Phase 3 Task 3.4 proved the invariants at the module-builder
+ * layer. This test proves they still hold when the module builder
+ * sits under real HarnessStore + real SandboxService + real
+ * HarnessOutcomeRecorder — the same composition production uses.
+ *
+ * Eight scenarios, one per documented failure mode:
+ *
+ *   Load-time failures (harness NOT loaded; sandbox degrades to
+ *   raw `tools.*`):
+ *     1. Syntax error in TEMPLATE_CODE
+ *     2. `meta()` throws at load
+ *     3. `meta()` returns a schema-invalid object
+ *
+ *   Runtime failures (harness loaded; per-invocation wrapper throws;
+ *   session continues):
+ *     4. Throw in `curate(ctx)` body
+ *     5. Infinite loop in `curate(ctx)` → vm.Script timeout
+ *     6. Infinite recursion in `curate(ctx)` → stack overflow
+ *     7. Never-resolving Promise from `curate(ctx)` → Promise.race
+ *        timer
+ *
+ *   Legitimate non-failure (not a degradation case but pinned here
+ *   so a future change doesn't accidentally classify it as one):
+ *     8. `curate(ctx)` resolves to `undefined`
+ *
+ * For each case, the sandbox MUST:
+ *   - continue executing unrelated plain-JS code after the harness
+ *     misbehaves
+ *   - not crash, not corrupt session state
+ *   - (runtime failures only) record an outcome so the heuristic
+ *     learns from the failure
+ */
+
+import {expect} from 'chai'
+import {createSandbox, type SinonSandbox} from 'sinon'
+
+import type {EnvironmentContext} from '../../../../src/agent/core/domain/environment/types.js'
+import type {HarnessVersion} from '../../../../src/agent/core/domain/harness/types.js'
+import type {ValidatedHarnessConfig} from '../../../../src/agent/infra/agent/agent-schemas.js'
+
+import {NoOpLogger} from '../../../../src/agent/core/interfaces/i-logger.js'
+import {SessionEventBus} from '../../../../src/agent/infra/events/event-emitter.js'
+import {HarnessModuleBuilder} from '../../../../src/agent/infra/harness/harness-module-builder.js'
+import {HarnessOutcomeRecorder} from '../../../../src/agent/infra/harness/harness-outcome-recorder.js'
+import {HarnessStore} from '../../../../src/agent/infra/harness/harness-store.js'
+import {SandboxService} from '../../../../src/agent/infra/sandbox/sandbox-service.js'
+import {FileKeyStorage} from '../../../../src/agent/infra/storage/file-key-storage.js'
+
+// Slug projectId to side-step the FileKeyStorage slug/path gap (same
+// workaround used by outcome-collection.test.ts and cold-start.test.ts).
+const PROJECT_ID = 'degradation-test-project'
+const SESSION_ID = 'degradation-sess-1'
+
+// Valid meta block — template used as a prefix when only the curate()
+// body should fail (scenarios 4-8). `meta()` must parse cleanly so the
+// module builder reaches the curate wrapper.
+const VALID_META = `
+  exports.meta = function() {
+    return {
+      capabilities: ['curate'],
+      commandType: 'curate',
+      projectPatterns: ['**/*'],
+      version: 1,
+    }
+  }
+`
+
+function makeEnvironmentContext(workingDirectory: string): EnvironmentContext {
+  return {
+    brvStructure: '',
+    fileTree: '',
+    isGitRepository: false,
+    nodeVersion: process.version,
+    osVersion: 'test',
+    platform: process.platform,
+    workingDirectory,
+  }
+}
+
+function makeConfig(): ValidatedHarnessConfig {
+  return {
+    autoLearn: true,
+    enabled: true,
+    language: 'generic',
+    maxVersions: 20,
+  }
+}
+
+function makeVersion(code: string, id: string = 'v-degradation'): HarnessVersion {
+  return {
+    code,
+    commandType: 'curate',
+    createdAt: 1_700_000_000_000,
+    heuristic: 0.3,
+    id,
+    metadata: {
+      capabilities: ['curate'],
+      commandType: 'curate',
+      projectPatterns: ['**/*'],
+      version: 1,
+    },
+    projectId: PROJECT_ID,
+    projectType: 'generic',
+    version: 1,
+  }
+}
+
+interface Stack {
+  readonly harnessStore: HarnessStore
+  readonly sandboxService: SandboxService
+}
+
+/** Wires the same component graph `service-initializer.ts` builds. */
+async function buildStack(): Promise<Stack> {
+  const logger = new NoOpLogger()
+  const keyStorage = new FileKeyStorage({inMemory: true})
+  await keyStorage.initialize()
+  const harnessStore = new HarnessStore(keyStorage, logger)
+  const config = makeConfig()
+  const sessionEventBus = new SessionEventBus()
+  const recorder = new HarnessOutcomeRecorder(
+    harnessStore,
+    sessionEventBus,
+    logger,
+    config,
+  )
+  const builder = new HarnessModuleBuilder(logger)
+
+  const sandboxService = new SandboxService()
+  sandboxService.setHarnessConfig(config)
+  sandboxService.setEnvironmentContext(makeEnvironmentContext(PROJECT_ID))
+  sandboxService.setHarnessStore(harnessStore)
+  sandboxService.setHarnessModuleBuilder(builder)
+  sandboxService.setHarnessOutcomeRecorder(recorder, logger)
+
+  return {harnessStore, sandboxService}
+}
+
+/**
+ * Run unrelated plain-JS code in the sandbox. Used after each failure
+ * scenario to prove the session didn't get corrupted — if `2 + 2`
+ * stops equaling `4`, the sandbox state is broken.
+ */
+async function expectSandboxHealthy(sandboxService: SandboxService): Promise<void> {
+  const result = await sandboxService.executeCode('2 + 2', SESSION_ID)
+  expect(result.returnValue, 'sandbox must still execute plain JS after harness failure').to.equal(4)
+}
+
+/** Poll the outcome store for a recorded entry; cold-start.test.ts pattern. */
+async function pollForOutcome(
+  harnessStore: HarnessStore,
+  timeoutMs: number = 2000,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    // eslint-disable-next-line no-await-in-loop
+    const outcomes = await harnessStore.listOutcomes(PROJECT_ID, 'curate', 10)
+    if (outcomes.length > 0) return true
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((r) => {
+      setTimeout(r, 50)
+    })
+  }
+
+  return false
+}
+
+describe('AutoHarness V2 — graceful-degradation regression (Phase 3.4 invariants)', function () {
+  this.timeout(25_000)
+
+  let sb: SinonSandbox
+
+  beforeEach(() => {
+    sb = createSandbox()
+  })
+
+  afterEach(() => {
+    sb.restore()
+  })
+
+  // ── Load-time failures: harness NOT loaded, sandbox degrades ──────────────
+
+  it('1. Syntax error → loadHarness returns {loaded:false, reason:syntax}; sandbox stays healthy', async () => {
+    const {harnessStore, sandboxService} = await buildStack()
+    await harnessStore.saveVersion(makeVersion('function {{ broken syntax', 'v-syn'))
+
+    const result = await sandboxService.loadHarness(SESSION_ID, PROJECT_ID, 'curate')
+    expect(result).to.deep.equal({loaded: false, reason: 'syntax'})
+
+    await expectSandboxHealthy(sandboxService)
+  })
+
+  it('2. meta() throws → {loaded:false, reason:meta-threw}; sandbox stays healthy', async () => {
+    const {harnessStore, sandboxService} = await buildStack()
+    const code = `exports.meta = function() { throw new Error('bad meta') }`
+    await harnessStore.saveVersion(makeVersion(code, 'v-meta-threw'))
+
+    const result = await sandboxService.loadHarness(SESSION_ID, PROJECT_ID, 'curate')
+    expect(result).to.deep.equal({loaded: false, reason: 'meta-threw'})
+
+    await expectSandboxHealthy(sandboxService)
+  })
+
+  it('3. meta() returns schema-invalid object → {loaded:false, reason:meta-invalid}; sandbox stays healthy', async () => {
+    const {harnessStore, sandboxService} = await buildStack()
+    // Missing `capabilities` + wrong `version` type — fails HarnessMetaSchema.
+    const code = `
+      exports.meta = function() {
+        return {commandType: 'curate', projectPatterns: [], version: 'not-a-number'}
+      }
+    `
+    await harnessStore.saveVersion(makeVersion(code, 'v-meta-invalid'))
+
+    const result = await sandboxService.loadHarness(SESSION_ID, PROJECT_ID, 'curate')
+    expect(result).to.deep.equal({loaded: false, reason: 'meta-invalid'})
+
+    await expectSandboxHealthy(sandboxService)
+  })
+
+  // ── Runtime failures: loaded; wrapper throws on invocation; session lives ─
+
+  it('4. curate() throws → error surfaces in stderr; outcome recorded; sandbox healthy', async () => {
+    const {harnessStore, sandboxService} = await buildStack()
+    const code = `${VALID_META}
+      exports.curate = async function(ctx) { throw new Error('user code bad') }
+    `
+    await harnessStore.saveVersion(makeVersion(code, 'v-throws'))
+
+    const loadResult = await sandboxService.loadHarness(SESSION_ID, PROJECT_ID, 'curate')
+    expect(loadResult.loaded).to.equal(true)
+
+    const exec = await sandboxService.executeCode(
+      '(async () => harness.curate())().catch((e) => { throw e })',
+      SESSION_ID,
+      {commandType: 'curate', taskDescription: 'degradation-4'},
+    )
+
+    // Phase 3 Task 3.2 normalizes thrown errors — stderr carries the
+    // wrapped message rather than a raw stack trace.
+    expect(exec.stderr).to.match(/curate\(\) failed/)
+    expect(await pollForOutcome(harnessStore)).to.equal(true)
+    await expectSandboxHealthy(sandboxService)
+  })
+
+  it('5. Infinite loop in curate() → vm.Script timeout; session healthy', async function () {
+    this.timeout(8000)
+    const {harnessStore, sandboxService} = await buildStack()
+    const code = `${VALID_META}
+      exports.curate = function(ctx) { while(true){} }
+    `
+    await harnessStore.saveVersion(makeVersion(code, 'v-loop'))
+
+    await sandboxService.loadHarness(SESSION_ID, PROJECT_ID, 'curate')
+
+    const exec = await sandboxService.executeCode(
+      '(async () => harness.curate())().catch((e) => { throw e })',
+      SESSION_ID,
+      {commandType: 'curate', taskDescription: 'degradation-5'},
+    )
+    expect(exec.stderr).to.match(/curate\(\) failed/)
+    expect(await pollForOutcome(harnessStore)).to.equal(true)
+    await expectSandboxHealthy(sandboxService)
+  })
+
+  it('6. Infinite recursion in curate() → stack overflow; session healthy', async () => {
+    const {harnessStore, sandboxService} = await buildStack()
+    const code = `${VALID_META}
+      function go() { go() }
+      exports.curate = function(ctx) { go() }
+    `
+    await harnessStore.saveVersion(makeVersion(code, 'v-recurse'))
+
+    await sandboxService.loadHarness(SESSION_ID, PROJECT_ID, 'curate')
+
+    const exec = await sandboxService.executeCode(
+      '(async () => harness.curate())().catch((e) => { throw e })',
+      SESSION_ID,
+      {commandType: 'curate', taskDescription: 'degradation-6'},
+    )
+    expect(exec.stderr).to.match(/curate\(\) failed/)
+    expect(await pollForOutcome(harnessStore)).to.equal(true)
+    await expectSandboxHealthy(sandboxService)
+  })
+
+  it('7. Never-resolving Promise from curate() → Promise.race timer throws; session healthy', async function () {
+    this.timeout(8000)
+    const {harnessStore, sandboxService} = await buildStack()
+    const code = `${VALID_META}
+      exports.curate = function(ctx) { return new Promise(function(){}) }
+    `
+    await harnessStore.saveVersion(makeVersion(code, 'v-hang'))
+
+    await sandboxService.loadHarness(SESSION_ID, PROJECT_ID, 'curate')
+
+    const exec = await sandboxService.executeCode(
+      '(async () => harness.curate())().catch((e) => { throw e })',
+      SESSION_ID,
+      {commandType: 'curate', taskDescription: 'degradation-7'},
+    )
+    expect(exec.stderr).to.match(/curate\(\) failed/)
+    expect(exec.stderr).to.match(/exceeded/)
+    expect(await pollForOutcome(harnessStore)).to.equal(true)
+    await expectSandboxHealthy(sandboxService)
+  })
+
+  // ── Legitimate non-failure — pin so a future change doesn't flag it ──────
+
+  it('8. curate() returns undefined → resolves cleanly (NOT a degradation case)', async () => {
+    const {harnessStore, sandboxService} = await buildStack()
+    const code = `${VALID_META}
+      exports.curate = async function(ctx) { return undefined }
+    `
+    await harnessStore.saveVersion(makeVersion(code, 'v-undefined'))
+
+    await sandboxService.loadHarness(SESSION_ID, PROJECT_ID, 'curate')
+
+    const exec = await sandboxService.executeCode(
+      '(async () => harness.curate())()',
+      SESSION_ID,
+      {commandType: 'curate', taskDescription: 'degradation-8'},
+    )
+    expect(exec.stderr, 'undefined return must NOT be treated as a failure').to.equal('')
+    await expectSandboxHealthy(sandboxService)
+  })
+})

--- a/test/integration/agent/harness/graceful-degradation-regression.test.ts
+++ b/test/integration/agent/harness/graceful-degradation-regression.test.ts
@@ -37,7 +37,6 @@
  */
 
 import {expect} from 'chai'
-import {createSandbox, type SinonSandbox} from 'sinon'
 
 import type {EnvironmentContext} from '../../../../src/agent/core/domain/environment/types.js'
 import type {HarnessVersion} from '../../../../src/agent/core/domain/harness/types.js'
@@ -91,7 +90,7 @@ function makeConfig(): ValidatedHarnessConfig {
   }
 }
 
-function makeVersion(code: string, id: string = 'v-degradation'): HarnessVersion {
+function makeVersion(code: string, id: string): HarnessVersion {
   return {
     code,
     commandType: 'curate',
@@ -151,6 +150,17 @@ async function expectSandboxHealthy(sandboxService: SandboxService): Promise<voi
   expect(result.returnValue, 'sandbox must still execute plain JS after harness failure').to.equal(4)
 }
 
+/**
+ * Assertion for load-time failures: the recorder fires from
+ * `executeCode`, not `loadHarness`. A future change that accidentally
+ * wires `record()` into the load path would silently record a spurious
+ * outcome — this guard catches that.
+ */
+async function expectNoOutcomeRecorded(harnessStore: HarnessStore): Promise<void> {
+  const outcomes = await harnessStore.listOutcomes(PROJECT_ID, 'curate', 10)
+  expect(outcomes, 'load-time failure must not record an outcome').to.have.length(0)
+}
+
 /** Poll the outcome store for a recorded entry; cold-start.test.ts pattern. */
 async function pollForOutcome(
   harnessStore: HarnessStore,
@@ -173,16 +183,6 @@ async function pollForOutcome(
 describe('AutoHarness V2 — graceful-degradation regression (Phase 3.4 invariants)', function () {
   this.timeout(25_000)
 
-  let sb: SinonSandbox
-
-  beforeEach(() => {
-    sb = createSandbox()
-  })
-
-  afterEach(() => {
-    sb.restore()
-  })
-
   // ── Load-time failures: harness NOT loaded, sandbox degrades ──────────────
 
   it('1. Syntax error → loadHarness returns {loaded:false, reason:syntax}; sandbox stays healthy', async () => {
@@ -193,6 +193,7 @@ describe('AutoHarness V2 — graceful-degradation regression (Phase 3.4 invarian
     expect(result).to.deep.equal({loaded: false, reason: 'syntax'})
 
     await expectSandboxHealthy(sandboxService)
+    await expectNoOutcomeRecorded(harnessStore)
   })
 
   it('2. meta() throws → {loaded:false, reason:meta-threw}; sandbox stays healthy', async () => {
@@ -204,6 +205,7 @@ describe('AutoHarness V2 — graceful-degradation regression (Phase 3.4 invarian
     expect(result).to.deep.equal({loaded: false, reason: 'meta-threw'})
 
     await expectSandboxHealthy(sandboxService)
+    await expectNoOutcomeRecorded(harnessStore)
   })
 
   it('3. meta() returns schema-invalid object → {loaded:false, reason:meta-invalid}; sandbox stays healthy', async () => {
@@ -220,6 +222,7 @@ describe('AutoHarness V2 — graceful-degradation regression (Phase 3.4 invarian
     expect(result).to.deep.equal({loaded: false, reason: 'meta-invalid'})
 
     await expectSandboxHealthy(sandboxService)
+    await expectNoOutcomeRecorded(harnessStore)
   })
 
   // ── Runtime failures: loaded; wrapper throws on invocation; session lives ─
@@ -234,8 +237,12 @@ describe('AutoHarness V2 — graceful-degradation regression (Phase 3.4 invarian
     const loadResult = await sandboxService.loadHarness(SESSION_ID, PROJECT_ID, 'curate')
     expect(loadResult.loaded).to.equal(true)
 
+    // The IIFE rejects; `LocalSandbox.execute` normalises the rejection
+    // into `REPLResult.stderr` rather than propagating a throw to the
+    // test. This contract is what the `/curate\(\) failed/` assertion
+    // below latches onto.
     const exec = await sandboxService.executeCode(
-      '(async () => harness.curate())().catch((e) => { throw e })',
+      '(async () => harness.curate())()',
       SESSION_ID,
       {commandType: 'curate', taskDescription: 'degradation-4'},
     )
@@ -257,8 +264,12 @@ describe('AutoHarness V2 — graceful-degradation regression (Phase 3.4 invarian
 
     await sandboxService.loadHarness(SESSION_ID, PROJECT_ID, 'curate')
 
+    // The IIFE rejects; `LocalSandbox.execute` normalises the rejection
+    // into `REPLResult.stderr` rather than propagating a throw to the
+    // test. This contract is what the `/curate\(\) failed/` assertion
+    // below latches onto.
     const exec = await sandboxService.executeCode(
-      '(async () => harness.curate())().catch((e) => { throw e })',
+      '(async () => harness.curate())()',
       SESSION_ID,
       {commandType: 'curate', taskDescription: 'degradation-5'},
     )
@@ -277,8 +288,12 @@ describe('AutoHarness V2 — graceful-degradation regression (Phase 3.4 invarian
 
     await sandboxService.loadHarness(SESSION_ID, PROJECT_ID, 'curate')
 
+    // The IIFE rejects; `LocalSandbox.execute` normalises the rejection
+    // into `REPLResult.stderr` rather than propagating a throw to the
+    // test. This contract is what the `/curate\(\) failed/` assertion
+    // below latches onto.
     const exec = await sandboxService.executeCode(
-      '(async () => harness.curate())().catch((e) => { throw e })',
+      '(async () => harness.curate())()',
       SESSION_ID,
       {commandType: 'curate', taskDescription: 'degradation-6'},
     )
@@ -297,8 +312,12 @@ describe('AutoHarness V2 — graceful-degradation regression (Phase 3.4 invarian
 
     await sandboxService.loadHarness(SESSION_ID, PROJECT_ID, 'curate')
 
+    // The IIFE rejects; `LocalSandbox.execute` normalises the rejection
+    // into `REPLResult.stderr` rather than propagating a throw to the
+    // test. This contract is what the `/curate\(\) failed/` assertion
+    // below latches onto.
     const exec = await sandboxService.executeCode(
-      '(async () => harness.curate())().catch((e) => { throw e })',
+      '(async () => harness.curate())()',
       SESSION_ID,
       {commandType: 'curate', taskDescription: 'degradation-7'},
     )


### PR DESCRIPTION
## Summary

- **Problem**: Phase 3 Task 3.4 proved the harness-failure invariants at the `HarnessModuleBuilder` layer in isolation. But production composes the builder under `HarnessStore` + `SandboxService` + `HarnessOutcomeRecorder`. A future refactor to any of those could break the invariants without 3.4's unit test noticing.
- **Why it matters**: Phase 8 regression gate. If a harness throws, the user's session must continue on raw `tools.*` AND the failure must be recorded so the heuristic learns from it. Both invariants matter; breaking either silently damages the refinement loop.
- **What changed**: Adds `test/integration/agent/harness/graceful-degradation-regression.test.ts` — 8 scenarios exercising the full stack, one per documented failure mode.
- **What did NOT change (scope boundary)**: No source code changes. No KPI measurement (Task 8.4). No lifecycle check (Task 8.1). Just the regression gate for Phase 3.4.

## Type of change

- [x] Test

## Scope (select all touched areas)

- [x] Agent / Tools

## Linked issues

- Closes ENG-2330
- Depends on (all merged): Phases 3, 4, 5
- Part of Phase 8 (the v1.0 ship gate)

## Root cause (bug fixes only, otherwise write `N/A`)

N/A

## Test plan

- Coverage added:
  - [x] Integration test
- Test file: `test/integration/agent/harness/graceful-degradation-regression.test.ts`
- 8 scenarios:
  - **Load-time** (loadHarness returns `{loaded: false, reason}`):
    1. Syntax error in code → `reason: 'syntax'`
    2. `meta()` throws → `reason: 'meta-threw'`
    3. `meta()` returns schema-invalid object → `reason: 'meta-invalid'`
  - **Runtime** (loaded; `executeCode('harness.curate()')` fails):
    4. `curate()` body throws → stderr contains `curate() failed`, outcome recorded
    5. Infinite loop → vm.Script timeout (5s) → outcome recorded
    6. Infinite recursion → stack overflow → outcome recorded
    7. Never-resolving Promise → Promise.race timer (5s) → outcome recorded
  - **Non-failure pin** (guards against future misclassification):
    8. `curate()` resolves to `undefined` → no error, session healthy

Every scenario also asserts the sandbox is still healthy via `expectSandboxHealthy` (`2 + 2` must still equal `4` after the failure).

## User-visible changes

None. Test-only.

## Evidence

- [x] Failing test/log before + passing after

```
$ npx mocha --forbid-only 'test/integration/agent/harness/graceful-degradation-regression.test.ts'
  AutoHarness V2 — graceful-degradation regression (Phase 3.4 invariants)
    ✔ 1. Syntax error → loadHarness returns {loaded:false, reason:syntax}; sandbox stays healthy
    ✔ 2. meta() throws → {loaded:false, reason:meta-threw}; sandbox stays healthy
    ✔ 3. meta() returns schema-invalid object → {loaded:false, reason:meta-invalid}; sandbox stays healthy
    ✔ 4. curate() throws → error surfaces in stderr; outcome recorded; sandbox healthy
    ✔ 5. Infinite loop in curate() → vm.Script timeout; session healthy (5005ms)
    ✔ 6. Infinite recursion in curate() → stack overflow; session healthy
    ✔ 7. Never-resolving Promise from curate() → Promise.race timer throws; session healthy (5005ms)
    ✔ 8. curate() returns undefined → resolves cleanly (NOT a degradation case)

  8 passing (10s)

$ npx mocha --forbid-only 'test/integration/agent/harness/**/*.test.ts'
  25 passing (13s)
```

## Checklist

- [x] Tests added or updated and passing
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow Conventional Commits format
- [ ] Documentation updated — N/A (test-only)
- [x] No breaking changes
- [x] Branch is up to date with `proj/autoharness-v2`

## Risks and mitigations

- **Risk: Slug `PROJECT_ID` instead of a real path** — sidesteps the known FileKeyStorage slug/path gap (documented in `outcome-collection.test.ts:32`). Means the test's working directory doesn't match what production would see at the keyStorage layer.
  - **Mitigation**: Every Phase 4–5 integration test uses the same workaround. When the gap closes in a follow-up, all of them switch together.

- **Risk: vm-timeout scenarios (5, 7) take 5s each** — CI budget sensitivity.
  - **Mitigation**: Per-test timeout set to 8s (generous slack). Total test file runtime ~10s, well under the 20s budget from the task doc. If CI becomes slower, the only risk is flakes on scenarios 5+7; the fix is to bump timeouts further, not shorten the vm timeout.

- **Risk: `pollForOutcome` race — what if the recorder's write takes >2s?** — Under extreme CI load the fire-and-forget write might miss the poll window.
  - **Mitigation**: 2s deadline × 50ms poll interval = 40 attempts, each a fast store read. Previous cold-start tests use the same pattern without flakes. If it does flake, bumping the deadline is a one-line fix.

- **Risk: `meta()` schema-invalid scenario 3 is NEW coverage** — not in Phase 3 Task 3.4's original 7.
  - **Mitigation**: `'meta-invalid'` IS a documented `HarnessLoadResult.reason` variant; the integration-level coverage for it was genuinely missing. Adding it here plugs a regression hole. If reviewers feel it belongs in Phase 3.4's unit test too, that's a separate amendment.