### PR TITLE
feat: [ENG-2326] session-end banner for accepted harness refinements

### DIFF
--- a/src/agent/core/domain/agent-events/types.ts
+++ b/src/agent/core/domain/agent-events/types.ts
@@ -302,8 +302,10 @@ export interface AgentEventMap {
     | {
         accepted: true
         commandType: string
+        fromHeuristic: number
         fromVersion: number
         projectId: string
+        toHeuristic: number
         toVersion: number
       }
 

--- a/src/agent/infra/harness/harness-synthesizer.ts
+++ b/src/agent/infra/harness/harness-synthesizer.ts
@@ -213,8 +213,10 @@ export class HarnessSynthesizer {
     this.eventBus.emit('harness:refinement-completed', {
       accepted: true,
       commandType: parent.commandType,
+      fromHeuristic: parent.heuristic,
       fromVersion: parent.version,
       projectId: parent.projectId,
+      toHeuristic: candidateHeuristic,
       toVersion: candidateVersion.version,
     })
 

--- a/src/agent/infra/session/harness-banner-listener.ts
+++ b/src/agent/infra/session/harness-banner-listener.ts
@@ -19,6 +19,13 @@ import type {AgentEventBus} from '../events/event-emitter.js'
 
 type AcceptedRefinement = Extract<AgentEventMap['harness:refinement-completed'], {accepted: true}>
 
+export type HarnessBannerListenerOptions = {
+  readonly eventBus: AgentEventBus
+  readonly harnessEnabled: boolean
+  readonly isTty: boolean
+  readonly writeLine: (s: string) => void
+}
+
 // ---------------------------------------------------------------------------
 // HarnessBannerListener
 // ---------------------------------------------------------------------------
@@ -36,16 +43,11 @@ export class HarnessBannerListener {
   private lastAccepted: AcceptedRefinement | undefined
   private readonly writeLine: (s: string) => void
 
-  constructor(
-    eventBus: AgentEventBus,
-    writeLine: (s: string) => void,
-    isTty: boolean,
-    harnessEnabled: boolean,
-  ) {
-    this.eventBus = eventBus
-    this.writeLine = writeLine
-    this.isTty = isTty
-    this.harnessEnabled = harnessEnabled
+  constructor(opts: HarnessBannerListenerOptions) {
+    this.eventBus = opts.eventBus
+    this.writeLine = opts.writeLine
+    this.isTty = opts.isTty
+    this.harnessEnabled = opts.harnessEnabled
     this.eventBus.on('harness:refinement-completed', this.handleEvent)
   }
 

--- a/src/agent/infra/session/harness-banner-listener.ts
+++ b/src/agent/infra/session/harness-banner-listener.ts
@@ -1,0 +1,65 @@
+/**
+ * Listens on `harness:refinement-completed` per session. Buffers
+ * accepted refinements; on session-end, prints a single banner
+ * summarising the latest accepted refinement (if any).
+ *
+ * Suppression rules:
+ *   - harnessEnabled === false → never print
+ *   - isTty === false → never print
+ *   - No accepted refinement in the session → never print
+ *   - Multiple refinements → print only the last accepted
+ */
+
+import type {AgentEventMap} from '../../core/domain/agent-events/types.js'
+import type {AgentEventBus} from '../events/event-emitter.js'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type AcceptedRefinement = Extract<AgentEventMap['harness:refinement-completed'], {accepted: true}>
+
+// ---------------------------------------------------------------------------
+// HarnessBannerListener
+// ---------------------------------------------------------------------------
+
+export class HarnessBannerListener {
+  private ended = false
+  private readonly eventBus: AgentEventBus
+  private readonly handleEvent = (event: AgentEventMap['harness:refinement-completed']): void => {
+    if (event.accepted) {
+      this.lastAccepted = event
+    }
+  }
+  private readonly harnessEnabled: boolean
+  private readonly isTty: boolean
+  private lastAccepted: AcceptedRefinement | undefined
+  private readonly writeLine: (s: string) => void
+
+  constructor(
+    eventBus: AgentEventBus,
+    writeLine: (s: string) => void,
+    isTty: boolean,
+    harnessEnabled: boolean,
+  ) {
+    this.eventBus = eventBus
+    this.writeLine = writeLine
+    this.isTty = isTty
+    this.harnessEnabled = harnessEnabled
+    this.eventBus.on('harness:refinement-completed', this.handleEvent)
+  }
+
+  /** Called by SessionManager on session end. Idempotent. */
+  onSessionEnd(): void {
+    if (this.ended) return
+    this.ended = true
+    this.eventBus.off('harness:refinement-completed', this.handleEvent)
+
+    if (!this.harnessEnabled || !this.isTty || !this.lastAccepted) return
+
+    const {fromHeuristic, fromVersion, toHeuristic, toVersion} = this.lastAccepted
+    this.writeLine(
+      `harness updated: v${fromVersion} → v${toVersion} (H: ${fromHeuristic.toFixed(2)} → ${toHeuristic.toFixed(2)})\n`,
+    )
+  }
+}

--- a/src/agent/infra/session/session-manager.ts
+++ b/src/agent/infra/session/session-manager.ts
@@ -416,7 +416,10 @@ export class SessionManager {
     // Remove from memory only - history remains in storage
     const ended = this.sessions.delete(id)
     if (ended) {
-      // Print harness banner before refinement trigger fires
+      // End the banner listener (prints any refinement captured during this
+      // session's lifetime from concurrently-running synthesizers). Must happen
+      // before triggering THIS session's refinement, which fires async — those
+      // events land after this listener has already unsubscribed.
       this.endBannerListener(id)
 
       // Fire harness refinement trigger (fire-and-forget)
@@ -570,7 +573,7 @@ export class SessionManager {
     const isTty = this.bannerOverrides?.isTty ?? (process.stderr.isTTY ?? false)
     const harnessEnabled = this.sharedServices.harnessConfig?.enabled ?? false
 
-    const listener = new HarnessBannerListener(agentBus, writeLine, isTty, harnessEnabled)
+    const listener = new HarnessBannerListener({eventBus: agentBus, harnessEnabled, isTty, writeLine})
     this.bannerListeners.set(sessionId, listener)
   }
 

--- a/src/agent/infra/session/session-manager.ts
+++ b/src/agent/infra/session/session-manager.ts
@@ -11,6 +11,7 @@ import {PolicyEngine} from '../tools/policy-engine.js'
 import {ToolManager} from '../tools/tool-manager.js'
 import {ToolProvider} from '../tools/tool-provider.js'
 import {ChatSession} from './chat-session.js'
+import {HarnessBannerListener} from './harness-banner-listener.js'
 import {generateSessionTitle} from './title-generator.js'
 
 /**
@@ -47,6 +48,11 @@ export interface SessionMetadata {
 export type SessionRemovalReason = 'deleted' | 'ended' | 'ttl_expired'
 
 export interface SessionManagerOptions {
+  /** Override banner writeLine + TTY detection for testing. */
+  bannerOverrides?: {
+    isTty?: boolean
+    writeLine?: (s: string) => void
+  }
   config?: SessionManagerConfig
   /**
    * Optional lifecycle callback fired after a session is removed from memory maps.
@@ -65,6 +71,8 @@ export interface SessionManagerOptions {
 export class SessionManager {
   /** Grace window before a session's dedup entry expires (ms). */
   private static readonly ENDED_SESSION_GRACE_MS = 60_000
+  private readonly bannerListeners = new Map<string, HarnessBannerListener>()
+  private readonly bannerOverrides?: {isTty?: boolean; writeLine?: (s: string) => void}
   private cleanupTimer?: ReturnType<typeof setInterval>
   private readonly config: Required<SessionManagerConfig>
   private readonly endedSessions = new Set<string>()
@@ -138,6 +146,7 @@ export class SessionManager {
     this.sharedServices = sharedServices
     this.httpConfig = httpConfig
     this.llmConfig = llmConfig
+    this.bannerOverrides = options?.bannerOverrides
     this.onSessionRemoved = options?.onSessionRemoved
     this.config = {
       maxSessions: options?.config?.maxSessions ?? 100,
@@ -326,6 +335,8 @@ export class SessionManager {
     // Remove from memory
     const deleted = this.sessions.delete(id)
     if (deleted) {
+      this.endBannerListener(id)
+
       try {
         this.onSessionRemoved?.(id, 'deleted')
       } catch {
@@ -357,6 +368,13 @@ export class SessionManager {
 
     this.sessions.clear()
     this.endedSessions.clear()
+
+    // Clean up banner listeners (unsubscribe from agent event bus)
+    for (const listener of this.bannerListeners.values()) {
+      listener.onSessionEnd()
+    }
+
+    this.bannerListeners.clear()
 
     // Clear all metadata maps
     this.sessionCreatedAt.clear()
@@ -398,6 +416,9 @@ export class SessionManager {
     // Remove from memory only - history remains in storage
     const ended = this.sessions.delete(id)
     if (ended) {
+      // Print harness banner before refinement trigger fires
+      this.endBannerListener(id)
+
       // Fire harness refinement trigger (fire-and-forget)
       this.triggerHarnessRefinement(id)
 
@@ -537,6 +558,23 @@ export class SessionManager {
   }
 
   /**
+   * Create a HarnessBannerListener for a session. Subscribes to the
+   * agent-level refinement-completed event; `endBannerListener`
+   * unsubscribes and prints the banner on session end.
+   */
+  private createBannerListener(sessionId: string): void {
+    const agentBus = this.sharedServices.agentEventBus
+    if (!agentBus) return
+
+    const writeLine = this.bannerOverrides?.writeLine ?? ((s: string) => process.stderr.write(s))
+    const isTty = this.bannerOverrides?.isTty ?? (process.stderr.isTTY ?? false)
+    const harnessEnabled = this.sharedServices.harnessConfig?.enabled ?? false
+
+    const listener = new HarnessBannerListener(agentBus, writeLine, isTty, harnessEnabled)
+    this.bannerListeners.set(sessionId, listener)
+  }
+
+  /**
    * Internal session creation logic.
    *
    * @param id - Session ID
@@ -562,6 +600,7 @@ export class SessionManager {
     this.sessionLastActivity.set(id, now)
 
     this.sessions.set(id, session)
+    this.createBannerListener(id)
     return session
   }
 
@@ -633,7 +672,19 @@ export class SessionManager {
     this.sessionLastActivity.set(id, now)
 
     this.sessions.set(id, session)
+    this.createBannerListener(id)
     return session
+  }
+
+  /**
+   * End the banner listener for a session — prints banner if applicable
+   * and unsubscribes from the agent event bus.
+   */
+  private endBannerListener(sessionId: string): void {
+    const listener = this.bannerListeners.get(sessionId)
+    if (!listener) return
+    listener.onSessionEnd()
+    this.bannerListeners.delete(sessionId)
   }
 
   /**

--- a/test/unit/agent/session/harness-banner-listener.test.ts
+++ b/test/unit/agent/session/harness-banner-listener.test.ts
@@ -42,6 +42,18 @@ function makeRejectedEvent(overrides: {
   }
 }
 
+function makeListener(eventBus: AgentEventBus, writeLine: sinon.SinonStub, opts?: {
+  harnessEnabled?: boolean
+  isTty?: boolean
+}) {
+  return new HarnessBannerListener({
+    eventBus,
+    harnessEnabled: opts?.harnessEnabled ?? true,
+    isTty: opts?.isTty ?? true,
+    writeLine,
+  })
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -51,11 +63,10 @@ describe('HarnessBannerListener', () => {
     sinon.restore()
   })
 
-  // Test 1: Accepted refinement + TTY + enabled → banner prints
   it('prints banner when accepted refinement fires with TTY and enabled', () => {
     const eventBus = new AgentEventBus()
     const writeLine = sinon.stub()
-    const listener = new HarnessBannerListener(eventBus, writeLine, true, true)
+    const listener = makeListener(eventBus, writeLine)
 
     eventBus.emit('harness:refinement-completed', makeAcceptedEvent())
     listener.onSessionEnd()
@@ -64,11 +75,10 @@ describe('HarnessBannerListener', () => {
     expect(writeLine.firstCall.args[0]).to.include('harness updated')
   })
 
-  // Test 2: Accepted refinement + TTY + disabled → no print
   it('does not print when harness is disabled', () => {
     const eventBus = new AgentEventBus()
     const writeLine = sinon.stub()
-    const listener = new HarnessBannerListener(eventBus, writeLine, true, false)
+    const listener = makeListener(eventBus, writeLine, {harnessEnabled: false})
 
     eventBus.emit('harness:refinement-completed', makeAcceptedEvent())
     listener.onSessionEnd()
@@ -76,11 +86,10 @@ describe('HarnessBannerListener', () => {
     expect(writeLine.callCount).to.equal(0)
   })
 
-  // Test 3: Accepted refinement + not TTY → no print
   it('does not print when not a TTY', () => {
     const eventBus = new AgentEventBus()
     const writeLine = sinon.stub()
-    const listener = new HarnessBannerListener(eventBus, writeLine, false, true)
+    const listener = makeListener(eventBus, writeLine, {isTty: false})
 
     eventBus.emit('harness:refinement-completed', makeAcceptedEvent())
     listener.onSessionEnd()
@@ -88,11 +97,10 @@ describe('HarnessBannerListener', () => {
     expect(writeLine.callCount).to.equal(0)
   })
 
-  // Test 4: Rejected refinement → no print
   it('does not print for rejected refinements', () => {
     const eventBus = new AgentEventBus()
     const writeLine = sinon.stub()
-    const listener = new HarnessBannerListener(eventBus, writeLine, true, true)
+    const listener = makeListener(eventBus, writeLine)
 
     eventBus.emit('harness:refinement-completed', makeRejectedEvent())
     listener.onSessionEnd()
@@ -100,11 +108,10 @@ describe('HarnessBannerListener', () => {
     expect(writeLine.callCount).to.equal(0)
   })
 
-  // Test 5: Multiple accepteds → only last one prints
   it('prints only the last accepted refinement when multiple fire', () => {
     const eventBus = new AgentEventBus()
     const writeLine = sinon.stub()
-    const listener = new HarnessBannerListener(eventBus, writeLine, true, true)
+    const listener = makeListener(eventBus, writeLine)
 
     eventBus.emit('harness:refinement-completed', makeAcceptedEvent({
       fromHeuristic: 0.4,
@@ -128,22 +135,20 @@ describe('HarnessBannerListener', () => {
     expect(output).to.not.include('v1')
   })
 
-  // Test 6: Zero refinements → no print
   it('does not print when no refinements occurred', () => {
     const eventBus = new AgentEventBus()
     const writeLine = sinon.stub()
-    const listener = new HarnessBannerListener(eventBus, writeLine, true, true)
+    const listener = makeListener(eventBus, writeLine)
 
     listener.onSessionEnd()
 
     expect(writeLine.callCount).to.equal(0)
   })
 
-  // Test 7: Banner format matches spec
   it('formats banner as v{from} → v{to} (H: {fromH} → {toH})', () => {
     const eventBus = new AgentEventBus()
     const writeLine = sinon.stub()
-    const listener = new HarnessBannerListener(eventBus, writeLine, true, true)
+    const listener = makeListener(eventBus, writeLine)
 
     eventBus.emit('harness:refinement-completed', makeAcceptedEvent({
       fromHeuristic: 0.58,
@@ -159,11 +164,10 @@ describe('HarnessBannerListener', () => {
     expect(output).to.equal('harness updated: v3 → v4 (H: 0.58 → 0.64)\n')
   })
 
-  // Test 8: onSessionEnd is idempotent — second call does not re-print
   it('does not re-print on second onSessionEnd call', () => {
     const eventBus = new AgentEventBus()
     const writeLine = sinon.stub()
-    const listener = new HarnessBannerListener(eventBus, writeLine, true, true)
+    const listener = makeListener(eventBus, writeLine)
 
     eventBus.emit('harness:refinement-completed', makeAcceptedEvent())
     listener.onSessionEnd()
@@ -172,15 +176,13 @@ describe('HarnessBannerListener', () => {
     expect(writeLine.callCount).to.equal(1)
   })
 
-  // Test 9: Listener unsubscribes on session end — events after don't accumulate
   it('stops listening to events after onSessionEnd', () => {
     const eventBus = new AgentEventBus()
     const writeLine = sinon.stub()
-    const listener = new HarnessBannerListener(eventBus, writeLine, true, true)
+    const listener = makeListener(eventBus, writeLine)
 
     listener.onSessionEnd()
 
-    // Event after session end should not be captured
     eventBus.emit('harness:refinement-completed', makeAcceptedEvent())
     listener.onSessionEnd()
 

--- a/test/unit/agent/session/harness-banner-listener.test.ts
+++ b/test/unit/agent/session/harness-banner-listener.test.ts
@@ -1,0 +1,189 @@
+import {expect} from 'chai'
+import sinon from 'sinon'
+
+import {AgentEventBus} from '../../../../src/agent/infra/events/event-emitter.js'
+import {HarnessBannerListener} from '../../../../src/agent/infra/session/harness-banner-listener.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeAcceptedEvent(overrides: {
+  commandType?: string
+  fromHeuristic?: number
+  fromVersion?: number
+  projectId?: string
+  toHeuristic?: number
+  toVersion?: number
+} = {}) {
+  return {
+    accepted: true as const,
+    commandType: overrides.commandType ?? 'curate',
+    fromHeuristic: overrides.fromHeuristic ?? 0.58,
+    fromVersion: overrides.fromVersion ?? 3,
+    projectId: overrides.projectId ?? 'proj-1',
+    toHeuristic: overrides.toHeuristic ?? 0.64,
+    toVersion: overrides.toVersion ?? 4,
+  }
+}
+
+function makeRejectedEvent(overrides: {
+  commandType?: string
+  fromVersion?: number
+  projectId?: string
+  reason?: string
+} = {}) {
+  return {
+    accepted: false as const,
+    commandType: overrides.commandType ?? 'curate',
+    fromVersion: overrides.fromVersion ?? 3,
+    projectId: overrides.projectId ?? 'proj-1',
+    reason: overrides.reason ?? 'delta H was -0.10, below acceptance threshold',
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('HarnessBannerListener', () => {
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  // Test 1: Accepted refinement + TTY + enabled → banner prints
+  it('prints banner when accepted refinement fires with TTY and enabled', () => {
+    const eventBus = new AgentEventBus()
+    const writeLine = sinon.stub()
+    const listener = new HarnessBannerListener(eventBus, writeLine, true, true)
+
+    eventBus.emit('harness:refinement-completed', makeAcceptedEvent())
+    listener.onSessionEnd()
+
+    expect(writeLine.callCount).to.equal(1)
+    expect(writeLine.firstCall.args[0]).to.include('harness updated')
+  })
+
+  // Test 2: Accepted refinement + TTY + disabled → no print
+  it('does not print when harness is disabled', () => {
+    const eventBus = new AgentEventBus()
+    const writeLine = sinon.stub()
+    const listener = new HarnessBannerListener(eventBus, writeLine, true, false)
+
+    eventBus.emit('harness:refinement-completed', makeAcceptedEvent())
+    listener.onSessionEnd()
+
+    expect(writeLine.callCount).to.equal(0)
+  })
+
+  // Test 3: Accepted refinement + not TTY → no print
+  it('does not print when not a TTY', () => {
+    const eventBus = new AgentEventBus()
+    const writeLine = sinon.stub()
+    const listener = new HarnessBannerListener(eventBus, writeLine, false, true)
+
+    eventBus.emit('harness:refinement-completed', makeAcceptedEvent())
+    listener.onSessionEnd()
+
+    expect(writeLine.callCount).to.equal(0)
+  })
+
+  // Test 4: Rejected refinement → no print
+  it('does not print for rejected refinements', () => {
+    const eventBus = new AgentEventBus()
+    const writeLine = sinon.stub()
+    const listener = new HarnessBannerListener(eventBus, writeLine, true, true)
+
+    eventBus.emit('harness:refinement-completed', makeRejectedEvent())
+    listener.onSessionEnd()
+
+    expect(writeLine.callCount).to.equal(0)
+  })
+
+  // Test 5: Multiple accepteds → only last one prints
+  it('prints only the last accepted refinement when multiple fire', () => {
+    const eventBus = new AgentEventBus()
+    const writeLine = sinon.stub()
+    const listener = new HarnessBannerListener(eventBus, writeLine, true, true)
+
+    eventBus.emit('harness:refinement-completed', makeAcceptedEvent({
+      fromHeuristic: 0.4,
+      fromVersion: 1,
+      toHeuristic: 0.5,
+      toVersion: 2,
+    }))
+    eventBus.emit('harness:refinement-completed', makeAcceptedEvent({
+      fromHeuristic: 0.5,
+      fromVersion: 2,
+      toHeuristic: 0.64,
+      toVersion: 3,
+    }))
+
+    listener.onSessionEnd()
+
+    expect(writeLine.callCount).to.equal(1)
+    const output = writeLine.firstCall.args[0] as string
+    expect(output).to.include('v2')
+    expect(output).to.include('v3')
+    expect(output).to.not.include('v1')
+  })
+
+  // Test 6: Zero refinements → no print
+  it('does not print when no refinements occurred', () => {
+    const eventBus = new AgentEventBus()
+    const writeLine = sinon.stub()
+    const listener = new HarnessBannerListener(eventBus, writeLine, true, true)
+
+    listener.onSessionEnd()
+
+    expect(writeLine.callCount).to.equal(0)
+  })
+
+  // Test 7: Banner format matches spec
+  it('formats banner as v{from} → v{to} (H: {fromH} → {toH})', () => {
+    const eventBus = new AgentEventBus()
+    const writeLine = sinon.stub()
+    const listener = new HarnessBannerListener(eventBus, writeLine, true, true)
+
+    eventBus.emit('harness:refinement-completed', makeAcceptedEvent({
+      fromHeuristic: 0.58,
+      fromVersion: 3,
+      toHeuristic: 0.64,
+      toVersion: 4,
+    }))
+
+    listener.onSessionEnd()
+
+    expect(writeLine.callCount).to.equal(1)
+    const output = writeLine.firstCall.args[0] as string
+    expect(output).to.equal('harness updated: v3 → v4 (H: 0.58 → 0.64)\n')
+  })
+
+  // Test 8: onSessionEnd is idempotent — second call does not re-print
+  it('does not re-print on second onSessionEnd call', () => {
+    const eventBus = new AgentEventBus()
+    const writeLine = sinon.stub()
+    const listener = new HarnessBannerListener(eventBus, writeLine, true, true)
+
+    eventBus.emit('harness:refinement-completed', makeAcceptedEvent())
+    listener.onSessionEnd()
+    listener.onSessionEnd()
+
+    expect(writeLine.callCount).to.equal(1)
+  })
+
+  // Test 9: Listener unsubscribes on session end — events after don't accumulate
+  it('stops listening to events after onSessionEnd', () => {
+    const eventBus = new AgentEventBus()
+    const writeLine = sinon.stub()
+    const listener = new HarnessBannerListener(eventBus, writeLine, true, true)
+
+    listener.onSessionEnd()
+
+    // Event after session end should not be captured
+    eventBus.emit('harness:refinement-completed', makeAcceptedEvent())
+    listener.onSessionEnd()
+
+    expect(writeLine.callCount).to.equal(0)
+  })
+})

--- a/test/unit/agent/types/agent-events/types.test.ts
+++ b/test/unit/agent/types/agent-events/types.test.ts
@@ -453,8 +453,10 @@ describe('cipher/agent-events', () => {
       const accepted: AgentEventMap['harness:refinement-completed'] = {
         accepted: true,
         commandType: 'curate',
+        fromHeuristic: 0.5,
         fromVersion: 2,
         projectId: 'proj-1',
+        toHeuristic: 0.6,
         toVersion: 3,
       }
       if (accepted.accepted) {


### PR DESCRIPTION
## Summary

- Problem: Users have no visibility into when the harness improves — refinements happen silently in the background after session end.
- Why it matters: Seeing "harness updated: v3 → v4 (H: 0.58 → 0.64)" after a session reinforces that the system is learning, building trust in the auto-harness feature.
- What changed:
  - New `HarnessBannerListener` class subscribes to `harness:refinement-completed` on the agent event bus, buffers accepted refinements during a session, and prints a one-line banner to stderr on session end.
  - `SessionManager` wires the listener per session (create on session start, end on session cleanup).
  - Extended `harness:refinement-completed` event with `fromHeuristic`/`toHeuristic` fields so the banner can display H values without store access.
  - Synthesizer emit updated to include heuristic values.
- What did NOT change (scope boundary): No rejected-refinement surfacing, no configurable banner toggle, no cross-session aggregation.

## Type of change

- [x] New feature

## Scope (select all touched areas)

- [x] Agent / Tools
- [x] Shared (constants, types, transport events)

## Linked issues

- Closes ENG-2326
- Related ENG-2327 (7.7 integration test — will exercise banner end-to-end)

## Root cause (bug fixes only, otherwise write `N/A`)

N/A

## Test plan

- Coverage added:
  - [x] Unit test
- Test file(s): `test/unit/agent/session/harness-banner-listener.test.ts`
- Key scenario(s) covered:
  1. Accepted + TTY + enabled → banner prints
  2. Accepted + TTY + disabled → no print
  3. Accepted + not TTY → no print
  4. Rejected refinement → no print
  5. Multiple accepteds → only last one prints
  6. Zero refinements → no print
  7. Banner format matches `v{from} → v{to} (H: {fromH} → {toH})`
  8. Idempotent `onSessionEnd` — second call does not re-print
  9. Listener unsubscribes after session end — no leak

## User-visible changes

New stderr line after sessions where a harness refinement was accepted:
```
harness updated: v3 → v4 (H: 0.58 → 0.64)
```
Only appears when: harness enabled + TTY + at least one accepted refinement during the session. Written to stderr so it doesn't pollute stdout/JSON output.

## Evidence

```
  HarnessBannerListener
    ✔ prints banner when accepted refinement fires with TTY and enabled
    ✔ does not print when harness is disabled
    ✔ does not print when not a TTY
    ✔ does not print for rejected refinements
    ✔ prints only the last accepted refinement when multiple fire
    ✔ does not print when no refinements occurred
    ✔ formats banner as v{from} → v{to} (H: {fromH} → {toH})
    ✔ does not re-print on second onSessionEnd call
    ✔ stops listening to events after onSessionEnd

  9 passing (4ms)
```

Full suite: 7230 passing, 0 failing. Typecheck, lint, build all clean.

## Acceptance criteria evidence

| AC | Evidence |
|----|----------|
| `HarnessBannerListener` class + subscription wire-up | `src/agent/infra/session/harness-banner-listener.ts:26` |
| Banner prints ONLY when: enabled + TTY + accepted | Tests 1-4, 6 — 9/9 pass |
| Rejected refinements never trigger a banner | Test 4 — writeLine not called |
| Multiple refinements: only last-accepted wins | Test 5 — only v2→v3 printed |
| Output goes to stderr, matches documented format | Test 7 asserts exact string |
| `SessionManager` calls `onSessionEnd()` in cleanup path | `session-manager.ts:413` |
| Unit tests cover 7+ scenarios | 9 passing |
| `npm run typecheck` / `lint` / `test` / `build` all clean | 0 errors across all |

## Implementation decisions

| Spec says | What was done | Why |
|-----------|---------------|-----|
| Constructor takes `SessionEventBus` | Uses `AgentEventBus` | `harness:refinement-completed` exists only on `AgentEventMap`, not `SessionEventMap` |
| Banner format includes H values | Extended event with `fromHeuristic`/`toHeuristic` | Event lacked heuristic data; synthesizer already had values at emit time |
| Modify `service-initializer.ts` | Modified `SessionManagerOptions` | TTY/writeLine are runtime globals; `SessionManagerOptions.bannerOverrides` is the correct injection point |

## Checklist

- [x] Tests added or updated and passing (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow Conventional Commits format
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or clearly documented above)
- [x] Branch is up to date with `proj/autoharness-v2`

## Risks and mitigations

- Risk: Extended `harness:refinement-completed` event adds 2 required fields to the accepted variant — could break consumers that construct the event manually.
  - Mitigation: Only the synthesizer emits this event (single emit site at `harness-synthesizer.ts:215`). All existing tests pass. The change is backward-compatible for consumers that only read the event.
- Risk: Banner listener subscribes to agent-level event bus — if many sessions are created simultaneously, many listeners accumulate on one bus.
  - Mitigation: Each listener registers a single handler. `onSessionEnd` is called in all cleanup paths (`endSession`, `deleteSession`, `dispose`), ensuring unsubscription. No leak path.