### PR TITLE
fix: [ENG-2345] serve webui SPA fallback when install path contains a dotfile

### DIFF
--- a/src/server/infra/webui/webui-middleware.ts
+++ b/src/server/infra/webui/webui-middleware.ts
@@ -1,6 +1,5 @@
 import express, {type Express} from 'express'
 import {existsSync} from 'node:fs'
-import {join} from 'node:path'
 
 interface WebUiConfig {
   daemonPort: number
@@ -56,9 +55,12 @@ export function createWebUiMiddleware({getConfig, webuiDistDir}: CreateWebUiMidd
   if (existsSync(webuiDistDir)) {
     app.use(express.static(webuiDistDir))
 
-    // SPA fallback: serve index.html for unmatched routes
+    // SPA fallback: serve index.html for unmatched routes.
+    // Pass `root` so send's dotfile check only scans the relative path,
+    // not the absolute install location (e.g. `~/.nvm/...` on nvm installs
+    // would otherwise trigger a 404 from send's default `dotfiles: 'ignore'`).
     app.get('*splat', (_req, res) => {
-      res.sendFile(join(webuiDistDir, 'index.html'))
+      res.sendFile('index.html', {root: webuiDistDir})
     })
   }
 

--- a/src/server/infra/webui/webui-middleware.ts
+++ b/src/server/infra/webui/webui-middleware.ts
@@ -55,10 +55,9 @@ export function createWebUiMiddleware({getConfig, webuiDistDir}: CreateWebUiMidd
   if (existsSync(webuiDistDir)) {
     app.use(express.static(webuiDistDir))
 
-    // SPA fallback: serve index.html for unmatched routes.
-    // Pass `root` so send's dotfile check only scans the relative path,
-    // not the absolute install location (e.g. `~/.nvm/...` on nvm installs
-    // would otherwise trigger a 404 from send's default `dotfiles: 'ignore'`).
+    // SPA fallback. `root` scopes send's dotfile check to the relative
+    // path; without it, a dotfile anywhere in the absolute install path
+    // (e.g. ~/.nvm/...) triggers a 404.
     app.get('*splat', (_req, res) => {
       res.sendFile('index.html', {root: webuiDistDir})
     })

--- a/test/unit/infra/webui/webui-middleware.test.ts
+++ b/test/unit/infra/webui/webui-middleware.test.ts
@@ -1,0 +1,98 @@
+import type {AddressInfo} from 'node:net'
+
+import {expect} from 'chai'
+import {mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync} from 'node:fs'
+import {createServer, get as httpGet, type Server as HttpServer, type IncomingMessage} from 'node:http'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+
+import {createWebUiMiddleware} from '../../../../src/server/infra/webui/webui-middleware.js'
+
+interface HttpResult {
+  body: string
+  status: number
+}
+
+async function httpRequest(url: string): Promise<HttpResult> {
+  return new Promise((resolve, reject) => {
+    httpGet(url, (res: IncomingMessage) => {
+      const chunks: Buffer[] = []
+      res.on('data', (chunk: Buffer) => chunks.push(chunk))
+      res.on('end', () => {
+        resolve({body: Buffer.concat(chunks).toString('utf8'), status: res.statusCode ?? 0})
+      })
+      res.on('error', reject)
+    }).on('error', reject)
+  })
+}
+
+describe('createWebUiMiddleware', () => {
+  let testDir: string
+  let httpServer: HttpServer | undefined
+
+  beforeEach(() => {
+    testDir = realpathSync(mkdtempSync(join(tmpdir(), 'brv-webui-mw-test-')))
+  })
+
+  afterEach(async () => {
+    if (httpServer) {
+      const server = httpServer
+      await new Promise<void>((resolve) => {
+        server.close(() => {
+          resolve()
+        })
+      })
+      httpServer = undefined
+    }
+
+    try {
+      rmSync(testDir, {force: true, recursive: true})
+    } catch {
+      // Ignore cleanup errors
+    }
+  })
+
+  async function startServer(webuiDistDir: string): Promise<number> {
+    const app = createWebUiMiddleware({
+      getConfig: () => ({daemonPort: 1, port: 2, projectCwd: '/', version: '0'}),
+      webuiDistDir,
+    })
+
+    const server = createServer(app)
+    httpServer = server
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', () => {
+        resolve()
+      })
+    })
+    const addr = server.address() as AddressInfo
+    return addr.port
+  }
+
+  it('should serve index.html for SPA routes when install path contains a dotfile component', async () => {
+    // Simulate global nvm install where path contains ".nvm"
+    const nestedRoot = join(testDir, '.nvm', 'dist', 'webui')
+    mkdirSync(nestedRoot, {recursive: true})
+    const indexHtml = '<!doctype html><html><body>brv</body></html>'
+    writeFileSync(join(nestedRoot, 'index.html'), indexHtml, 'utf8')
+
+    const port = await startServer(nestedRoot)
+    const response = await httpRequest(`http://127.0.0.1:${port}/contexts?branch=main`)
+
+    expect(response.status).to.equal(200)
+    expect(response.body).to.equal(indexHtml)
+  })
+
+  it('should serve static assets when install path contains a dotfile component', async () => {
+    const nestedRoot = join(testDir, '.nvm', 'dist', 'webui')
+    mkdirSync(join(nestedRoot, 'assets'), {recursive: true})
+    writeFileSync(join(nestedRoot, 'index.html'), 'index', 'utf8')
+    writeFileSync(join(nestedRoot, 'assets', 'main.js'), 'console.log(1)', 'utf8')
+
+    const port = await startServer(nestedRoot)
+    const response = await httpRequest(`http://127.0.0.1:${port}/assets/main.js`)
+
+    expect(response.status).to.equal(200)
+    expect(response.body).to.equal('console.log(1)')
+  })
+})

