### PR TITLE
feat: [ENG-2325] ship brv harness baseline command (Task 7.5 AC gap)

### DIFF
--- a/src/oclif/commands/harness/baseline.ts
+++ b/src/oclif/commands/harness/baseline.ts
@@ -49,7 +49,6 @@ import {
 import {resolveProject} from '../../../server/infra/project/resolve-project.js'
 import {
   HARNESS_COMMAND_TYPES,
-  type HarnessCommandType,
   isHarnessCommandType,
   openHarnessStoreForProject,
 } from '../../lib/harness-cli.js'
@@ -97,16 +96,24 @@ function pct(n: number): string {
   return `${(n * 100).toFixed(0)}%`
 }
 
+function signedPct(n: number): string {
+  return n >= 0 ? `+${pct(n)}` : pct(n)
+}
+
 function symbol(ok: boolean): string {
   return ok ? '✓' : '✗'
 }
 
 export function renderBaselineText(report: BaselineReport): string {
   const lines: string[] = [
+    '⚠  Baseline runs with a no-op tool stub — `readFile` throws, and',
+    '   any harness that calls it counts as a failure. Treat results',
+    '   as a crash-rate signal, not a tool-interaction-quality signal.',
+    '',
     `scenarios: ${report.scenarioCount}`,
     `raw:       ${pct(report.rawSuccessRate)}`,
     `harness:   ${pct(report.harnessSuccessRate)}`,
-    `delta:     ${signedFixed2(report.delta)}  (${pct(report.delta)})`,
+    `delta:     ${signedFixed2(report.delta)}  (${signedPct(report.delta)})`,
     '',
     '── per-scenario ─────────────────────────────────────',
   ]
@@ -173,6 +180,11 @@ export default class HarnessBaseline extends Command {
 
   async run(): Promise<void> {
     const {flags} = await this.parse(HarnessBaseline)
+    // oclif's `options:` validator rejects unknown values before we
+    // reach here — this guard is a TypeScript type predicate, not
+    // runtime validation. It narrows `flags.commandType` from
+    // `string` to `HarnessCommandType` so the runner call below
+    // needs no `as` cast.
     if (!isHarnessCommandType(flags.commandType)) {
       this.error(`invalid --commandType value '${flags.commandType}'`, {exit: 1})
     }
@@ -192,7 +204,7 @@ export default class HarnessBaseline extends Command {
     try {
       const runner = new HarnessBaselineRunner(opened.store, new NoOpLogger(), makeStubToolsFactory())
       const report = await runner.runBaseline({
-        commandType: commandType as HarnessCommandType,
+        commandType,
         count: flags.count,
         projectId: opened.projectId,
       })

--- a/src/oclif/commands/harness/baseline.ts
+++ b/src/oclif/commands/harness/baseline.ts
@@ -1,0 +1,218 @@
+/**
+ * `brv harness baseline` — AutoHarness V2 Phase 7 Task 7.5 (completion).
+ *
+ * Replays the last N stored scenarios through two arms — raw Option-C
+ * pass-through template vs the current stored harness — and reports
+ * the success-rate delta. Tier 1 Q1 brutal-review item from the
+ * AutoHarness V2 doc set: "is the harness actually doing anything
+ * for me on my scenarios?"
+ *
+ * The underlying `HarnessBaselineRunner` shipped in the first PR for
+ * ENG-2325. This file is the oclif wrapper owed by the task AC — it
+ * was deferred in the earlier PR on the (incorrect) judgment that
+ * 7.1's CLI transport pattern had to land first, and Phat called
+ * the gap when the command wasn't there.
+ *
+ * ## Tool factory choice
+ *
+ * The runner needs a `HarnessToolsFactory` to execute the harness
+ * module per scenario. Two reasonable options:
+ *
+ *   - **Production-style**: boot `SandboxService`, wire
+ *     `buildHarnessTools({dryRun: true})`. More authentic — tool
+ *     calls go through the real sandbox plumbing in dry-run mode.
+ *   - **Stub-only**: the command's success semantic is "harness
+ *     function invocation completed without throwing" — a no-op
+ *     tool surface is sufficient to detect crashes, syntax errors,
+ *     and bad tool lookups.
+ *
+ * We take the stub path: lighter CLI footprint, same success/
+ * failure signal shape, no sandbox startup. If we ever want the
+ * baseline to measure tool-interaction quality (not just crash
+ * rates), the factory is a one-line swap to the production wiring.
+ */
+
+import {Command, Flags} from '@oclif/core'
+
+import type {HarnessContextTools} from '../../../agent/core/domain/harness/types.js'
+import type {
+  BaselineReport,
+  BaselineScenarioResult,
+} from '../../../agent/infra/harness/harness-baseline-runner.js'
+
+import {NoOpLogger} from '../../../agent/core/interfaces/i-logger.js'
+import {
+  BASELINE_MAX_COUNT,
+  HarnessBaselineRunner,
+  HarnessBaselineRunnerError,
+} from '../../../agent/infra/harness/harness-baseline-runner.js'
+import {resolveProject} from '../../../server/infra/project/resolve-project.js'
+import {
+  HARNESS_COMMAND_TYPES,
+  type HarnessCommandType,
+  isHarnessCommandType,
+  openHarnessStoreForProject,
+} from '../../lib/harness-cli.js'
+
+const DEFAULT_COUNT = 10
+
+/**
+ * §C2-shaped per-scenario entry for JSON output. The runner's
+ * internal `BaselineScenarioResult` carries stderr fields for text
+ * rendering; the pinned handoff shape trims to outcome only.
+ */
+export interface BaselineJsonPerScenario {
+  readonly harnessOutcome: 'failure' | 'success'
+  readonly rawOutcome: 'failure' | 'success'
+  readonly scenarioId: string
+}
+
+export interface BaselineJsonReport {
+  readonly delta: number
+  readonly harnessSuccessRate: number
+  readonly perScenario: readonly BaselineJsonPerScenario[]
+  readonly rawSuccessRate: number
+  readonly scenarioCount: number
+}
+
+export function toBaselineJsonReport(report: BaselineReport): BaselineJsonReport {
+  return {
+    delta: report.delta,
+    harnessSuccessRate: report.harnessSuccessRate,
+    perScenario: report.perScenario.map((r) => ({
+      harnessOutcome: r.harnessSuccess ? 'success' : 'failure',
+      rawOutcome: r.rawSuccess ? 'success' : 'failure',
+      scenarioId: r.scenarioId,
+    })),
+    rawSuccessRate: report.rawSuccessRate,
+    scenarioCount: report.scenarioCount,
+  }
+}
+
+function signedFixed2(n: number): string {
+  return n >= 0 ? `+${n.toFixed(2)}` : n.toFixed(2)
+}
+
+function pct(n: number): string {
+  return `${(n * 100).toFixed(0)}%`
+}
+
+function symbol(ok: boolean): string {
+  return ok ? '✓' : '✗'
+}
+
+export function renderBaselineText(report: BaselineReport): string {
+  const lines: string[] = [
+    `scenarios: ${report.scenarioCount}`,
+    `raw:       ${pct(report.rawSuccessRate)}`,
+    `harness:   ${pct(report.harnessSuccessRate)}`,
+    `delta:     ${signedFixed2(report.delta)}  (${pct(report.delta)})`,
+    '',
+    '── per-scenario ─────────────────────────────────────',
+  ]
+
+  const rows = report.perScenario.map((r) => formatScenarioRow(r))
+  lines.push(...rows)
+
+  return lines.join('\n')
+}
+
+function formatScenarioRow(r: BaselineScenarioResult): string {
+  const base = `${symbol(r.rawSuccess)} raw  ${symbol(r.harnessSuccess)} harness  ${r.scenarioId}`
+  const errors: string[] = []
+  if (r.rawStderr !== undefined) errors.push(`raw: ${r.rawStderr}`)
+  if (r.harnessStderr !== undefined) errors.push(`harness: ${r.harnessStderr}`)
+  return errors.length === 0 ? base : `${base}\n    ${errors.join(' | ')}`
+}
+
+/**
+ * Stub `HarnessToolsFactory` for CLI use. No-op tools mean the
+ * baseline measures crash rate and tool-call-shape correctness,
+ * not tool output quality. See the module header for the
+ * production-wiring alternative.
+ */
+function makeStubToolsFactory(): () => HarnessContextTools {
+  return () => ({
+    async curate() {
+      return {
+        applied: [],
+        summary: {added: 0, deleted: 0, failed: 0, merged: 0, updated: 0},
+      }
+    },
+    async readFile() {
+      throw new Error('readFile unavailable in baseline stub — harness should not read files in a dry-run baseline.')
+    },
+  })
+}
+
+export default class HarnessBaseline extends Command {
+  static description = 'Replay stored scenarios through raw vs harness arms and report the success-rate delta'
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --count 20',
+    '<%= config.bin %> <%= command.id %> --format json',
+  ]
+  static flags = {
+    commandType: Flags.string({
+      default: 'curate',
+      description: 'Harness pair command type',
+      options: [...HARNESS_COMMAND_TYPES],
+    }),
+    count: Flags.integer({
+      default: DEFAULT_COUNT,
+      description: `Number of most-recent scenarios to replay (1-${BASELINE_MAX_COUNT})`,
+      max: BASELINE_MAX_COUNT,
+      min: 1,
+    }),
+    format: Flags.string({
+      default: 'text',
+      description: 'Output format',
+      options: ['text', 'json'],
+    }),
+  }
+
+  async run(): Promise<void> {
+    const {flags} = await this.parse(HarnessBaseline)
+    if (!isHarnessCommandType(flags.commandType)) {
+      this.error(`invalid --commandType value '${flags.commandType}'`, {exit: 1})
+    }
+
+    const {commandType} = flags
+    const format = flags.format === 'json' ? 'json' : 'text'
+
+    const projectRoot = resolveProject()?.projectRoot ?? process.cwd()
+    const opened = await openHarnessStoreForProject(projectRoot)
+    if (opened === undefined) {
+      this.error(
+        `no harness storage for this project (${projectRoot}) — run curate once to bootstrap.`,
+        {exit: 1},
+      )
+    }
+
+    try {
+      const runner = new HarnessBaselineRunner(opened.store, new NoOpLogger(), makeStubToolsFactory())
+      const report = await runner.runBaseline({
+        commandType: commandType as HarnessCommandType,
+        count: flags.count,
+        projectId: opened.projectId,
+      })
+
+      if (format === 'json') {
+        this.log(JSON.stringify(toBaselineJsonReport(report), null, 2))
+      } else {
+        this.log(renderBaselineText(report))
+      }
+    } catch (error) {
+      if (error instanceof HarnessBaselineRunnerError) {
+        // All runner-level errors are user-input / state problems
+        // per §C1 — exit 1 with the runner's own message (already
+        // includes remediation hints, e.g. "Run curate N more times").
+        this.error(error.message, {exit: 1})
+      }
+
+      throw error
+    } finally {
+      opened.close()
+    }
+  }
+}

--- a/test/unit/oclif/commands/harness/baseline.test.ts
+++ b/test/unit/oclif/commands/harness/baseline.test.ts
@@ -1,3 +1,24 @@
+/**
+ * Unit tests for `brv harness baseline`.
+ *
+ * Tests the pure logic functions (`toBaselineJsonReport`,
+ * `renderBaselineText`) extracted from the command. The oclif
+ * `run()` method is NOT covered here.
+ *
+ * Coverage exemption rationale: `run()` is thin glue — flag parse,
+ * resolve project, open store, delegate to `HarnessBaselineRunner`
+ * (separately tested), format-switch, release store. Each branch is
+ * one-liner routing; the logic lives in the helpers and the runner.
+ * Following the convention of sibling harness CLI commands
+ * (`diff.test.ts`, `status.test.ts`, `inspect.test.ts`, `use.test.ts`)
+ * which cover pure functions only. `reset.test.ts` is the one sibling
+ * that exercises `run()`, via a dedicated integration test — because
+ * `reset` has interactive-prompt behavior worth end-to-end coverage.
+ *
+ * If we later decide every harness CLI command needs `run()`
+ * coverage, that's a cross-command refactor, not this PR.
+ */
+
 import {expect} from 'chai'
 
 import type {BaselineReport} from '../../../../../src/agent/infra/harness/harness-baseline-runner.js'

--- a/test/unit/oclif/commands/harness/baseline.test.ts
+++ b/test/unit/oclif/commands/harness/baseline.test.ts
@@ -57,14 +57,21 @@ describe('HarnessBaseline command — toBaselineJsonReport + renderBaselineText'
       expect(text).to.include('scenarios: 4')
       expect(text).to.include('raw:       25%')
       expect(text).to.include('harness:   75%')
-      expect(text).to.match(/delta:\s+\+0\.50/)
+      expect(text).to.match(/delta:\s+\+0\.50\s+\(\+50%\)/)
     })
 
-    it('2. prefixes delta with "+" when positive, bare "-" when negative', () => {
+    it('2. signs both the decimal delta AND the percent delta consistently', () => {
       const positive = renderBaselineText(makeReport({delta: 0.3}))
-      expect(positive).to.match(/delta:\s+\+0\.30/)
+      expect(positive).to.match(/delta:\s+\+0\.30\s+\(\+30%\)/)
       const negative = renderBaselineText(makeReport({delta: -0.2}))
-      expect(negative).to.match(/delta:\s+-0\.20/)
+      expect(negative).to.match(/delta:\s+-0\.20\s+\(-20%\)/)
+    })
+
+    it('2b. leads with a stub-tool warning banner so users understand the signal shape', () => {
+      const text = renderBaselineText(makeReport())
+      expect(text).to.include('no-op tool stub')
+      expect(text).to.include('readFile')
+      expect(text).to.include('crash-rate signal')
     })
 
     it('3. includes per-scenario rows with ✓/✗ markers', () => {

--- a/test/unit/oclif/commands/harness/baseline.test.ts
+++ b/test/unit/oclif/commands/harness/baseline.test.ts
@@ -1,0 +1,93 @@
+import {expect} from 'chai'
+
+import type {BaselineReport} from '../../../../../src/agent/infra/harness/harness-baseline-runner.js'
+
+import {
+  renderBaselineText,
+  toBaselineJsonReport,
+} from '../../../../../src/oclif/commands/harness/baseline.js'
+
+function makeReport(overrides: Partial<BaselineReport> = {}): BaselineReport {
+  return {
+    delta: 0.5,
+    harnessSuccessRate: 0.75,
+    perScenario: [
+      {harnessSuccess: true, rawStderr: 'boom', rawSuccess: false, scenarioId: 's-1'},
+      {harnessSuccess: true, rawStderr: 'boom', rawSuccess: false, scenarioId: 's-2'},
+      {harnessSuccess: true, rawSuccess: true, scenarioId: 's-3'},
+      {harnessStderr: 'crash', harnessSuccess: false, rawSuccess: true, scenarioId: 's-4'},
+    ],
+    rawSuccessRate: 0.25,
+    scenarioCount: 4,
+    ...overrides,
+  }
+}
+
+describe('HarnessBaseline command — toBaselineJsonReport + renderBaselineText', () => {
+  describe('toBaselineJsonReport', () => {
+    it('1. maps per-scenario outcomes to the handoff §C2 "success"/"failure" shape', () => {
+      const json = toBaselineJsonReport(makeReport())
+      expect(json.perScenario).to.deep.equal([
+        {harnessOutcome: 'success', rawOutcome: 'failure', scenarioId: 's-1'},
+        {harnessOutcome: 'success', rawOutcome: 'failure', scenarioId: 's-2'},
+        {harnessOutcome: 'success', rawOutcome: 'success', scenarioId: 's-3'},
+        {harnessOutcome: 'failure', rawOutcome: 'success', scenarioId: 's-4'},
+      ])
+    })
+
+    it('2. propagates scalar fields unchanged (rates + delta + count)', () => {
+      const json = toBaselineJsonReport(makeReport())
+      expect(json.scenarioCount).to.equal(4)
+      expect(json.rawSuccessRate).to.equal(0.25)
+      expect(json.harnessSuccessRate).to.equal(0.75)
+      expect(json.delta).to.equal(0.5)
+    })
+
+    it('3. JSON shape does not leak stderr fields (pinned contract)', () => {
+      const json = toBaselineJsonReport(makeReport())
+      for (const entry of json.perScenario) {
+        expect(Object.keys(entry).sort()).to.deep.equal(['harnessOutcome', 'rawOutcome', 'scenarioId'])
+      }
+    })
+  })
+
+  describe('renderBaselineText', () => {
+    it('1. renders a human-readable summary block with rates + delta', () => {
+      const text = renderBaselineText(makeReport())
+      expect(text).to.include('scenarios: 4')
+      expect(text).to.include('raw:       25%')
+      expect(text).to.include('harness:   75%')
+      expect(text).to.match(/delta:\s+\+0\.50/)
+    })
+
+    it('2. prefixes delta with "+" when positive, bare "-" when negative', () => {
+      const positive = renderBaselineText(makeReport({delta: 0.3}))
+      expect(positive).to.match(/delta:\s+\+0\.30/)
+      const negative = renderBaselineText(makeReport({delta: -0.2}))
+      expect(negative).to.match(/delta:\s+-0\.20/)
+    })
+
+    it('3. includes per-scenario rows with ✓/✗ markers', () => {
+      const text = renderBaselineText(makeReport())
+      expect(text).to.include('✗ raw  ✓ harness  s-1')
+      expect(text).to.include('✓ raw  ✗ harness  s-4')
+    })
+
+    it('4. appends stderr text when either arm surfaced one', () => {
+      const text = renderBaselineText(makeReport())
+      expect(text).to.include('raw: boom')
+      expect(text).to.include('harness: crash')
+    })
+
+    it('5. scenarios with no stderr get the row alone (no trailing error line)', () => {
+      const text = renderBaselineText(makeReport({
+        perScenario: [
+          {harnessSuccess: true, rawSuccess: true, scenarioId: 's-ok'},
+        ],
+      }))
+      // The row is present, and no "raw: " or "harness: " error payload follows.
+      expect(text).to.include('✓ raw  ✓ harness  s-ok')
+      expect(text).to.not.match(/s-ok\n\s+(raw|harness): /)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Completes Task 7.5's first AC — **\`brv harness baseline\` implemented with text + json output** — which was missed in the first PR for ENG-2325. The underlying \`HarnessBaselineRunner\` shipped then; only the oclif wrapper is new here.

### Why this is a second PR under the same ticket

The earlier PR's "v1.0 scope narrowing" rationale (deferral of the CLI wrapper pending Task 7.1's transport pattern) was a judgment call I invented; the task AC explicitly required the command. 

### New files

- \`src/oclif/commands/harness/baseline.ts\` — thin wrapper over \`HarnessBaselineRunner\`. Flags: \`--commandType\`, \`--count\` (1..50, default 10), \`--format\` (text/json).
- \`test/unit/oclif/commands/harness/baseline.test.ts\` — 8 tests covering JSON-shape mapping (per handoff §C2), text rendering with +/- delta sign, ✓/✗ per-scenario markers, stderr attachment, and absence-of-stderr path.

### Tool-factory decision

The runner needs a \`HarnessToolsFactory\`. The CLI uses a **no-op stub** (documented in the file header). The runner's success semantic is "function invocation didn't throw", which the stub satisfies — we detect crashes and bad tool lookups without booting \`SandboxService\`. Swapping to production wiring (\`SandboxService.buildHarnessTools({dryRun: true})\`) is a one-line change if we later want tool-interaction-quality
measurement.

### Output shapes

- \`--format json\` → §C2 shape exactly (stderr fields filtered out per the pinned contract).
- \`--format text\` → summary block + per-scenario rows with ✓/✗ markers. Stderrs inlined beneath rows that have them.

### Exit codes (§C1)

- \`0\` on successful run (even negative or zero delta).
- \`1\` on \`HarnessBaselineRunnerError\` (\`COUNT_OUT_OF_RANGE\`,
  \`INSUFFICIENT_SCENARIOS\`, \`NO_CURRENT_VERSION\`,
  \`UNSUPPORTED_COMMAND_TYPE\`).
- \`1\` on missing harness storage.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — 0 errors (271 pre-existing warnings)
- [x] \`npm test\` — 7283 passing, 16 pending, 0 failing
- [x] \`npm run build\` — clean

## Acceptance criteria (re-verified against task_05-baseline.md)

- [x] \`brv harness baseline\` implemented with text + json output
- [x] Dual-arm replay (raw template vs current harness) — via the runner already shipped
- [x] \`dryRun\` enforcement on both arms — stub factory is inherently side-effect-free; \`readFile\` throws loudly if the harness tries to read disk
- [x] Minimum 3 scenarios; clear error below that — runner emits \`INSUFFICIENT_SCENARIOS\` which the command surfaces via \`this.error({exit: 1})\`
- [x] JSON shape matches \`phase_7_8_handoff.md §C2\`
