### PR TITLE
fix: [ENG-2459] prevent unnecessary frontmatter field reordering in dream operations

### DIFF
--- a/src/server/infra/context-tree/summary-frontmatter.ts
+++ b/src/server/infra/context-tree/summary-frontmatter.ts
@@ -52,7 +52,7 @@ export function generateSummaryContent(frontmatter: SummaryFrontmatter, body: st
     type: 'summary',
   }
 
-  const yamlContent = yamlDump(fm, {flowLevel: 1, lineWidth: -1, sortKeys: true}).trimEnd()
+  const yamlContent = yamlDump(fm, {flowLevel: 1, lineWidth: -1, sortKeys: false}).trimEnd()
 
   return `---\n${yamlContent}\n---\n${body}`
 }
@@ -92,7 +92,7 @@ export function generateArchiveStubContent(frontmatter: ArchiveStubFrontmatter, 
     type: 'archive_stub',
   }
 
-  const yamlContent = yamlDump(fm, {flowLevel: 1, lineWidth: -1, sortKeys: true}).trimEnd()
+  const yamlContent = yamlDump(fm, {flowLevel: 1, lineWidth: -1, sortKeys: false}).trimEnd()
 
   return `---\n${yamlContent}\n---\n${ghostCue}`
 }

--- a/src/server/infra/dream/operations/consolidate.ts
+++ b/src/server/infra/dream/operations/consolidate.ts
@@ -293,6 +293,7 @@ function addFrontmatterFields(content: string, fields: Record<string, unknown>):
       try {
         const parsed = yamlLoad(yamlBlock) as null | Record<string, unknown>
         if (parsed && typeof parsed === 'object') {
+          // Spread preserves existing key order; new fields are appended at end.
           const merged = {...parsed, ...fields}
           const newYaml = yamlDump(merged, {flowLevel: 2, lineWidth: -1, sortKeys: false}).trimEnd()
           return `---\n${newYaml}\n---\n${body}`

--- a/src/server/infra/dream/operations/consolidate.ts
+++ b/src/server/infra/dream/operations/consolidate.ts
@@ -294,7 +294,7 @@ function addFrontmatterFields(content: string, fields: Record<string, unknown>):
         const parsed = yamlLoad(yamlBlock) as null | Record<string, unknown>
         if (parsed && typeof parsed === 'object') {
           const merged = {...parsed, ...fields}
-          const newYaml = yamlDump(merged, {flowLevel: 2, lineWidth: -1, sortKeys: true}).trimEnd()
+          const newYaml = yamlDump(merged, {flowLevel: 2, lineWidth: -1, sortKeys: false}).trimEnd()
           return `---\n${newYaml}\n---\n${body}`
         }
       } catch {
@@ -304,7 +304,7 @@ function addFrontmatterFields(content: string, fields: Record<string, unknown>):
   }
 
   // No valid frontmatter — prepend
-  const yaml = yamlDump(fields, {flowLevel: 2, lineWidth: -1, sortKeys: true}).trimEnd()
+  const yaml = yamlDump(fields, {flowLevel: 2, lineWidth: -1, sortKeys: false}).trimEnd()
   return `---\n${yaml}\n---\n${content}`
 }
 
@@ -661,7 +661,7 @@ async function addRelatedLinks(filePath: string, relatedPaths: string[]): Promis
         if (parsed && typeof parsed === 'object') {
           const existing = Array.isArray(parsed.related) ? (parsed.related as string[]) : []
           parsed.related = [...new Set([...existing, ...relatedPaths])]
-          const newYaml = yamlDump(parsed, {flowLevel: 1, lineWidth: -1, sortKeys: true}).trimEnd()
+          const newYaml = yamlDump(parsed, {flowLevel: 1, lineWidth: -1, sortKeys: false}).trimEnd()
           await atomicWrite(filePath, `---\n${newYaml}\n---\n${body}`)
           return
         }
@@ -672,7 +672,7 @@ async function addRelatedLinks(filePath: string, relatedPaths: string[]): Promis
   }
 
   // No existing frontmatter — add one with related field
