### PR TITLE
feat: [ENG-2319] AutoHarness V2 harness use + diff CLI (Phase 7 Task 7.2)

### DIFF
--- a/src/agent/core/domain/harness/types.ts
+++ b/src/agent/core/domain/harness/types.ts
@@ -181,6 +181,27 @@ export const EvaluationScenarioSchema = z
 export type EvaluationScenario = z.input<typeof EvaluationScenarioSchema>
 export type ValidatedEvaluationScenario = z.output<typeof EvaluationScenarioSchema>
 
+/**
+ * User-initiated version pin. Exactly one pin per
+ * `(projectId, commandType)` pair; a new `brv harness use` replaces the
+ * previous record rather than appending.
+ *
+ * Consulted by `SandboxService.loadHarness` BEFORE `getLatest` — this is
+ * the rollback path's reason to exist. When the pinned id has been
+ * pruned (retention policy dropped it), callers warn-log and fall back
+ * to `getLatest` rather than erroring.
+ */
+export const HarnessPinSchema = z
+  .object({
+    commandType: z.string().min(1),
+    pinnedAt: z.number().int().nonnegative(),
+    pinnedVersionId: z.string().min(1),
+    projectId: z.string().min(1),
+  })
+  .strict()
+export type HarnessPin = z.input<typeof HarnessPinSchema>
+export type ValidatedHarnessPin = z.output<typeof HarnessPinSchema>
+
 // ---------------------------------------------------------------------------
 // Phase 3 — HarnessContext + module contract
 // ---------------------------------------------------------------------------

--- a/src/agent/core/interfaces/i-harness-store.ts
+++ b/src/agent/core/interfaces/i-harness-store.ts
@@ -181,16 +181,6 @@ export interface IHarnessStore {
   saveOutcome(outcome: CodeExecOutcome): Promise<void>
 
   /**
-   * Persist a user-initiated version pin for a `(projectId, commandType)`
-   * pair. Idempotent overwrite: a subsequent `setPin` replaces the
-   * previous record rather than appending (exactly one pin per pair).
-   *
-   * Does NOT validate that `pinnedVersionId` exists — that's the
-   * caller's responsibility (usually after a `resolveVersionRef`
-   * success). The sandbox-side prune-fallback handles "pinned id no
-   * longer exists" at load time.
-   */
-  /**
    * Persist an evaluation scenario for a `(projectId, commandType)` pair.
    * Scenarios are captured from both successful AND failed sessions —
    * negative scenarios prevent the refiner from "improving" into a harness

--- a/src/agent/core/interfaces/i-harness-store.ts
+++ b/src/agent/core/interfaces/i-harness-store.ts
@@ -42,6 +42,7 @@
 import type {
   CodeExecOutcome,
   EvaluationScenario,
+  HarnessPin,
   HarnessVersion,
 } from '../domain/harness/types.js'
 
@@ -80,12 +81,22 @@ export interface IHarnessStore {
   /**
    * Return the most-recently-written version for a `(projectId, commandType)`
    * pair — ranked by the stored `version` number, not by `heuristic`. This
-   * is "newest" semantics, not "best" semantics. Phase 7's pinned-version
-   * concept lives in a separate method (see the Known extension note in
-   * the module header). Returns `undefined` when no version exists for
-   * the pair.
+   * is "newest" semantics, not "best" semantics. User-initiated pins live
+   * in a separate record; see `getPin`. Returns `undefined` when no
+   * version exists for the pair.
    */
   getLatest(projectId: string, commandType: string): Promise<HarnessVersion | undefined>
+
+  /**
+   * Return the active user-initiated version pin for a
+   * `(projectId, commandType)` pair, or `undefined` when no pin exists.
+   *
+   * Consulted by `SandboxService.loadHarness` before `getLatest`. When
+   * the pinned id has since been pruned (retention policy), callers
+   * MUST fall back to `getLatest` rather than erroring — pin is a
+   * preference, not a requirement.
+   */
+  getPin(projectId: string, commandType: string): Promise<HarnessPin | undefined>
 
   /**
    * Fetch a specific version by its id. Returns `undefined` when the id is
@@ -170,6 +181,16 @@ export interface IHarnessStore {
   saveOutcome(outcome: CodeExecOutcome): Promise<void>
 
   /**
+   * Persist a user-initiated version pin for a `(projectId, commandType)`
+   * pair. Idempotent overwrite: a subsequent `setPin` replaces the
+   * previous record rather than appending (exactly one pin per pair).
+   *
+   * Does NOT validate that `pinnedVersionId` exists — that's the
+   * caller's responsibility (usually after a `resolveVersionRef`
+   * success). The sandbox-side prune-fallback handles "pinned id no
+   * longer exists" at load time.
+   */
+  /**
    * Persist an evaluation scenario for a `(projectId, commandType)` pair.
    * Scenarios are captured from both successful AND failed sessions —
    * negative scenarios prevent the refiner from "improving" into a harness
@@ -186,4 +207,16 @@ export interface IHarnessStore {
    *   tuple, already exists.
    */
   saveVersion(version: HarnessVersion): Promise<void>
+
+  /**
+   * Persist a user-initiated version pin for a `(projectId, commandType)`
+   * pair. Idempotent overwrite: a subsequent `setPin` replaces the
+   * previous record rather than appending (exactly one pin per pair).
+   *
+   * Does NOT validate that `pinnedVersionId` exists — that's the
+   * caller's responsibility (usually after a `resolveVersionRef`
+   * success). The sandbox-side prune-fallback handles "pinned id no
+   * longer exists" at load time.
+   */
+  setPin(pin: HarnessPin): Promise<void>
 }

--- a/src/agent/infra/harness/harness-store.ts
+++ b/src/agent/infra/harness/harness-store.ts
@@ -26,6 +26,7 @@
 import type {
   CodeExecOutcome,
   EvaluationScenario,
+  HarnessPin,
   HarnessVersion,
 } from '../../core/domain/harness/types.js'
 import type {IHarnessStore} from '../../core/interfaces/i-harness-store.js'
@@ -36,6 +37,7 @@ import {HarnessStoreError} from '../../core/domain/errors/harness-store-error.js
 import {
   CodeExecOutcomeSchema,
   EvaluationScenarioSchema,
+  HarnessPinSchema,
   HarnessVersionSchema,
   ProjectTypeSchema,
 } from '../../core/domain/harness/types.js'
@@ -44,6 +46,7 @@ const HARNESS_PREFIX = 'harness'
 const VERSION_PREFIX = 'version'
 const OUTCOME_PREFIX = 'outcome'
 const SCENARIO_PREFIX = 'scenario'
