### PR TITLE
feat: [ENG-2331] null-mode integration test + manual smoke script

### DIFF
--- a/package.json
+++ b/package.json
@@ -206,6 +206,7 @@
     "postpack": "shx rm -f oclif.manifest.json",
     "prepack": "npm run build && BRV_ENV=production oclif manifest",
     "prepare": "husky",
+    "smoke:harness": "node --loader ts-node/esm scripts/harness-smoke.ts",
     "test": "mocha --forbid-only \"test/**/*.test.ts\"",
     "typecheck": "tsc --noEmit && tsc --noEmit -p src/webui/tsconfig.json",
     "version": "git add README.md"

--- a/scripts/harness-smoke.ts
+++ b/scripts/harness-smoke.ts
@@ -1,0 +1,674 @@
+#!/usr/bin/env npx ts-node --esm
+/**
+ * AutoHarness V2 — manual smoke script.
+ *
+ * Walks the 12-step §4.3 smoke (execution-plan.md) in a single run
+ * against an inMemory stack. Engineers run `npm run smoke:harness`
+ * before a manual dogfood pass. Exits 0 on full pass, non-zero with
+ * the failing step number on failure.
+ *
+ * Step functions are exported so `test/unit/scripts/harness-smoke.test.ts`
+ * can exercise each one in isolation.
+ *
+ * Usage:
+ *   npm run smoke:harness
+ *   node --loader ts-node/esm scripts/harness-smoke.ts [--project <dir>] [--llm stub|real]
+ */
+
+import {mkdtempSync, realpathSync, rmSync, writeFileSync} from 'node:fs'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+
+import type {CodeExecOutcome, EvaluationScenario, HarnessContextTools, HarnessVersion} from '../src/agent/core/domain/harness/types.js'
+import type {ValidatedHarnessConfig} from '../src/agent/infra/agent/agent-schemas.js'
+import type {HarnessToolsFactory} from '../src/agent/infra/harness/harness-evaluator.js'
+import type {IRefinerClient} from '../src/agent/infra/harness/harness-refiner-client.js'
+
+import {computeHeuristic} from '../src/agent/core/domain/harness/heuristic.js'
+import {NoOpLogger} from '../src/agent/core/interfaces/i-logger.js'
+import {AgentEventBus, SessionEventBus} from '../src/agent/infra/events/event-emitter.js'
+import {FileSystemService} from '../src/agent/infra/file-system/file-system-service.js'
+import {_clearPolyglotWarningState} from '../src/agent/infra/harness/detect-and-pick-template.js'
+import {HarnessBaselineRunner} from '../src/agent/infra/harness/harness-baseline-runner.js'
+import {HarnessEvaluator} from '../src/agent/infra/harness/harness-evaluator.js'
+import {SYNTHETIC_DELIMITER} from '../src/agent/infra/harness/harness-outcome-recorder.js'
+import {
+  HarnessBootstrap,
+  HarnessModuleBuilder,
+  HarnessOutcomeRecorder,
+  HarnessScenarioCapture,
+  HarnessStore,
+  HarnessSynthesizer,
+} from '../src/agent/infra/harness/index.js'
+import {SandboxService} from '../src/agent/infra/sandbox/sandbox-service.js'
+import {HarnessBannerListener} from '../src/agent/infra/session/harness-banner-listener.js'
+import {FileKeyStorage} from '../src/agent/infra/storage/file-key-storage.js'
+import {buildDiffReport} from '../src/oclif/commands/harness/diff.js'
+import {toInspectReport} from '../src/oclif/commands/harness/inspect.js'
+import {buildStatusReport} from '../src/oclif/commands/harness/status.js'
+import {attachFeedbackToStore} from '../src/oclif/lib/harness-feedback.js'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SmokeState {
+  refinementEvents: Array<Record<string, unknown>>
+  v1?: HarnessVersion
+  v2?: HarnessVersion
+}
+
+export interface SmokeContext {
+  readonly agentEventBus: AgentEventBus
+  readonly bannerLines: string[]
+  readonly bannerListener: HarnessBannerListener
+  readonly baselineRunner: HarnessBaselineRunner
+  readonly bootstrap: HarnessBootstrap
+  readonly config: ValidatedHarnessConfig
+  readonly keyStorage: FileKeyStorage
+  readonly projectId: string
+  readonly sandboxService: SandboxService
+  readonly state: SmokeState
+  readonly store: HarnessStore
+  readonly synthesizer: HarnessSynthesizer
+  readonly tempDir: string
+}
+
+// ---------------------------------------------------------------------------
+// Assertion helper
+// ---------------------------------------------------------------------------
+
+export class SmokeAssertionError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'SmokeAssertionError'
+  }
+}
+
+function assert(condition: boolean, message: string): asserts condition {
+  if (!condition) throw new SmokeAssertionError(message)
+}
+
+// ---------------------------------------------------------------------------
+// Stub refiner LLM
+// ---------------------------------------------------------------------------
+
+const V2_CODE = `
+exports.meta = function meta() {
+  return {
+    capabilities: ['curate'],
+    commandType: 'curate',
+    projectPatterns: ['**/*.ts', '**/*.tsx', 'tsconfig.json'],
+    version: 1,
+  }
+}
+
+exports.curate = async function curate(ctx) {
+  if (ctx.env.customConfig == null) return
+  return ctx.tools.curate(ctx.env.customConfig.operations)
+}
+`.trimStart()
+
+const CRITIC_ANALYSIS = [
+  'Failure pattern: reads undefined x.',
+  'Root cause: missing null check on ctx.env.customConfig.',
+  'Suggested change: add if (ctx.env.customConfig == null) return',
+].join('\n')
+
+class FakeRefinerLLM implements IRefinerClient {
+  criticCallCount = 0
+  readonly modelId: string
+  refinerCallCount = 0
+  private readonly refinerResponse: string
+
+  constructor(opts: {modelId?: string; refinerResponse?: string} = {}) {
+    this.modelId = opts.modelId ?? 'test-model-capable'
+    this.refinerResponse = opts.refinerResponse ?? V2_CODE
+  }
+
+  async completeCritic(_prompt: string): Promise<string> {
+    this.criticCallCount++
+    return CRITIC_ANALYSIS
+  }
+
+  async completeRefiner(_prompt: string): Promise<string> {
+    this.refinerCallCount++
+    return this.refinerResponse
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Eval tools factory (dryRun stubs)
+// ---------------------------------------------------------------------------
+
+// Script-level double-casts: the factory returns simplified stubs whose
+// parameter signatures don't match the full HarnessContextTools contract.
+const evalToolsFactory: HarnessToolsFactory = () => ({
+  curate: (async () => {
+    throw new Error('WRITE_BLOCKED_DURING_EVAL')
+  }) as unknown as HarnessContextTools['curate'],
+  readFile: (async () => ({
+    content: '',
+    encoding: 'utf8',
+    formattedContent: '',
+    lines: 0,
+    message: '',
+    size: 0,
+    totalLines: 0,
+    truncated: false,
+  })) as unknown as HarnessContextTools['readFile'],
+})
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const COMMAND_TYPE = 'curate' as const
+const SESSION_ID = 'smoke-sess-1'
+
+interface EnvironmentContext {
+  brvStructure: string
+  fileTree: string
+  isGitRepository: boolean
+  nodeVersion: string
+  osVersion: string
+  platform: string
+  workingDirectory: string
+}
+
+function makeEnvironmentContext(workingDirectory: string): EnvironmentContext {
+  return {
+    brvStructure: '',
+    fileTree: '',
+    isGitRepository: false,
+    nodeVersion: process.version,
+    osVersion: 'test',
+    platform: process.platform,
+    workingDirectory,
+  }
+}
+
+async function seedOutcomes(params: {
+  commandType?: 'curate' | 'query'
+  count: number
+  failureRatio?: number
+  projectId: string
+  startIndex?: number
+  store: HarnessStore
+  usedHarness?: boolean
+}): Promise<void> {
+  const now = Date.now()
+  const commandType = params.commandType ?? COMMAND_TYPE
+  const failureRatio = params.failureRatio ?? 0.8
+  const startIndex = params.startIndex ?? 0
+  const usedHarness = params.usedHarness ?? false
+  for (let i = 0; i < params.count; i++) {
+    const isFailing = i < Math.floor(params.count * failureRatio)
+    const outcome: CodeExecOutcome = {
+      code: 'tools.search("x")',
+      commandType,
+      executionTimeMs: 42,
+      id: `smoke-${commandType}-outcome-${startIndex + i}`,
+      projectId: params.projectId,
+      projectType: 'typescript',
+      sessionId: 'smoke-seed',
+      stderr: isFailing ? "TypeError: Cannot read properties of undefined (reading 'x')" : undefined,
+      success: !isFailing,
+      timestamp: now - 50_000 + i * 1000,
+      usedHarness,
+    }
+    // eslint-disable-next-line no-await-in-loop
+    await params.store.saveOutcome(outcome)
+  }
+}
+
+async function seedScenarios(store: HarnessStore, projectId: string, count: number): Promise<void> {
+  for (let i = 0; i < count; i++) {
+    const isPositive = i < Math.floor(count / 2)
+    const scenario: EvaluationScenario = {
+      code: 'harness.curate(ctx)',
+      commandType: COMMAND_TYPE,
+      createdAt: Date.now() - 30_000 + i * 1000,
+      expectedBehavior: isPositive
+        ? 'Succeeds without errors'
+        : 'Throws TypeError on undefined property access',
+      id: `smoke-scenario-${i}`,
+      projectId,
+      projectType: 'typescript',
+      taskDescription: isPositive ? 'Normal curate operation' : 'Null-pointer failure case',
+    }
+    // eslint-disable-next-line no-await-in-loop
+    await store.saveScenario(scenario)
+  }
+}
+
+async function waitForOutcomes(params: {
+  expectedMin: number
+  projectId: string
+  store: HarnessStore
+  timeoutMs?: number
+}): Promise<CodeExecOutcome[]> {
+  const deadline = Date.now() + (params.timeoutMs ?? 3000)
+  let outcomes = await params.store.listOutcomes(params.projectId, COMMAND_TYPE, 200)
+  while (outcomes.length < params.expectedMin && Date.now() < deadline) {
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((r) => {
+      setTimeout(r, 50)
+    })
+    // eslint-disable-next-line no-await-in-loop
+    outcomes = await params.store.listOutcomes(params.projectId, COMMAND_TYPE, 200)
+  }
+
+  return outcomes
+}
+
+// ---------------------------------------------------------------------------
+// Context factory
+// ---------------------------------------------------------------------------
+
+export async function createSmokeContext(opts: {
+  llmMode?: 'real' | 'stub'
+  projectDir?: string
+} = {}): Promise<SmokeContext> {
+  const llmMode = opts.llmMode ?? 'stub'
+  const tempDir = opts.projectDir
+    ?? realpathSync(mkdtempSync(join(tmpdir(), 'brv-smoke-harness-')))
+  const projectId = 'smoke-harness-test'
+
+  writeFileSync(join(tempDir, 'tsconfig.json'), '{}')
+  _clearPolyglotWarningState()
+
+  const config: ValidatedHarnessConfig = {
+    autoLearn: true,
+    enabled: true,
+    language: 'auto',
+    maxVersions: 20,
+  }
+  const logger = new NoOpLogger()
+
+  const keyStorage = new FileKeyStorage({inMemory: true})
+  await keyStorage.initialize()
+  const store = new HarnessStore(keyStorage, logger)
+
+  const fileSystem = new FileSystemService({
+    allowedPaths: [tempDir],
+    workingDirectory: tempDir,
+  })
+  await fileSystem.initialize()
+
+  const builder = new HarnessModuleBuilder(logger)
+  const bootstrap = new HarnessBootstrap(store, fileSystem, config, logger)
+
+  const sessionEventBus = new SessionEventBus()
+  const recorder = new HarnessOutcomeRecorder(store, sessionEventBus, logger, config)
+
+  const sandboxService = new SandboxService()
+  sandboxService.setHarnessConfig(config)
+  sandboxService.setEnvironmentContext(makeEnvironmentContext(projectId))
+  sandboxService.setHarnessStore(store)
+  sandboxService.setHarnessModuleBuilder(builder)
+  sandboxService.setFileSystem(fileSystem)
+  sandboxService.setHarnessOutcomeRecorder(recorder, logger)
+
+  const agentEventBus = new AgentEventBus()
+
+  let refiner: IRefinerClient
+  if (llmMode === 'real') {
+    throw new Error(
+      '--llm real requires a configured LLM provider. ' +
+      'Set BYTEROVER_LLM_API_KEY in env. Not yet implemented.',
+    )
+  } else {
+    refiner = new FakeRefinerLLM()
+  }
+
+  const evaluator = new HarnessEvaluator(store, logger, evalToolsFactory)
+  const scenarioCapture = new HarnessScenarioCapture(store, logger)
+  const synthesizer = new HarnessSynthesizer(
+    store, evaluator, scenarioCapture, refiner,
+    agentEventBus, config, logger,
+  )
+
+  const bannerLines: string[] = []
+  const bannerListener = new HarnessBannerListener({
+    eventBus: agentEventBus,
+    harnessEnabled: true,
+    isTty: true,
+    writeLine(line: string) {
+      bannerLines.push(line)
+    },
+  })
+
+  const baselineRunner = new HarnessBaselineRunner(store, logger, evalToolsFactory)
+
+  return {
+    agentEventBus,
+    bannerLines,
+    bannerListener,
+    baselineRunner,
+    bootstrap,
+    config,
+    keyStorage,
+    projectId,
+    sandboxService,
+    state: {refinementEvents: []},
+    store,
+    synthesizer,
+    tempDir,
+  }
+}
+
+export function cleanupSmokeContext(ctx: SmokeContext): void {
+  ctx.sandboxService.cleanup?.()
+  ctx.keyStorage.close()
+  // Only remove tempDirs we created (contain 'brv-smoke-harness-')
+  if (ctx.tempDir.includes('brv-smoke-harness-')) {
+    rmSync(ctx.tempDir, {force: true, recursive: true})
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Step functions — exported for unit testing
+// ---------------------------------------------------------------------------
+
+/** Step 1: Enable harness -> status shows enabled, no version. */
+export async function step01EnableAndStatus(ctx: SmokeContext): Promise<void> {
+  const status = await buildStatusReport({
+    commandType: COMMAND_TYPE,
+    featureConfig: {autoLearn: true, enabled: true},
+    projectId: ctx.projectId,
+    store: ctx.store,
+  })
+
+  assert(status.enabled, 'expected enabled=true')
+  assert(status.currentVersionId === null, 'expected no current version')
+}
+
+/** Step 2: Bootstrap + 3 curate calls -> v1 created, outcomes recorded. */
+export async function step02BootstrapAndCurate(ctx: SmokeContext): Promise<void> {
+  await ctx.bootstrap.bootstrapIfNeeded(ctx.projectId, COMMAND_TYPE, ctx.tempDir)
+
+  const v1 = await ctx.store.getLatest(ctx.projectId, COMMAND_TYPE)
+  assert(v1 !== undefined, 'bootstrap must create v1')
+  assert(v1.version === 1, `expected version=1, got ${v1.version}`)
+  assert(v1.projectType === 'typescript', `expected projectType=typescript, got ${v1.projectType}`)
+  ctx.state.v1 = v1
+
+  const loadV1 = await ctx.sandboxService.loadHarness(SESSION_ID, ctx.projectId, COMMAND_TYPE)
+  assert(loadV1.loaded, 'v1 must load successfully')
+
+  for (let i = 0; i < 3; i++) {
+    // eslint-disable-next-line no-await-in-loop
+    const exec = await ctx.sandboxService.executeCode(
+      `typeof harness !== 'undefined' && typeof harness.curate === 'function'`,
+      SESSION_ID,
+      {commandType: COMMAND_TYPE, taskDescription: `smoke-curate-${i}`},
+    )
+    assert(exec.returnValue === true, `curate exec ${i}: expected returnValue=true`)
+  }
+
+  const outcomes = await waitForOutcomes({expectedMin: 3, projectId: ctx.projectId, store: ctx.store})
+  assert(outcomes.length >= 3, `expected >=3 outcomes, got ${outcomes.length}`)
+}
+
+/** Step 3: Inspect v1 -> pass-through body visible. */
+export async function step03InspectV1(ctx: SmokeContext): Promise<void> {
+  assert(ctx.state.v1 !== undefined, 'v1 must exist (step 2 prerequisite)')
+  const report = toInspectReport(ctx.state.v1)
+  assert(report.code.includes('ctx.tools.curate(ctx.env)'), 'v1 code must contain pass-through body')
+  assert(report.version === 1, `expected version=1, got ${report.version}`)
+  assert(report.projectType === 'typescript', 'expected projectType=typescript')
+}
+
+/** Step 4: Seed 20+ outcomes + refinement -> v2 created. */
+export async function step04RefinementToV2(ctx: SmokeContext): Promise<void> {
+  // 47 more outcomes (3 from step 2 = 50 total). 0.8 failure ratio
+  // passes the synthesizer's minimum-signal check.
+  await seedOutcomes({count: 47, projectId: ctx.projectId, store: ctx.store})
+  await seedScenarios(ctx.store, ctx.projectId, 10)
+
+  ctx.agentEventBus.on('harness:refinement-completed', (payload) => {
+    ctx.state.refinementEvents.push(payload as unknown as Record<string, unknown>)
+  })
+
+  const result = await ctx.synthesizer.refineIfNeeded(ctx.projectId, COMMAND_TYPE)
+  assert(result !== undefined, 'synthesizer must produce a refinement result')
+  assert(result.accepted, 'refinement must be accepted')
+
+  const versions = await ctx.store.listVersions(ctx.projectId, COMMAND_TYPE)
+  assert(versions.length === 2, `expected 2 versions, got ${versions.length}`)
+  const v2 = versions.find((v) => v.version === 2)
+  assert(v2 !== undefined, 'v2 must exist')
+  assert(v2.code.includes('ctx.env.customConfig == null'), 'v2 must contain null guard')
+  ctx.state.v2 = v2
+
+  assert(ctx.state.refinementEvents.length === 1, 'expected 1 refinement event')
+  assert(ctx.state.refinementEvents[0].accepted === true, 'event must be accepted')
+}
+
+/** Step 5: Banner prints "harness updated: v1 -> v2". */
+export async function step05SessionBanner(ctx: SmokeContext): Promise<void> {
+  ctx.bannerListener.onSessionEnd()
+
+  assert(ctx.bannerLines.length === 1, `expected 1 banner line, got ${ctx.bannerLines.length}`)
+  const banner = ctx.bannerLines[0]
+  assert(typeof banner === 'string', 'banner must be a string')
+  assert(/harness updated: v1 → v2 \(H: /.test(banner), `banner must match pattern, got: ${banner}`)
+}
+
+/** Step 6: Diff v1 v2 -> unified diff shows refined logic. */
+export async function step06DiffV1V2(ctx: SmokeContext): Promise<void> {
+  assert(ctx.state.v1 !== undefined, 'v1 must exist')
+  assert(ctx.state.v2 !== undefined, 'v2 must exist')
+  const report = buildDiffReport(ctx.state.v1, ctx.state.v2)
+  assert(report.unifiedDiff.includes('-'), 'diff must contain deletions')
+  assert(report.unifiedDiff.includes('+'), 'diff must contain additions')
+  assert(report.unifiedDiff.includes('ctx.env.customConfig == null'), 'diff must show null guard')
+  assert(report.lineAdds > 0, 'must have line additions')
+}
+
+/** Step 7: Curate with v2 injected. */
+export async function step07CurateWithV2(ctx: SmokeContext): Promise<void> {
+  const session2 = 'smoke-sess-2'
+  const loadV2 = await ctx.sandboxService.loadHarness(session2, ctx.projectId, COMMAND_TYPE)
+  assert(loadV2.loaded, 'v2 must load')
+  if (!loadV2.loaded) throw new Error('unreachable')
+  assert(loadV2.version.version === 2, `expected version=2, got ${loadV2.version.version}`)
+
+  const exec = await ctx.sandboxService.executeCode(
+    `typeof harness !== 'undefined' && typeof harness.curate === 'function'`,
+    session2,
+    {commandType: COMMAND_TYPE, taskDescription: 'smoke-curate-v2'},
+  )
+  assert(exec.returnValue === true, 'v2 curate must return true')
+}
+
+/** Step 8: Feedback bad -> synthetics inserted. */
+export async function step08FeedbackBad(ctx: SmokeContext): Promise<void> {
+  // Seed 15 query outcomes (all success) so feedback has a target.
+  await seedOutcomes({commandType: 'query', count: 15, failureRatio: 0, projectId: ctx.projectId, store: ctx.store})
+
+  const result = await attachFeedbackToStore(
+    ctx.store,
+    ctx.projectId,
+    'query',
+    'bad',
+    {autoLearn: true, enabled: true},
+  )
+
+  assert(result.verdict === 'bad', `expected verdict=bad, got ${result.verdict}`)
+  assert(result.syntheticCount === 3, `expected 3 synthetics, got ${result.syntheticCount}`)
+}
+
+/** Step 9: H drops after bad feedback synthetics. */
+export async function step09HeuristicDrops(ctx: SmokeContext): Promise<void> {
+  // Compute H from real outcomes vs all outcomes (including synthetics).
+  const allOutcomes = await ctx.store.listOutcomes(ctx.projectId, 'query', 200)
+  const realOutcomes = allOutcomes.filter((o) => !o.id.includes(SYNTHETIC_DELIMITER))
+  const hBefore = computeHeuristic(realOutcomes, Date.now())
+  const hAfter = computeHeuristic(allOutcomes, Date.now())
+
+  assert(hBefore !== null, 'H-before must be computable')
+  assert(hAfter !== null, 'H-after must be computable')
+  assert(hAfter < hBefore, `H must drop: before=${hBefore}, after=${hAfter}`)
+}
+
+/** Step 10: Pin v1 -> loadHarness returns v1. */
+export async function step10PinV1(ctx: SmokeContext): Promise<void> {
+  assert(ctx.state.v1 !== undefined, 'v1 must exist')
+  await ctx.store.setPin({
+    commandType: COMMAND_TYPE,
+    pinnedAt: Date.now(),
+    pinnedVersionId: ctx.state.v1.id,
+    projectId: ctx.projectId,
+  })
+
+  const session3 = 'smoke-sess-3'
+  const loadPinned = await ctx.sandboxService.loadHarness(session3, ctx.projectId, COMMAND_TYPE)
+  assert(loadPinned.loaded, 'pinned version must load')
+  if (!loadPinned.loaded) throw new Error('unreachable')
+  assert(loadPinned.version.id === ctx.state.v1.id, 'loaded version must be v1')
+  assert(loadPinned.version.version === 1, 'loaded version number must be 1')
+}
+
+/** Step 11: Baseline -> dual-arm replay. */
+export async function step11Baseline(ctx: SmokeContext): Promise<void> {
+  // Remove pin so baseline uses latest (v2) for harness arm.
+  await ctx.store.deletePin(ctx.projectId, COMMAND_TYPE)
+
+  const baseline = await ctx.baselineRunner.runBaseline({
+    commandType: COMMAND_TYPE,
+    count: 10,
+    projectId: ctx.projectId,
+  })
+
+  assert(baseline.scenarioCount > 0, `expected >0 scenarios, got ${baseline.scenarioCount}`)
+  assert(typeof baseline.harnessSuccessRate === 'number', 'harnessSuccessRate must be a number')
+  assert(typeof baseline.rawSuccessRate === 'number', 'rawSuccessRate must be a number')
+  assert(typeof baseline.delta === 'number', 'delta must be a number')
+  assert(baseline.perScenario.length === baseline.scenarioCount, 'perScenario length must match')
+  assert(baseline.delta >= 0, `delta should be >=0, got ${baseline.delta}`)
+}
+
+/** Step 12: Disable harness -> no injection. */
+export async function step12DisableHarness(ctx: SmokeContext): Promise<void> {
+  const status = await buildStatusReport({
+    commandType: COMMAND_TYPE,
+    featureConfig: {autoLearn: true, enabled: false},
+    projectId: ctx.projectId,
+    store: ctx.store,
+  })
+  assert(status.enabled === false, 'status must show disabled')
+
+  ctx.sandboxService.setHarnessConfig({...ctx.config, enabled: false})
+  const session4 = 'smoke-sess-4'
+  const loadDisabled = await ctx.sandboxService.loadHarness(session4, ctx.projectId, COMMAND_TYPE)
+  assert(!loadDisabled.loaded, 'loadHarness must return loaded=false when disabled')
+}
+
+// ---------------------------------------------------------------------------
+// Step registry
+// ---------------------------------------------------------------------------
+
+export type StepFn = (ctx: SmokeContext) => Promise<void>
+
+export const STEPS: ReadonlyArray<{fn: StepFn; label: string}> = [
+  {fn: step01EnableAndStatus, label: 'Enable harness, run status'},
+  {fn: step02BootstrapAndCurate, label: 'Bootstrap + 3 curate calls'},
+  {fn: step03InspectV1, label: 'Inspect v1'},
+  {fn: step04RefinementToV2, label: 'Seed outcomes + refinement -> v2'},
+  {fn: step05SessionBanner, label: 'Session-end banner'},
+  {fn: step06DiffV1V2, label: 'Diff v1 v2'},
+  {fn: step07CurateWithV2, label: 'Curate with v2'},
+  {fn: step08FeedbackBad, label: 'Feedback bad -> synthetics'},
+  {fn: step09HeuristicDrops, label: 'H drops after bad feedback'},
+  {fn: step10PinV1, label: 'Pin v1 -> loadHarness returns v1'},
+  {fn: step11Baseline, label: 'Baseline dual-arm replay'},
+  {fn: step12DisableHarness, label: 'Disable harness'},
+]
+
+// ---------------------------------------------------------------------------
+// Runner
+// ---------------------------------------------------------------------------
+
+export interface StepResult {
+  readonly details?: string
+  readonly label: string
+  readonly passed: boolean
+  readonly stepNumber: number
+}
+
+export async function runSmoke(ctx: SmokeContext): Promise<StepResult[]> {
+  const results: StepResult[] = []
+
+  for (const [i, {fn, label}] of STEPS.entries()) {
+    const stepNumber = i + 1
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      await fn(ctx)
+      results.push({label, passed: true, stepNumber})
+       
+      console.log(`  PASS  Step ${stepNumber}: ${label}`)
+    } catch (error) {
+      const details = error instanceof Error ? error.message : String(error)
+      results.push({details, label, passed: false, stepNumber})
+       
+      console.log(`  FAIL  Step ${stepNumber}: ${label} — ${details}`)
+      // Sequential dependency: if step N fails, steps N+1..12 can't run.
+      break
+    }
+  }
+
+  return results
+}
+
+// ---------------------------------------------------------------------------
+// Main — only runs when invoked directly
+// ---------------------------------------------------------------------------
+
+const isDirectExecution = process.argv[1]?.endsWith('harness-smoke.ts')
+  || process.argv[1]?.endsWith('harness-smoke.js')
+
+if (isDirectExecution) {
+  const args = process.argv.slice(2)
+  let projectDir: string | undefined
+  let llmMode: 'real' | 'stub' = 'stub'
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--project' && i + 1 < args.length) {
+      projectDir = args[++i]
+    } else if (args[i] === '--llm' && i + 1 < args.length) {
+      const mode = args[++i]
+      if (mode !== 'stub' && mode !== 'real') {
+        console.error(`Invalid --llm value: ${mode}. Use 'stub' or 'real'.`)
+        // eslint-disable-next-line n/no-process-exit
+        process.exit(1)
+      }
+
+      llmMode = mode
+    }
+  }
+
+  console.log('AutoHarness V2 — Smoke Test')
+  console.log(`LLM mode: ${llmMode}`)
+  console.log('')
+
+  const ctx = await createSmokeContext({llmMode, projectDir})
+
+  try {
+    const results = await runSmoke(ctx)
+    console.log('')
+
+    const passed = results.filter((r) => r.passed).length
+    const total = STEPS.length
+    console.log(`${passed}/${total} steps passed`)
+
+    if (passed < total) {
+      const firstFail = results.find((r) => !r.passed)
+      // eslint-disable-next-line n/no-process-exit
+      process.exit(firstFail?.stepNumber ?? 1)
+    }
+  } finally {
+    cleanupSmokeContext(ctx)
+  }
+}

--- a/scripts/harness-smoke.ts
+++ b/scripts/harness-smoke.ts
@@ -66,6 +66,7 @@ export interface SmokeContext {
   readonly bootstrap: HarnessBootstrap
   readonly config: ValidatedHarnessConfig
   readonly keyStorage: FileKeyStorage
+  readonly ownsTempDir: boolean
   readonly projectId: string
   readonly sandboxService: SandboxService
   readonly state: SmokeState
@@ -271,11 +272,26 @@ export async function createSmokeContext(opts: {
   projectDir?: string
 } = {}): Promise<SmokeContext> {
   const llmMode = opts.llmMode ?? 'stub'
+
+  // Validate llmMode before any side effects (temp dir creation).
+  if (llmMode === 'real') {
+    throw new Error(
+      '--llm real requires a configured LLM provider. ' +
+      'Set BYTEROVER_LLM_API_KEY in env. Not yet implemented.',
+    )
+  }
+
+  const ownsTempDir = opts.projectDir === undefined
   const tempDir = opts.projectDir
     ?? realpathSync(mkdtempSync(join(tmpdir(), 'brv-smoke-harness-')))
   const projectId = 'smoke-harness-test'
 
-  writeFileSync(join(tempDir, 'tsconfig.json'), '{}')
+  // Only write tsconfig for internally-created temp dirs to avoid
+  // clobbering an existing project config in user-provided dirs.
+  if (ownsTempDir) {
+    writeFileSync(join(tempDir, 'tsconfig.json'), '{}')
+  }
+
   _clearPolyglotWarningState()
 
   const config: ValidatedHarnessConfig = {
@@ -312,15 +328,8 @@ export async function createSmokeContext(opts: {
 
   const agentEventBus = new AgentEventBus()
 
-  let refiner: IRefinerClient
-  if (llmMode === 'real') {
-    throw new Error(
-      '--llm real requires a configured LLM provider. ' +
-      'Set BYTEROVER_LLM_API_KEY in env. Not yet implemented.',
-    )
-  } else {
-    refiner = new FakeRefinerLLM()
-  }
+  // llmMode validated at top of function; only 'stub' reaches here.
+  const refiner: IRefinerClient = new FakeRefinerLLM()
 
   const evaluator = new HarnessEvaluator(store, logger, evalToolsFactory)
   const scenarioCapture = new HarnessScenarioCapture(store, logger)
@@ -349,6 +358,7 @@ export async function createSmokeContext(opts: {
     bootstrap,
     config,
     keyStorage,
+    ownsTempDir,
     projectId,
     sandboxService,
     state: {refinementEvents: []},
@@ -361,8 +371,7 @@ export async function createSmokeContext(opts: {
 export function cleanupSmokeContext(ctx: SmokeContext): void {
   ctx.sandboxService.cleanup?.()
   ctx.keyStorage.close()
-  // Only remove tempDirs we created (contain 'brv-smoke-harness-')
-  if (ctx.tempDir.includes('brv-smoke-harness-')) {
+  if (ctx.ownsTempDir) {
     rmSync(ctx.tempDir, {force: true, recursive: true})
   }
 }
@@ -472,7 +481,6 @@ export async function step07CurateWithV2(ctx: SmokeContext): Promise<void> {
   const session2 = 'smoke-sess-2'
   const loadV2 = await ctx.sandboxService.loadHarness(session2, ctx.projectId, COMMAND_TYPE)
   assert(loadV2.loaded, 'v2 must load')
-  if (!loadV2.loaded) throw new Error('unreachable')
   assert(loadV2.version.version === 2, `expected version=2, got ${loadV2.version.version}`)
 
   const exec = await ctx.sandboxService.executeCode(
@@ -526,7 +534,6 @@ export async function step10PinV1(ctx: SmokeContext): Promise<void> {
   const session3 = 'smoke-sess-3'
   const loadPinned = await ctx.sandboxService.loadHarness(session3, ctx.projectId, COMMAND_TYPE)
   assert(loadPinned.loaded, 'pinned version must load')
-  if (!loadPinned.loaded) throw new Error('unreachable')
   assert(loadPinned.version.id === ctx.state.v1.id, 'loaded version must be v1')
   assert(loadPinned.version.version === 1, 'loaded version number must be 1')
 }
@@ -626,8 +633,8 @@ export async function runSmoke(ctx: SmokeContext): Promise<StepResult[]> {
 // Main — only runs when invoked directly
 // ---------------------------------------------------------------------------
 
-const isDirectExecution = process.argv[1]?.endsWith('harness-smoke.ts')
-  || process.argv[1]?.endsWith('harness-smoke.js')
+const isDirectExecution = process.argv[1]?.endsWith('/scripts/harness-smoke.ts')
+  || process.argv[1]?.endsWith('/scripts/harness-smoke.js')
 
 if (isDirectExecution) {
   const args = process.argv.slice(2)

--- a/scripts/harness-smoke.ts
+++ b/scripts/harness-smoke.ts
@@ -614,12 +614,10 @@ export async function runSmoke(ctx: SmokeContext): Promise<StepResult[]> {
       // eslint-disable-next-line no-await-in-loop
       await fn(ctx)
       results.push({label, passed: true, stepNumber})
-       
       console.log(`  PASS  Step ${stepNumber}: ${label}`)
     } catch (error) {
       const details = error instanceof Error ? error.message : String(error)
       results.push({details, label, passed: false, stepNumber})
-       
       console.log(`  FAIL  Step ${stepNumber}: ${label} — ${details}`)
       // Sequential dependency: if step N fails, steps N+1..12 can't run.
       break

--- a/test/integration/agent/harness/null-mode-skip.test.ts
+++ b/test/integration/agent/harness/null-mode-skip.test.ts
@@ -162,8 +162,7 @@ async function buildStack(
     // HarnessBootstrap's 2nd arg is `IFileSystem`, used only inside
     // `bootstrapIfNeeded` for project-type detection. Not called in
     // this test — versions are seeded directly.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    {} as any,
+    {} as unknown as ConstructorParameters<typeof HarnessBootstrap>[1],
     harnessConfig,
     logger,
   )

--- a/test/integration/agent/harness/null-mode-skip.test.ts
+++ b/test/integration/agent/harness/null-mode-skip.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Integration test — null-mode path when H is below Mode A threshold.
+ *
+ * Exercises the full stack to prove that when heuristic H = 0 (below
+ * Mode A floor of 0.30), harness injection is cleanly skipped:
+ *
+ *   - `ensureHarnessReady` returns `undefined`
+ *   - `harness:mode-selected` event does NOT fire
+ *   - System prompt does NOT contain `<harness-v2 …>`
+ *   - Sandbox code evaluates `typeof harness === 'undefined'` as true
+ *
+ * Then proves the skip is transient: seeding outcomes that climb H
+ * above 0.30 enables Mode A on the next call, with event emission
+ * and harness namespace available in the sandbox.
+ *
+ * Complements the cli-lifecycle test (7.7) and mode-selection test
+ * (5.5 scenario 5) — those verify lifecycle and mode gating; this
+ * pins the null-mode → Mode A transition in a single continuous flow.
+ */
+
+import {expect} from 'chai'
+import {createSandbox, type SinonSandbox} from 'sinon'
+
+import type {HarnessMode, HarnessVersion} from '../../../../src/agent/core/domain/harness/types.js'
+import type {IContentGenerator} from '../../../../src/agent/core/interfaces/i-content-generator.js'
+import type {IToolProvider} from '../../../../src/agent/core/interfaces/i-tool-provider.js'
+import type {ValidatedHarnessConfig} from '../../../../src/agent/infra/agent/agent-schemas.js'
+
+import {NoOpLogger} from '../../../../src/agent/core/interfaces/i-logger.js'
+import {SessionEventBus} from '../../../../src/agent/infra/events/event-emitter.js'
+import {HarnessBootstrap} from '../../../../src/agent/infra/harness/harness-bootstrap.js'
+import {HarnessModuleBuilder} from '../../../../src/agent/infra/harness/harness-module-builder.js'
+import {HarnessStore} from '../../../../src/agent/infra/harness/harness-store.js'
+import {
+  GLOBAL_RATE_LIMITER,
+  TEST_ONLY_RESET,
+} from '../../../../src/agent/infra/harness/rate-limiter.js'
+import {AgentLLMService} from '../../../../src/agent/infra/llm/agent-llm-service.js'
+import {SandboxService} from '../../../../src/agent/infra/sandbox/sandbox-service.js'
+import {FileKeyStorage} from '../../../../src/agent/infra/storage/file-key-storage.js'
+import {HarnessContributor} from '../../../../src/agent/infra/system-prompt/contributors/harness-contributor.js'
+import {SystemPromptManager} from '../../../../src/agent/infra/system-prompt/system-prompt-manager.js'
+import {ToolManager} from '../../../../src/agent/infra/tools/tool-manager.js'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const PROJECT_ID = 'null-mode-skip-test'
+const COMMAND_TYPE = 'curate' as const
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeConfig(overrides: Partial<ValidatedHarnessConfig> = {}): ValidatedHarnessConfig {
+  return {
+    autoLearn: true,
+    enabled: true,
+    language: 'typescript',
+    maxVersions: 20,
+    ...overrides,
+  }
+}
+
+function makeVersion(projectId: string): HarnessVersion {
+  return {
+    code: `
+      exports.meta = function() {
+        return {
+          capabilities: ['curate'],
+          commandType: 'curate',
+          projectPatterns: ['**/*'],
+          version: 1,
+        }
+      }
+      exports.curate = async function(ctx) {
+        return {ok: true}
+      }
+    `,
+    commandType: 'curate',
+    createdAt: Date.now(),
+    heuristic: 0.45,
+    id: 'v-null-mode-test',
+    metadata: {
+      capabilities: ['curate'],
+      commandType: 'curate',
+      projectPatterns: ['**/*'],
+      version: 1,
+    },
+    projectId,
+    projectType: 'typescript',
+    version: 1,
+  }
+}
+
+/**
+ * Seed N outcomes into the store. Uses `batchIndex` to space timestamps:
+ * batch 0 outcomes are older, batch 1 are newer. This ensures the
+ * window (most-recent 50) is dominated by the later batch when both
+ * exist.
+ */
+async function seedOutcomes(
+  store: HarnessStore,
+  projectId: string,
+  spec: {batchIndex?: number; count: number; stderr: string; success: boolean},
+): Promise<void> {
+  const now = Date.now()
+  // Batch 0 timestamps: 100s ago. Batch 1: recent.
+  // Ensures batch 1 outcomes are strictly more recent than batch 0.
+  const baseOffset = spec.batchIndex === 1 ? 0 : 100_000
+  const promises: Promise<void>[] = []
+  for (let i = 0; i < spec.count; i++) {
+    promises.push(
+      store.saveOutcome({
+        code: `step ${i}`,
+        commandType: COMMAND_TYPE,
+        delegated: true,
+        executionTimeMs: 10,
+        id: `o-batch${spec.batchIndex ?? 0}-${i}-${now}`,
+        projectId,
+        projectType: 'typescript',
+        sessionId: 'integ-sess',
+        stderr: spec.stderr,
+        success: spec.success,
+        timestamp: now - baseOffset + i * 1000,
+        usedHarness: true,
+      }),
+    )
+  }
+
+  await Promise.all(promises)
+}
+
+interface Stack {
+  readonly agentService: AgentLLMService
+  readonly harnessStore: HarnessStore
+  readonly sandboxService: SandboxService
+  readonly sessionEventBus: SessionEventBus
+  readonly systemPromptManager: SystemPromptManager
+}
+
+async function buildStack(
+  sessionId: string,
+  harnessConfig: ValidatedHarnessConfig,
+): Promise<Stack> {
+  const logger = new NoOpLogger()
+  const sessionEventBus = new SessionEventBus()
+
+  const keyStorage = new FileKeyStorage({inMemory: true})
+  await keyStorage.initialize()
+  const harnessStore = new HarnessStore(keyStorage, logger)
+
+  const sandboxService = new SandboxService()
+  const builder = new HarnessModuleBuilder(logger)
+  sandboxService.setHarnessConfig(harnessConfig)
+  sandboxService.setHarnessStore(harnessStore)
+  sandboxService.setHarnessModuleBuilder(builder)
+
+  const harnessBootstrap = new HarnessBootstrap(
+    harnessStore,
+    // HarnessBootstrap's 2nd arg is `IFileSystem`, used only inside
+    // `bootstrapIfNeeded` for project-type detection. Not called in
+    // this test — versions are seeded directly.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    {} as any,
+    harnessConfig,
+    logger,
+  )
+
+  const systemPromptManager = new SystemPromptManager()
+  if (harnessConfig.enabled) {
+    systemPromptManager.registerContributor(new HarnessContributor())
+  }
+
+  const mockToolProvider = {
+    getAllTools: () => ({}),
+    getAvailableMarkers: () => new Set<string>(),
+    getToolNames: () => [],
+  }
+  const toolManager = new ToolManager(mockToolProvider as unknown as IToolProvider)
+
+  const generator: IContentGenerator = {
+    generateContent() {
+      throw new Error('integration test: content generator must not be invoked')
+    },
+  } as unknown as IContentGenerator
+
+  const agentService = new AgentLLMService(
+    sessionId,
+    generator,
+    {model: 'gemini-2.5-flash'},
+    {
+      harnessBootstrap,
+      harnessConfig,
+      harnessStore,
+      sandboxService,
+      sessionEventBus,
+      systemPromptManager,
+      toolManager,
+    },
+  )
+
+  return {agentService, harnessStore, sandboxService, sessionEventBus, systemPromptManager}
+}
+
+/** Private-method test access — same pattern as mode-selection.test.ts. */
+type EnsureHarnessReadyResult = undefined | {mode: HarnessMode; version: HarnessVersion}
+function callEnsureHarnessReady(
+  service: AgentLLMService,
+  commandType: 'chat' | 'curate' | 'query',
+): Promise<EnsureHarnessReadyResult> {
+  const internal = service as unknown as {
+    ensureHarnessReady: (ct: 'chat' | 'curate' | 'query') => Promise<EnsureHarnessReadyResult>
+  }
+  return internal.ensureHarnessReady(commandType)
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('AutoHarness V2 — null-mode skip integration', function () {
+  this.timeout(10_000)
+
+  let sb: SinonSandbox
+  let modeEvents: Array<{heuristic: number; mode: HarnessMode}>
+
+  beforeEach(() => {
+    sb = createSandbox()
+    sb.stub(process, 'cwd').returns(PROJECT_ID)
+    modeEvents = []
+    GLOBAL_RATE_LIMITER[TEST_ONLY_RESET]()
+  })
+
+  afterEach(() => {
+    sb.restore()
+    GLOBAL_RATE_LIMITER[TEST_ONLY_RESET]()
+  })
+
+  it('H=0 skips cleanly, then H climb enables Mode A', async () => {
+    // ── Step 1: Stack setup ──────────────────────────────────────────
+    // harness.enabled: true, no modeOverride.
+    const sessionId = 'null-mode-sess'
+    const config = makeConfig()
+    const stack = await buildStack(sessionId, config)
+    stack.sessionEventBus.on('harness:mode-selected', (payload) => {
+      modeEvents.push(payload as {heuristic: number; mode: HarnessMode})
+    })
+
+    // ── Step 2: Seed v1 ──────────────────────────────────────────────
+    const version = makeVersion(PROJECT_ID)
+    await stack.harnessStore.saveVersion(version)
+
+    // ── Step 3: Seed 15 outcomes → H = 0 ─────────────────────────────
+    // success=false, stderr='err' → successRate=0, errorRate=1,
+    // realHarnessRate=0 → H = 0.2·0 + 0.3·(1-1) + 0.5·0 = 0.
+    await seedOutcomes(stack.harnessStore, PROJECT_ID, {
+      batchIndex: 0,
+      count: 15,
+      stderr: 'err',
+      success: false,
+    })
+
+    // ── Step 4: ensureHarnessReady → undefined, no event ─────────────
+    const ready = await callEnsureHarnessReady(stack.agentService, COMMAND_TYPE)
+
+    expect(ready).to.equal(undefined)
+    expect(modeEvents).to.have.length(0)
+
+    // ── Step 5: System prompt has no harness block ────────────────────
+    const prompt = await stack.systemPromptManager.build({
+      commandType: COMMAND_TYPE,
+      harnessMode: ready?.mode,
+      harnessVersion: ready?.version,
+    })
+    expect(prompt).to.not.include('<harness-v2')
+
+    // ── Step 6: Sandbox code → typeof harness === 'undefined' ────────
+    // Use a fresh session that never had loadHarness called — proves
+    // the null-mode code path leaves the sandbox clean.
+    const cleanSessionId = 'no-harness-session'
+    const exec = await stack.sandboxService.executeCode(
+      `typeof harness === 'undefined'`,
+      cleanSessionId,
+    )
+    expect(exec.returnValue).to.equal(true)
+
+    // ── Step 7: Seed outcomes to climb H above 0.30 ──────────────────
+    // 40 outcomes with success=true, stderr='' at more-recent timestamps.
+    // Window of 50: ~40 successes + ~10 failures from batch 0.
+    // H ≈ 0.2·(40/50) + 0.3·(1 - 10/50) + 0 = 0.16 + 0.24 = 0.40.
+    await seedOutcomes(stack.harnessStore, PROJECT_ID, {
+      batchIndex: 1,
+      count: 40,
+      stderr: '',
+      success: true,
+    })
+
+    // ── Step 8: ensureHarnessReady → Mode A, event fires ─────────────
+    // The first call (step 4) returned before the dedup check, so
+    // the dedup key was NOT added. This call emits the event.
+    const readyAfter = await callEnsureHarnessReady(stack.agentService, COMMAND_TYPE)
+
+    expect(readyAfter).to.not.equal(undefined)
+    if (readyAfter === undefined) throw new Error('expected Mode A selection after H climb')
+    expect(readyAfter.mode).to.equal('assisted')
+
+    expect(modeEvents).to.have.length(1)
+    expect(modeEvents[0].mode).to.equal('assisted')
+    expect(modeEvents[0].heuristic).to.be.greaterThanOrEqual(0.3)
+
+    // Subsequent sandbox exec sees harness namespace. The session
+    // used by ensureHarnessReady had loadHarness called internally,
+    // so that session's sandbox has the harness module loaded.
+    const execAfter = await stack.sandboxService.executeCode(
+      `typeof harness !== 'undefined' && typeof harness.curate === 'function'`,
+      sessionId,
+    )
+    expect(execAfter.returnValue).to.equal(true)
+  })
+})

--- a/test/unit/scripts/harness-smoke.test.ts
+++ b/test/unit/scripts/harness-smoke.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Unit tests for the harness smoke script step functions.
+ *
+ * Each step is tested in isolation against an inMemory stack. Steps
+ * that depend on prior state (e.g., step 3 needs v1 from step 2)
+ * have their preconditions set up directly in the test.
+ *
+ * The full sequential run is also tested to verify end-to-end
+ * completion under 30s.
+ */
+
+import {expect} from 'chai'
+
+import type {SmokeContext} from '../../../scripts/harness-smoke.js'
+
+import {
+  cleanupSmokeContext,
+  createSmokeContext,
+  runSmoke,
+  SmokeAssertionError,
+  step01EnableAndStatus,
+  step02BootstrapAndCurate,
+  step03InspectV1,
+  step04RefinementToV2,
+  step05SessionBanner,
+  step06DiffV1V2,
+  step07CurateWithV2,
+  step08FeedbackBad,
+  step09HeuristicDrops,
+  step10PinV1,
+  step11Baseline,
+  step12DisableHarness,
+  STEPS,
+} from '../../../scripts/harness-smoke.js'
+
+describe('harness-smoke step functions', function () {
+  this.timeout(30_000)
+
+  let ctx: SmokeContext
+
+  beforeEach(async () => {
+    ctx = await createSmokeContext({llmMode: 'stub'})
+  })
+
+  afterEach(() => {
+    cleanupSmokeContext(ctx)
+  })
+
+  describe('step 1 — enable and status', () => {
+    it('passes with enabled config and empty store', async () => {
+      await step01EnableAndStatus(ctx)
+    })
+  })
+
+  describe('step 2 — bootstrap and curate', () => {
+    it('creates v1 and records 3 outcomes', async () => {
+      await step02BootstrapAndCurate(ctx)
+      expect(ctx.state.v1).to.not.equal(undefined)
+      expect(ctx.state.v1?.version).to.equal(1)
+    })
+  })
+
+  describe('step 3 — inspect v1', () => {
+    it('fails without v1 in state', async () => {
+      try {
+        await step03InspectV1(ctx)
+        expect.fail('should have thrown')
+      } catch (error) {
+        expect(error).to.be.instanceOf(SmokeAssertionError)
+      }
+    })
+
+    it('passes after step 2 populates v1', async () => {
+      await step02BootstrapAndCurate(ctx)
+      await step03InspectV1(ctx)
+    })
+  })
+
+  describe('step 4 — refinement to v2', () => {
+    it('creates v2 via synthesizer', async () => {
+      await step02BootstrapAndCurate(ctx)
+      await step04RefinementToV2(ctx)
+      expect(ctx.state.v2).to.not.equal(undefined)
+      expect(ctx.state.v2?.version).to.equal(2)
+      expect(ctx.state.refinementEvents).to.have.length(1)
+    })
+  })
+
+  describe('step 5 — session banner', () => {
+    it('prints banner after refinement', async () => {
+      await step02BootstrapAndCurate(ctx)
+      await step04RefinementToV2(ctx)
+      await step05SessionBanner(ctx)
+      expect(ctx.bannerLines).to.have.length(1)
+      expect(ctx.bannerLines[0]).to.match(/harness updated/)
+    })
+  })
+
+  describe('step 6 — diff v1 v2', () => {
+    it('shows diff between versions', async () => {
+      await step02BootstrapAndCurate(ctx)
+      await step04RefinementToV2(ctx)
+      await step06DiffV1V2(ctx)
+    })
+  })
+
+  describe('step 7 — curate with v2', () => {
+    it('loads and executes v2', async () => {
+      await step02BootstrapAndCurate(ctx)
+      await step04RefinementToV2(ctx)
+      await step07CurateWithV2(ctx)
+    })
+  })
+
+  describe('step 8 — feedback bad', () => {
+    it('inserts 3 synthetic failures', async () => {
+      await step08FeedbackBad(ctx)
+    })
+  })
+
+  describe('step 9 — heuristic drops', () => {
+    it('H drops after synthetics from step 8', async () => {
+      await step08FeedbackBad(ctx)
+      await step09HeuristicDrops(ctx)
+    })
+  })
+
+  describe('step 10 — pin v1', () => {
+    it('loadHarness returns pinned v1', async () => {
+      await step02BootstrapAndCurate(ctx)
+      await step10PinV1(ctx)
+    })
+  })
+
+  describe('step 11 — baseline', () => {
+    it('runs dual-arm replay', async () => {
+      await step02BootstrapAndCurate(ctx)
+      await step04RefinementToV2(ctx)
+      await step11Baseline(ctx)
+    })
+  })
+
+  describe('step 12 — disable harness', () => {
+    it('loadHarness returns loaded=false', async () => {
+      await step12DisableHarness(ctx)
+    })
+  })
+
+  describe('full sequential run', () => {
+    it('all 12 steps pass in under 30s', async () => {
+      const results = await runSmoke(ctx)
+      const allPassed = results.every((r) => r.passed)
+      const failDetails = results
+        .filter((r) => !r.passed)
+        .map((r) => `${r.stepNumber}: ${r.details}`)
+        .join(', ')
+      expect(allPassed, `failed steps: ${failDetails}`).to.equal(true)
+      expect(results).to.have.length(STEPS.length)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Problem: Phase 8 lacked a test for the null-mode (H below threshold) path and a runnable smoke script for the §4.3 12-step pre-ship verification.
- Why it matters: The null-mode path is a coverage gap — no test explicitly pinned that H=0 cleanly skips harness injection. The smoke script is a pre-ship ritual engineers run before dogfooding.
- What changed:
  - **Part A**: `test/integration/agent/harness/null-mode-skip.test.ts` — 8-step integration test proving H=0 skips cleanly (no event, no prompt block, no sandbox harness), then H climb enables Mode A.
  - **Part B**: `scripts/harness-smoke.ts` — 12-step §4.3 smoke script with exported step functions. `npm run smoke:harness` walks the full lifecycle against an inMemory stack.
  - **Part B tests**: `test/unit/scripts/harness-smoke.test.ts` — 14 tests (each step in isolation + negative case + full sequential run, 209ms total).
  - `package.json` — Added `smoke:harness` npm script.
- What did NOT change (scope boundary): No production code modified. No changes to harness, agent, or CLI commands. Script is `.ts` (not `.mjs`) for source-import convenience — ticket says "(or .ts)".

## Type of change

- [x] New feature
- [x] Test

## Scope (select all touched areas)

- [x] Agent / Tools

## Linked issues

- Closes ENG-2331

## Root cause (bug fixes only, otherwise write `N/A`)

N/A

## Test plan

- Coverage added:
  - [x] Unit test
  - [x] Integration test
  - [x] Manual verification only
- Test file(s):
  - `test/integration/agent/harness/null-mode-skip.test.ts` (1 test, 8 steps)
  - `test/unit/scripts/harness-smoke.test.ts` (14 tests)
- Key scenario(s) covered:
  - Null-mode: H=0 → ensureHarnessReady returns undefined, no mode-selected event, system prompt has no harness block, sandbox has no harness namespace
  - Null-mode → Mode A transition: seeding success outcomes pushes H above 0.30 → Mode A selection, event fires, sandbox sees harness
  - Smoke: all 12 §4.3 steps (status, bootstrap, inspect, refinement, banner, diff, curate-v2, feedback, H-drop, pin, baseline, disable) pass end-to-end

## User-visible changes

- `npm run smoke:harness` — new npm script for pre-ship smoke verification (12/12 steps, <1s on inMemory stack).

## Evidence

```
$ npm run smoke:harness
AutoHarness V2 — Smoke Test
LLM mode: stub

  PASS  Step 1: Enable harness, run status
  PASS  Step 2: Bootstrap + 3 curate calls
  PASS  Step 3: Inspect v1
  PASS  Step 4: Seed outcomes + refinement -> v2
  PASS  Step 5: Session-end banner
  PASS  Step 6: Diff v1 v2
  PASS  Step 7: Curate with v2
  PASS  Step 8: Feedback bad -> synthetics
  PASS  Step 9: H drops after bad feedback
  PASS  Step 10: Pin v1 -> loadHarness returns v1
  PASS  Step 11: Baseline dual-arm replay
  PASS  Step 12: Disable harness

12/12 steps passed
```

```
$ npx mocha "test/integration/agent/harness/null-mode-skip.test.ts" "test/unit/scripts/harness-smoke.test.ts"
  15 passing (209ms)
```

```
$ npm test
  7246 passing (55s)
  16 pending
```

## Checklist

- [x] Tests added or updated and passing (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow Conventional Commits format
- [x] No breaking changes

## Risks and mitigations

- Risk: Smoke script imports from source via ts-node — could break if ts-node ESM loader changes behavior.
  - Mitigation: The `--loader ts-node/esm` flag matches the project's mocha config. If mocha works, the smoke script works.