-  const yaml = yamlDump({related: relatedPaths}, {flowLevel: 1, lineWidth: -1, sortKeys: true}).trimEnd()
+  const yaml = yamlDump({related: relatedPaths}, {flowLevel: 1, lineWidth: -1, sortKeys: false}).trimEnd()
   await atomicWrite(filePath, `---\n${yaml}\n---\n${content}`)
 }
 

--- a/src/server/infra/dream/operations/synthesize.ts
+++ b/src/server/infra/dream/operations/synthesize.ts
@@ -265,7 +265,7 @@ async function writeSynthesisFile(
     type: 'synthesis',
   }
   /* eslint-enable camelcase */
-  const yaml = yamlDump(frontmatter, {lineWidth: -1, sortKeys: true}).trimEnd()
+  const yaml = yamlDump(frontmatter, {lineWidth: -1, sortKeys: false}).trimEnd()
   const body = [
     `# ${candidate.title}`,
     '',

--- a/test/unit/infra/context-tree/summary-frontmatter.test.ts
+++ b/test/unit/infra/context-tree/summary-frontmatter.test.ts
@@ -153,7 +153,7 @@ Body without closing`
       expect(content.startsWith('---\n')).to.be.true
     })
 
-    it('should produce sorted YAML keys', () => {
+    it('should produce YAML keys in object-literal insertion order', () => {
       const frontmatter = {
         children_hash: 'hash',
         compression_ratio: 0.5,
@@ -170,9 +170,12 @@ Body without closing`
       const keys = yamlSection.split('\n')
         .filter((line) => /^\w/.test(line))
         .map((line) => line.split(':')[0])
-      // Keys should be in alphabetical order
-      const sortedKeys = [...keys].sort()
-      expect(keys).to.deep.equal(sortedKeys)
+      // Keys should follow the insertion order from generateSummaryContent,
+      // not be force-sorted alphabetically (sortKeys: false).
+      expect(keys).to.deep.equal([
+        'children_hash', 'compression_ratio', 'condensation_order',
+        'covers', 'covers_token_total', 'summary_level', 'token_count', 'type',
+      ])
     })
   })
 
@@ -262,7 +265,7 @@ Body`
       expect(content.startsWith('---\n')).to.be.true
     })
 
-    it('should produce sorted YAML keys', () => {
+    it('should produce YAML keys in object-literal insertion order', () => {
       const frontmatter = {
         evicted_at: '2026-03-01T00:00:00.000Z',
         evicted_importance: 25,
@@ -277,8 +280,12 @@ Body`
       const keys = yamlSection.split('\n')
         .filter((line) => /^\w/.test(line))
         .map((line) => line.split(':')[0])
-      const sortedKeys = [...keys].sort()
-      expect(keys).to.deep.equal(sortedKeys)
+      // Keys should follow the insertion order from generateArchiveStubContent,
+      // not be force-sorted alphabetically (sortKeys: false).
+      expect(keys).to.deep.equal([
+        'evicted_at', 'evicted_importance', 'original_path',
+        'original_token_count', 'points_to', 'type',
+      ])
     })
   })
 })