+const PIN_PREFIX = 'pin'
 
 /**
  * Default cap when `listOutcomes` is called without an explicit `limit`.
@@ -153,6 +156,13 @@ export class HarnessStore implements IHarnessStore {
     // (`maxVersions` default 20).
     const sorted = await this.listVersions(projectId, commandType)
     return sorted[0]
+  }
+
+  async getPin(
+    projectId: string,
+    commandType: string,
+  ): Promise<HarnessPin | undefined> {
+    return this.keyStorage.get<HarnessPin>(this.pinKey(projectId, commandType))
   }
 
   async getVersion(
@@ -376,6 +386,13 @@ export class HarnessStore implements IHarnessStore {
     }
   }
 
+  async setPin(pin: HarnessPin): Promise<void> {
+    const parsed = HarnessPinSchema.parse(pin)
+    // Idempotent overwrite: exactly one pin per pair, new `use` replaces
+    // the previous record rather than appending.
+    await this.keyStorage.set(this.pinKey(parsed.projectId, parsed.commandType), parsed)
+  }
+
   // ── internals ──────────────────────────────────────────────────────────────
 
   private async findOutcomeKey(
@@ -433,6 +450,10 @@ export class HarnessStore implements IHarnessStore {
     outcomeId: string,
   ): StorageKey {
     return [HARNESS_PREFIX, OUTCOME_PREFIX, projectType, projectId, commandType, outcomeId]
+  }
+
+  private pinKey(projectId: string, commandType: string): StorageKey {
+    return [HARNESS_PREFIX, PIN_PREFIX, projectId, commandType]
   }
 
   private scenarioKey(

--- a/src/agent/infra/sandbox/sandbox-service.ts
+++ b/src/agent/infra/sandbox/sandbox-service.ts
@@ -4,6 +4,7 @@ import type {
   HarnessLoadResult,
   HarnessMeta,
   HarnessModule,
+  HarnessVersion,
   ProjectType,
 } from '../../core/domain/harness/types.js'
 import type { REPLResult, SandboxConfig } from '../../core/domain/sandbox/types.js'
@@ -285,7 +286,32 @@ export class SandboxService implements ISandboxService {
       return {loaded: false, reason: 'no-version'}
     }
 
-    const version = await this.harnessStore.getLatest(projectId, commandType)
+    // Pin-first resolution: a user-initiated `brv harness use` record
+    // beats the default `getLatest`. When the pinned id has since been
+    // pruned (retention policy), warn-log and fall back to `getLatest`
+    // rather than refusing to load — a broken pin is a preference
+    // failure, not a feature failure.
+    const pin = await this.harnessStore.getPin(projectId, commandType)
+    let version: HarnessVersion | undefined
+    if (pin !== undefined) {
+      version = await this.harnessStore.getVersion(
+        projectId,
+        commandType,
+        pin.pinnedVersionId,
+      )
+      if (version === undefined) {
+        this.logger?.warn('SandboxService.loadHarness: pinned version pruned, falling back to latest', {
+          commandType,
+          pinnedVersionId: pin.pinnedVersionId,
+          projectId,
+        })
+      }
+    }
+
+    if (version === undefined) {
+      version = await this.harnessStore.getLatest(projectId, commandType)
+    }
+
     if (version === undefined) {
       return {loaded: false, reason: 'no-version'}
     }

--- a/src/oclif/commands/harness/diff.ts
+++ b/src/oclif/commands/harness/diff.ts
@@ -1,0 +1,121 @@
+/**
+ * `brv harness diff <from> <to>` — AutoHarness V2 Phase 7 Task 7.2.
+ *
+ * Produces a unified diff between two harness versions' code bodies.
+ * Closes brutal-review item Tier 2 D3.
+ *
+ * Exits `1` on unresolvable refs per handoff §C1. JSON shape is
+ * pinned to §C2's `diff` entry.
+ */
+
+import {Args, Command, Flags} from '@oclif/core'
+
+import type {HarnessVersion} from '../../../agent/core/domain/harness/types.js'
+
+import {resolveProject} from '../../../server/infra/project/resolve-project.js'
+import {
+  HARNESS_COMMAND_TYPES,
+  isHarnessCommandType,
+  openHarnessStoreForProject,
+} from '../../lib/harness-cli.js'
+import {resolveVersionRef, VersionRefError} from '../../lib/resolve-version-ref.js'
+import {unifiedDiff} from '../../lib/unified-diff.js'
+
+export interface DiffReport {
+  readonly fromVersionId: string
+  readonly lineAdds: number
+  readonly lineDeletes: number
+  readonly toVersionId: string
+  readonly unifiedDiff: string
+}
+
+export function buildDiffReport(from: HarnessVersion, to: HarnessVersion): DiffReport {
+  const diff = unifiedDiff(from.code, to.code, from.id, to.id)
+  return {
+    fromVersionId: from.id,
+    lineAdds: diff.lineAdds,
+    lineDeletes: diff.lineDeletes,
+    toVersionId: to.id,
+    unifiedDiff: diff.unifiedDiff,
+  }
+}
+
+export function renderDiffText(report: DiffReport): string {
+  if (report.unifiedDiff === '') {
+    return `${report.fromVersionId} == ${report.toVersionId} (identical code)`
+  }
+
+  return `${report.unifiedDiff}\n\n+${report.lineAdds} additions, -${report.lineDeletes} deletions`
+}
+
+export default class HarnessDiff extends Command {
+  static args = {
+    from: Args.string({
+      description: 'From-version ref: raw id, "latest", "best", or "v<N>"',
+      required: true,
+    }),
+    to: Args.string({
+      description: 'To-version ref: raw id, "latest", "best", or "v<N>"',
+      required: true,
+    }),
+  }
+  static description = 'Show a unified diff between two harness versions'
+  static examples = [
+    '<%= config.bin %> <%= command.id %> v1 v2',
+    '<%= config.bin %> <%= command.id %> v-abc v-def --format json',
+    '<%= config.bin %> <%= command.id %> v2 latest',
+  ]
+  static flags = {
+    commandType: Flags.string({
+      default: 'curate',
+      description: 'Harness pair command type',
+      options: [...HARNESS_COMMAND_TYPES],
+    }),
+    format: Flags.string({
+      default: 'text',
+      description: 'Output format',
+      options: ['text', 'json'],
+    }),
+  }
+
+  async run(): Promise<void> {
+    const {args, flags} = await this.parse(HarnessDiff)
+    if (!isHarnessCommandType(flags.commandType)) {
+      this.error(`invalid --commandType value '${flags.commandType}'`, {exit: 1})
+    }
+
+    const {commandType} = flags
+    const format = flags.format === 'json' ? 'json' : 'text'
+
+    const projectRoot = resolveProject()?.projectRoot ?? process.cwd()
+    const opened = await openHarnessStoreForProject(projectRoot)
+    if (opened === undefined) {
+      this.error(
+        `no harness storage for this project (${projectRoot}) — run curate once to bootstrap.`,
+        {exit: 1},
+      )
+    }
+
+    try {
+      const [fromRes, toRes] = await Promise.all([
+        resolveVersionRef(args.from, opened.projectId, commandType, opened.store),
+        resolveVersionRef(args.to, opened.projectId, commandType, opened.store),
+      ])
+      const report = buildDiffReport(fromRes.version, toRes.version)
+
+      if (format === 'json') {
+        this.log(JSON.stringify(report, null, 2))
+      } else {
+        this.log(renderDiffText(report))
+      }
+    } catch (error) {
+      if (error instanceof VersionRefError) {
+        this.error(error.message, {exit: 1})
+      }
+
+      throw error
+    } finally {
+      opened.close()
+    }
+  }
+}

