### PR TITLE
feat: [ENG-2318] AutoHarness V2 harness status + inspect CLI (Phase 7 Task 7.1)

### DIFF
--- a/src/oclif/commands/harness/inspect.ts
+++ b/src/oclif/commands/harness/inspect.ts
@@ -1,0 +1,132 @@
+/**
+ * `brv harness inspect <version-ref>` — AutoHarness V2 Phase 7 Task 7.1.
+ *
+ * Dumps a stored version's full record. Accepts the §C3 version-ref
+ * grammar (`latest` | `best` | `v<N>` | raw id).
+ *
+ * Exits `1` on unresolvable refs (user input error, per handoff §C1).
+ */
+
+import {Args, Command, Flags} from '@oclif/core'
+
+import type {HarnessVersion} from '../../../agent/core/domain/harness/types.js'
+
+import {resolveProject} from '../../../server/infra/project/resolve-project.js'
+import {openHarnessStoreForProject} from '../../lib/harness-cli.js'
+import {resolveVersionRef, VersionRefError} from '../../lib/resolve-version-ref.js'
+
+const COMMAND_TYPES = ['chat', 'curate', 'query'] as const
+type HarnessCommandType = (typeof COMMAND_TYPES)[number]
+
+export interface InspectReport {
+  readonly code: string
+  readonly commandType: string
+  readonly createdAt: number
+  readonly heuristic: number
+  readonly id: string
+  readonly metadata: HarnessVersion['metadata']
+  readonly parentId: null | string
+  readonly projectId: string
+  readonly projectType: HarnessVersion['projectType']
+  readonly version: number
+}
+
+export function toInspectReport(v: HarnessVersion): InspectReport {
+  return {
+    code: v.code,
+    commandType: v.commandType,
+    createdAt: v.createdAt,
+    heuristic: v.heuristic,
+    id: v.id,
+    metadata: v.metadata,
+    parentId: v.parentId ?? null,
+    projectId: v.projectId,
+    projectType: v.projectType,
+    version: v.version,
+  }
+}
+
+export function renderInspectText(report: InspectReport): string {
+  const lines: string[] = [
+    `id:        ${report.id}`,
+    `version:   #${report.version}`,
+    `pair:      (${report.projectId}, ${report.commandType})`,
+    `project:   ${report.projectType}`,
+    `H:         ${report.heuristic.toFixed(4)}`,
+    `created:   ${new Date(report.createdAt).toISOString()}`,
+    `parent:    ${report.parentId ?? '<none — bootstrap>'}`,
+    `metadata:  ${JSON.stringify(report.metadata)}`,
+    '',
+    '── code ──────────────────────────────────────────────',
+    report.code,
+  ]
+  return lines.join('\n')
+}
+
+export default class HarnessInspect extends Command {
+  static args = {
+    versionRef: Args.string({
+      description: 'Version to inspect: raw id, "latest", "best", or "v<N>"',
+      required: true,
+    }),
+  }
+  static description = 'Inspect a stored harness version in full'
+  static examples = [
+    '<%= config.bin %> <%= command.id %> latest',
+    '<%= config.bin %> <%= command.id %> best',
+    '<%= config.bin %> <%= command.id %> v3',
+    '<%= config.bin %> <%= command.id %> v-abc123 --format json',
+  ]
+  static flags = {
+    commandType: Flags.string({
+      default: 'curate',
+      description: 'Harness pair command type',
+      options: [...COMMAND_TYPES],
+    }),
+    format: Flags.string({
+      default: 'text',
+      description: 'Output format',
+      options: ['text', 'json'],
+    }),
+  }
+
+  async run(): Promise<void> {
+    const {args, flags} = await this.parse(HarnessInspect)
+    const commandType = flags.commandType as HarnessCommandType
+    const format = flags.format === 'json' ? 'json' : 'text'
+
+    const projectRoot = resolveProject()?.projectRoot ?? process.cwd()
+    const opened = await openHarnessStoreForProject(projectRoot)
+    if (opened === undefined) {
+      this.error(
+        `no harness storage for this project (${projectRoot}) — run curate once to bootstrap.`,
+        {exit: 1},
+      )
+    }
+
+    try {
+      const resolution = await resolveVersionRef(
+        args.versionRef,
+        opened.projectId,
+        commandType,
+        opened.store,
+      )
+      const report = toInspectReport(resolution.version)
+
+      if (format === 'json') {
+        this.log(JSON.stringify(report, null, 2))
+      } else {
+        this.log(renderInspectText(report))
+      }
+    } catch (error) {
+      if (error instanceof VersionRefError) {
+        // Input error per §C1 → exit 1 with a clear message naming the ref.
+        this.error(error.message, {exit: 1})
+      }
+
+      throw error
+    } finally {
+      opened.close()
+    }
+  }
+}

--- a/src/oclif/commands/harness/inspect.ts
+++ b/src/oclif/commands/harness/inspect.ts
@@ -12,11 +12,12 @@ import {Args, Command, Flags} from '@oclif/core'
 import type {HarnessVersion} from '../../../agent/core/domain/harness/types.js'
 
 import {resolveProject} from '../../../server/infra/project/resolve-project.js'
-import {openHarnessStoreForProject} from '../../lib/harness-cli.js'
+import {
+  HARNESS_COMMAND_TYPES,
+  isHarnessCommandType,
+  openHarnessStoreForProject,
+} from '../../lib/harness-cli.js'
 import {resolveVersionRef, VersionRefError} from '../../lib/resolve-version-ref.js'