--- a/test/unit/infra/dream/operations/consolidate.test.ts
+++ b/test/unit/infra/dream/operations/consolidate.test.ts
@@ -10,9 +10,10 @@ import type {DreamOperation} from '../../../../../src/server/infra/dream/dream-l
 import {consolidate, type ConsolidateDeps} from '../../../../../src/server/infra/dream/operations/consolidate.js'
 
 /**
- * Write a file with canonical (non-alphabetical) field order matching
- * MarkdownWriter.generateFrontmatter(). This bypasses the createMdFile
- * helper which uses sortKeys: false and JS object insertion order.
+ * Create a file with canonical (non-alphabetical) frontmatter order
+ * (title -> summary -> tags -> related -> keywords -> createdAt -> updatedAt),
+ * matching MarkdownWriter's canonical order. Used to verify dream operations
+ * preserve this ordering rather than re-sorting alphabetically.
  */
 async function createCanonicalFile(dir: string, relativePath: string, body: string): Promise<void> {
   const fullPath = join(dir, relativePath)
@@ -588,6 +589,12 @@ describe('consolidate', () => {
       const titleIdx = fieldNames.indexOf('title')
       const createdAtIdx = fieldNames.indexOf('createdAt')
       expect(titleIdx, 'title should appear before createdAt (canonical order)').to.be.lessThan(createdAtIdx)
+
+      // Verify order is also preserved in the second file
+      const tokens = await readFile(join(ctxDir, 'auth/tokens.md'), 'utf8')
+      const tokensYaml = tokens.slice(tokens.indexOf('---\n') + 4, tokens.indexOf('\n---\n', 4))
+      const tokensFields = tokensYaml.split('\n').map(line => line.split(':')[0].trim()).filter(Boolean)
+      expect(tokensFields.indexOf('title')).to.be.lessThan(tokensFields.indexOf('createdAt'))
     })
 
     it('MERGE preserves field order from target file frontmatter', async () => {

--- a/test/unit/infra/dream/operations/consolidate.test.ts
+++ b/test/unit/infra/dream/operations/consolidate.test.ts
@@ -9,6 +9,28 @@ import type {DreamOperation} from '../../../../../src/server/infra/dream/dream-l
 
 import {consolidate, type ConsolidateDeps} from '../../../../../src/server/infra/dream/operations/consolidate.js'
 
+/**
+ * Write a file with canonical (non-alphabetical) field order matching
+ * MarkdownWriter.generateFrontmatter(). This bypasses the createMdFile
+ * helper which uses sortKeys: false and JS object insertion order.
+ */
+async function createCanonicalFile(dir: string, relativePath: string, body: string): Promise<void> {
+  const fullPath = join(dir, relativePath)
+  await mkdir(join(fullPath, '..'), {recursive: true})
+  const frontmatter = [
+    '---',
+    'title: Auth Session',
+    "summary: Session handling overview",
+    'tags: [auth, session]',
+    'related: []',
+    'keywords: [session, cookie]',
+    "createdAt: '2026-04-01T00:00:00.000Z'",
+    "updatedAt: '2026-04-10T00:00:00.000Z'",
+    '---',
+  ].join('\n')
+  await writeFile(fullPath, `${frontmatter}\n${body}`, 'utf8')
+}
+
 /** Narrow DreamOperation to CONSOLIDATE variant for test assertions */
 function asConsolidate(op: DreamOperation) {
   expect(op.type).to.equal('CONSOLIDATE')
@@ -22,7 +44,7 @@ async function createMdFile(dir: string, relativePath: string, body: string, fro
   let content = body
   if (frontmatter) {
     const {dump} = await import('js-yaml')
-    const yaml = dump(frontmatter, {flowLevel: 1, lineWidth: -1, sortKeys: true}).trimEnd()
+    const yaml = dump(frontmatter, {flowLevel: 1, lineWidth: -1, sortKeys: false}).trimEnd()
     content = `---\n${yaml}\n---\n${body}`
   }
 
@@ -498,6 +520,115 @@ describe('consolidate', () => {
 
       // No write needed when there's nothing to clear
       expect(dreamStateService.write.called).to.be.false
+    })
+  })
+
+  // ==========================================================================
+  // Frontmatter field order preservation
+  // ==========================================================================
+
+  describe('frontmatter field order preservation', () => {
+    it('TEMPORAL_UPDATE preserves existing frontmatter field order', async () => {
+      await createCanonicalFile(ctxDir, 'auth/session.md', '# Old session info')
+
+      // LLM returns updatedContent WITH frontmatter in canonical order.
+      // addFrontmatterFields merges consolidated_at into it — sortKeys must
+      // not reorder the existing fields.
+      const updatedWithFm = [
+        '---',
+        'title: Auth Session',
+        "summary: Updated session handling",
+        'tags: [auth, session]',
+        'related: []',
+        'keywords: [session, cookie]',
+        "createdAt: '2026-04-01T00:00:00.000Z'",
+        "updatedAt: '2026-04-10T00:00:00.000Z'",
+        '---',
+        '# Updated session info',
+        'New content.',
+      ].join('\n')
+
+      agent.executeOnSession.resolves(llmResponse([{
+        files: ['auth/session.md'],
+        reason: 'Outdated info',
+        type: 'TEMPORAL_UPDATE',
+        updatedContent: updatedWithFm,
+      }]))
+
+      await consolidate(['auth/session.md'], deps)
+
+      const updated = await readFile(join(ctxDir, 'auth/session.md'), 'utf8')
+      // Extract frontmatter field names in order
+      const yamlBlock = updated.slice(updated.indexOf('---\n') + 4, updated.indexOf('\n---\n', 4))
+      const fieldNames = yamlBlock.split('\n').map(line => line.split(':')[0].trim()).filter(Boolean)
+
+      // title must come before createdAt (canonical order, not alphabetical)
+      const titleIdx = fieldNames.indexOf('title')
+      const createdAtIdx = fieldNames.indexOf('createdAt')
+      expect(titleIdx, 'title should appear before createdAt (canonical order)').to.be.lessThan(createdAtIdx)
+    })
+
+    it('CROSS_REFERENCE preserves existing frontmatter field order', async () => {
+      await createCanonicalFile(ctxDir, 'auth/session.md', '# Session')
+      await createCanonicalFile(ctxDir, 'auth/tokens.md', '# Tokens')
+
+      agent.executeOnSession.resolves(llmResponse([{
+        files: ['auth/session.md', 'auth/tokens.md'],
+        reason: 'Related auth topics',
+        type: 'CROSS_REFERENCE',
+      }]))
+
+      await consolidate(['auth/session.md', 'auth/tokens.md'], deps)
+
+      const session = await readFile(join(ctxDir, 'auth/session.md'), 'utf8')
+      const yamlBlock = session.slice(session.indexOf('---\n') + 4, session.indexOf('\n---\n', 4))
+      const fieldNames = yamlBlock.split('\n').map(line => line.split(':')[0].trim()).filter(Boolean)
+
+      // title must come before createdAt (canonical order, not alphabetical)
+      const titleIdx = fieldNames.indexOf('title')
+      const createdAtIdx = fieldNames.indexOf('createdAt')
+      expect(titleIdx, 'title should appear before createdAt (canonical order)').to.be.lessThan(createdAtIdx)
+    })
+
+    it('MERGE preserves field order from target file frontmatter', async () => {
+      await createCanonicalFile(ctxDir, 'auth/session.md', '# Session')
+      await createMdFile(ctxDir, 'auth/session-v2.md', '# Session V2')
+
+      // LLM returns mergedContent WITH frontmatter in canonical order.
+      // addFrontmatterFields merges consolidated_at/consolidated_from — sortKeys
+      // must not reorder the existing fields.
+      const mergedWithFm = [
+        '---',
+        'title: Auth Session',
+        "summary: Unified session handling",
+        'tags: [auth, session]',
+        'related: []',
+        'keywords: [session, cookie]',
+        "createdAt: '2026-04-01T00:00:00.000Z'",
+        "updatedAt: '2026-04-10T00:00:00.000Z'",
+        '---',
+        '# Unified Session',
+        'Merged.',
+      ].join('\n')
+
+      agent.executeOnSession.resolves(llmResponse([{
+        files: ['auth/session.md', 'auth/session-v2.md'],
+        mergedContent: mergedWithFm,
+        outputFile: 'auth/session.md',
+        reason: 'Redundant',
+        type: 'MERGE',
+      }]))
+
+      await consolidate(['auth/session.md', 'auth/session-v2.md'], deps)
+
+      const merged = await readFile(join(ctxDir, 'auth/session.md'), 'utf8')
+      const yamlBlock = merged.slice(merged.indexOf('---\n') + 4, merged.indexOf('\n---\n', 4))
+      const fieldNames = yamlBlock.split('\n').map(line => line.split(':')[0].trim()).filter(Boolean)
+
+      // title must come before createdAt (canonical order, not alphabetical)
+      const titleIdx = fieldNames.indexOf('title')
+      const createdAtIdx = fieldNames.indexOf('createdAt')
+      expect(titleIdx, 'title should appear before createdAt (canonical order)').to.be.lessThan(createdAtIdx)
     })
   })
 })

--- a/test/unit/infra/dream/operations/prune.test.ts
+++ b/test/unit/infra/dream/operations/prune.test.ts
@@ -1,5 +1,5 @@
 import {expect} from 'chai'
-import {mkdir, stat, utimes, writeFile} from 'node:fs/promises'
+import {mkdir, mkdtemp, stat, utimes, writeFile} from 'node:fs/promises'
 import {tmpdir} from 'node:os'
 import {join} from 'node:path'
 import {restore, type SinonStub, stub} from 'sinon'
@@ -18,7 +18,7 @@ async function createMdFile(dir: string, relativePath: string, body: string, fro
   let content = body
   if (frontmatter) {
     const {dump} = await import('js-yaml')
-    const yaml = dump(frontmatter, {flowLevel: 1, lineWidth: -1, sortKeys: true}).trimEnd()
+    const yaml = dump(frontmatter, {flowLevel: 1, lineWidth: -1, sortKeys: false}).trimEnd()
     content = `---\n${yaml}\n---\n${body}`
   }
 
@@ -65,9 +65,8 @@ describe('prune', () => {
   let deps: PruneDeps
 
   beforeEach(async () => {
-    ctxDir = join(tmpdir(), `brv-prune-test-${Date.now()}`)
+    ctxDir = await mkdtemp(join(tmpdir(), 'brv-prune-test-'))
     projectRoot = ctxDir // simplified for tests — prune uses ctxDir directly
-    await mkdir(ctxDir, {recursive: true})
 
     agent = {
       createTaskSession: stub().resolves('session-1'),

--- a/test/unit/infra/dream/operations/synthesize.test.ts
+++ b/test/unit/infra/dream/operations/synthesize.test.ts
@@ -18,7 +18,7 @@ async function createMdFile(dir: string, relativePath: string, body: string, fro
   let content = body
   if (frontmatter) {
     const {dump} = await import('js-yaml')
-    const yaml = dump(frontmatter, {flowLevel: 1, lineWidth: -1, sortKeys: true}).trimEnd()
+    const yaml = dump(frontmatter, {flowLevel: 1, lineWidth: -1, sortKeys: false}).trimEnd()
     content = `---\n${yaml}\n---\n${body}`
   }
 


### PR DESCRIPTION
## Summary

- Changed `sortKeys: true` to `sortKeys: false` in all dream YAML serialization paths (consolidate, synthesize, summary-frontmatter) to prevent alphabetical reordering of frontmatter fields
- Added 3 unit tests verifying field order preservation for TEMPORAL_UPDATE, CROSS_REFERENCE, and MERGE operations
- Fixed flaky prune test caused by `Date.now()` collisions in temp directory names (replaced with `mkdtemp`)

## Root Cause

Dream operations used `yamlDump(..., {sortKeys: true})` which alphabetized frontmatter fields on every write. Curate uses `sortKeys: false` with canonical order (title, summary, tags, related, keywords, createdAt, updatedAt). When both paths touched the same file, the field order flip-flopped, producing pure-reorder diffs with zero semantic change.

## Changes

| File | Change |
|------|--------|
| `consolidate.ts` | `sortKeys: true` -> `false` (4 sites: addFrontmatterFields, addRelatedLinks) |
| `synthesize.ts` | `sortKeys: true` -> `false` (1 site: writeSynthesisFile) |
| `summary-frontmatter.ts` | `sortKeys: true` -> `false` (2 sites: generateSummaryContent, generateArchiveStubContent) |
| `consolidate.test.ts` | +3 field-order tests, test helper sortKeys alignment |
| `synthesize.test.ts` | Test helper sortKeys alignment |
| `prune.test.ts` | Test helper sortKeys alignment + flaky test fix (Date.now -> mkdtemp) |
| `summary-frontmatter.test.ts` | Updated assertions: "sorted keys" -> "insertion-order keys" |

## Test plan

- [x] 3 new unit tests: TEMPORAL_UPDATE, CROSS_REFERENCE, MERGE preserve canonical field order
- [x] Full test suite: 6859 passing, 0 failing (flaky prune test fixed)
- [x] Typecheck clean, lint clean, build clean
- [x] Interactive testing on real `.brv/context-tree`:
  - `brv curate` (3 curations) -> canonical field order confirmed
  - `brv dream --force` (2 runs) -> MERGE, CROSS_REFERENCE, synthesis all preserve field order
  - `brv dream --undo` (2 runs) -> restore preserves field order
  - Pre-existing alphabetized files untouched (checksums verified)
  - Summary `_index.md` and synthesis files: insertion-order preserved