--- a/src/oclif/commands/harness/use.ts
+++ b/src/oclif/commands/harness/use.ts
@@ -1,0 +1,171 @@
+/**
+ * `brv harness use <version-ref>` — AutoHarness V2 Phase 7 Task 7.2.
+ *
+ * Pins a specific harness version as the one the sandbox loads,
+ * overriding the default `getLatest` behaviour. Closes brutal-review
+ * item Tier 2 D2 (manual rollback without disabling the whole
+ * feature).
+ *
+ * Exits `1` on unresolvable refs per handoff §C1. JSON shape is
+ * pinned to §C2's `use` entry.
+ */
+
+import {Args, Command, Flags} from '@oclif/core'
+
+import type {HarnessVersion} from '../../../agent/core/domain/harness/types.js'
+import type {IHarnessStore} from '../../../agent/core/interfaces/i-harness-store.js'
+
+import {selectHarnessMode} from '../../../agent/infra/harness/harness-mode-selector.js'
+import {resolveProject} from '../../../server/infra/project/resolve-project.js'
+import {
+  HARNESS_COMMAND_TYPES,
+  type HarnessCommandType,
+  isHarnessCommandType,
+  openHarnessStoreForProject,
+} from '../../lib/harness-cli.js'
+import {resolveVersionRef, VersionRefError} from '../../lib/resolve-version-ref.js'
+
+export interface UseReport {
+  readonly newMode: 'assisted' | 'filter' | 'policy' | null
+  readonly pinnedVersionId: string
+  readonly previousVersionId: null | string
+}
+
+export interface UseInputs {
+  readonly commandType: HarnessCommandType
+  readonly pinnedVersion: HarnessVersion
+  readonly previousVersionId: null | string
+  readonly projectId: string
+  readonly store: IHarnessStore
+}
+
+/**
+ * Pin `pinnedVersion` for `(projectId, commandType)` and compute the
+ * resulting mode from the pinned version's stored H.
+ *
+ * Mode derivation mirrors the sandbox's own `selectHarnessMode` call
+ * (same thresholds, same override behavior). The stored H is used
+ * as-is rather than recomputing from recent outcomes — the user's
+ * explicit choice of version beats whatever the heuristic would say
+ * today, which is the whole point of pinning.
+ */
+export async function applyPin(inputs: UseInputs): Promise<UseReport> {
+  const {commandType, pinnedVersion, previousVersionId, projectId, store} = inputs
+
+  await store.setPin({
+    commandType,
+    pinnedAt: Date.now(),
+    pinnedVersionId: pinnedVersion.id,
+    projectId,
+  })
+
+  const modeSelection = selectHarnessMode(pinnedVersion.heuristic, {
+    autoLearn: true,
+    enabled: true,
+    language: 'auto',
+    maxVersions: 20,
+  })
+
+  return {
+    newMode: modeSelection?.mode ?? null,
+    pinnedVersionId: pinnedVersion.id,
+    previousVersionId,
+  }
+}
+
+export function renderUseText(report: UseReport): string {
+  const prev = report.previousVersionId ?? '<none>'
+  const mode = report.newMode ?? 'below Mode A floor'
+  return [
+    `pinned: ${report.pinnedVersionId}`,
+    `was:    ${prev}`,
+    `mode:   ${mode}`,
+    '',
+    'next session: harness.* will load the pinned version.',
+    'drop the pin with `brv harness use latest`.',
+  ].join('\n')
+}
+
+export default class HarnessUse extends Command {
+  static args = {
+    versionRef: Args.string({
+      description: 'Version to pin: raw id, "latest", "best", or "v<N>"',
+      required: true,
+    }),
+  }
+  static description = 'Pin a specific harness version (manual rollback path)'
+  static examples = [
+    '<%= config.bin %> <%= command.id %> v3',
+    '<%= config.bin %> <%= command.id %> v-abc123 --commandType query',
+    '<%= config.bin %> <%= command.id %> latest --format json',
+  ]
+  static flags = {
+    commandType: Flags.string({
+      default: 'curate',
+      description: 'Harness pair command type',
+      options: [...HARNESS_COMMAND_TYPES],
+    }),
+    format: Flags.string({
+      default: 'text',
+      description: 'Output format',
+      options: ['text', 'json'],
+    }),
+  }
+
+  async run(): Promise<void> {
+    const {args, flags} = await this.parse(HarnessUse)
+    if (!isHarnessCommandType(flags.commandType)) {
+      this.error(`invalid --commandType value '${flags.commandType}'`, {exit: 1})
+    }
+
+    const {commandType} = flags
+    const format = flags.format === 'json' ? 'json' : 'text'
+
+    const projectRoot = resolveProject()?.projectRoot ?? process.cwd()
+    const opened = await openHarnessStoreForProject(projectRoot)
+    if (opened === undefined) {
+      this.error(
+        `no harness storage for this project (${projectRoot}) — run curate once to bootstrap.`,
+        {exit: 1},
+      )
+    }
+
+    try {
+      // Capture the previous pin-or-latest as `previousVersionId` so
+      // the caller sees the rollback transition explicitly.
+      const [existingPin, latest] = await Promise.all([
+        opened.store.getPin(opened.projectId, commandType),
+        opened.store.getLatest(opened.projectId, commandType),
+      ])
+      const previousVersionId = existingPin?.pinnedVersionId ?? latest?.id ?? null
+
+      const resolution = await resolveVersionRef(
+        args.versionRef,
+        opened.projectId,
+        commandType,
+        opened.store,
+      )
+      const report = await applyPin({
+        commandType,
+        pinnedVersion: resolution.version,
+        previousVersionId,
+        projectId: opened.projectId,
+        store: opened.store,
+      })
+
+      if (format === 'json') {
+        this.log(JSON.stringify(report, null, 2))
+      } else {
+        this.log(renderUseText(report))
+      }
+    } catch (error) {
+      if (error instanceof VersionRefError) {
+        this.error(error.message, {exit: 1})
+      }
+
+      throw error
+    } finally {
+      opened.close()
+    }
+  }
+}

--- a/src/oclif/commands/harness/use.ts
+++ b/src/oclif/commands/harness/use.ts
@@ -59,6 +59,14 @@ export async function applyPin(inputs: UseInputs): Promise<UseReport> {
     projectId,
   })
 