-
-const COMMAND_TYPES = ['chat', 'curate', 'query'] as const
-type HarnessCommandType = (typeof COMMAND_TYPES)[number]
 
 export interface InspectReport {
   readonly code: string
@@ -81,7 +82,7 @@ export default class HarnessInspect extends Command {
     commandType: Flags.string({
       default: 'curate',
       description: 'Harness pair command type',
-      options: [...COMMAND_TYPES],
+      options: [...HARNESS_COMMAND_TYPES],
     }),
     format: Flags.string({
       default: 'text',
@@ -92,7 +93,11 @@ export default class HarnessInspect extends Command {
 
   async run(): Promise<void> {
     const {args, flags} = await this.parse(HarnessInspect)
-    const commandType = flags.commandType as HarnessCommandType
+    if (!isHarnessCommandType(flags.commandType)) {
+      this.error(`invalid --commandType value '${flags.commandType}'`, {exit: 1})
+    }
+
+    const {commandType} = flags
     const format = flags.format === 'json' ? 'json' : 'text'
 
     const projectRoot = resolveProject()?.projectRoot ?? process.cwd()

--- a/src/oclif/commands/harness/status.ts
+++ b/src/oclif/commands/harness/status.ts
@@ -14,14 +14,16 @@ import {Command, Flags} from '@oclif/core'
 
 import type {HarnessVersion} from '../../../agent/core/domain/harness/types.js'
 import type {IHarnessStore} from '../../../agent/core/interfaces/i-harness-store.js'
-import type {HarnessFeatureConfig} from '../../lib/harness-cli.js'
+import type {HarnessCommandType, HarnessFeatureConfig} from '../../lib/harness-cli.js'
 
 import {selectHarnessMode} from '../../../agent/infra/harness/harness-mode-selector.js'
 import {resolveProject} from '../../../server/infra/project/resolve-project.js'
-import {openHarnessStoreForProject, readHarnessFeatureConfig} from '../../lib/harness-cli.js'
-
-const COMMAND_TYPES = ['chat', 'curate', 'query'] as const
-type HarnessCommandType = (typeof COMMAND_TYPES)[number]
+import {
+  HARNESS_COMMAND_TYPES,
+  isHarnessCommandType,
+  openHarnessStoreForProject,
+  readHarnessFeatureConfig,
+} from '../../lib/harness-cli.js'
 
 export interface LastRefinement {
   readonly acceptedAt: number
@@ -182,6 +184,10 @@ export function renderStatusText(report: StatusReport): string {
 }
 
 function humaniseAgo(ms: number): string {
+  // Clock-skew safety: if a stored `acceptedAt` is ever in the future
+  // (rare — clock jumps, bad backfills), clamp to "just now" rather
+  // than print a negative duration.
+  if (ms <= 0) return 'just now'
   if (ms < 60_000) return `${Math.round(ms / 1000)}s`
   if (ms < 3_600_000) return `${Math.round(ms / 60_000)}m`
   if (ms < 86_400_000) return `${Math.round(ms / 3_600_000)}h`
@@ -199,7 +205,7 @@ export default class HarnessStatus extends Command {
     commandType: Flags.string({
       default: 'curate',
       description: 'Harness pair command type',
-      options: [...COMMAND_TYPES],
+      options: [...HARNESS_COMMAND_TYPES],
     }),
     format: Flags.string({
       default: 'text',
@@ -210,7 +216,14 @@ export default class HarnessStatus extends Command {
 
   async run(): Promise<void> {
     const {flags} = await this.parse(HarnessStatus)
-    const commandType = flags.commandType as HarnessCommandType
+    // oclif's `options:` constraint means parse throws on unknown values
+    // before we reach here; the guard exists to narrow the string type
+    // without an `as` cast rather than to catch a bypass.
+    if (!isHarnessCommandType(flags.commandType)) {
+      this.error(`invalid --commandType value '${flags.commandType}'`, {exit: 1})
+    }
+
+    const {commandType} = flags
     const format = flags.format === 'json' ? 'json' : 'text'
 
     const projectRoot = resolveProject()?.projectRoot ?? process.cwd()

--- a/src/oclif/commands/harness/status.ts
+++ b/src/oclif/commands/harness/status.ts
@@ -1,0 +1,237 @@
+/**
+ * `brv harness status` — AutoHarness V2 Phase 7 Task 7.1.
+ *
+ * Read-only summary of harness state for a `(project, commandType)`
+ * pair. Text output is human-oriented; `--format json` emits the shape
+ * pinned in `phase_7_8_handoff.md §C2` (consumed by Phase 8's smoke
+ * script and KPI harness, so key renames are a handoff break).
+ *
+ * `status` never errors — a missing store, no version, or a disabled
+ * flag all print a clear message and exit `0` per handoff §C1.
+ */
+
+import {Command, Flags} from '@oclif/core'
+
+import type {HarnessVersion} from '../../../agent/core/domain/harness/types.js'
+import type {IHarnessStore} from '../../../agent/core/interfaces/i-harness-store.js'
+import type {HarnessFeatureConfig} from '../../lib/harness-cli.js'
+
+import {selectHarnessMode} from '../../../agent/infra/harness/harness-mode-selector.js'
+import {resolveProject} from '../../../server/infra/project/resolve-project.js'
+import {openHarnessStoreForProject, readHarnessFeatureConfig} from '../../lib/harness-cli.js'
+
+const COMMAND_TYPES = ['chat', 'curate', 'query'] as const
+type HarnessCommandType = (typeof COMMAND_TYPES)[number]
+
+export interface LastRefinement {
+  readonly acceptedAt: number
+  readonly deltaH: number
+  readonly fromVersion: number
+  readonly toVersion: number
+}
+
+export interface StatusReport {
+  readonly autoLearn: boolean
+  readonly commandType: HarnessCommandType
+  readonly currentVersion: null | number
+  readonly currentVersionId: null | string
+  readonly enabled: boolean
+  readonly heuristic: null | number
+  readonly lastRefinement?: LastRefinement
+  readonly mode: 'assisted' | 'filter' | 'policy' | null
+  readonly outcomeCount: number
+  readonly outcomesWithFeedback: number
+  readonly projectId: string
+}
+
+export interface StatusInputs {
+  readonly commandType: HarnessCommandType
+  readonly featureConfig: HarnessFeatureConfig
+  readonly projectId: string
+  readonly store: IHarnessStore | undefined
+}
+
+/**
+ * Build a `StatusReport` from live store reads.
+ *
+ * Pure logic, no I/O beyond the `IHarnessStore` calls — the oclif
+ * `run()` wrapper injects a resolved store or `undefined`.
+ */
+export async function buildStatusReport(inputs: StatusInputs): Promise<StatusReport> {
+  const {commandType, featureConfig, projectId, store} = inputs
+
+  if (store === undefined) {
+    return {
+      autoLearn: featureConfig.autoLearn,
+      commandType,
+      currentVersion: null,
+      currentVersionId: null,
+      enabled: featureConfig.enabled,
+      heuristic: null,
+      mode: null,
+      outcomeCount: 0,
+      outcomesWithFeedback: 0,
+      projectId,
+    }
+  }
+
+  // Fetch current version, every version (for lastRefinement lookup),
+  // and the complete outcomes set. Passing `MAX_SAFE_INTEGER` is the
+  // documented "give me everything" idiom for `HarnessStore.listOutcomes` —
+  // it walks the key partition and slices; no pathological cost at v1.0
+  // scale (outcomes cap well under 1k per pair in normal use).
+  const [currentVersion, allVersions, outcomes] = await Promise.all([
+    store.getLatest(projectId, commandType),
+    store.listVersions(projectId, commandType),
+    store.listOutcomes(projectId, commandType, Number.MAX_SAFE_INTEGER),
+  ])
+
+  if (currentVersion === undefined) {
+    return {
+      autoLearn: featureConfig.autoLearn,
+      commandType,
+      currentVersion: null,
+      currentVersionId: null,
+      enabled: featureConfig.enabled,
+      heuristic: null,
+      mode: null,
+      outcomeCount: outcomes.length,
+      outcomesWithFeedback: outcomes.filter((o) => o.userFeedback === 'bad' || o.userFeedback === 'good').length,
+      projectId,
+    }
+  }
+
+  const modeSelection = selectHarnessMode(currentVersion.heuristic, {
+    autoLearn: featureConfig.autoLearn,
+    enabled: featureConfig.enabled,
+    language: 'auto',
+    maxVersions: 20,
+  })
+
+  const lastRefinement = findLastRefinement(allVersions)
+  return {
+    autoLearn: featureConfig.autoLearn,
+    commandType,
+    currentVersion: currentVersion.version,
+    currentVersionId: currentVersion.id,
+    enabled: featureConfig.enabled,
+    heuristic: currentVersion.heuristic,
+    ...(lastRefinement === undefined ? {} : {lastRefinement}),
+    mode: modeSelection?.mode ?? null,
+    outcomeCount: outcomes.length,
+    outcomesWithFeedback: outcomes.filter((o) => o.userFeedback === 'bad' || o.userFeedback === 'good').length,
+    projectId,
+  }
+}
+
+/**
+ * The most recent refinement = the highest-`version` version that has
+ * a `parentId`. Returns `undefined` when no version is a refinement
+ * (only a v1 bootstrap exists).
+ */
+function findLastRefinement(allVersions: readonly HarnessVersion[]): LastRefinement | undefined {
+  const refined = allVersions.filter((v) => v.parentId !== undefined)
+  if (refined.length === 0) return undefined
+
+  // `listVersions` returns newest-first by `version`, so refined[0] is
+  // the latest refinement. Look up its parent for the deltaH computation.
+  const [latest] = refined
+  const parent = allVersions.find((v) => v.id === latest.parentId)
+  if (parent === undefined) return undefined
+
+  return {
+    acceptedAt: latest.createdAt,
+    deltaH: latest.heuristic - parent.heuristic,
+    fromVersion: parent.version,
+    toVersion: latest.version,
+  }
+}
+
+export function renderStatusText(report: StatusReport): string {
+  const enabledLabel = report.enabled ? `enabled (autoLearn: ${report.autoLearn})` : 'disabled'
+  const lines: string[] = [
+    `harness: ${enabledLabel}`,
+    `project: ${report.projectId}`,
+    `command: ${report.commandType}`,
+  ]
+
+  if (report.currentVersionId === null || report.currentVersion === null) {
+    lines.push('version: <none — run curate once to bootstrap>')
+  } else {
+    const h = report.heuristic === null ? 'n/a' : report.heuristic.toFixed(2)
+    const mode = report.mode ?? 'below Mode A floor'
+    lines.push(
+      `version: ${report.currentVersionId} (#${report.currentVersion})  H: ${h}  mode: ${mode}`,
+    )
+  }
+
+  lines.push(
+    `outcomes: ${report.outcomeCount} recorded (${report.outcomesWithFeedback} w/ feedback)`,
+  )
+
+  if (report.lastRefinement !== undefined) {
+    const {acceptedAt, deltaH, fromVersion, toVersion} = report.lastRefinement
+    const ago = humaniseAgo(Date.now() - acceptedAt)
+    const sign = deltaH >= 0 ? '+' : ''
+    lines.push(
+      `last refinement: accepted ${ago} ago  v${fromVersion} → v${toVersion}  ΔH: ${sign}${deltaH.toFixed(2)}`,
+    )
+  }
+
+  return lines.join('\n')
+}
+
+function humaniseAgo(ms: number): string {
+  if (ms < 60_000) return `${Math.round(ms / 1000)}s`
+  if (ms < 3_600_000) return `${Math.round(ms / 60_000)}m`
+  if (ms < 86_400_000) return `${Math.round(ms / 3_600_000)}h`
+  return `${Math.round(ms / 86_400_000)}d`
+}
+
+export default class HarnessStatus extends Command {
+  static description = 'Show current harness state for a (project, commandType) pair'
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --commandType query',
+    '<%= config.bin %> <%= command.id %> --format json',
+  ]
+  static flags = {
+    commandType: Flags.string({
+      default: 'curate',
+      description: 'Harness pair command type',
+      options: [...COMMAND_TYPES],
+    }),
+    format: Flags.string({
+      default: 'text',
+      description: 'Output format',
+      options: ['text', 'json'],
+    }),
+  }
+
+  async run(): Promise<void> {
+    const {flags} = await this.parse(HarnessStatus)
+    const commandType = flags.commandType as HarnessCommandType
+    const format = flags.format === 'json' ? 'json' : 'text'
+
+    const projectRoot = resolveProject()?.projectRoot ?? process.cwd()
+    const featureConfig = await readHarnessFeatureConfig(projectRoot)
+    const opened = await openHarnessStoreForProject(projectRoot)
+
+    try {
+      const report = await buildStatusReport({
+        commandType,
+        featureConfig,
+        projectId: opened?.projectId ?? projectRoot,
+        store: opened?.store,
+      })
+
+      if (format === 'json') {
+        this.log(JSON.stringify(report, null, 2))
+      } else {
+        this.log(renderStatusText(report))
+      }
+    } finally {
+      opened?.close()
+    }
+  }
+}

--- a/src/oclif/lib/harness-cli.ts
+++ b/src/oclif/lib/harness-cli.ts
@@ -25,13 +25,6 @@ import {getGlobalDataDir} from '../../server/utils/global-data-path.js'
 import {resolvePath, sanitizeProjectPath} from '../../server/utils/path-utils.js'
 
 /**
- * Public feature-flag view for `brv harness status` and friends.
- *
- * `enabled` / `autoLearn` mirror `ValidatedHarnessConfig` but are
- * decoupled from the agent schema so the CLI doesn't pull in the full
- * agent-schemas surface for a flag read.
- */
-/**
  * Command types supported by the harness pair. Single source of
  * truth for the `brv harness *` command family — status / inspect /
  * use / diff / reset / baseline all constrain the `--commandType`
@@ -44,6 +37,13 @@ export function isHarnessCommandType(value: string): value is HarnessCommandType
   return (HARNESS_COMMAND_TYPES as readonly string[]).includes(value)
 }
 
+/**
+ * Public feature-flag view for `brv harness status` and friends.
+ *
+ * `enabled` / `autoLearn` mirror `ValidatedHarnessConfig` but are
+ * decoupled from the agent schema so the CLI doesn't pull in the full
+ * agent-schemas surface for a flag read.
+ */
 export interface HarnessFeatureConfig {
   readonly autoLearn: boolean
   readonly enabled: boolean

--- a/src/oclif/lib/harness-cli.ts
+++ b/src/oclif/lib/harness-cli.ts
@@ -31,6 +31,19 @@ import {resolvePath, sanitizeProjectPath} from '../../server/utils/path-utils.js
  * decoupled from the agent schema so the CLI doesn't pull in the full
  * agent-schemas surface for a flag read.
  */
+/**
+ * Command types supported by the harness pair. Single source of
+ * truth for the `brv harness *` command family — status / inspect /
+ * use / diff / reset / baseline all constrain the `--commandType`
+ * flag against this list.
+ */
+export const HARNESS_COMMAND_TYPES = ['chat', 'curate', 'query'] as const
+export type HarnessCommandType = (typeof HARNESS_COMMAND_TYPES)[number]
+
+export function isHarnessCommandType(value: string): value is HarnessCommandType {
+  return (HARNESS_COMMAND_TYPES as readonly string[]).includes(value)
+}
+
 export interface HarnessFeatureConfig {
   readonly autoLearn: boolean
   readonly enabled: boolean
@@ -122,13 +135,17 @@ export async function readHarnessFeatureConfig(
     return HARNESS_CONFIG_DEFAULTS
   }
 
-  if (typeof parsed !== 'object' || parsed === null) return HARNESS_CONFIG_DEFAULTS
-  const harnessField = (parsed as Record<string, unknown>).harness
+  if (typeof parsed !== 'object' || parsed === null || !('harness' in parsed)) {
+    return HARNESS_CONFIG_DEFAULTS
+  }
+
+  const harnessField = parsed.harness
   if (typeof harnessField !== 'object' || harnessField === null) return HARNESS_CONFIG_DEFAULTS
 
-  const h = harnessField as Record<string, unknown>
+  const autoLearn = 'autoLearn' in harnessField ? harnessField.autoLearn : undefined
+  const enabled = 'enabled' in harnessField ? harnessField.enabled : undefined
   return {
-    autoLearn: typeof h.autoLearn === 'boolean' ? h.autoLearn : HARNESS_CONFIG_DEFAULTS.autoLearn,
-    enabled: typeof h.enabled === 'boolean' ? h.enabled : HARNESS_CONFIG_DEFAULTS.enabled,
+    autoLearn: typeof autoLearn === 'boolean' ? autoLearn : HARNESS_CONFIG_DEFAULTS.autoLearn,
+    enabled: typeof enabled === 'boolean' ? enabled : HARNESS_CONFIG_DEFAULTS.enabled,
   }
 }

--- a/src/oclif/lib/harness-cli.ts
+++ b/src/oclif/lib/harness-cli.ts
@@ -1,0 +1,134 @@
+/**
+ * AutoHarness V2 — shared CLI helpers.
+ *
+ * Used by `brv harness status` / `inspect` / `use` / `diff` / `baseline`
+ * to stand up an `IHarnessStore` against the same on-disk state the
+ * daemon writes to, without booting the full agent pipeline.
+ *
+ * Design: stateless read helpers. No daemon roundtrip, no agent config
+ * validation. CLI commands call `openHarnessStoreForProject` to get a
+ * live store, `readHarnessFeatureConfig` for the enabled/autoLearn
+ * flags, and `closeHarnessStore` on their way out.
+ */
+
+import {existsSync} from 'node:fs'
+import {readFile} from 'node:fs/promises'
+import {join} from 'node:path'
+
+import type {IHarnessStore} from '../../agent/core/interfaces/i-harness-store.js'
+
+import {NoOpLogger} from '../../agent/core/interfaces/i-logger.js'
+import {HarnessStore} from '../../agent/infra/harness/harness-store.js'
+import {FileKeyStorage} from '../../agent/infra/storage/file-key-storage.js'
+import {BRV_DIR, GLOBAL_PROJECTS_DIR, PROJECT_CONFIG_FILE} from '../../server/constants.js'
+import {getGlobalDataDir} from '../../server/utils/global-data-path.js'
+import {resolvePath, sanitizeProjectPath} from '../../server/utils/path-utils.js'
+
+/**
+ * Public feature-flag view for `brv harness status` and friends.
+ *
+ * `enabled` / `autoLearn` mirror `ValidatedHarnessConfig` but are
+ * decoupled from the agent schema so the CLI doesn't pull in the full
+ * agent-schemas surface for a flag read.
+ */
+export interface HarnessFeatureConfig {
+  readonly autoLearn: boolean
+  readonly enabled: boolean
+}
+
+export interface OpenedHarnessStore {
+  readonly close: () => void
+  /**
+   * Absolute project path — used as the `projectId` partition key in
+   * the store (mirrors the daemon's `AgentLLMService` convention).
+   */
+  readonly projectId: string
+  readonly store: IHarnessStore
+}
+
+const HARNESS_CONFIG_DEFAULTS: HarnessFeatureConfig = {
+  autoLearn: true,
+  enabled: false,
+}
+
+/**
+ * Open a live `HarnessStore` rooted at the same XDG location the
+ * daemon writes to.
+ *
+ * Uses the same `sanitizeProjectPath` rule as `ProjectRegistry.register`
+ * so the CLI reads the exact directory the daemon wrote. No registry
+ * mutation — running `brv harness status` on an unknown project must
+ * not create sessions directories or persist a registry entry.
+ *
+ * Returns `undefined` when the storage directory doesn't exist yet
+ * (project has never been touched by the daemon). Callers interpret
+ * that as "no stored harness state" and produce the empty shape.
+ */
+export async function openHarnessStoreForProject(
+  projectRoot: string,
+): Promise<OpenedHarnessStore | undefined> {
+  const resolvedRoot = resolvePath(projectRoot)
+  const sanitized = sanitizeProjectPath(resolvedRoot)
+  const storagePath = join(getGlobalDataDir(), GLOBAL_PROJECTS_DIR, sanitized)
+
+  if (!existsSync(storagePath)) {
+    return undefined
+  }
+
+  const keyStorage = new FileKeyStorage({storageDir: storagePath})
+  await keyStorage.initialize()
+  const store = new HarnessStore(keyStorage, new NoOpLogger())
+
+  return {
+    close: () => keyStorage.close(),
+    projectId: resolvedRoot,
+    store,
+  }
+}
+
+/**
+ * Read the harness feature-flags off the project's
+ * `.brv/config.json`, under a top-level `harness` key:
+ *
+ * ```json
+ * { "createdAt": "...", "harness": { "enabled": true, "autoLearn": true } }
+ * ```
+ *
+ * Missing file / missing key / malformed JSON all degrade to the
+ * defaults (`enabled: false, autoLearn: true`) — read-only CLI
+ * commands must never refuse to run because the config is absent.
+ *
+ * Kept outside of `BrvConfig`'s typed surface because the daemon
+ * config plumbing for harness lives in a follow-up PR — the CLI
+ * ships first to unblock 7.2/7.4 which also need the flags.
+ */
+export async function readHarnessFeatureConfig(
+  projectRoot: string,
+): Promise<HarnessFeatureConfig> {
+  const configPath = join(projectRoot, BRV_DIR, PROJECT_CONFIG_FILE)
+  if (!existsSync(configPath)) return HARNESS_CONFIG_DEFAULTS
+
+  let raw: string
+  try {
+    raw = await readFile(configPath, 'utf8')
+  } catch {
+    return HARNESS_CONFIG_DEFAULTS
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return HARNESS_CONFIG_DEFAULTS
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) return HARNESS_CONFIG_DEFAULTS
+  const harnessField = (parsed as Record<string, unknown>).harness
+  if (typeof harnessField !== 'object' || harnessField === null) return HARNESS_CONFIG_DEFAULTS
+
+  const h = harnessField as Record<string, unknown>
+  return {
+    autoLearn: typeof h.autoLearn === 'boolean' ? h.autoLearn : HARNESS_CONFIG_DEFAULTS.autoLearn,
+    enabled: typeof h.enabled === 'boolean' ? h.enabled : HARNESS_CONFIG_DEFAULTS.enabled,
+  }
+}

--- a/src/oclif/lib/resolve-version-ref.ts
+++ b/src/oclif/lib/resolve-version-ref.ts
@@ -1,0 +1,124 @@
+/**
+ * AutoHarness V2 — shared version-ref resolver.
+ *
+ * Implements the grammar defined in
+ * `features/autoharness-v2/tasks/phase_7_8_handoff.md §C3`:
+ *
+ *   - 'latest'    → most-recently-written version (by `version` number)
+ *   - 'best'      → highest-H version; ties broken by newest `createdAt`
+ *   - 'v<N>'      → version whose integer `version` field equals N
+ *   - '<raw-id>'  → direct id lookup
+ *
+ * Used by `brv harness inspect` / `use` / `diff` / `reset` so the
+ * grammar lives in exactly one place — a new ref type lights up
+ * everywhere the moment it's added here.
+ */
+
+import type {HarnessVersion} from '../../agent/core/domain/harness/types.js'
+import type {IHarnessStore} from '../../agent/core/interfaces/i-harness-store.js'
+
+export interface VersionRefResolution {
+  readonly version: HarnessVersion
+  readonly versionId: string
+}
+
+export type VersionRefErrorCode = 'INVALID_GRAMMAR' | 'NO_VERSIONS' | 'NOT_FOUND'
+
+export class VersionRefError extends Error {
+  constructor(
+    message: string,
+    public readonly code: VersionRefErrorCode,
+    public readonly details: Readonly<Record<string, unknown>> = {},
+  ) {
+    super(message)
+    this.name = 'VersionRefError'
+  }
+}
+
+/** `v<N>` where N is a positive integer — `v0`, `v-1`, `v1.5` don't match. */
+const V_N_PATTERN = /^v(\d+)$/
+
+/**
+ * Resolve a version-ref to the concrete `HarnessVersion` for a pair.
+ *
+ * @throws {VersionRefError} with code `NOT_FOUND` when the ref is
+ *   well-formed but no matching version exists, `NO_VERSIONS` when
+ *   the pair has no versions at all (only for `latest`/`best`).
+ *   Raw-id misses surface as `NOT_FOUND`.
+ */
+export async function resolveVersionRef(
+  ref: string,
+  projectId: string,
+  commandType: string,
+  store: IHarnessStore,
+): Promise<VersionRefResolution> {
+  if (ref === 'latest') {
+    const latest = await store.getLatest(projectId, commandType)
+    if (latest === undefined) {
+      throw new VersionRefError(
+        `no versions stored for (${projectId}, ${commandType}) — run curate once to bootstrap.`,
+        'NO_VERSIONS',
+        {commandType, projectId, ref},
+      )
+    }
+
+    return {version: latest, versionId: latest.id}
+  }
+
+  if (ref === 'best') {
+    const versions = await store.listVersions(projectId, commandType)
+    if (versions.length === 0) {
+      throw new VersionRefError(
+        `no versions stored for (${projectId}, ${commandType}) — run curate once to bootstrap.`,
+        'NO_VERSIONS',
+        {commandType, projectId, ref},
+      )
+    }
+
+    // Max heuristic; tie-break on newest createdAt per §C3.
+    let best = versions[0]
+    for (let i = 1; i < versions.length; i++) {
+      const v = versions[i]
+      if (v.heuristic > best.heuristic) best = v
+      else if (v.heuristic === best.heuristic && v.createdAt > best.createdAt) best = v
+    }
+
+    return {version: best, versionId: best.id}
+  }
+
+  const vNMatch = V_N_PATTERN.exec(ref)
+  if (vNMatch !== null) {
+    const n = Number.parseInt(vNMatch[1], 10)
+    if (n <= 0) {
+      throw new VersionRefError(
+        `invalid v<N> ref '${ref}' — N must be a positive integer (1-indexed).`,
+        'INVALID_GRAMMAR',
+        {ref},
+      )
+    }
+
+    const versions = await store.listVersions(projectId, commandType)
+    const match = versions.find((v) => v.version === n)
+    if (match === undefined) {
+      throw new VersionRefError(
+        `no version #${n} for (${projectId}, ${commandType}). Available: ${versions.map((v) => `#${v.version}`).join(', ') || 'none'}.`,
+        'NOT_FOUND',
+        {available: versions.map((v) => v.version), commandType, projectId, ref, requested: n},
+      )
+    }
+
+    return {version: match, versionId: match.id}
+  }
+
+  // Fallback: raw id lookup.
+  const version = await store.getVersion(projectId, commandType, ref)
+  if (version === undefined) {
+    throw new VersionRefError(
+      `version '${ref}' not found for (${projectId}, ${commandType}).`,
+      'NOT_FOUND',
+      {commandType, projectId, ref},
+    )
+  }
+
+  return {version, versionId: version.id}
+}

--- a/src/oclif/lib/resolve-version-ref.ts
+++ b/src/oclif/lib/resolve-version-ref.ts
@@ -35,7 +35,11 @@ export class VersionRefError extends Error {
   }
 }
 
-/** `v<N>` where N is a positive integer — `v0`, `v-1`, `v1.5` don't match. */
+/**
+ * `v<N>` where the regex matches any `\d+` (including `0`), then the
+ * resolver rejects `N <= 0` explicitly so the error message is clearer
+ * than a silent "not found". `v-1` and `v1.5` never match the regex.
+ */
 const V_N_PATTERN = /^v(\d+)$/
 
 /**

--- a/test/unit/oclif/commands/harness/inspect.test.ts
+++ b/test/unit/oclif/commands/harness/inspect.test.ts
@@ -1,0 +1,79 @@
+import {expect} from 'chai'
+
+import type {HarnessVersion} from '../../../../../src/agent/core/domain/harness/types.js'
+
+import {
+  renderInspectText,
+  toInspectReport,
+} from '../../../../../src/oclif/commands/harness/inspect.js'
+
+function makeVersion(overrides: Partial<HarnessVersion> = {}): HarnessVersion {
+  return {
+    code: 'exports.curate = async () => {}',
+    commandType: 'curate',
+    createdAt: 1_700_000_000_000,
+    heuristic: 0.72,
+    id: 'v-abc',
+    metadata: {
+      capabilities: ['curate'],
+      commandType: 'curate',
+      projectPatterns: ['**/*'],
+      version: 1,
+    },
+    projectId: '/fixture/proj',
+    projectType: 'typescript',
+    version: 3,
+    ...overrides,
+  }
+}
+
+describe('HarnessInspect command — toInspectReport + renderInspectText', () => {
+  describe('toInspectReport', () => {
+  it('1. maps HarnessVersion into the §C2 inspect shape', () => {
+    const v = makeVersion({parentId: 'v-parent-x'})
+    const report = toInspectReport(v)
+
+    expect(report.id).to.equal('v-abc')
+    expect(report.version).to.equal(3)
+    expect(report.commandType).to.equal('curate')
+    expect(report.projectType).to.equal('typescript')
+    expect(report.heuristic).to.equal(0.72)
+    expect(report.createdAt).to.equal(1_700_000_000_000)
+    expect(report.parentId).to.equal('v-parent-x')
+    expect(report.code).to.equal('exports.curate = async () => {}')
+    expect(report.metadata).to.deep.equal({
+      capabilities: ['curate'],
+      commandType: 'curate',
+      projectPatterns: ['**/*'],
+      version: 1,
+    })
+  })
+
+  it('2. normalises missing parentId to null (not undefined) — stable JSON shape', () => {
+    const v = makeVersion()
+    const report = toInspectReport(v)
+    expect(report.parentId).to.equal(null)
+  })
+  })
+
+  describe('renderInspectText', () => {
+  it('includes id, version, pair, created timestamp, parent, and code', () => {
+    const v = makeVersion({parentId: 'v-parent-x'})
+    const text = renderInspectText(toInspectReport(v))
+
+    expect(text).to.include('id:        v-abc')
+    expect(text).to.include('version:   #3')
+    expect(text).to.include('pair:      (/fixture/proj, curate)')
+    expect(text).to.include('H:         0.7200')
+    expect(text).to.include('parent:    v-parent-x')
+    expect(text).to.include('── code ──')
+    expect(text).to.include('exports.curate')
+  })
+
+  it('labels bootstrap versions ("<none — bootstrap>") when parentId is null', () => {
+    const v = makeVersion()
+    const text = renderInspectText(toInspectReport(v))
+    expect(text).to.include('<none — bootstrap>')
+  })
+  })
+})

--- a/test/unit/oclif/commands/harness/inspect.test.ts
+++ b/test/unit/oclif/commands/harness/inspect.test.ts
@@ -29,51 +29,51 @@ function makeVersion(overrides: Partial<HarnessVersion> = {}): HarnessVersion {
 
 describe('HarnessInspect command — toInspectReport + renderInspectText', () => {
   describe('toInspectReport', () => {
-  it('1. maps HarnessVersion into the §C2 inspect shape', () => {
-    const v = makeVersion({parentId: 'v-parent-x'})
-    const report = toInspectReport(v)
+    it('1. maps HarnessVersion into the §C2 inspect shape', () => {
+      const v = makeVersion({parentId: 'v-parent-x'})
+      const report = toInspectReport(v)
 
-    expect(report.id).to.equal('v-abc')
-    expect(report.version).to.equal(3)
-    expect(report.commandType).to.equal('curate')
-    expect(report.projectType).to.equal('typescript')
-    expect(report.heuristic).to.equal(0.72)
-    expect(report.createdAt).to.equal(1_700_000_000_000)
-    expect(report.parentId).to.equal('v-parent-x')
-    expect(report.code).to.equal('exports.curate = async () => {}')
-    expect(report.metadata).to.deep.equal({
-      capabilities: ['curate'],
-      commandType: 'curate',
-      projectPatterns: ['**/*'],
-      version: 1,
+      expect(report.id).to.equal('v-abc')
+      expect(report.version).to.equal(3)
+      expect(report.commandType).to.equal('curate')
+      expect(report.projectType).to.equal('typescript')
+      expect(report.heuristic).to.equal(0.72)
+      expect(report.createdAt).to.equal(1_700_000_000_000)
+      expect(report.parentId).to.equal('v-parent-x')
+      expect(report.code).to.equal('exports.curate = async () => {}')
+      expect(report.metadata).to.deep.equal({
+        capabilities: ['curate'],
+        commandType: 'curate',
+        projectPatterns: ['**/*'],
+        version: 1,
+      })
+    })
+
+    it('2. normalises missing parentId to null (not undefined) — stable JSON shape', () => {
+      const v = makeVersion()
+      const report = toInspectReport(v)
+      expect(report.parentId).to.equal(null)
     })
   })
 
-  it('2. normalises missing parentId to null (not undefined) — stable JSON shape', () => {
-    const v = makeVersion()
-    const report = toInspectReport(v)
-    expect(report.parentId).to.equal(null)
-  })
-  })
-
   describe('renderInspectText', () => {
-  it('includes id, version, pair, created timestamp, parent, and code', () => {
-    const v = makeVersion({parentId: 'v-parent-x'})
-    const text = renderInspectText(toInspectReport(v))
+    it('includes id, version, pair, created timestamp, parent, and code', () => {
+      const v = makeVersion({parentId: 'v-parent-x'})
+      const text = renderInspectText(toInspectReport(v))
 
-    expect(text).to.include('id:        v-abc')
-    expect(text).to.include('version:   #3')
-    expect(text).to.include('pair:      (/fixture/proj, curate)')
-    expect(text).to.include('H:         0.7200')
-    expect(text).to.include('parent:    v-parent-x')
-    expect(text).to.include('── code ──')
-    expect(text).to.include('exports.curate')
-  })
+      expect(text).to.include('id:        v-abc')
+      expect(text).to.include('version:   #3')
+      expect(text).to.include('pair:      (/fixture/proj, curate)')
+      expect(text).to.include('H:         0.7200')
+      expect(text).to.include('parent:    v-parent-x')
+      expect(text).to.include('── code ──')
+      expect(text).to.include('exports.curate')
+    })
 
-  it('labels bootstrap versions ("<none — bootstrap>") when parentId is null', () => {
-    const v = makeVersion()
-    const text = renderInspectText(toInspectReport(v))
-    expect(text).to.include('<none — bootstrap>')
-  })
+    it('labels bootstrap versions ("<none — bootstrap>") when parentId is null', () => {
+      const v = makeVersion()
+      const text = renderInspectText(toInspectReport(v))
+      expect(text).to.include('<none — bootstrap>')
+    })
   })
 })

--- a/test/unit/oclif/commands/harness/status.test.ts
+++ b/test/unit/oclif/commands/harness/status.test.ts
@@ -1,0 +1,246 @@
+import {expect} from 'chai'
+import {createSandbox, type SinonSandbox, type SinonStub} from 'sinon'
+
+import type {
+  CodeExecOutcome,
+  HarnessVersion,
+} from '../../../../../src/agent/core/domain/harness/types.js'
+import type {IHarnessStore} from '../../../../../src/agent/core/interfaces/i-harness-store.js'
+
+import {
+  buildStatusReport,
+  renderStatusText,
+  type StatusInputs,
+} from '../../../../../src/oclif/commands/harness/status.js'
+
+const PROJECT_ID = '/fixture/proj'
+
+function makeVersion(overrides: Partial<HarnessVersion> = {}): HarnessVersion {
+  return {
+    code: 'exports.curate = async () => {}',
+    commandType: 'curate',
+    createdAt: 1_700_000_000_000,
+    heuristic: 0.62,
+    id: 'v-abc',
+    metadata: {
+      capabilities: ['curate'],
+      commandType: 'curate',
+      projectPatterns: ['**/*'],
+      version: 1,
+    },
+    projectId: PROJECT_ID,
+    projectType: 'typescript',
+    version: 1,
+    ...overrides,
+  }
+}
+
+function makeOutcome(overrides: Partial<CodeExecOutcome> = {}): CodeExecOutcome {
+  return {
+    code: 'ctx.tools.curate([])',
+    commandType: 'curate',
+    executionTimeMs: 12,
+    id: 'o-x',
+    projectId: PROJECT_ID,
+    projectType: 'typescript',
+    sessionId: 's-x',
+    success: true,
+    timestamp: 1_700_000_000_000,
+    usedHarness: false,
+    ...overrides,
+  }
+}
+
+function makeStoreStub(sb: SinonSandbox): IHarnessStore {
+  return {
+    deleteOutcome: sb.stub(),
+    deleteOutcomes: sb.stub(),
+    deleteScenario: sb.stub(),
+    getLatest: sb.stub(),
+    getVersion: sb.stub(),
+    listOutcomes: sb.stub(),
+    listScenarios: sb.stub(),
+    listVersions: sb.stub(),
+    pruneOldVersions: sb.stub(),
+    recordFeedback: sb.stub(),
+    saveOutcome: sb.stub(),
+    saveScenario: sb.stub(),
+    saveVersion: sb.stub(),
+  } satisfies IHarnessStore
+}
+
+function makeInputs(overrides: Partial<StatusInputs> = {}): StatusInputs {
+  return {
+    commandType: 'curate',
+    featureConfig: {autoLearn: true, enabled: true},
+    projectId: PROJECT_ID,
+    store: undefined,
+    ...overrides,
+  }
+}
+
+describe('HarnessStatus command — buildStatusReport + renderStatusText', () => {
+  describe('buildStatusReport', () => {
+  let sb: SinonSandbox
+
+  beforeEach(() => {
+    sb = createSandbox()
+  })
+
+  afterEach(() => {
+    sb.restore()
+  })
+
+  it('1. no store (fresh project) → enabled flag only, empty counters', async () => {
+    const report = await buildStatusReport(
+      makeInputs({featureConfig: {autoLearn: true, enabled: false}}),
+    )
+    expect(report.enabled).to.equal(false)
+    expect(report.currentVersionId).to.equal(null)
+    expect(report.currentVersion).to.equal(null)
+    expect(report.heuristic).to.equal(null)
+    expect(report.mode).to.equal(null)
+    expect(report.outcomeCount).to.equal(0)
+    expect(report.lastRefinement).to.equal(undefined)
+  })
+
+  it('2. store present but no version → outcomeCount populated, version fields null', async () => {
+    const store = makeStoreStub(sb)
+    ;(store.getLatest as SinonStub).resolves()
+    ;(store.listVersions as SinonStub).resolves([])
+    ;(store.listOutcomes as SinonStub).resolves([
+      makeOutcome({id: 'o1'}),
+      makeOutcome({id: 'o2', userFeedback: 'good'}),
+    ])
+
+    const report = await buildStatusReport(makeInputs({store}))
+
+    expect(report.currentVersionId).to.equal(null)
+    expect(report.outcomeCount).to.equal(2)
+    expect(report.outcomesWithFeedback).to.equal(1)
+    expect(report.mode).to.equal(null)
+  })
+
+  it('3. loaded version H=0.62 → mode="filter" (B floor 0.60)', async () => {
+    const store = makeStoreStub(sb)
+    const v1 = makeVersion({id: 'v-a', version: 1})
+    ;(store.getLatest as SinonStub).resolves(v1)
+    ;(store.listVersions as SinonStub).resolves([v1])
+    ;(store.listOutcomes as SinonStub).resolves([])
+
+    const report = await buildStatusReport(makeInputs({store}))
+
+    expect(report.currentVersionId).to.equal('v-a')
+    expect(report.currentVersion).to.equal(1)
+    expect(report.heuristic).to.equal(0.62)
+    expect(report.mode).to.equal('filter')
+    expect(report.lastRefinement).to.equal(undefined)
+  })
+
+  it('4. heuristic below 0.30 → mode=null', async () => {
+    const store = makeStoreStub(sb)
+    const v1 = makeVersion({heuristic: 0.1})
+    ;(store.getLatest as SinonStub).resolves(v1)
+    ;(store.listVersions as SinonStub).resolves([v1])
+    ;(store.listOutcomes as SinonStub).resolves([])
+
+    const report = await buildStatusReport(makeInputs({store}))
+    expect(report.mode).to.equal(null)
+  })
+
+  it('5. refinement present → lastRefinement populated with deltaH', async () => {
+    const store = makeStoreStub(sb)
+    const v1 = makeVersion({heuristic: 0.5, id: 'v-a', version: 1})
+    const v2 = makeVersion({
+      createdAt: 1_700_000_100_000,
+      heuristic: 0.62,
+      id: 'v-b',
+      parentId: 'v-a',
+      version: 2,
+    })
+    ;(store.getLatest as SinonStub).resolves(v2)
+    ;(store.listVersions as SinonStub).resolves([v2, v1]) // newest-first per listVersions contract
+    ;(store.listOutcomes as SinonStub).resolves([])
+
+    const report = await buildStatusReport(makeInputs({store}))
+
+    expect(report.lastRefinement).to.deep.equal({
+      acceptedAt: 1_700_000_100_000,
+      deltaH: 0.12,
+      fromVersion: 1,
+      toVersion: 2,
+    })
+  })
+
+  it('6. only v1 bootstrap (no parentId) → lastRefinement undefined', async () => {
+    const store = makeStoreStub(sb)
+    const v1 = makeVersion()
+    ;(store.getLatest as SinonStub).resolves(v1)
+    ;(store.listVersions as SinonStub).resolves([v1])
+    ;(store.listOutcomes as SinonStub).resolves([])
+
+    const report = await buildStatusReport(makeInputs({store}))
+    expect(report.lastRefinement).to.equal(undefined)
+  })
+
+  it('7. listOutcomes is invoked with MAX_SAFE_INTEGER so the count is accurate', async () => {
+    const store = makeStoreStub(sb)
+    const listOutcomes = store.listOutcomes as SinonStub
+    ;(store.getLatest as SinonStub).resolves()
+    ;(store.listVersions as SinonStub).resolves([])
+    listOutcomes.resolves([])
+
+    await buildStatusReport(makeInputs({store}))
+
+    expect(listOutcomes.calledOnce).to.equal(true)
+    expect(listOutcomes.firstCall.args[2]).to.equal(Number.MAX_SAFE_INTEGER)
+  })
+  })
+
+  describe('renderStatusText', () => {
+    it('renders a disabled + no-version report in the expected shape', () => {
+    const text = renderStatusText({
+      autoLearn: true,
+      commandType: 'curate',
+      currentVersion: null,
+      currentVersionId: null,
+      enabled: false,
+      heuristic: null,
+      mode: null,
+      outcomeCount: 0,
+      outcomesWithFeedback: 0,
+      projectId: PROJECT_ID,
+    })
+
+    expect(text).to.include('harness: disabled')
+    expect(text).to.include(`project: ${PROJECT_ID}`)
+    expect(text).to.include('version: <none')
+  })
+
+  it('renders a loaded version with H, mode, and last-refinement line', () => {
+    const text = renderStatusText({
+      autoLearn: true,
+      commandType: 'curate',
+      currentVersion: 3,
+      currentVersionId: 'v-abc',
+      enabled: true,
+      heuristic: 0.64,
+      lastRefinement: {
+        acceptedAt: Date.now() - 2 * 3_600_000, // 2h ago
+        deltaH: 0.06,
+        fromVersion: 2,
+        toVersion: 3,
+      },
+      mode: 'filter',
+      outcomeCount: 47,
+      outcomesWithFeedback: 5,
+      projectId: PROJECT_ID,
+    })
+
+    expect(text).to.match(/harness: enabled/)
+    expect(text).to.match(/version: v-abc \(#3\)\s+H: 0\.64\s+mode: filter/)
+    expect(text).to.include('outcomes: 47 recorded (5 w/ feedback)')
+    expect(text).to.match(/last refinement: accepted 2h ago\s+v2 → v3\s+ΔH: \+0\.06/)
+  })
+  })
+})

--- a/test/unit/oclif/commands/harness/status.test.ts
+++ b/test/unit/oclif/commands/harness/status.test.ts
@@ -81,120 +81,120 @@ function makeInputs(overrides: Partial<StatusInputs> = {}): StatusInputs {
 
 describe('HarnessStatus command — buildStatusReport + renderStatusText', () => {
   describe('buildStatusReport', () => {
-  let sb: SinonSandbox
+    let sb: SinonSandbox
 
-  beforeEach(() => {
-    sb = createSandbox()
-  })
-
-  afterEach(() => {
-    sb.restore()
-  })
-
-  it('1. no store (fresh project) → enabled flag only, empty counters', async () => {
-    const report = await buildStatusReport(
-      makeInputs({featureConfig: {autoLearn: true, enabled: false}}),
-    )
-    expect(report.enabled).to.equal(false)
-    expect(report.currentVersionId).to.equal(null)
-    expect(report.currentVersion).to.equal(null)
-    expect(report.heuristic).to.equal(null)
-    expect(report.mode).to.equal(null)
-    expect(report.outcomeCount).to.equal(0)
-    expect(report.lastRefinement).to.equal(undefined)
-  })
-
-  it('2. store present but no version → outcomeCount populated, version fields null', async () => {
-    const store = makeStoreStub(sb)
-    ;(store.getLatest as SinonStub).resolves()
-    ;(store.listVersions as SinonStub).resolves([])
-    ;(store.listOutcomes as SinonStub).resolves([
-      makeOutcome({id: 'o1'}),
-      makeOutcome({id: 'o2', userFeedback: 'good'}),
-    ])
-
-    const report = await buildStatusReport(makeInputs({store}))
-
-    expect(report.currentVersionId).to.equal(null)
-    expect(report.outcomeCount).to.equal(2)
-    expect(report.outcomesWithFeedback).to.equal(1)
-    expect(report.mode).to.equal(null)
-  })
-
-  it('3. loaded version H=0.62 → mode="filter" (B floor 0.60)', async () => {
-    const store = makeStoreStub(sb)
-    const v1 = makeVersion({id: 'v-a', version: 1})
-    ;(store.getLatest as SinonStub).resolves(v1)
-    ;(store.listVersions as SinonStub).resolves([v1])
-    ;(store.listOutcomes as SinonStub).resolves([])
-
-    const report = await buildStatusReport(makeInputs({store}))
-
-    expect(report.currentVersionId).to.equal('v-a')
-    expect(report.currentVersion).to.equal(1)
-    expect(report.heuristic).to.equal(0.62)
-    expect(report.mode).to.equal('filter')
-    expect(report.lastRefinement).to.equal(undefined)
-  })
-
-  it('4. heuristic below 0.30 → mode=null', async () => {
-    const store = makeStoreStub(sb)
-    const v1 = makeVersion({heuristic: 0.1})
-    ;(store.getLatest as SinonStub).resolves(v1)
-    ;(store.listVersions as SinonStub).resolves([v1])
-    ;(store.listOutcomes as SinonStub).resolves([])
-
-    const report = await buildStatusReport(makeInputs({store}))
-    expect(report.mode).to.equal(null)
-  })
-
-  it('5. refinement present → lastRefinement populated with deltaH', async () => {
-    const store = makeStoreStub(sb)
-    const v1 = makeVersion({heuristic: 0.5, id: 'v-a', version: 1})
-    const v2 = makeVersion({
-      createdAt: 1_700_000_100_000,
-      heuristic: 0.62,
-      id: 'v-b',
-      parentId: 'v-a',
-      version: 2,
+    beforeEach(() => {
+      sb = createSandbox()
     })
-    ;(store.getLatest as SinonStub).resolves(v2)
-    ;(store.listVersions as SinonStub).resolves([v2, v1]) // newest-first per listVersions contract
-    ;(store.listOutcomes as SinonStub).resolves([])
 
-    const report = await buildStatusReport(makeInputs({store}))
-
-    expect(report.lastRefinement).to.deep.equal({
-      acceptedAt: 1_700_000_100_000,
-      deltaH: 0.12,
-      fromVersion: 1,
-      toVersion: 2,
+    afterEach(() => {
+      sb.restore()
     })
-  })
 
-  it('6. only v1 bootstrap (no parentId) → lastRefinement undefined', async () => {
-    const store = makeStoreStub(sb)
-    const v1 = makeVersion()
-    ;(store.getLatest as SinonStub).resolves(v1)
-    ;(store.listVersions as SinonStub).resolves([v1])
-    ;(store.listOutcomes as SinonStub).resolves([])
+    it('1. no store (fresh project) → enabled flag only, empty counters', async () => {
+      const report = await buildStatusReport(
+        makeInputs({featureConfig: {autoLearn: true, enabled: false}}),
+      )
+      expect(report.enabled).to.equal(false)
+      expect(report.currentVersionId).to.equal(null)
+      expect(report.currentVersion).to.equal(null)
+      expect(report.heuristic).to.equal(null)
+      expect(report.mode).to.equal(null)
+      expect(report.outcomeCount).to.equal(0)
+      expect(report.lastRefinement).to.equal(undefined)
+    })
 
-    const report = await buildStatusReport(makeInputs({store}))
-    expect(report.lastRefinement).to.equal(undefined)
-  })
+    it('2. store present but no version → outcomeCount populated, version fields null', async () => {
+      const store = makeStoreStub(sb)
+      ;(store.getLatest as SinonStub).resolves()
+      ;(store.listVersions as SinonStub).resolves([])
+      ;(store.listOutcomes as SinonStub).resolves([
+        makeOutcome({id: 'o1'}),
+        makeOutcome({id: 'o2', userFeedback: 'good'}),
+      ])
 
-  it('7. listOutcomes is invoked with MAX_SAFE_INTEGER so the count is accurate', async () => {
-    const store = makeStoreStub(sb)
-    const listOutcomes = store.listOutcomes as SinonStub
-    ;(store.getLatest as SinonStub).resolves()
-    ;(store.listVersions as SinonStub).resolves([])
-    listOutcomes.resolves([])
+      const report = await buildStatusReport(makeInputs({store}))
 
-    await buildStatusReport(makeInputs({store}))
+      expect(report.currentVersionId).to.equal(null)
+      expect(report.outcomeCount).to.equal(2)
+      expect(report.outcomesWithFeedback).to.equal(1)
+      expect(report.mode).to.equal(null)
+    })
 
-    expect(listOutcomes.calledOnce).to.equal(true)
-    expect(listOutcomes.firstCall.args[2]).to.equal(Number.MAX_SAFE_INTEGER)
-  })
+    it('3. loaded version H=0.62 → mode="filter" (B floor 0.60)', async () => {
+      const store = makeStoreStub(sb)
+      const v1 = makeVersion({id: 'v-a', version: 1})
+      ;(store.getLatest as SinonStub).resolves(v1)
+      ;(store.listVersions as SinonStub).resolves([v1])
+      ;(store.listOutcomes as SinonStub).resolves([])
+
+      const report = await buildStatusReport(makeInputs({store}))
+
+      expect(report.currentVersionId).to.equal('v-a')
+      expect(report.currentVersion).to.equal(1)
+      expect(report.heuristic).to.equal(0.62)
+      expect(report.mode).to.equal('filter')
+      expect(report.lastRefinement).to.equal(undefined)
+    })
+
+    it('4. heuristic below 0.30 → mode=null', async () => {
+      const store = makeStoreStub(sb)
+      const v1 = makeVersion({heuristic: 0.1})
+      ;(store.getLatest as SinonStub).resolves(v1)
+      ;(store.listVersions as SinonStub).resolves([v1])
+      ;(store.listOutcomes as SinonStub).resolves([])
+
+      const report = await buildStatusReport(makeInputs({store}))
+      expect(report.mode).to.equal(null)
+    })
+
+    it('5. refinement present → lastRefinement populated with deltaH', async () => {
+      const store = makeStoreStub(sb)
+      const v1 = makeVersion({heuristic: 0.5, id: 'v-a', version: 1})
+      const v2 = makeVersion({
+        createdAt: 1_700_000_100_000,
+        heuristic: 0.62,
+        id: 'v-b',
+        parentId: 'v-a',
+        version: 2,
+      })
+      ;(store.getLatest as SinonStub).resolves(v2)
+      ;(store.listVersions as SinonStub).resolves([v2, v1]) // newest-first per listVersions contract
+      ;(store.listOutcomes as SinonStub).resolves([])
+
+      const report = await buildStatusReport(makeInputs({store}))
+
+      expect(report.lastRefinement).to.deep.equal({
+        acceptedAt: 1_700_000_100_000,
+        deltaH: 0.12,
+        fromVersion: 1,
+        toVersion: 2,
+      })
+    })
+
+    it('6. only v1 bootstrap (no parentId) → lastRefinement undefined', async () => {
+      const store = makeStoreStub(sb)
+      const v1 = makeVersion()
+      ;(store.getLatest as SinonStub).resolves(v1)
+      ;(store.listVersions as SinonStub).resolves([v1])
+      ;(store.listOutcomes as SinonStub).resolves([])
+
+      const report = await buildStatusReport(makeInputs({store}))
+      expect(report.lastRefinement).to.equal(undefined)
+    })
+
+    it('7. listOutcomes is invoked with MAX_SAFE_INTEGER so the count is accurate', async () => {
+      const store = makeStoreStub(sb)
+      const listOutcomes = store.listOutcomes as SinonStub
+      ;(store.getLatest as SinonStub).resolves()
+      ;(store.listVersions as SinonStub).resolves([])
+      listOutcomes.resolves([])
+
+      await buildStatusReport(makeInputs({store}))
+
+      expect(listOutcomes.calledOnce).to.equal(true)
+      expect(listOutcomes.firstCall.args[2]).to.equal(Number.MAX_SAFE_INTEGER)
+    })
   })
 
   describe('renderStatusText', () => {

--- a/test/unit/oclif/lib/harness-cli.test.ts
+++ b/test/unit/oclif/lib/harness-cli.test.ts
@@ -1,0 +1,61 @@
+import {expect} from 'chai'
+import {mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+
+import {readHarnessFeatureConfig} from '../../../../src/oclif/lib/harness-cli.js'
+
+describe('readHarnessFeatureConfig', () => {
+  let tempRoot: string
+
+  beforeEach(async () => {
+    tempRoot = await mkdtemp(join(tmpdir(), 'brv-harness-cli-test-'))
+  })
+
+  afterEach(async () => {
+    await rm(tempRoot, {force: true, recursive: true})
+  })
+
+  it('1. returns defaults (disabled, autoLearn=true) when .brv/ absent', async () => {
+    const cfg = await readHarnessFeatureConfig(tempRoot)
+    expect(cfg).to.deep.equal({autoLearn: true, enabled: false})
+  })
+
+  it('2. returns defaults when config.json is malformed JSON', async () => {
+    await mkdir(join(tempRoot, '.brv'), {recursive: true})
+    await writeFile(join(tempRoot, '.brv', 'config.json'), '{not valid')
+    const cfg = await readHarnessFeatureConfig(tempRoot)
+    expect(cfg).to.deep.equal({autoLearn: true, enabled: false})
+  })
+
+  it('3. returns defaults when config.json has no harness key', async () => {
+    await mkdir(join(tempRoot, '.brv'), {recursive: true})
+    await writeFile(
+      join(tempRoot, '.brv', 'config.json'),
+      JSON.stringify({createdAt: '2026-04-22'}),
+    )
+    const cfg = await readHarnessFeatureConfig(tempRoot)
+    expect(cfg).to.deep.equal({autoLearn: true, enabled: false})
+  })
+
+  it('4. reads harness.enabled=true from config.json', async () => {
+    await mkdir(join(tempRoot, '.brv'), {recursive: true})
+    await writeFile(
+      join(tempRoot, '.brv', 'config.json'),
+      JSON.stringify({createdAt: '2026-04-22', harness: {autoLearn: false, enabled: true}}),
+    )
+    const cfg = await readHarnessFeatureConfig(tempRoot)
+    expect(cfg).to.deep.equal({autoLearn: false, enabled: true})
+  })
+
+  it('5. non-boolean fields in harness block fall back to the default', async () => {
+    await mkdir(join(tempRoot, '.brv'), {recursive: true})
+    await writeFile(
+      join(tempRoot, '.brv', 'config.json'),
+      JSON.stringify({createdAt: '2026-04-22', harness: {enabled: 'yes'}}),
+    )
+    const cfg = await readHarnessFeatureConfig(tempRoot)
+    expect(cfg.enabled).to.equal(false)
+    expect(cfg.autoLearn).to.equal(true)
+  })
+})

--- a/test/unit/oclif/lib/harness-cli.test.ts
+++ b/test/unit/oclif/lib/harness-cli.test.ts
@@ -42,57 +42,57 @@ describe('harness-cli helpers', () => {
   })
 
   describe('readHarnessFeatureConfig', () => {
-  let tempRoot: string
+    let tempRoot: string
 
-  beforeEach(async () => {
-    tempRoot = await mkdtemp(join(tmpdir(), 'brv-harness-cli-test-'))
-  })
+    beforeEach(async () => {
+      tempRoot = await mkdtemp(join(tmpdir(), 'brv-harness-cli-test-'))
+    })
 
-  afterEach(async () => {
-    await rm(tempRoot, {force: true, recursive: true})
-  })
+    afterEach(async () => {
+      await rm(tempRoot, {force: true, recursive: true})
+    })
 
-  it('1. returns defaults (disabled, autoLearn=true) when .brv/ absent', async () => {
-    const cfg = await readHarnessFeatureConfig(tempRoot)
-    expect(cfg).to.deep.equal({autoLearn: true, enabled: false})
-  })
+    it('1. returns defaults (disabled, autoLearn=true) when .brv/ absent', async () => {
+      const cfg = await readHarnessFeatureConfig(tempRoot)
+      expect(cfg).to.deep.equal({autoLearn: true, enabled: false})
+    })
 
-  it('2. returns defaults when config.json is malformed JSON', async () => {
-    await mkdir(join(tempRoot, '.brv'), {recursive: true})
-    await writeFile(join(tempRoot, '.brv', 'config.json'), '{not valid')
-    const cfg = await readHarnessFeatureConfig(tempRoot)
-    expect(cfg).to.deep.equal({autoLearn: true, enabled: false})
-  })
+    it('2. returns defaults when config.json is malformed JSON', async () => {
+      await mkdir(join(tempRoot, '.brv'), {recursive: true})
+      await writeFile(join(tempRoot, '.brv', 'config.json'), '{not valid')
+      const cfg = await readHarnessFeatureConfig(tempRoot)
+      expect(cfg).to.deep.equal({autoLearn: true, enabled: false})
+    })
 
-  it('3. returns defaults when config.json has no harness key', async () => {
-    await mkdir(join(tempRoot, '.brv'), {recursive: true})
-    await writeFile(
-      join(tempRoot, '.brv', 'config.json'),
-      JSON.stringify({createdAt: '2026-04-22'}),
-    )
-    const cfg = await readHarnessFeatureConfig(tempRoot)
-    expect(cfg).to.deep.equal({autoLearn: true, enabled: false})
-  })
+    it('3. returns defaults when config.json has no harness key', async () => {
+      await mkdir(join(tempRoot, '.brv'), {recursive: true})
+      await writeFile(
+        join(tempRoot, '.brv', 'config.json'),
+        JSON.stringify({createdAt: '2026-04-22'}),
+      )
+      const cfg = await readHarnessFeatureConfig(tempRoot)
+      expect(cfg).to.deep.equal({autoLearn: true, enabled: false})
+    })
 
-  it('4. reads harness.enabled=true from config.json', async () => {
-    await mkdir(join(tempRoot, '.brv'), {recursive: true})
-    await writeFile(
-      join(tempRoot, '.brv', 'config.json'),
-      JSON.stringify({createdAt: '2026-04-22', harness: {autoLearn: false, enabled: true}}),
-    )
-    const cfg = await readHarnessFeatureConfig(tempRoot)
-    expect(cfg).to.deep.equal({autoLearn: false, enabled: true})
-  })
+    it('4. reads harness.enabled=true from config.json', async () => {
+      await mkdir(join(tempRoot, '.brv'), {recursive: true})
+      await writeFile(
+        join(tempRoot, '.brv', 'config.json'),
+        JSON.stringify({createdAt: '2026-04-22', harness: {autoLearn: false, enabled: true}}),
+      )
+      const cfg = await readHarnessFeatureConfig(tempRoot)
+      expect(cfg).to.deep.equal({autoLearn: false, enabled: true})
+    })
 
-  it('5. non-boolean fields in harness block fall back to the default', async () => {
-    await mkdir(join(tempRoot, '.brv'), {recursive: true})
-    await writeFile(
-      join(tempRoot, '.brv', 'config.json'),
-      JSON.stringify({createdAt: '2026-04-22', harness: {enabled: 'yes'}}),
-    )
-    const cfg = await readHarnessFeatureConfig(tempRoot)
-    expect(cfg.enabled).to.equal(false)
-    expect(cfg.autoLearn).to.equal(true)
-  })
+    it('5. non-boolean fields in harness block fall back to the default', async () => {
+      await mkdir(join(tempRoot, '.brv'), {recursive: true})
+      await writeFile(
+        join(tempRoot, '.brv', 'config.json'),
+        JSON.stringify({createdAt: '2026-04-22', harness: {enabled: 'yes'}}),
+      )
+      const cfg = await readHarnessFeatureConfig(tempRoot)
+      expect(cfg.enabled).to.equal(false)
+      expect(cfg.autoLearn).to.equal(true)
+    })
   })
 })

--- a/test/unit/oclif/lib/harness-cli.test.ts
+++ b/test/unit/oclif/lib/harness-cli.test.ts
@@ -3,9 +3,45 @@ import {mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises'
 import {tmpdir} from 'node:os'
 import {join} from 'node:path'
 
-import {readHarnessFeatureConfig} from '../../../../src/oclif/lib/harness-cli.js'
+import {
+  isHarnessCommandType,
+  openHarnessStoreForProject,
+  readHarnessFeatureConfig,
+} from '../../../../src/oclif/lib/harness-cli.js'
 
-describe('readHarnessFeatureConfig', () => {
+describe('harness-cli helpers', () => {
+  describe('isHarnessCommandType', () => {
+    it('accepts the three canonical values', () => {
+      expect(isHarnessCommandType('chat')).to.equal(true)
+      expect(isHarnessCommandType('curate')).to.equal(true)
+      expect(isHarnessCommandType('query')).to.equal(true)
+    })
+
+    it('rejects anything else', () => {
+      expect(isHarnessCommandType('CURATE')).to.equal(false)
+      expect(isHarnessCommandType('')).to.equal(false)
+      expect(isHarnessCommandType('bogus')).to.equal(false)
+    })
+  })
+
+  describe('openHarnessStoreForProject', () => {
+    it('returns undefined when the derived storage directory does not exist', async () => {
+      // tmpdir path is registered — but no XDG storage directory has
+      // ever been written for it, so the resolver's `existsSync` short-
+      // circuits to undefined. This is the only externally-observable
+      // behaviour of the "unused project" path; the happy path is
+      // exercised implicitly via daemon integration (Phase 7.7 test).
+      const tempRoot = await mkdtemp(join(tmpdir(), 'brv-harness-open-'))
+      try {
+        const opened = await openHarnessStoreForProject(tempRoot)
+        expect(opened).to.equal(undefined)
+      } finally {
+        await rm(tempRoot, {force: true, recursive: true})
+      }
+    })
+  })
+
+  describe('readHarnessFeatureConfig', () => {
   let tempRoot: string
 
   beforeEach(async () => {
@@ -57,5 +93,6 @@ describe('readHarnessFeatureConfig', () => {
     const cfg = await readHarnessFeatureConfig(tempRoot)
     expect(cfg.enabled).to.equal(false)
     expect(cfg.autoLearn).to.equal(true)
+  })
   })
 })

--- a/test/unit/oclif/lib/resolve-version-ref.test.ts
+++ b/test/unit/oclif/lib/resolve-version-ref.test.ts
@@ -156,6 +156,7 @@ describe('resolveVersionRef', () => {
       caught = error
     }
 
+    expect(caught).to.be.instanceOf(VersionRefError)
     expect((caught as VersionRefError).code).to.equal('NOT_FOUND')
     expect((caught as VersionRefError).message).to.include('#1')
     expect((caught as VersionRefError).message).to.include('#2')
@@ -171,6 +172,7 @@ describe('resolveVersionRef', () => {
       caught = error
     }
 
+    expect(caught).to.be.instanceOf(VersionRefError)
     expect((caught as VersionRefError).code).to.equal('INVALID_GRAMMAR')
   })
 
@@ -195,6 +197,7 @@ describe('resolveVersionRef', () => {
       caught = error
     }
 
+    expect(caught).to.be.instanceOf(VersionRefError)
     expect((caught as VersionRefError).code).to.equal('NOT_FOUND')
     expect((caught as VersionRefError).message).to.include('v-unknown')
   })

--- a/test/unit/oclif/lib/resolve-version-ref.test.ts
+++ b/test/unit/oclif/lib/resolve-version-ref.test.ts
@@ -1,0 +1,214 @@
+import {expect} from 'chai'
+import {createSandbox, type SinonSandbox, type SinonStub} from 'sinon'
+
+import type {HarnessVersion} from '../../../../src/agent/core/domain/harness/types.js'
+import type {IHarnessStore} from '../../../../src/agent/core/interfaces/i-harness-store.js'
+
+import {
+  resolveVersionRef,
+  VersionRefError,
+} from '../../../../src/oclif/lib/resolve-version-ref.js'
+
+const PROJECT_ID = '/fixture/proj'
+const COMMAND_TYPE = 'curate'
+
+function makeVersion(overrides: Partial<HarnessVersion> = {}): HarnessVersion {
+  return {
+    code: 'exports.curate = async () => {}',
+    commandType: COMMAND_TYPE,
+    createdAt: 1_700_000_000_000,
+    heuristic: 0.5,
+    id: 'v-default',
+    metadata: {
+      capabilities: ['curate'],
+      commandType: COMMAND_TYPE,
+      projectPatterns: ['**/*'],
+      version: 1,
+    },
+    projectId: PROJECT_ID,
+    projectType: 'generic',
+    version: 1,
+    ...overrides,
+  }
+}
+
+function makeStoreStub(sb: SinonSandbox): IHarnessStore {
+  return {
+    deleteOutcome: sb.stub(),
+    deleteOutcomes: sb.stub(),
+    deleteScenario: sb.stub(),
+    getLatest: sb.stub(),
+    getVersion: sb.stub(),
+    listOutcomes: sb.stub(),
+    listScenarios: sb.stub(),
+    listVersions: sb.stub(),
+    pruneOldVersions: sb.stub(),
+    recordFeedback: sb.stub(),
+    saveOutcome: sb.stub(),
+    saveScenario: sb.stub(),
+    saveVersion: sb.stub(),
+  } satisfies IHarnessStore
+}
+
+describe('resolveVersionRef', () => {
+  let sb: SinonSandbox
+
+  beforeEach(() => {
+    sb = createSandbox()
+  })
+
+  afterEach(() => {
+    sb.restore()
+  })
+
+  it('1. resolves "latest" to the result of getLatest', async () => {
+    const store = makeStoreStub(sb)
+    const latest = makeVersion({id: 'v-L', version: 7})
+    ;(store.getLatest as SinonStub).resolves(latest)
+
+    const out = await resolveVersionRef('latest', PROJECT_ID, COMMAND_TYPE, store)
+
+    expect(out.versionId).to.equal('v-L')
+    expect(out.version.version).to.equal(7)
+  })
+
+  it('2. "latest" with no versions throws NO_VERSIONS', async () => {
+    const store = makeStoreStub(sb)
+    ;(store.getLatest as SinonStub).resolves()
+
+    let caught: unknown
+    try {
+      await resolveVersionRef('latest', PROJECT_ID, COMMAND_TYPE, store)
+    } catch (error) {
+      caught = error
+    }
+
+    expect(caught).to.be.instanceOf(VersionRefError)
+    expect((caught as VersionRefError).code).to.equal('NO_VERSIONS')
+  })
+
+  it('3. "best" returns the highest-H version', async () => {
+    const store = makeStoreStub(sb)
+    ;(store.listVersions as SinonStub).resolves([
+      makeVersion({heuristic: 0.3, id: 'v-low', version: 3}),
+      makeVersion({heuristic: 0.9, id: 'v-top', version: 2}),
+      makeVersion({heuristic: 0.5, id: 'v-mid', version: 1}),
+    ])
+
+    const out = await resolveVersionRef('best', PROJECT_ID, COMMAND_TYPE, store)
+
+    expect(out.versionId).to.equal('v-top')
+  })
+
+  it('4. "best" ties broken by newest createdAt', async () => {
+    const store = makeStoreStub(sb)
+    ;(store.listVersions as SinonStub).resolves([
+      makeVersion({createdAt: 100, heuristic: 0.7, id: 'v-old', version: 1}),
+      makeVersion({createdAt: 500, heuristic: 0.7, id: 'v-new', version: 2}),
+      makeVersion({createdAt: 300, heuristic: 0.7, id: 'v-mid', version: 3}),
+    ])
+
+    const out = await resolveVersionRef('best', PROJECT_ID, COMMAND_TYPE, store)
+
+    expect(out.versionId).to.equal('v-new')
+  })
+
+  it('5. "best" with no versions throws NO_VERSIONS', async () => {
+    const store = makeStoreStub(sb)
+    ;(store.listVersions as SinonStub).resolves([])
+
+    let caught: unknown
+    try {
+      await resolveVersionRef('best', PROJECT_ID, COMMAND_TYPE, store)
+    } catch (error) {
+      caught = error
+    }
+
+    expect((caught as VersionRefError).code).to.equal('NO_VERSIONS')
+  })
+
+  it('6. "v3" returns the version whose version number equals 3', async () => {
+    const store = makeStoreStub(sb)
+    ;(store.listVersions as SinonStub).resolves([
+      makeVersion({id: 'v-a', version: 1}),
+      makeVersion({id: 'v-b', version: 2}),
+      makeVersion({id: 'v-c', version: 3}),
+    ])
+
+    const out = await resolveVersionRef('v3', PROJECT_ID, COMMAND_TYPE, store)
+
+    expect(out.versionId).to.equal('v-c')
+    expect(out.version.version).to.equal(3)
+  })
+
+  it('7. "v99" returns NOT_FOUND with a hint about available versions', async () => {
+    const store = makeStoreStub(sb)
+    ;(store.listVersions as SinonStub).resolves([
+      makeVersion({id: 'v-a', version: 1}),
+      makeVersion({id: 'v-b', version: 2}),
+    ])
+
+    let caught: unknown
+    try {
+      await resolveVersionRef('v99', PROJECT_ID, COMMAND_TYPE, store)
+    } catch (error) {
+      caught = error
+    }
+
+    expect((caught as VersionRefError).code).to.equal('NOT_FOUND')
+    expect((caught as VersionRefError).message).to.include('#1')
+    expect((caught as VersionRefError).message).to.include('#2')
+  })
+
+  it('8. "v0" is invalid grammar', async () => {
+    const store = makeStoreStub(sb)
+
+    let caught: unknown
+    try {
+      await resolveVersionRef('v0', PROJECT_ID, COMMAND_TYPE, store)
+    } catch (error) {
+      caught = error
+    }
+
+    expect((caught as VersionRefError).code).to.equal('INVALID_GRAMMAR')
+  })
+
+  it('9. raw id resolves via getVersion', async () => {
+    const store = makeStoreStub(sb)
+    const v = makeVersion({id: 'v-raw-123', version: 5})
+    ;(store.getVersion as SinonStub).resolves(v)
+
+    const out = await resolveVersionRef('v-raw-123', PROJECT_ID, COMMAND_TYPE, store)
+
+    expect(out.versionId).to.equal('v-raw-123')
+  })
+
+  it('10. raw id miss throws NOT_FOUND and names the ref', async () => {
+    const store = makeStoreStub(sb)
+    ;(store.getVersion as SinonStub).resolves()
+
+    let caught: unknown
+    try {
+      await resolveVersionRef('v-unknown', PROJECT_ID, COMMAND_TYPE, store)
+    } catch (error) {
+      caught = error
+    }
+
+    expect((caught as VersionRefError).code).to.equal('NOT_FOUND')
+    expect((caught as VersionRefError).message).to.include('v-unknown')
+  })
+
+  it('11. "v1.5" falls through to raw-id lookup (not v<N>)', async () => {
+    const store = makeStoreStub(sb)
+    const getVersion = store.getVersion as SinonStub
+    getVersion.resolves()
+
+    try {
+      await resolveVersionRef('v1.5', PROJECT_ID, COMMAND_TYPE, store)
+    } catch {
+      // Expected — getVersion miss
+    }
+
+    expect(getVersion.calledOnceWith(PROJECT_ID, COMMAND_TYPE, 'v1.5')).to.equal(true)
+  })
+})

--- a/test/unit/oclif/lib/resolve-version-ref.test.ts
+++ b/test/unit/oclif/lib/resolve-version-ref.test.ts
@@ -124,6 +124,7 @@ describe('resolveVersionRef', () => {
       caught = error
     }
 
+    expect(caught).to.be.instanceOf(VersionRefError)
     expect((caught as VersionRefError).code).to.equal('NO_VERSIONS')
   })
 


### PR DESCRIPTION
## Summary

Phase 7 Task 7.1 — ships the first two read-only `brv harness *` CLI
commands plus the shared version-ref resolver consumed by the rest of
Phase 7.

- **`brv harness status`** — pair summary with text + JSON output.
  JSON shape pinned to `phase_7_8_handoff.md §C2` (consumed by
  Phase 8's smoke script + KPI harness). Never errors: disabled /
  no-storage / no-version all exit 0 per §C1.
- **`brv harness inspect <versionRef>`** — full version dump.
  Accepts the §C3 grammar: `latest` | `best` | `v<N>` | raw id.
  Exits 1 on unresolvable refs with a message naming the ref.
- **`src/oclif/lib/resolve-version-ref.ts`** — shared resolver for
  the version-ref grammar. Also imported by Tasks 7.2 (use/diff)
  and 7.3 (reset) once they land. Tie-break for `best` on newest
  `createdAt` per §C3.
- **`src/oclif/lib/harness-cli.ts`** — `openHarnessStoreForProject`
  stands up an `IHarnessStore` against the daemon's XDG storage
  without registering the project (read-only, no side effects if
  the project has never been used). `readHarnessFeatureConfig`
  reads an optional `harness` block from `.brv/config.json`.

## Scope narrowing

- **No `brv harness` oclif topic yet**: both commands are reachable
  directly (`brv harness status`, `brv harness inspect ...`) through
  oclif's file-based topic discovery. Explicit topic config lands
  with 7.2/7.4/7.5 when there are ≥3 commands to group.
- **Daemon-side config wiring**: v1.0 still defaults
  `harness.enabled: false` because `agent-process.ts` doesn't yet
  thread a `harness` block into the agent config. Status reports
  the CLI-visible state correctly today; a follow-up PR will
  connect the config plumbing.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (256 pre-existing warnings)
- [x] `npm test` — 7176 passing, 16 pending, 0 failing
- [x] `npm run build` — clean
- [x] 27 new unit tests across 4 files:
  - resolve-version-ref (11): grammar happy paths + NO_VERSIONS /
    NOT_FOUND / INVALID_GRAMMAR + \`v1.5\` falls through to raw-id
  - status buildStatusReport (7): no-store, no-version, loaded
    version mode=filter, below-A-floor → mode=null, refinement
    deltaH, only-v1 bootstrap, listOutcomes invoked with
    MAX_SAFE_INTEGER
  - status renderStatusText (2): disabled + loaded renders
  - inspect (4): shape mapping, parentId normalisation, text
    layout, bootstrap label
  - harness-cli readHarnessFeatureConfig (5): defaults on absent /
    malformed / missing-key / populated / non-boolean fields

## Acceptance criteria

- [x] \`brv harness status\` implemented with text + json output
- [x] \`brv harness inspect <versionRef>\` implemented with text + json
- [x] \`resolveVersionRef\` handles \`<id>\`, \`latest\`, \`best\`, \`v<N>\`
- [x] \`--format json\` shape matches \`phase_7_8_handoff.md §C2\`
- [x] \`status\` exits \`0\` in every no-op state
- [x] \`inspect <unknown>\` exits \`1\` with a message naming the ref
- [x] unit tests cover the 9+ scenarios listed in the task doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)