--- a/test/unit/infra/webui/webui-middleware.test.ts
+++ b/test/unit/infra/webui/webui-middleware.test.ts
@@ -1,5 +1,3 @@
-import type {AddressInfo} from 'node:net'
-
 import {expect} from 'chai'
 import {mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync} from 'node:fs'
 import {createServer, get as httpGet, type Server as HttpServer, type IncomingMessage} from 'node:http'
@@ -65,7 +63,11 @@ describe('createWebUiMiddleware', () => {
         resolve()
       })
     })
-    const addr = server.address() as AddressInfo
+    const addr = server.address()
+    if (!addr || typeof addr === 'string') {
+      throw new Error('unexpected server address type')
+    }
+
     return addr.port
   }
 
@@ -94,5 +96,30 @@ describe('createWebUiMiddleware', () => {
 
     expect(response.status).to.equal(200)
     expect(response.body).to.equal('console.log(1)')
+  })
+
+  it('should serve index.html for SPA routes on a normal install path', async () => {
+    const distRoot = join(testDir, 'dist', 'webui')
+    mkdirSync(distRoot, {recursive: true})
+    const indexHtml = '<!doctype html><html><body>brv</body></html>'
+    writeFileSync(join(distRoot, 'index.html'), indexHtml, 'utf8')
+
+    const port = await startServer(distRoot)
+    const response = await httpRequest(`http://127.0.0.1:${port}/contexts?branch=main`)
+
+    expect(response.status).to.equal(200)
+    expect(response.body).to.equal(indexHtml)
+  })
+
+  it('should not register static or SPA routes when webuiDistDir does not exist', async () => {
+    const missingRoot = join(testDir, 'does-not-exist')
+    const port = await startServer(missingRoot)
+
+    const spaResponse = await httpRequest(`http://127.0.0.1:${port}/contexts`)
+    expect(spaResponse.status).to.equal(404)
+
+    // Config endpoint should still be reachable so the browser can bootstrap
+    const configResponse = await httpRequest(`http://127.0.0.1:${port}/api/ui/config`)
+    expect(configResponse.status).to.equal(200)
   })
 })


### PR DESCRIPTION
res.sendFile() was called with an absolute path to dist/webui/index.html. send's default dotfiles: 'ignore' scans every component of the provided path, so global installs under ~/.nvm/... (or any parent starting with '.') returned 404 on hard reloads of SPA routes like /contexts. Pass 'root' so the dotfile check only applies to the relative 'index.html'.