+  // `selectHarnessMode` only reads `modeOverride` off the config — the
+  // other fields (`autoLearn`, `enabled`, `language`, `maxVersions`)
+  // are required by the schema but ignored by the selector. Hardcoding
+  // them to schema defaults keeps the CLI honest about what it can
+  // honour: v1.0 doesn't plumb `modeOverride` into `HarnessFeatureConfig`,
+  // so reporting a `newMode` that disagrees with a user-pinned override
+  // is a known gap. When 7.4 / daemon-side wiring surfaces
+  // `modeOverride` to the CLI, thread it through here.
   const modeSelection = selectHarnessMode(pinnedVersion.heuristic, {
     autoLearn: true,
     enabled: true,
@@ -82,7 +90,7 @@ export function renderUseText(report: UseReport): string {
     `mode:   ${mode}`,
     '',
     'next session: harness.* will load the pinned version.',
-    'drop the pin with `brv harness use latest`.',
+    'to replace this pin, run `brv harness use <other-ref>`.',
   ].join('\n')
 }
 

--- a/src/oclif/lib/unified-diff.ts
+++ b/src/oclif/lib/unified-diff.ts
@@ -1,0 +1,120 @@
+/**
+ * Line-oriented unified diff — inline implementation.
+ *
+ * Used by `brv harness diff` to show what the refiner changed between
+ * two harness versions. Kept inline (no new devDep) per the
+ * dependency-minimization policy: the algorithm below is a standard
+ * LCS-on-lines + emit, correct for the v1.0 use case (harness code
+ * bodies ≲ a few hundred lines, all-text, no binary).
+ *
+ * Output shape is intentionally minimal: header lines (`--- a`,
+ * `+++ b`) + line-by-line `-`/`+`/` ` markers, no hunk headers. Phase
+ * 8's smoke script asserts on `+`/`-` presence, not on `@@` hunks;
+ * adding hunk windowing is a follow-up if a renderer wants it.
+ */
+
+export interface UnifiedDiff {
+  readonly lineAdds: number
+  readonly lineDeletes: number
+  /**
+   * Unified diff as a single string, newline-separated. Empty when
+   * the inputs are identical.
+   */
+  readonly unifiedDiff: string
+}
+
+/**
+ * Produce a line-oriented unified diff for two text blobs.
+ *
+ * `fromLabel` / `toLabel` are the header tags (usually version ids)
+ * displayed on the `--- ` / `+++ ` lines. Identical inputs produce
+ * `{unifiedDiff: '', lineAdds: 0, lineDeletes: 0}`.
+ */
+export function unifiedDiff(
+  from: string,
+  to: string,
+  fromLabel = 'from',
+  toLabel = 'to',
+): UnifiedDiff {
+  if (from === to) {
+    return {lineAdds: 0, lineDeletes: 0, unifiedDiff: ''}
+  }
+
+  const fromLines = splitLines(from)
+  const toLines = splitLines(to)
+  const edits = diffLines(fromLines, toLines)
+
+  let lineAdds = 0
+  let lineDeletes = 0
+  const out: string[] = [`--- ${fromLabel}`, `+++ ${toLabel}`]
+
+  for (const edit of edits) {
+    if (edit.kind === 'add') {
+      out.push(`+${edit.line}`)
+      lineAdds++
+    } else if (edit.kind === 'delete') {
+      out.push(`-${edit.line}`)
+      lineDeletes++
+    } else {
+      out.push(` ${edit.line}`)
+    }
+  }
+
+  return {lineAdds, lineDeletes, unifiedDiff: out.join('\n')}
+}
+
+interface Edit {
+  readonly kind: 'add' | 'delete' | 'keep'
+  readonly line: string
+}
+
+/**
+ * Classic O(n·m) LCS DP, then reconstruct the edit script. v1.0-safe
+ * for inputs under a few thousand lines — harness bodies are tiny.
+ * Revisit with Myers if we ever diff full module files.
+ */
+function diffLines(a: readonly string[], b: readonly string[]): Edit[] {
+  const n = a.length
+  const m = b.length
+  // dp[i][j] = length of LCS of a[0..i-1] and b[0..j-1]
+  const dp: number[][] = Array.from({length: n + 1}, () => Array.from({length: m + 1}, () => 0))
+  for (let i = 1; i <= n; i++) {
+    for (let j = 1; j <= m; j++) {
+      dp[i][j] = a[i - 1] === b[j - 1] ? dp[i - 1][j - 1] + 1 : Math.max(dp[i - 1][j], dp[i][j - 1])
+    }
+  }
+
+  const edits: Edit[] = []
+  let i = n
+  let j = m
+  while (i > 0 && j > 0) {
+    if (a[i - 1] === b[j - 1]) {
+      edits.push({kind: 'keep', line: a[i - 1]})
+      i--
+      j--
+    } else if (dp[i - 1][j] >= dp[i][j - 1]) {
+      edits.push({kind: 'delete', line: a[i - 1]})
+      i--
+    } else {
+      edits.push({kind: 'add', line: b[j - 1]})
+      j--
+    }
+  }
+
+  while (i > 0) {
+    edits.push({kind: 'delete', line: a[i - 1]})
+    i--
+  }
+
+  while (j > 0) {
+    edits.push({kind: 'add', line: b[j - 1]})
+    j--
+  }
+
+  return edits.reverse()
+}
+
+function splitLines(s: string): string[] {
+  if (s === '') return []
+  return s.split('\n')
+}

--- a/src/oclif/lib/unified-diff.ts
+++ b/src/oclif/lib/unified-diff.ts
@@ -114,7 +114,16 @@ function diffLines(a: readonly string[], b: readonly string[]): Edit[] {
   return edits.reverse()
 }
 
+/**
+ * Normalise trailing-newline divergence before splitting. A file that
+ * ends with `\n` and one that doesn't should diff only on real content
+ * changes, not on the presence of an empty string after the last line.
+ * `'a\n'.split('\n') === ['a', '']` is JavaScript's line-splitting trap;
+ * stripping one trailing newline (only when present) makes the result
+ * match the user's mental model of "lines".
+ */
 function splitLines(s: string): string[] {
   if (s === '') return []
-  return s.split('\n')
+  const trimmed = s.endsWith('\n') ? s.slice(0, -1) : s
+  return trimmed.split('\n')
 }

--- a/test/helpers/in-memory-harness-store.ts
+++ b/test/helpers/in-memory-harness-store.ts
@@ -33,6 +33,7 @@
 import type {
   CodeExecOutcome,
   EvaluationScenario,
+  HarnessPin,
   HarnessVersion,
 } from '../../src/agent/core/domain/harness/types.js'
 import type {IHarnessStore} from '../../src/agent/core/interfaces/i-harness-store.js'
@@ -51,6 +52,7 @@ function compositeKey(projectId: string, commandType: string, versionId: string)
 
 export class InMemoryHarnessStore implements IHarnessStore {
   private outcomes = new Map<string, CodeExecOutcome>()
+  private pins = new Map<string, HarnessPin>()
   private scenarios = new Map<string, EvaluationScenario>()
   private versions = new Map<string, HarnessVersion>()
 
@@ -95,6 +97,14 @@ export class InMemoryHarnessStore implements IHarnessStore {
     }
 
     return structuredClone(latest)
+  }
+
+  async getPin(
+    projectId: string,
+    commandType: string,
+  ): Promise<HarnessPin | undefined> {
+    const hit = this.pins.get(partitionKey(projectId, commandType))
+    return hit ? structuredClone(hit) : undefined
   }
 
   async getVersion(
@@ -201,6 +211,10 @@ export class InMemoryHarnessStore implements IHarnessStore {
     }
 
     this.versions.set(key, structuredClone(version))
+  }
+
+  async setPin(pin: HarnessPin): Promise<void> {
+    this.pins.set(partitionKey(pin.projectId, pin.commandType), structuredClone(pin))
   }
 
   private versionsForPartition(projectId: string, commandType: string): HarnessVersion[] {

--- a/test/unit/agent/harness/harness-baseline-runner.test.ts
+++ b/test/unit/agent/harness/harness-baseline-runner.test.ts
@@ -76,6 +76,7 @@ function makeStoreStub(sb: SinonSandbox): {
     deleteOutcomes: sb.stub(),
     deleteScenario: sb.stub(),
     getLatest,
+    getPin: sb.stub(),
     getVersion: sb.stub(),
     listOutcomes: sb.stub(),
     listScenarios,
@@ -85,6 +86,7 @@ function makeStoreStub(sb: SinonSandbox): {
     saveOutcome: sb.stub(),
     saveScenario: sb.stub(),
     saveVersion: sb.stub(),
+    setPin: sb.stub(),
   } satisfies IHarnessStore
 
   return {getLatest, listScenarios, store}

--- a/test/unit/agent/harness/harness-bootstrap.test.ts
+++ b/test/unit/agent/harness/harness-bootstrap.test.ts
@@ -41,6 +41,7 @@ function makeStoreStub(sb: SinonSandbox): {
     deleteOutcomes: sb.stub(),
     deleteScenario: sb.stub(),
     getLatest,
+    getPin: sb.stub(),
     getVersion: sb.stub(),
     listOutcomes: sb.stub(),
     listScenarios: sb.stub(),
@@ -50,6 +51,7 @@ function makeStoreStub(sb: SinonSandbox): {
     saveOutcome: sb.stub(),
     saveScenario: sb.stub(),
     saveVersion,
+    setPin: sb.stub(),
   } satisfies IHarnessStore
 
   return {getLatest, saveVersion, store}

--- a/test/unit/agent/harness/harness-evaluator.test.ts
+++ b/test/unit/agent/harness/harness-evaluator.test.ts
@@ -190,6 +190,7 @@ function makeStoreStub(sb: SinonSandbox): {
     deleteOutcomes: sb.stub(),
     deleteScenario: sb.stub(),
     getLatest: sb.stub(),
+    getPin: sb.stub(),
     getVersion: sb.stub(),
     listOutcomes,
     listScenarios: sb.stub(),
@@ -199,6 +200,7 @@ function makeStoreStub(sb: SinonSandbox): {
     saveOutcome: sb.stub(),
     saveScenario: sb.stub(),
     saveVersion: sb.stub(),
+    setPin: sb.stub(),
   } satisfies IHarnessStore
 
   return {listOutcomes, store}

--- a/test/unit/agent/harness/harness-store-pin.test.ts
+++ b/test/unit/agent/harness/harness-store-pin.test.ts
@@ -1,0 +1,69 @@
+/**
+ * HarnessStore pin persistence — Phase 7 Task 7.2 addition.
+ *
+ * Uses the real HarnessStore against an in-memory FileKeyStorage so
+ * the key layout (`harness:pin:<projectId>:<commandType>`) and
+ * Zod-validated envelope stay bound to the production path, not a
+ * test double.
+ */
+
+import {expect} from 'chai'
+
+import type {HarnessPin} from '../../../../src/agent/core/domain/harness/types.js'
+
+import {NoOpLogger} from '../../../../src/agent/core/interfaces/i-logger.js'
+import {HarnessStore} from '../../../../src/agent/infra/harness/harness-store.js'
+import {FileKeyStorage} from '../../../../src/agent/infra/storage/file-key-storage.js'
+
+async function makeStore(): Promise<HarnessStore> {
+  const keyStorage = new FileKeyStorage({inMemory: true})
+  await keyStorage.initialize()
+  return new HarnessStore(keyStorage, new NoOpLogger())
+}
+
+function makePin(overrides: Partial<HarnessPin> = {}): HarnessPin {
+  return {
+    commandType: 'curate',
+    pinnedAt: 1_700_000_000_000,
+    pinnedVersionId: 'v-abc',
+    projectId: 'fixture-proj',
+    ...overrides,
+  }
+}
+
+describe('HarnessStore pin persistence', () => {
+  it('1. getPin returns undefined when no pin has been written', async () => {
+    const store = await makeStore()
+    const pin = await store.getPin('fixture-proj', 'curate')
+    expect(pin).to.equal(undefined)
+  })
+
+  it('2. setPin then getPin round-trips the pin record', async () => {
+    const store = await makeStore()
+    const pin = makePin()
+    await store.setPin(pin)
+    const got = await store.getPin('fixture-proj', 'curate')
+    expect(got).to.deep.equal(pin)
+  })
+
+  it('3. setPin is an idempotent overwrite (one pin per pair)', async () => {
+    const store = await makeStore()
+    await store.setPin(makePin({pinnedVersionId: 'v-old'}))
+    await store.setPin(makePin({pinnedVersionId: 'v-new'}))
+    const got = await store.getPin('fixture-proj', 'curate')
+    expect(got?.pinnedVersionId).to.equal('v-new')
+  })
+
+  it('4. pins are partitioned by (projectId, commandType)', async () => {
+    const store = await makeStore()
+    await store.setPin(makePin({commandType: 'curate', pinnedVersionId: 'v-c'}))
+    await store.setPin(makePin({commandType: 'query', pinnedVersionId: 'v-q'}))
+    await store.setPin(
+      makePin({commandType: 'curate', pinnedVersionId: 'v-other', projectId: 'other-proj'}),
+    )
+
+    expect((await store.getPin('fixture-proj', 'curate'))?.pinnedVersionId).to.equal('v-c')
+    expect((await store.getPin('fixture-proj', 'query'))?.pinnedVersionId).to.equal('v-q')
+    expect((await store.getPin('other-proj', 'curate'))?.pinnedVersionId).to.equal('v-other')
+  })
+})

--- a/test/unit/infra/sandbox/sandbox-service-harness-load.test.ts
+++ b/test/unit/infra/sandbox/sandbox-service-harness-load.test.ts
@@ -55,13 +55,22 @@ function makeEnabledConfig(overrides: Partial<ValidatedHarnessConfig> = {}): Val
 describe('SandboxService.loadHarness', () => {
   let sandbox: SinonSandbox
   let service: SandboxService
-  let store: Partial<IHarnessStore> & {getLatest: SinonStub}
+  let store: Partial<IHarnessStore> & {
+    getLatest: SinonStub
+    getPin: SinonStub
+    getVersion: SinonStub
+  }
   let builder: Partial<HarnessModuleBuilder> & {build: SinonStub}
 
   beforeEach(() => {
     sandbox = createSandbox()
     service = new SandboxService()
-    store = {getLatest: sandbox.stub().resolves()}
+    // Default: no pin, no version. Individual tests override.
+    store = {
+      getLatest: sandbox.stub().resolves(),
+      getPin: sandbox.stub().resolves(),
+      getVersion: sandbox.stub().resolves(),
+    }
     builder = {build: sandbox.stub().returns({loaded: false, reason: 'syntax'})}
   })
 
@@ -240,5 +249,82 @@ describe('SandboxService.loadHarness', () => {
       harnessVersionIdBySession: Map<string, string>
     }
     expect(internal.harnessVersionIdBySession.get('s1')).to.equal('v-abc')
+  })
+
+  // ── Phase 7 Task 7.2: pin-first resolution ───────────────────────────────
+
+  it('consults the pin BEFORE getLatest and injects the pinned version when present', async () => {
+    service.setHarnessConfig(makeEnabledConfig())
+    service.setHarnessStore(store as unknown as IHarnessStore)
+    service.setHarnessModuleBuilder(builder as unknown as HarnessModuleBuilder)
+
+    const pinnedVersion = makeVersion({id: 'v-pinned'})
+    const latestVersion = makeVersion({id: 'v-latest', version: 2})
+    store.getPin.resolves({
+      commandType: 'curate',
+      pinnedAt: 1_700_000_000_000,
+      pinnedVersionId: 'v-pinned',
+      projectId: 'p1',
+    })
+    store.getVersion.resolves(pinnedVersion)
+    store.getLatest.resolves(latestVersion)
+    builder.build.returns({loaded: true, module: {meta: () => pinnedVersion.metadata}, version: pinnedVersion})
+
+    const result = await service.loadHarness('s1', 'p1', 'curate')
+
+    expect(result.loaded).to.equal(true)
+    // Pin wins: builder saw the pinned version, not the latest.
+    const built = builder.build.firstCall.args[0] as HarnessVersion
+    expect(built.id).to.equal('v-pinned')
+    // `getLatest` is NOT called when the pin resolves to a live version.
+    expect(store.getLatest.called).to.equal(false)
+  })
+
+  it('falls back to getLatest when the pinned version has been pruned', async () => {
+    service.setHarnessConfig(makeEnabledConfig())
+    service.setHarnessStore(store as unknown as IHarnessStore)
+    service.setHarnessModuleBuilder(builder as unknown as HarnessModuleBuilder)
+
+    const latestVersion = makeVersion({id: 'v-latest', version: 5})
+    store.getPin.resolves({
+      commandType: 'curate',
+      pinnedAt: 1_700_000_000_000,
+      pinnedVersionId: 'v-pruned',
+      projectId: 'p1',
+    })
+    // Pinned id no longer exists — retention policy dropped it.
+    store.getVersion.resolves()
+    store.getLatest.resolves(latestVersion)
+    builder.build.returns({
+      loaded: true,
+      module: {meta: () => latestVersion.metadata},
+      version: latestVersion,
+    })
+
+    const result = await service.loadHarness('s1', 'p1', 'curate')
+
+    expect(result.loaded).to.equal(true)
+    // Broken-pin path: getVersion was attempted (hit undefined), then
+    // getLatest ran and its value drove the build call.
+    expect(store.getVersion.calledOnceWith('p1', 'curate', 'v-pruned')).to.equal(true)
+    expect(store.getLatest.calledOnceWith('p1', 'curate')).to.equal(true)
+    const built = builder.build.firstCall.args[0] as HarnessVersion
+    expect(built.id).to.equal('v-latest')
+  })
+
+  it('skips the pin path entirely when no pin is set', async () => {
+    service.setHarnessConfig(makeEnabledConfig())
+    service.setHarnessStore(store as unknown as IHarnessStore)
+    service.setHarnessModuleBuilder(builder as unknown as HarnessModuleBuilder)
+
+    // getPin default stub resolves to undefined — no pin.
+    store.getLatest.resolves(makeVersion())
+    builder.build.returns({loaded: false, reason: 'syntax'})
+
+    await service.loadHarness('s1', 'p1', 'curate')
+
+    // `getVersion` is never called when the pin is absent.
+    expect(store.getVersion.called).to.equal(false)
+    expect(store.getLatest.calledOnceWith('p1', 'curate')).to.equal(true)
   })
 })

--- a/test/unit/oclif/commands/harness/diff.test.ts
+++ b/test/unit/oclif/commands/harness/diff.test.ts
@@ -1,0 +1,88 @@
+import {expect} from 'chai'
+
+import type {HarnessVersion} from '../../../../../src/agent/core/domain/harness/types.js'
+
+import {
+  buildDiffReport,
+  renderDiffText,
+} from '../../../../../src/oclif/commands/harness/diff.js'
+
+function makeVersion(overrides: Partial<HarnessVersion> = {}): HarnessVersion {
+  return {
+    code: 'exports.curate = async () => {}',
+    commandType: 'curate',
+    createdAt: 1_700_000_000_000,
+    heuristic: 0.5,
+    id: 'v-default',
+    metadata: {
+      capabilities: ['curate'],
+      commandType: 'curate',
+      projectPatterns: ['**/*'],
+      version: 1,
+    },
+    projectId: '/fixture/proj',
+    projectType: 'typescript',
+    version: 1,
+    ...overrides,
+  }
+}
+
+describe('HarnessDiff command — buildDiffReport + renderDiffText', () => {
+  describe('buildDiffReport', () => {
+    it('1. identical code → empty unifiedDiff + zero adds/deletes', () => {
+      const v = makeVersion()
+      const report = buildDiffReport(v, {...v, id: 'v-copy'})
+      expect(report.fromVersionId).to.equal('v-default')
+      expect(report.toVersionId).to.equal('v-copy')
+      expect(report.unifiedDiff).to.equal('')
+      expect(report.lineAdds).to.equal(0)
+      expect(report.lineDeletes).to.equal(0)
+    })
+
+    it('2. line-level change produces +/- markers and accurate counts', () => {
+      const from = makeVersion({code: 'line1\nline2-old\nline3', id: 'v-a'})
+      const to = makeVersion({code: 'line1\nline2-new\nline3', id: 'v-b'})
+      const report = buildDiffReport(from, to)
+      expect(report.lineAdds).to.equal(1)
+      expect(report.lineDeletes).to.equal(1)
+      expect(report.unifiedDiff).to.include('-line2-old')
+      expect(report.unifiedDiff).to.include('+line2-new')
+      expect(report.unifiedDiff).to.include('--- v-a')
+      expect(report.unifiedDiff).to.include('+++ v-b')
+    })
+
+    it('3. pure insertion reports lineAdds > 0 and lineDeletes == 0', () => {
+      const from = makeVersion({code: 'a', id: 'v-a'})
+      const to = makeVersion({code: 'a\nb\nc', id: 'v-b'})
+      const report = buildDiffReport(from, to)
+      expect(report.lineAdds).to.equal(2)
+      expect(report.lineDeletes).to.equal(0)
+    })
+  })
+
+  describe('renderDiffText', () => {
+    it('1. identical versions render as a single informative line', () => {
+      const text = renderDiffText({
+        fromVersionId: 'v-a',
+        lineAdds: 0,
+        lineDeletes: 0,
+        toVersionId: 'v-b',
+        unifiedDiff: '',
+      })
+      expect(text).to.include('v-a == v-b')
+      expect(text).to.include('identical')
+    })
+
+    it('2. non-empty diff trails with +N additions / -M deletions summary', () => {
+      const text = renderDiffText({
+        fromVersionId: 'v-a',
+        lineAdds: 3,
+        lineDeletes: 2,
+        toVersionId: 'v-b',
+        unifiedDiff: '--- v-a\n+++ v-b\n-x\n+y',
+      })
+      expect(text).to.include('--- v-a')
+      expect(text).to.include('+3 additions, -2 deletions')
+    })
+  })
+})

--- a/test/unit/oclif/commands/harness/diff.test.ts
+++ b/test/unit/oclif/commands/harness/diff.test.ts
@@ -58,6 +58,16 @@ describe('HarnessDiff command — buildDiffReport + renderDiffText', () => {
       expect(report.lineAdds).to.equal(2)
       expect(report.lineDeletes).to.equal(0)
     })
+
+    it('4. pure deletion reports lineDeletes > 0 and lineAdds == 0', () => {
+      const from = makeVersion({code: 'a\nb\nc', id: 'v-a'})
+      const to = makeVersion({code: 'a', id: 'v-b'})
+      const report = buildDiffReport(from, to)
+      expect(report.lineAdds).to.equal(0)
+      expect(report.lineDeletes).to.equal(2)
+      expect(report.unifiedDiff).to.include('-b')
+      expect(report.unifiedDiff).to.include('-c')
+    })
   })
 
   describe('renderDiffText', () => {

--- a/test/unit/oclif/commands/harness/status.test.ts
+++ b/test/unit/oclif/commands/harness/status.test.ts
@@ -57,6 +57,7 @@ function makeStoreStub(sb: SinonSandbox): IHarnessStore {
     deleteOutcomes: sb.stub(),
     deleteScenario: sb.stub(),
     getLatest: sb.stub(),
+    getPin: sb.stub(),
     getVersion: sb.stub(),
     listOutcomes: sb.stub(),
     listScenarios: sb.stub(),
@@ -66,6 +67,7 @@ function makeStoreStub(sb: SinonSandbox): IHarnessStore {
     saveOutcome: sb.stub(),
     saveScenario: sb.stub(),
     saveVersion: sb.stub(),
+    setPin: sb.stub(),
   } satisfies IHarnessStore
 }
 

--- a/test/unit/oclif/commands/harness/use.test.ts
+++ b/test/unit/oclif/commands/harness/use.test.ts
@@ -138,7 +138,7 @@ describe('HarnessUse command — applyPin + renderUseText', () => {
       expect(text).to.include('pinned: v-abc')
       expect(text).to.include('was:    v-xyz')
       expect(text).to.include('mode:   filter')
-      expect(text).to.include('brv harness use latest')
+      expect(text).to.include('to replace this pin, run')
     })
 
     it('2. previousVersionId null renders as "<none>"', () => {

--- a/test/unit/oclif/commands/harness/use.test.ts
+++ b/test/unit/oclif/commands/harness/use.test.ts
@@ -1,0 +1,154 @@
+import {expect} from 'chai'
+import {createSandbox, type SinonSandbox, type SinonStub} from 'sinon'
+
+import type {HarnessVersion} from '../../../../../src/agent/core/domain/harness/types.js'
+import type {IHarnessStore} from '../../../../../src/agent/core/interfaces/i-harness-store.js'
+
+import {
+  applyPin,
+  renderUseText,
+  type UseReport,
+} from '../../../../../src/oclif/commands/harness/use.js'
+
+const PROJECT_ID = '/fixture/proj'
+
+function makeVersion(overrides: Partial<HarnessVersion> = {}): HarnessVersion {
+  return {
+    code: 'exports.curate = async () => {}',
+    commandType: 'curate',
+    createdAt: 1_700_000_000_000,
+    heuristic: 0.62,
+    id: 'v-pin-me',
+    metadata: {
+      capabilities: ['curate'],
+      commandType: 'curate',
+      projectPatterns: ['**/*'],
+      version: 1,
+    },
+    projectId: PROJECT_ID,
+    projectType: 'typescript',
+    version: 2,
+    ...overrides,
+  }
+}
+
+function makeStoreStub(sb: SinonSandbox): IHarnessStore {
+  return {
+    deleteOutcome: sb.stub(),
+    deleteOutcomes: sb.stub(),
+    deleteScenario: sb.stub(),
+    getLatest: sb.stub(),
+    getPin: sb.stub(),
+    getVersion: sb.stub(),
+    listOutcomes: sb.stub(),
+    listScenarios: sb.stub(),
+    listVersions: sb.stub(),
+    pruneOldVersions: sb.stub(),
+    recordFeedback: sb.stub(),
+    saveOutcome: sb.stub(),
+    saveScenario: sb.stub(),
+    saveVersion: sb.stub(),
+    setPin: sb.stub(),
+  } satisfies IHarnessStore
+}
+
+describe('HarnessUse command — applyPin + renderUseText', () => {
+  describe('applyPin', () => {
+    let sb: SinonSandbox
+
+    beforeEach(() => {
+      sb = createSandbox()
+    })
+
+    afterEach(() => {
+      sb.restore()
+    })
+
+    it('1. writes a HarnessPin and returns the correct mode for pinned H', async () => {
+      const store = makeStoreStub(sb)
+      const setPin = store.setPin as SinonStub
+      setPin.resolves()
+      const pinned = makeVersion({heuristic: 0.9, id: 'v-hi'})
+
+      const report = await applyPin({
+        commandType: 'curate',
+        pinnedVersion: pinned,
+        previousVersionId: 'v-old',
+        projectId: PROJECT_ID,
+        store,
+      })
+
+      expect(setPin.calledOnce).to.equal(true)
+      const pinRecord = setPin.firstCall.args[0]
+      expect(pinRecord.projectId).to.equal(PROJECT_ID)
+      expect(pinRecord.commandType).to.equal('curate')
+      expect(pinRecord.pinnedVersionId).to.equal('v-hi')
+      expect(pinRecord.pinnedAt).to.be.a('number')
+
+      // H=0.9 ≥ 0.85 floor → policy mode.
+      expect(report.newMode).to.equal('policy')
+      expect(report.pinnedVersionId).to.equal('v-hi')
+      expect(report.previousVersionId).to.equal('v-old')
+    })
+
+    it('2. mode is null when pinned H falls below Mode A floor', async () => {
+      const store = makeStoreStub(sb)
+      ;(store.setPin as SinonStub).resolves()
+      const pinned = makeVersion({heuristic: 0.2, id: 'v-low'})
+
+      const report = await applyPin({
+        commandType: 'curate',
+        pinnedVersion: pinned,
+        previousVersionId: null,
+        projectId: PROJECT_ID,
+        store,
+      })
+
+      // Mode field is still present (explicit null) per task note,
+      // so scripts can access `newMode` reliably.
+      expect(report.newMode).to.equal(null)
+      expect(report.previousVersionId).to.equal(null)
+    })
+
+    it('3. mode="filter" for H=0.65 (B floor 0.60, C floor 0.85)', async () => {
+      const store = makeStoreStub(sb)
+      ;(store.setPin as SinonStub).resolves()
+      const pinned = makeVersion({heuristic: 0.65})
+
+      const report = await applyPin({
+        commandType: 'curate',
+        pinnedVersion: pinned,
+        previousVersionId: null,
+        projectId: PROJECT_ID,
+        store,
+      })
+
+      expect(report.newMode).to.equal('filter')
+    })
+  })
+
+  describe('renderUseText', () => {
+    it('1. renders the transition with mode line', () => {
+      const report: UseReport = {
+        newMode: 'filter',
+        pinnedVersionId: 'v-abc',
+        previousVersionId: 'v-xyz',
+      }
+      const text = renderUseText(report)
+      expect(text).to.include('pinned: v-abc')
+      expect(text).to.include('was:    v-xyz')
+      expect(text).to.include('mode:   filter')
+      expect(text).to.include('brv harness use latest')
+    })
+
+    it('2. previousVersionId null renders as "<none>"', () => {
+      const text = renderUseText({
+        newMode: null,
+        pinnedVersionId: 'v-abc',
+        previousVersionId: null,
+      })
+      expect(text).to.include('was:    <none>')
+      expect(text).to.include('below Mode A floor')
+    })
+  })
+})

--- a/test/unit/oclif/lib/resolve-version-ref.test.ts
+++ b/test/unit/oclif/lib/resolve-version-ref.test.ts
@@ -38,6 +38,7 @@ function makeStoreStub(sb: SinonSandbox): IHarnessStore {
     deleteOutcomes: sb.stub(),
     deleteScenario: sb.stub(),
     getLatest: sb.stub(),
+    getPin: sb.stub(),
     getVersion: sb.stub(),
     listOutcomes: sb.stub(),
     listScenarios: sb.stub(),
@@ -47,6 +48,7 @@ function makeStoreStub(sb: SinonSandbox): IHarnessStore {
     saveOutcome: sb.stub(),
     saveScenario: sb.stub(),
     saveVersion: sb.stub(),
+    setPin: sb.stub(),
   } satisfies IHarnessStore
 }
 

--- a/test/unit/oclif/lib/unified-diff.test.ts
+++ b/test/unit/oclif/lib/unified-diff.test.ts
@@ -1,0 +1,56 @@
+import {expect} from 'chai'
+
+import {unifiedDiff} from '../../../../src/oclif/lib/unified-diff.js'
+
+describe('unifiedDiff', () => {
+  it('1. identical inputs → empty diff, zero adds/deletes', () => {
+    const result = unifiedDiff('a\nb\nc', 'a\nb\nc', 'v1', 'v2')
+    expect(result.unifiedDiff).to.equal('')
+    expect(result.lineAdds).to.equal(0)
+    expect(result.lineDeletes).to.equal(0)
+  })
+
+  it('2. pure insertion: all new lines appear with "+" markers', () => {
+    const result = unifiedDiff('', 'line-a\nline-b', 'v1', 'v2')
+    expect(result.lineAdds).to.equal(2)
+    expect(result.lineDeletes).to.equal(0)
+    expect(result.unifiedDiff).to.include('+line-a')
+    expect(result.unifiedDiff).to.include('+line-b')
+  })
+
+  it('3. pure deletion: removed lines appear with "-" markers', () => {
+    const result = unifiedDiff('gone-1\ngone-2', '', 'v1', 'v2')
+    expect(result.lineAdds).to.equal(0)
+    expect(result.lineDeletes).to.equal(2)
+    expect(result.unifiedDiff).to.include('-gone-1')
+    expect(result.unifiedDiff).to.include('-gone-2')
+  })
+
+  it('4. mixed change: kept lines get " " prefix, changed get -/+', () => {
+    const from = 'common\nold-line\nshared'
+    const to = 'common\nnew-line\nshared'
+    const result = unifiedDiff(from, to, 'v1', 'v2')
+    expect(result.lineAdds).to.equal(1)
+    expect(result.lineDeletes).to.equal(1)
+    expect(result.unifiedDiff).to.match(/^--- v1$/m)
+    expect(result.unifiedDiff).to.match(/^\+\+\+ v2$/m)
+    expect(result.unifiedDiff).to.include(' common')
+    expect(result.unifiedDiff).to.include('-old-line')
+    expect(result.unifiedDiff).to.include('+new-line')
+    expect(result.unifiedDiff).to.include(' shared')
+  })
+
+  it('5. diff header uses supplied labels', () => {
+    const result = unifiedDiff('x', 'y', 'label-a', 'label-b')
+    expect(result.unifiedDiff).to.include('--- label-a')
+    expect(result.unifiedDiff).to.include('+++ label-b')
+  })
+
+  it('6. handles single-line inputs without trailing newlines', () => {
+    const result = unifiedDiff('hello', 'world')
+    expect(result.lineAdds).to.equal(1)
+    expect(result.lineDeletes).to.equal(1)
+    expect(result.unifiedDiff).to.include('-hello')
+    expect(result.unifiedDiff).to.include('+world')
+  })
+})


### PR DESCRIPTION
## Summary

Phase 7 Task 7.2 — closes brutal-review Tier 2 D2 (manual rollback)
and D3 (unified diff), and wires pin-first resolution into the
sandbox's `loadHarness` path so the rollback surface isn't purely
cosmetic.

### Domain + store
- New `HarnessPin` type + Zod schema. Exactly one pin per
  `(projectId, commandType)`.
- `IHarnessStore.getPin` / `setPin` added (additive interface
  extension; every test stub updated).
- `HarnessStore` persists pins under `harness:pin:<pid>:<ct>`.

### Sandbox integration
- `SandboxService.loadHarness` now consults `getPin` **before**
  `getLatest`. When the pinned id has been pruned (retention
  policy), a warn-log fires and we fall back to `getLatest`
  rather than erroring — pin is a preference, not a requirement.

### CLI commands
- `brv harness use <versionRef>` — pins via the shared
  `resolveVersionRef`, reports previous-id → pinned-id
  transition, recomputes mode from pinned H per task-doc design
  note. JSON shape per handoff §C2.
- `brv harness diff <from> <to>` — resolves two refs, produces a
  line-oriented unified diff plus add/delete counts. JSON shape
  per handoff §C2.

### Shared lib
- `src/oclif/lib/unified-diff.ts` — inline LCS-on-lines diff
  (no new devDep per policy). Header (`--- / +++`) + line-level
  `-`/`+`/` ` markers; hunk windowing is a follow-up.

## Scope narrowing

The warn-log for the pruned-pin fallback is asserted indirectly via
the fallback behavior (getVersion → undefined ⇒ getLatest ran; build
saw the latest version). A direct log-capture test would need a
public `setLogger` on `SandboxService` which doesn't exist yet;
adding one is out of scope for 7.2. The behavior contract is pinned
by the fallback test.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — 0 errors (257 pre-existing warnings)
- [x] \`npm test\` — 7202 passing, 16 pending, 0 failing
- [x] \`npm run build\` — clean
- [x] 24 new unit tests across 6 files:
  - unified-diff (6): identical, pure insert, pure delete, mixed,
    label propagation, single-line
  - HarnessUse applyPin (3) + renderUseText (2): mode=policy/
    filter/null by pinned H, previousVersionId propagation
  - HarnessDiff buildDiffReport (3) + renderDiffText (2):
    identical versions, line-change, insertion, both renders
  - HarnessStore pin persistence (4): round-trip, idempotent
    overwrite, (projectId, commandType) partitioning, no-pin
  - SandboxService.loadHarness pin-path (3): pin-first, pruned
    fallback, no-pin skips the pin path

## Acceptance criteria

- [x] \`brv harness use <ref>\` pins and recomputes mode
- [x] \`brv harness diff <from> <to>\` prints a unified diff
- [x] \`HarnessPin\` persisted via new \`getPin\` / \`setPin\`
- [x] \`SandboxService.loadHarness\` consults the pin first
- [x] Pruned-pin fallback to \`getLatest\`
- [x] JSON shapes match \`phase_7_8_handoff.md §C2\`
- [x] Unit tests cover the 8 scenarios listed in the task doc