### PR TITLE
feat: [ENG-2465] add web UI Configuration page + promote ByteRover provider onboarding

### DIFF
--- a/src/server/infra/transport/handlers/config-handler.ts
+++ b/src/server/infra/transport/handlers/config-handler.ts
@@ -22,6 +22,7 @@ export class ConfigHandler {
     this.transport.onRequest<void, ConfigGetEnvironmentResponse>(ConfigEvents.GET_ENVIRONMENT, () => {
       const config = getCurrentConfig()
       return {
+        gitRemoteBaseUrl: config.gitRemoteBaseUrl,
         iamBaseUrl: config.iamBaseUrl,
         isDevelopment: isDevelopment(),
         webAppUrl: config.webAppUrl,

--- a/src/server/infra/transport/handlers/locations-handler.ts
+++ b/src/server/infra/transport/handlers/locations-handler.ts
@@ -57,9 +57,8 @@ export class LocationsHandler {
       }
     })
 
-    this.transport.onRequest<LocationsRevealRequest, LocationsRevealResponse>(
-      LocationsEvents.REVEAL,
-      async (data) => this.handleReveal(data),
+    this.transport.onRequest<LocationsRevealRequest, LocationsRevealResponse>(LocationsEvents.REVEAL, async (data) =>
+      this.handleReveal(data),
     )
   }
 
@@ -124,7 +123,7 @@ export class LocationsHandler {
     if (!exists) throw new Error('Project folder no longer exists.')
 
     const {args, command} = resolveRevealCommand(process.platform, projectPath)
-    const child = spawn(command, args, {detached: true, stdio: 'ignore'})
+    const child = spawn(command, args, {detached: true, stdio: 'ignore', windowsHide: true})
     child.on('error', () => {
       /* best-effort — nothing to report back once the ack resolved */
     })

--- a/src/server/infra/transport/handlers/locations-handler.ts
+++ b/src/server/infra/transport/handlers/locations-handler.ts
@@ -1,3 +1,4 @@
+import {spawn} from 'node:child_process'
 import {join} from 'node:path'
 
 import type {ProjectLocationDTO} from '../../../../shared/transport/types/dto.js'
@@ -5,9 +6,15 @@ import type {IContextTreeService} from '../../../core/interfaces/context-tree/i-
 import type {IProjectRegistry} from '../../../core/interfaces/project/i-project-registry.js'
 import type {ITransportServer} from '../../../core/interfaces/transport/i-transport-server.js'
 
-import {LocationsEvents, type LocationsGetResponse} from '../../../../shared/transport/events/locations-events.js'
+import {
+  LocationsEvents,
+  type LocationsGetResponse,
+  type LocationsRevealRequest,
+  type LocationsRevealResponse,
+} from '../../../../shared/transport/events/locations-events.js'
 import {BRV_DIR, CONTEXT_TREE_DIR} from '../../../constants.js'
 import {type ProjectPathResolver} from './handler-types.js'
+import {resolveRevealCommand} from './reveal-command.js'
 
 export interface LocationsHandlerDeps {
   contextTreeService: IContextTreeService
@@ -49,6 +56,11 @@ export class LocationsHandler {
         return {locations: []}
       }
     })
+
+    this.transport.onRequest<LocationsRevealRequest, LocationsRevealResponse>(
+      LocationsEvents.REVEAL,
+      async (data) => this.handleReveal(data),
+    )
   }
 
   private async buildLocations(currentProjectPath?: string): Promise<ProjectLocationDTO[]> {
@@ -95,5 +107,29 @@ export class LocationsHandler {
       if (a.isInitialized !== b.isInitialized) return a.isInitialized ? -1 : 1
       return (all.get(b.projectPath)?.registeredAt ?? 0) - (all.get(a.projectPath)?.registeredAt ?? 0)
     })
+  }
+
+  private async handleReveal(data: LocationsRevealRequest): Promise<LocationsRevealResponse> {
+    const {projectPath} = data
+    if (!projectPath) throw new Error('projectPath is required')
+
+    // Only allow revealing paths that are registered projects — the client
+    // controls this argument, so we must not trust it blindly.
+    const registered = this.projectRegistry.getAll()
+    if (!registered.has(projectPath)) {
+      throw new Error('Project is not registered.')
+    }
+
+    const exists = await this.pathExists(projectPath).catch(() => false)
+    if (!exists) throw new Error('Project folder no longer exists.')
+
+    const {args, command} = resolveRevealCommand(process.platform, projectPath)
+    const child = spawn(command, args, {detached: true, stdio: 'ignore'})
+    child.on('error', () => {
+      /* best-effort — nothing to report back once the ack resolved */
+    })
+    child.unref()
+
+    return {projectPath}
   }
 }

--- a/src/server/infra/transport/handlers/reveal-command.ts
+++ b/src/server/infra/transport/handlers/reveal-command.ts
@@ -1,0 +1,14 @@
+/**
+ * Resolves the OS-native command for revealing a path in the system file manager.
+ * Extracted so the branching can be unit-tested without spawning real processes.
+ */
+export type RevealCommand = {
+  args: string[]
+  command: string
+}
+
+export function resolveRevealCommand(platformName: NodeJS.Platform, targetPath: string): RevealCommand {
+  if (platformName === 'darwin') return {args: [targetPath], command: 'open'}
+  if (platformName === 'win32') return {args: [targetPath], command: 'explorer'}
+  return {args: [targetPath], command: 'xdg-open'}
+}

--- a/src/server/infra/webui/webui-middleware.ts
+++ b/src/server/infra/webui/webui-middleware.ts
@@ -35,7 +35,7 @@ export function createWebUiMiddleware({getConfig, webuiDistDir}: CreateWebUiMidd
         "connect-src 'self' ws: wss:",
         "font-src 'self' data: https://fonts.gstatic.com",
         "frame-ancestors 'none'",
-        "img-src 'self' data:",
+        "img-src 'self' data: https:",
         "object-src 'none'",
         "script-src 'self'",
         "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",

--- a/src/server/infra/webui/webui-middleware.ts
+++ b/src/server/infra/webui/webui-middleware.ts
@@ -35,6 +35,11 @@ export function createWebUiMiddleware({getConfig, webuiDistDir}: CreateWebUiMidd
         "connect-src 'self' ws: wss:",
         "font-src 'self' data: https://fonts.gstatic.com",
         "frame-ancestors 'none'",
+        // `img-src https:` is deliberately broad: user avatars come from an
+        // open-ended set of OAuth provider CDNs (Google, GitHub, Gravatar,
+        // self-hosted identity providers, …) that can't be enumerated ahead
+        // of time. Images can't execute code, so the attack surface is just
+        // pixel exfiltration / tracking, which we accept for this use case.
         "img-src 'self' data: https:",
         "object-src 'none'",
         "script-src 'self'",

--- a/src/shared/transport/events/config-events.ts
+++ b/src/shared/transport/events/config-events.ts
@@ -7,6 +7,7 @@ export const ConfigEvents = {
 } as const
 
 export interface ConfigGetEnvironmentResponse {
+  gitRemoteBaseUrl: string
   iamBaseUrl: string
   isDevelopment: boolean
   webAppUrl: string

--- a/src/shared/transport/events/locations-events.ts
+++ b/src/shared/transport/events/locations-events.ts
@@ -2,8 +2,17 @@ import type {ProjectLocationDTO} from '../types/dto.js'
 
 export const LocationsEvents = {
   GET: 'locations:get',
+  REVEAL: 'locations:reveal',
 } as const
 
 export interface LocationsGetResponse {
   locations: ProjectLocationDTO[]
+}
+
+export interface LocationsRevealRequest {
+  projectPath: string
+}
+
+export interface LocationsRevealResponse {
+  projectPath: string
 }

--- a/src/webui/App.tsx
+++ b/src/webui/App.tsx
@@ -8,7 +8,7 @@ export function App() {
   return (
     <AppProviders>
       <RouterProvider router={router} />
-      <Toaster />
+      <Toaster position="top-center" />
     </AppProviders>
   )
 }

--- a/src/webui/components/status-dot.tsx
+++ b/src/webui/components/status-dot.tsx
@@ -1,0 +1,44 @@
+import {cn} from '@campfirein/byterover-packages/lib/utils'
+
+type Tone = 'amber' | 'destructive' | 'info' | 'success'
+
+type Props = {
+  className?: string
+  /** When true, wrap the dot in a `ping`-animated halo to draw attention. */
+  pulsing?: boolean
+  tone: Tone
+}
+
+const TONE_BG: Record<Tone, string> = {
+  amber: 'bg-amber-500',
+  destructive: 'bg-destructive',
+  info: 'bg-blue-500',
+  success: 'bg-primary-foreground',
+}
+
+/**
+ * Small colored dot for status annotations.
+ *
+ * - Default: a single solid dot — use for permanent indicators
+ *   (e.g. "connected", "X unread").
+ * - `pulsing`: dot wrapped in a `ping`-animated halo — use for exceptions
+ *   that want attention (e.g. "configuration required").
+ *
+ * Default size is 6px; pass `size-*` via `className` to resize. `className`
+ * can also add border/position utilities (e.g. overlaying as a corner badge
+ * on an icon).
+ */
+export function StatusDot({className, pulsing = false, tone}: Props) {
+  const bg = TONE_BG[tone]
+
+  if (pulsing) {
+    return (
+      <span className={cn('relative inline-flex size-1.5 shrink-0', className)}>
+        <span className={cn('absolute inline-flex size-full animate-ping rounded-full opacity-75', bg)} />
+        <span className={cn('relative inline-flex size-full rounded-full', bg)} />
+      </span>
+    )
+  }
+
+  return <span className={cn('inline-block size-1.5 shrink-0 rounded-full', bg, className)} />
+}

--- a/src/webui/features/auth/components/auth-menu.tsx
+++ b/src/webui/features/auth/components/auth-menu.tsx
@@ -24,7 +24,7 @@ function UnauthorizedTrigger() {
 
   return (
     <>
-      <Button className="h-auto rounded-full p-0 ml-2.5" onClick={() => setIsOpen(true)} variant="ghost">
+      <Button className="h-auto rounded-full p-0" onClick={() => setIsOpen(true)} variant="ghost">
         <Avatar>
           <AvatarFallback className="bg-transparent">
             <User className="size-4 shrink-0" />
@@ -49,7 +49,7 @@ function AuthorizedMenu() {
 
   if (!user) {
     return (
-      <Button className="ml-2.5" disabled size="sm" variant="outline">
+      <Button disabled size="sm" variant="outline">
         <User className="size-4 shrink-0 text-muted-foreground" />
         <span>Signed in</span>
       </Button>
@@ -89,7 +89,7 @@ export function AuthMenu() {
 
   if (isLoadingInitial) {
     return (
-      <Button className="ml-2.5" disabled size="icon" variant="outline">
+      <Button disabled size="icon" variant="outline">
         <User className="size-4 shrink-0 text-muted-foreground animate-pulse" />
       </Button>
     )

--- a/src/webui/features/auth/components/login-dialog.tsx
+++ b/src/webui/features/auth/components/login-dialog.tsx
@@ -51,7 +51,7 @@ export function LoginDialog({onOpenChange, open}: LoginDialogProps) {
 
     const unsubscribe = subscribeToLoginCompleted((data) => {
       if (data.success && data.user) {
-        toast.success(`Logged in as ${data.user.email}`, {position: 'top-center'})
+        toast.success(`Logged in as ${data.user.email}`)
         queryClient.invalidateQueries({queryKey: getAuthStateQueryOptions().queryKey})
         onOpenChange(false)
       } else {
@@ -76,7 +76,7 @@ export function LoginDialog({onOpenChange, open}: LoginDialogProps) {
         const result = await queryClient.fetchQuery(getAuthStateQueryOptions())
         if (cancelled) return
         if (result.isAuthorized && result.user) {
-          toast.success(`Logged in as ${result.user.email}`, {position: 'top-center'})
+          toast.success(`Logged in as ${result.user.email}`)
           setLoggingIn(false)
           onOpenChange(false)
         }

--- a/src/webui/features/connectors/components/connectors-panel.tsx
+++ b/src/webui/features/connectors/components/connectors-panel.tsx
@@ -1,19 +1,25 @@
-import { Button } from '@campfirein/byterover-packages/components/button'
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@campfirein/byterover-packages/components/dropdown-menu'
-import { ChevronDown, LoaderCircle, Plus } from 'lucide-react'
-import { useState } from 'react'
-import { toast } from 'sonner'
+import {Button} from '@campfirein/byterover-packages/components/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@campfirein/byterover-packages/components/dropdown-menu'
+import {Skeleton} from '@campfirein/byterover-packages/components/skeleton'
+import {ChevronDown, LoaderCircle, Plus} from 'lucide-react'
+import {useState} from 'react'
+import {toast} from 'sonner'
 
-import type { ConnectorDTO } from '../../../../shared/transport/types/dto'
-import type { Agent } from '../../../../shared/types/agent'
-import type { ConnectorType } from '../../../../shared/types/connector-type'
+import type {ConnectorDTO} from '../../../../shared/transport/types/dto'
+import type {Agent} from '../../../../shared/types/agent'
+import type {ConnectorType} from '../../../../shared/types/connector-type'
 
-import { requiresAgentRestart } from '../../../../shared/types/connector-type'
-import { useGetAgents } from '../api/get-agents'
-import { useGetConnectors } from '../api/get-connectors'
-import { useInstallConnector } from '../api/install-connector'
-import { AddConnectorDialog } from './add-connector-dialog'
-import { agentIcons } from './agent-icons'
+import {requiresAgentRestart} from '../../../../shared/types/connector-type'
+import {useGetAgents} from '../api/get-agents'
+import {useGetConnectors} from '../api/get-connectors'
+import {useInstallConnector} from '../api/install-connector'
+import {AddConnectorDialog} from './add-connector-dialog'
+import {agentIcons} from './agent-icons'
 
 const connectorLabels: Record<ConnectorType, string> = {
   hook: 'Hook',
@@ -23,8 +29,8 @@ const connectorLabels: Record<ConnectorType, string> = {
 }
 
 export function ConnectorsPanel() {
-  const { data: connectorsData, isLoading: isLoadingConnectors } = useGetConnectors()
-  const { data: agentsData, isLoading: isLoadingAgents } = useGetAgents()
+  const {data: connectorsData, isLoading: isLoadingConnectors} = useGetConnectors()
+  const {data: agentsData, isLoading: isLoadingAgents} = useGetAgents()
   const installMutation = useInstallConnector()
   const [addDialogOpen, setAddDialogOpen] = useState(false)
   const [pendingAgentId, setPendingAgentId] = useState<string | undefined>()
@@ -37,7 +43,7 @@ export function ConnectorsPanel() {
     if (newType === connector.connectorType) return
 
     try {
-      await installMutation.mutateAsync({ agentId: connector.agent, connectorType: newType })
+      await installMutation.mutateAsync({agentId: connector.agent, connectorType: newType})
       const needsRestart = requiresAgentRestart(newType)
       toast.success(
         needsRestart
@@ -51,19 +57,11 @@ export function ConnectorsPanel() {
 
   const handleAddConnector = async (agentId: Agent, connectorType: ConnectorType) => {
     try {
-      await installMutation.mutateAsync({ agentId, connectorType })
+      await installMutation.mutateAsync({agentId, connectorType})
       toast.success(`${agentId} connected via ${connectorLabels[connectorType]}.`)
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Failed to install connector')
     }
-  }
-
-  if (isLoading) {
-    return (
-      <div className="flex items-center justify-center py-12">
-        <LoaderCircle className="text-muted-foreground size-5 animate-spin" />
-      </div>
-    )
   }
 
   return (
@@ -71,13 +69,18 @@ export function ConnectorsPanel() {
       {/* Title + Add button */}
       <div className="flex items-center justify-between">
         <div className="flex flex-col gap-1">
-          <h2 className="text-foreground text-lg font-bold">Connectors</h2>
-          <p className="text-muted-foreground text-sm">Manage how AI agents connect to ByteRover.</p>
+          <h2 className="text-foreground text-[0.95rem] font-semibold leading-tight">Connectors</h2>
+          <p className="text-muted-foreground mt-0.5 text-[0.8125rem] leading-snug">
+            Manage how AI agents connect to ByteRover.
+          </p>
         </div>
 
-        <Button onClick={() => setAddDialogOpen(true)} variant="default">
-          <Plus strokeWidth={3} /> Add connector
-        </Button>
+        <div className="flex items-center gap-2">
+          {isLoading && <LoaderCircle className="text-muted-foreground size-4 animate-spin" />}
+          <Button disabled={isLoading} onClick={() => setAddDialogOpen(true)} size="sm" variant="outline">
+            <Plus strokeWidth={3} /> Add connector
+          </Button>
+        </div>
       </div>
 
       <AddConnectorDialog
@@ -97,34 +100,51 @@ export function ConnectorsPanel() {
       />
 
       {/* Connector list */}
-      {connectors.length === 0 ? (
-        <p className="text-muted-foreground py-8 text-center text-sm">No connectors installed. Add one to get started.</p>
+      {isLoading ? (
+        <div className="bg-card border rounded-xl px-6 py-5">
+          <div className="flex items-center gap-3">
+            <Skeleton className="size-5 shrink-0 rounded-full" />
+            <Skeleton className="h-4 flex-1" />
+            <Skeleton className="h-8 w-16 shrink-0" />
+          </div>
+        </div>
+      ) : connectors.length === 0 ? (
+        <p className="text-muted-foreground py-8 text-center text-sm">
+          No connectors installed. Add one to get started.
+        </p>
       ) : (
-        <div className='border rounded-xl px-6 py-5 flex flex-col gap-4'>{
-          connectors.map((connector, index) => (
-            <div className='flex flex-col gap-4' key={connector.agent}>
-              <div className='flex justify-between items-center'>
-                <div className='flex items-center gap-3 text-sm'>
+        <div className="bg-card border rounded-xl px-6 py-5 flex flex-col gap-4">
+          {connectors.map((connector, index) => (
+            <div className="flex flex-col gap-4" key={connector.agent}>
+              <div className="flex justify-between items-center">
+                <div className="flex items-center gap-3 text-sm">
                   {agentIcons[connector.agent] ? (
                     <img alt="" className="size-5 shrink-0" src={agentIcons[connector.agent]} />
                   ) : (
                     <div className="size-5 shrink-0" />
                   )}
-                  <div className='flex flex-col'>
+                  <div className="flex flex-col">
                     <span>{connector.agent}</span>
-                    <span className='text-primary text-xs'>Connected</span>
+                    <span className="text-primary text-xs">Connected</span>
                   </div>
                 </div>
-                <div className='flex items-center'>
+                <div className="flex items-center">
                   <DropdownMenu>
                     <DropdownMenuTrigger
                       disabled={installMutation.isPending}
-                      render={<Button className="text-sm" disabled={installMutation.isPending} size="sm" variant="outline" />}
+                      render={
+                        <Button
+                          className="text-sm"
+                          disabled={installMutation.isPending}
+                          size="sm"
+                          variant="secondary"
+                        />
+                      }
                     >
                       {connectorLabels[connector.connectorType]}
                       <ChevronDown className="size-3.5 shrink-0" />
                     </DropdownMenuTrigger>
-                    <DropdownMenuContent align='end'>
+                    <DropdownMenuContent align="end">
                       {connector.supportedTypes.map((type) => (
                         <DropdownMenuItem key={type} onClick={() => handleTypeChange(connector, type)}>
                           {connectorLabels[type]}
@@ -134,10 +154,10 @@ export function ConnectorsPanel() {
                   </DropdownMenu>
                 </div>
               </div>
-              {index < connectors.length - 1 && <div className='border-b' />}
+              {index < connectors.length - 1 && <div className="border-b" />}
             </div>
-          ))
-        }</div>
+          ))}
+        </div>
       )}
     </div>
   )

--- a/src/webui/features/connectors/components/connectors-panel.tsx
+++ b/src/webui/features/connectors/components/connectors-panel.tsx
@@ -65,7 +65,7 @@ export function ConnectorsPanel() {
   }
 
   return (
-    <div className="flex flex-col gap-5 w-full sm:max-w-lg md:max-w-xl lg:max-w-2xl">
+    <div className="flex w-full flex-col gap-5">
       {/* Title + Add button */}
       <div className="flex items-center justify-between">
         <div className="flex flex-col gap-1">

--- a/src/webui/features/context/components/context-detail-panel.tsx
+++ b/src/webui/features/context/components/context-detail-panel.tsx
@@ -7,14 +7,13 @@ import { useMemo } from 'react'
 
 import type { ContextNode } from '../types'
 
+import { noop } from '../../../lib/noop'
 import { useGetContextFileMetadata } from '../api/get-context-file-metadata'
 import { useGetContextHistory } from '../api/get-context-history'
 import { useContextTree } from '../hooks/use-context-tree'
 import { isFilePath } from '../utils/tree-utils'
 import { ContextBreadcrumb } from './context-breadcrumb'
 import { MarkdownView } from './markdown-view'
-
-const NOOP = () => { }
 
 interface ContextDetailPanelProps {
   onToggleHistory?: () => void
@@ -136,7 +135,7 @@ export function ContextDetailPanel({ onToggleHistory }: ContextDetailPanelProps)
           onContentChange={setEditContent}
           onEnterEditMode={enterEditMode}
           onSaveChanges={saveChanges}
-          onToggleHistory={onToggleHistory ?? NOOP}
+          onToggleHistory={onToggleHistory ?? noop}
           showTags={false}
           tags={fileData?.tags}
           timeline={

--- a/src/webui/features/onboarding/components/help-menu.tsx
+++ b/src/webui/features/onboarding/components/help-menu.tsx
@@ -7,7 +7,7 @@ import {
   DropdownMenuTrigger,
 } from '@campfirein/byterover-packages/components/dropdown-menu'
 import {cn} from '@campfirein/byterover-packages/lib/utils'
-import {BookOpen, Bug, HelpCircle, PlayCircle} from 'lucide-react'
+import {BookOpen, Bug, LifeBuoy, PlayCircle} from 'lucide-react'
 
 import {useOnboardingStore} from '../stores/onboarding-store'
 
@@ -25,7 +25,7 @@ export function HelpMenu() {
       <DropdownMenuTrigger
         render={
           <Button size="sm" variant="ghost">
-            <HelpCircle className="size-4" />
+            <LifeBuoy className="size-4 mr-1" />
             Help
             {showHint && <span aria-hidden className={cn('size-1.5 rounded-full bg-orange-500')} />}
           </Button>

--- a/src/webui/features/onboarding/components/tour-backdrop.tsx
+++ b/src/webui/features/onboarding/components/tour-backdrop.tsx
@@ -1,0 +1,26 @@
+import {useOnboardingStore} from '../stores/onboarding-store'
+
+/**
+ * Page-wide dim + blur during the curate/query tour steps. Sits beneath the
+ * tour bar (z-100) and beneath any TourPointer-wrapped target (z-50), so the
+ * highlighted controls stay sharp while the rest of the UI fades back.
+ *
+ * Active on every route (not just `/tasks`) because the Tasks-tab coachmark
+ * lives in the global header — when the user is on a different page, the
+ * backdrop draws focus to that coachmark too.
+ *
+ * Click-blocking is intentional: the rest of the page is clearly out of
+ * focus, and we don't want a stray click on a blurred Configuration tab to
+ * yank the user away from the tour. They exit via the TourBar.
+ */
+export function TourBackdrop() {
+  const tourActive = useOnboardingStore((s) => s.tourActive)
+  const tourStep = useOnboardingStore((s) => s.tourStep)
+  const tourTaskId = useOnboardingStore((s) => s.tourTaskId)
+
+  const inComposerStep = tourStep === 'curate' || tourStep === 'query'
+  const show = tourActive && inComposerStep && !tourTaskId
+  if (!show) return null
+
+  return <div aria-hidden className="bg-background/50 fixed inset-0 z-40 backdrop-blur-xs" />
+}

--- a/src/webui/features/onboarding/components/tour-host.tsx
+++ b/src/webui/features/onboarding/components/tour-host.tsx
@@ -31,8 +31,8 @@ function snapshotIsProviderStep() {
 }
 
 const CURATE_EXAMPLE =
-  'JWT tokens expire after 24h. Refresh window is 7 days. Rotation happens on every successful refresh — old refresh token is invalidated immediately.'
-const QUERY_EXAMPLE = 'What is our auth token expiration policy?'
+  'List the most important conventions and patterns used in this codebase — naming, file organization, testing approach, and any rules a new contributor should know before making changes.'
+const QUERY_EXAMPLE = 'What conventions should I follow when making changes?'
 
 export function TourHost() {
   const tourActive = useOnboardingStore((s) => s.tourActive)

--- a/src/webui/features/onboarding/components/tour-host.tsx
+++ b/src/webui/features/onboarding/components/tour-host.tsx
@@ -1,25 +1,16 @@
 /**
  * Tour host
  *
- * Mounted once at the layout level. Reads the tour step from the onboarding
- * store and renders the right "tour-driven" surface for that step:
- *
- *   provider  → ProviderFlowDialog (auto-advances via use-tour-watchers when
- *               an active provider becomes configured)
- *   curate    → TaskComposerSheet prefilled with a curate example (advances
- *               on successful submit via the sheet's onSubmitted callback)
- *   query     → same, prefilled with a query example
- *   connector → ConnectorStep (advances on the user's "Done" click)
- *
- * Tour-aware UI (the step pill on the provider dialog, etc.) lives inside the
- * relevant components themselves and toggles on `useOnboardingStore.tourStep`.
+ * Mounted once at the layout level. Renders surfaces that are *fully owned*
+ * by the tour FSM — the provider dialog (step 1) and the connector step
+ * (step 4). Steps 2/3 (curate/query) intentionally do not auto-mount the
+ * composer here: `useTourWatchers` routes the user to `/tasks`, where the
+ * empty-state coachmark guides them to click "New task" themselves. The
+ * normal-mode `TaskComposerSheet` then opens with tour-aware prefill (see
+ * `TaskListView`).
  */
 
-import {useRef} from 'react'
-import {useNavigate} from 'react-router-dom'
-
 import {ProviderFlowDialog} from '../../provider/components/provider-flow'
-import {TaskComposerSheet} from '../../tasks/components/task-composer'
 import {useOnboardingStore} from '../stores/onboarding-store'
 import {ConnectorStep} from './connector-step'
 
@@ -30,32 +21,13 @@ function snapshotIsProviderStep() {
   return useOnboardingStore.getState().tourStep === 'provider'
 }
 
-const CURATE_EXAMPLE =
-  'List the most important conventions and patterns used in this codebase — naming, file organization, testing approach, and any rules a new contributor should know before making changes.'
-const QUERY_EXAMPLE = 'What conventions should I follow when making changes?'
-
 export function TourHost() {
   const tourActive = useOnboardingStore((s) => s.tourActive)
   const tourStep = useOnboardingStore((s) => s.tourStep)
-  const tourTaskId = useOnboardingStore((s) => s.tourTaskId)
   const exitTour = useOnboardingStore((s) => s.exitTour)
   const advanceTour = useOnboardingStore((s) => s.advanceTour)
-  const setTourTaskId = useOnboardingStore((s) => s.setTourTaskId)
-  const navigate = useNavigate()
-
-  // The composer fires onSubmitted *and then* onClose synchronously after a
-  // successful submit. Without this guard, onClose would call exitTour() right
-  // after onSubmitted set the tour task — and exitTour would win the batched
-  // setState. The flag is set in onSubmitted and consumed in onClose so only
-  // user-initiated closes exit the tour.
-  const submittedRef = useRef(false)
 
   if (!tourActive || !tourStep) return null
-
-  // While a tour task is in flight (curate/query submitted, awaiting completion)
-  // keep the composer closed so the user can watch the task run in the detail
-  // view. The Continue CTA in the detail view advances the tour.
-  const showComposer = (tourStep === 'curate' || tourStep === 'query') && !tourTaskId
 
   return (
     <>
@@ -71,36 +43,6 @@ export function TourHost() {
           onProviderActivated={() => advanceTour()}
           open
           tourStepLabel="Step 1 of 4"
-        />
-      )}
-
-      {showComposer && (
-        <TaskComposerSheet
-          initialContent={tourStep === 'curate' ? CURATE_EXAMPLE : QUERY_EXAMPLE}
-          initialType={tourStep}
-          // key forces a remount when the tour transitions curate → query so
-          // the composer's internal state (content, type) re-seeds from the
-          // new initial props instead of retaining the previous step's draft.
-          key={tourStep}
-          onClose={() => {
-            if (submittedRef.current) {
-              submittedRef.current = false
-              return
-            }
-
-            exitTour()
-          }}
-          onSubmitted={(taskId) => {
-            submittedRef.current = true
-            // Tour stays on the current step; record the in-flight task and
-            // navigate to its detail. The user advances via the Continue CTA
-            // once the task completes.
-            setTourTaskId(taskId)
-            navigate(`/tasks?task=${taskId}`)
-          }}
-          open
-          prefillNotice="example"
-          tourStepLabel={tourStep === 'curate' ? 'Step 2 of 4' : 'Step 3 of 4'}
         />
       )}
 

--- a/src/webui/features/onboarding/components/tour-pointer.tsx
+++ b/src/webui/features/onboarding/components/tour-pointer.tsx
@@ -83,9 +83,14 @@ function CurvedArrow({
 export function TourPointer({active, align = 'center', children, className, label, side = 'bottom'}: Props) {
   if (!active) return <>{children}</>
 
-  // Arrow stick curves from the same side as the label so the assembly
-  // reads as one piece. For centered alignment we default the curve to the
-  // right (it's a self-contained vertical stack so either looks fine).
+  // Curve the stick from the side the label *visually sits on* — not the
+  // side of its anchor. For `align="end"` the label is right-anchored
+  // (`right-0`) but `whitespace-nowrap` makes it extend LEFT from the
+  // target's right edge, so it sits on the LEFT side of the target's
+  // center; `curveFrom: 'left'` makes the stick start at the left side of
+  // the SVG (viewBox x=6) so the curve flows label → tip without doubling
+  // back. `align="start"` is the inverse. `align="center"` is symmetric,
+  // so we default to right.
   const curveFrom: CurveFrom = align === 'end' ? 'left' : 'right'
 
   return (

--- a/src/webui/features/onboarding/components/tour-pointer.tsx
+++ b/src/webui/features/onboarding/components/tour-pointer.tsx
@@ -1,0 +1,128 @@
+import {cn} from '@campfirein/byterover-packages/lib/utils'
+import {type ReactNode} from 'react'
+
+type Side = 'bottom' | 'top'
+type Align = 'center' | 'end' | 'start'
+
+type Props = {
+  /**
+   * When false the wrapped child is rendered untouched, so callers can drop
+   * <TourPointer> into existing markup without conditionals.
+   */
+  active: boolean
+  align?: Align
+  children: ReactNode
+  className?: string
+  label: string
+  side?: Side
+}
+
+/**
+ * A gentle curved arrow connecting the label to the highlighted target.
+ * Hand-drawn feel — slightly bowed line + arrowhead, ~32px long so the
+ * label has room to breathe above/below the target.
+ */
+type CurveFrom = 'left' | 'right'
+
+function CurvedArrow({
+  className,
+  curveFrom,
+  direction,
+}: {
+  className?: string
+  curveFrom: CurveFrom
+  direction: 'down' | 'up'
+}) {
+  // The stick's source side flips so it always curves from where the label
+  // sits toward the target's tip — otherwise the curve "points away" from
+  // the label and the assembly looks disjointed.
+  const fromRight = curveFrom === 'right'
+  return (
+    <svg
+      aria-hidden
+      className={cn('h-12 w-6', className)}
+      fill="none"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.5"
+      viewBox="0 0 24 48"
+    >
+      {direction === 'up' ? (
+        fromRight ? (
+          <>
+            <path d="M 18 46 Q 4 30 12 4" stroke="currentColor" />
+            <path d="M 7 9 L 12 4 L 13 11" stroke="currentColor" />
+          </>
+        ) : (
+          <>
+            <path d="M 6 46 Q 20 30 12 4" stroke="currentColor" />
+            <path d="M 11 11 L 12 4 L 17 9" stroke="currentColor" />
+          </>
+        )
+      ) : fromRight ? (
+        <>
+          <path d="M 18 2 Q 4 18 12 44" stroke="currentColor" />
+          <path d="M 7 39 L 12 44 L 13 37" stroke="currentColor" />
+        </>
+      ) : (
+        <>
+          <path d="M 6 2 Q 20 18 12 44" stroke="currentColor" />
+          <path d="M 11 37 L 12 44 L 17 39" stroke="currentColor" />
+        </>
+      )}
+    </svg>
+  )
+}
+
+/**
+ * Onboarding coachmark. Wraps a target with a soft primary-tinted glow,
+ * with a small label connected by a curved arrow that points at the
+ * highlighted control. Static — attention comes from the glow + the
+ * directional arrow rather than motion.
+ */
+export function TourPointer({active, align = 'center', children, className, label, side = 'bottom'}: Props) {
+  if (!active) return <>{children}</>
+
+  // Arrow stick curves from the same side as the label so the assembly
+  // reads as one piece. For centered alignment we default the curve to the
+  // right (it's a self-contained vertical stack so either looks fine).
+  const curveFrom: CurveFrom = align === 'end' ? 'left' : 'right'
+
+  return (
+    // z-50 lifts the target above the page-wide TourBackdrop (z-40) so the
+    // highlighted control stays sharp while everything else fades back.
+    <span className={cn('relative z-50 inline-flex', className)}>
+      <span className="rounded-md shadow-[0_0_0_2px_var(--primary-foreground),0_0_24px_4px_color-mix(in_oklch,var(--primary-foreground)_45%,transparent)]">
+        {children}
+      </span>
+
+      {/* Arrow always pinned to the target's horizontal center so the tip
+          lands on the highlighted control. */}
+      <span
+        aria-hidden
+        className={cn(
+          'pointer-events-none absolute left-1/2 -translate-x-1/2',
+          side === 'bottom' ? 'top-full mt-1' : 'bottom-full mb-1',
+        )}
+      >
+        <CurvedArrow curveFrom={curveFrom} direction={side === 'bottom' ? 'up' : 'down'} />
+      </span>
+
+      {/* Label aligned independently — for `align="end"` the label sits to
+          the left of the arrow tail, etc. — so the assembly never overflows
+          past the target's edge. */}
+      <span
+        aria-hidden
+        className={cn(
+          'pointer-events-none absolute',
+          side === 'bottom' ? 'top-[calc(100%+3.25rem)]' : 'bottom-[calc(100%+3.25rem)]',
+          align === 'start' && 'left-0',
+          align === 'center' && 'left-1/2 -translate-x-1/2',
+          align === 'end' && 'right-0',
+        )}
+      >
+        <span className="text-xl whitespace-nowrap font-medium tracking-wide leading-tight">{label}</span>
+      </span>
+    </span>
+  )
+}

--- a/src/webui/features/onboarding/components/tour-step-badge.tsx
+++ b/src/webui/features/onboarding/components/tour-step-badge.tsx
@@ -8,7 +8,10 @@ import {Badge} from '@campfirein/byterover-packages/components/badge'
 export function TourStepBadge({label}: {label: string}) {
   return (
     <Badge
-      className="mono border-primary-foreground bg-primary-foreground/20 h-6 w-fit gap-1 px-2 text-[10px] tracking-[0.08em] uppercase"
+      // `leading-none` collapses the line-height to the glyph height so the
+      // 10px label centers cleanly inside the 24px (h-6) pill instead of
+      // sitting on the default text baseline.
+      className="mono border-primary-foreground bg-primary-foreground/20 inline-flex h-6 w-fit items-center gap-1 px-2 text-[10px] leading-none tracking-[0.08em] uppercase"
       variant="outline"
     >
       {label}

--- a/src/webui/features/onboarding/components/tour-task-banner.tsx
+++ b/src/webui/features/onboarding/components/tour-task-banner.tsx
@@ -3,7 +3,6 @@ import {ArrowRight, Check} from 'lucide-react'
 
 import type {StoredTask} from '../../tasks/types/stored-task'
 
-import {isTerminalStatus} from '../../tasks/utils/task-status'
 import {useOnboardingStore} from '../stores/onboarding-store'
 import {TourStepBadge} from './tour-step-badge'
 
@@ -38,6 +37,13 @@ function useActiveTourTask(task: StoredTask) {
   return isMatch ? (tourStep as 'curate' | 'query') : null
 }
 
+function bannerHint(status: StoredTask['status'], step: 'curate' | 'query'): string {
+  if (status === 'completed') return 'Task done. Scroll for the Continue button.'
+  if (status === 'error') return 'Task failed. Use Try again below or fix the provider config.'
+  if (status === 'cancelled') return 'Task cancelled. Use Try again below to retry.'
+  return RUNNING_HINT[step]
+}
+
 /**
  * Top-of-detail banner. Pins the tour step pill + a brief running hint above
  * the task content so the user knows they're still in the tour.
@@ -49,21 +55,20 @@ export function TourTaskBanner({task}: {task: StoredTask}) {
   return (
     <div className="border-primary-foreground/30 bg-primary/8 flex items-center gap-3 rounded-lg border px-4 py-2.5">
       <TourStepBadge label={STEP_LABEL[step]} />
-      <span className="text-muted-foreground text-sm">
-        {isTerminalStatus(task.status) ? 'Task done. Scroll for the Continue button.' : RUNNING_HINT[step]}
-      </span>
+      <span className="text-muted-foreground text-sm">{bannerHint(task.status, step)}</span>
     </div>
   )
 }
 
 /**
- * Bottom-of-detail CTA. Only renders once the task reaches a terminal state —
- * the user has had a chance to scroll through events and see the result.
+ * Bottom-of-detail CTA. Only renders on a successful completion — failed and
+ * cancelled tasks need to be retried before the tour can advance, so we let
+ * the ErrorSection's "Try again" CTA carry the action and stay silent here.
  */
 export function TourTaskContinueCta({task}: {task: StoredTask}) {
   const advanceTour = useOnboardingStore((s) => s.advanceTour)
   const step = useActiveTourTask(task)
-  if (!step || !isTerminalStatus(task.status)) return null
+  if (!step || task.status !== 'completed') return null
 
   return (
     <div className="border-primary-foreground/40 bg-primary/12 flex items-center gap-4 rounded-lg border px-4 py-3.5">

--- a/src/webui/features/onboarding/hooks/use-tour-watchers.ts
+++ b/src/webui/features/onboarding/hooks/use-tour-watchers.ts
@@ -6,9 +6,11 @@ import {useOnboardingStore} from '../stores/onboarding-store'
 /**
  * Watches store/state transitions that should auto-advance the tour.
  *
- * Currently: when the user finishes provider setup (active provider config
- * becomes available), advance from the `provider` step to `curate`. The other
- * steps advance on direct user action (composer submit, connector "Done").
+ * Currently only the `provider → curate` jump runs here (active provider
+ * config becomes available). Curate and query advance on direct user action
+ * via the composer's `onSubmitted`. The Tasks-tab coachmark is what guides
+ * the user across the tab boundary — we deliberately don't auto-navigate so
+ * the click itself becomes the teaching moment.
  */
 export function useTourWatchers() {
   const tourActive = useOnboardingStore((s) => s.tourActive)

--- a/src/webui/features/onboarding/hooks/use-tour-watchers.ts
+++ b/src/webui/features/onboarding/hooks/use-tour-watchers.ts
@@ -1,21 +1,30 @@
 import {useEffect} from 'react'
+import {useSearchParams} from 'react-router-dom'
 
 import {useGetActiveProviderConfig} from '../../provider/api/get-active-provider-config'
 import {useOnboardingStore} from '../stores/onboarding-store'
 
 /**
- * Watches store/state transitions that should auto-advance the tour.
+ * Watches store/state transitions that should auto-advance the tour and run
+ * any side-effects that the FSM doesn't model directly.
  *
- * Currently only the `provider → curate` jump runs here (active provider
- * config becomes available). Curate and query advance on direct user action
- * via the composer's `onSubmitted`. The Tasks-tab coachmark is what guides
- * the user across the tab boundary — we deliberately don't auto-navigate so
- * the click itself becomes the teaching moment.
+ * - `provider → curate` auto-advances when the active provider config
+ *   becomes available.
+ * - On entering `query`, close any open task detail (`?task=…`) — otherwise
+ *   the just-finished curate task's detail sheet would still be open and
+ *   would hide the FilterBar's "New task" button that the next coachmark
+ *   points at.
+ *
+ * Curate and query advance on direct user action via the composer's
+ * `onSubmitted`. The Tasks-tab coachmark is what guides the user across the
+ * tab boundary — we deliberately don't auto-navigate so the click itself
+ * becomes the teaching moment.
  */
 export function useTourWatchers() {
   const tourActive = useOnboardingStore((s) => s.tourActive)
   const tourStep = useOnboardingStore((s) => s.tourStep)
   const advanceTour = useOnboardingStore((s) => s.advanceTour)
+  const [, setSearchParams] = useSearchParams()
 
   const {data: activeConfig} = useGetActiveProviderConfig({
     queryConfig: {enabled: tourActive && tourStep === 'provider'},
@@ -25,4 +34,17 @@ export function useTourWatchers() {
     if (!tourActive || tourStep !== 'provider') return
     if (activeConfig?.activeModel) advanceTour()
   }, [tourActive, tourStep, activeConfig?.activeModel, advanceTour])
+
+  useEffect(() => {
+    if (!tourActive || tourStep !== 'query') return
+    setSearchParams(
+      (prev) => {
+        if (!prev.has('task')) return prev
+        const next = new URLSearchParams(prev)
+        next.delete('task')
+        return next
+      },
+      {replace: true},
+    )
+  }, [tourActive, tourStep, setSearchParams])
 }

--- a/src/webui/features/onboarding/hooks/use-tour-watchers.ts
+++ b/src/webui/features/onboarding/hooks/use-tour-watchers.ts
@@ -23,6 +23,7 @@ import {useOnboardingStore} from '../stores/onboarding-store'
 export function useTourWatchers() {
   const tourActive = useOnboardingStore((s) => s.tourActive)
   const tourStep = useOnboardingStore((s) => s.tourStep)
+  const tourTaskId = useOnboardingStore((s) => s.tourTaskId)
   const advanceTour = useOnboardingStore((s) => s.advanceTour)
   const [, setSearchParams] = useSearchParams()
 
@@ -37,6 +38,11 @@ export function useTourWatchers() {
 
   useEffect(() => {
     if (!tourActive || tourStep !== 'query') return
+    // Only strip when no tour task is in flight — `advanceTour` clears
+    // `tourTaskId` on transition, so this catches the curate→query moment.
+    // After the user submits a query and `tourTaskId` is set again, we
+    // bail out so the new query's detail sheet stays open.
+    if (tourTaskId) return
     setSearchParams(
       (prev) => {
         if (!prev.has('task')) return prev
@@ -46,5 +52,5 @@ export function useTourWatchers() {
       },
       {replace: true},
     )
-  }, [tourActive, tourStep, setSearchParams])
+  }, [tourActive, tourStep, tourTaskId, setSearchParams])
 }

--- a/src/webui/features/onboarding/lib/tour-examples.ts
+++ b/src/webui/features/onboarding/lib/tour-examples.ts
@@ -1,0 +1,9 @@
+export const CURATE_EXAMPLE =
+  'List the most important conventions and patterns used in this codebase — naming, file organization, testing approach, and any rules a new contributor should know before making changes.'
+
+export const QUERY_EXAMPLE = 'What conventions should I follow when making changes?'
+
+export const TOUR_STEP_LABEL = {
+  curate: 'Step 2 of 4',
+  query: 'Step 3 of 4',
+} as const

--- a/src/webui/features/project/api/reveal-project-folder.ts
+++ b/src/webui/features/project/api/reveal-project-folder.ts
@@ -1,0 +1,26 @@
+import {useMutation} from '@tanstack/react-query'
+
+import type {MutationConfig} from '../../../lib/react-query'
+
+import {
+  LocationsEvents,
+  type LocationsRevealRequest,
+  type LocationsRevealResponse,
+} from '../../../../shared/transport/events/locations-events'
+import {useTransportStore} from '../../../stores/transport-store'
+
+export const revealProjectFolder = (input: LocationsRevealRequest): Promise<LocationsRevealResponse> => {
+  const {apiClient} = useTransportStore.getState()
+  if (!apiClient) return Promise.reject(new Error('Not connected'))
+  return apiClient.request<LocationsRevealResponse, LocationsRevealRequest>(LocationsEvents.REVEAL, input)
+}
+
+type UseRevealProjectFolderOptions = {
+  mutationConfig?: MutationConfig<typeof revealProjectFolder>
+}
+
+export const useRevealProjectFolder = ({mutationConfig}: UseRevealProjectFolderOptions = {}) =>
+  useMutation({
+    ...mutationConfig,
+    mutationFn: revealProjectFolder,
+  })

--- a/src/webui/features/project/components/project-dropdown.tsx
+++ b/src/webui/features/project/components/project-dropdown.tsx
@@ -20,14 +20,16 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '@campfirein/byterover-packages/components/dropdown-menu'
-import {ArrowRightLeft, ChevronDown, FolderOpen, SquareArrowOutUpRight} from 'lucide-react'
+import {ArrowRightLeft, ChevronDown, FolderOpen, FolderSearch, SquareArrowOutUpRight} from 'lucide-react'
 import {useMemo, useState} from 'react'
+import {toast} from 'sonner'
 
 import {ProjectLocationDTO} from '../../../../shared/transport/events'
 import {useTransportStore} from '../../../stores/transport-store'
 import {isSafeHttpUrl} from '../../auth/utils/is-safe-http-url'
 import {useGetProjectConfig} from '../api/get-project-config'
 import {useGetProjectList} from '../api/get-project-list'
+import {useRevealProjectFolder} from '../api/reveal-project-folder'
 import {displayPath} from '../utils/display-path'
 import {getProjectName} from '../utils/project-name'
 import {AllProjectsDialog} from './all-projects-dialog'
@@ -97,14 +99,25 @@ type OpenProjectItemProps = {
 function OpenProjectItem({isSelected, onSelect, project}: OpenProjectItemProps) {
   const name = getProjectName(project.projectPath)
   const {data: projectConfig} = useGetProjectConfig({projectPath: project.projectPath})
+  const reveal = useRevealProjectFolder()
   const teamName = projectConfig?.brvConfig?.teamName
   const spaceName = projectConfig?.brvConfig?.spaceName
   const remoteLabel = teamName && spaceName ? `${teamName} / ${spaceName}` : undefined
   // Only open http(s) URLs — SSH remotes (git@host:…) can't open in a browser,
   // and a tampered `.git/config` could otherwise smuggle `javascript:` / `file:` URIs.
-  const openableRemoteUrl = projectConfig?.remoteUrl && isSafeHttpUrl(projectConfig.remoteUrl)
-    ? projectConfig.remoteUrl
-    : undefined
+  const openableRemoteUrl =
+    projectConfig?.remoteUrl && isSafeHttpUrl(projectConfig.remoteUrl) ? projectConfig.remoteUrl : undefined
+
+  function handleRevealLocal() {
+    reveal.mutate(
+      {projectPath: project.projectPath},
+      {
+        onError(error) {
+          toast.error(error instanceof Error ? error.message : 'Failed to open folder.')
+        },
+      },
+    )
+  }
 
   return (
     <DropdownMenuSub>
@@ -124,6 +137,10 @@ function OpenProjectItem({isSelected, onSelect, project}: OpenProjectItemProps) 
         >
           <SquareArrowOutUpRight className="size-4" />
           <span className="text-sm">Open Remote space</span>
+        </DropdownMenuItem>
+        <DropdownMenuItem disabled={reveal.isPending} onClick={handleRevealLocal}>
+          <FolderSearch className="size-4" />
+          <span className="text-sm">Open local folder</span>
         </DropdownMenuItem>
       </DropdownMenuSubContent>
     </DropdownMenuSub>

--- a/src/webui/features/provider/components/global-provider-dialog.tsx
+++ b/src/webui/features/provider/components/global-provider-dialog.tsx
@@ -1,0 +1,15 @@
+import {useProviderStore} from '../stores/provider-store'
+import {ProviderFlowDialog} from './provider-flow'
+
+/**
+ * Store-backed mount of ProviderFlowDialog so any component can open it
+ * without owning its own dialog state. Triggered via
+ * `useProviderStore.getState().openProviderDialog()` (or a selector).
+ * Existing local-state mounts (Header, TaskComposer, TourHost) keep working.
+ */
+export function GlobalProviderDialog() {
+  const isOpen = useProviderStore((s) => s.isDialogOpen)
+  const closeProviderDialog = useProviderStore((s) => s.closeProviderDialog)
+
+  return <ProviderFlowDialog onOpenChange={(open) => !open && closeProviderDialog()} open={isOpen} />
+}

--- a/src/webui/features/provider/components/provider-flow/login-prompt-step.tsx
+++ b/src/webui/features/provider/components/provider-flow/login-prompt-step.tsx
@@ -1,32 +1,103 @@
 import {Button} from '@campfirein/byterover-packages/components/button'
 import {DialogFooter, DialogHeader, DialogTitle} from '@campfirein/byterover-packages/components/dialog'
 import {useQueryClient} from '@tanstack/react-query'
-import {ChevronLeft, LoaderCircle} from 'lucide-react'
-import {useEffect, useState} from 'react'
+import {ChevronLeft, ExternalLink, LoaderCircle} from 'lucide-react'
+import {useEffect, useRef, useState} from 'react'
 
 import {getAuthStateQueryOptions} from '../../../auth/api/get-auth-state'
 import {login, subscribeToLoginCompleted} from '../../../auth/api/login'
 import {useAuthStore} from '../../../auth/stores/auth-store'
 import {isSafeHttpUrl} from '../../../auth/utils/is-safe-http-url'
 
+/**
+ * The Window reference returned by window.open, expressed without naming the
+ * DOM type directly (ESLint's no-undef doesn't ship with browser globals).
+ */
+type PopupRef = ReturnType<typeof globalThis.open>
+
 interface LoginPromptStepProps {
   onAuthenticated: () => void
   onBack: () => void
+  /**
+   * The OAuth popup. ProviderSelectStep opens it synchronously from the row
+   * click (user-gesture context), then hands it here for the step to navigate
+   * once the auth URL is ready.
+   */
+  popup: PopupRef
 }
 
 type InnerState =
+  | {authUrl: string; type: 'blocked'}
   | {authUrl: string; type: 'waiting'}
   | {message: string; type: 'error'}
-  | {type: 'idle'}
   | {type: 'starting'}
 
 const POLL_INTERVAL_MS = 2500
+/**
+ * Minimum time the "Signing in to ByteRover" dialog stays visible before we
+ * navigate the popup. Keeps the transition legible — without it the popup
+ * races to the auth URL before the user sees the step.
+ */
+const MIN_VISIBLE_DELAY_MS = 800
 
-export function LoginPromptStep({onAuthenticated, onBack}: LoginPromptStepProps) {
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+export function LoginPromptStep({onAuthenticated, onBack, popup}: LoginPromptStepProps) {
   const queryClient = useQueryClient()
   const isAuthorized = useAuthStore((s) => s.isAuthorized)
   const setLoggingIn = useAuthStore((s) => s.setLoggingIn)
-  const [state, setState] = useState<InnerState>({type: 'idle'})
+  const [state, setState] = useState<InnerState>({type: 'starting'})
+  const didStartRef = useRef(false)
+
+  // Kick off the OAuth request as soon as the step mounts. The popup was
+  // already opened synchronously in the row click handler upstream.
+  useEffect(() => {
+    if (didStartRef.current) return
+    didStartRef.current = true
+    setLoggingIn(true)
+    let cancelled = false
+
+    async function start() {
+      try {
+        const [response] = await Promise.all([login(), sleep(MIN_VISIBLE_DELAY_MS)])
+        if (cancelled) return
+        if (!isSafeHttpUrl(response.authUrl)) {
+          popup?.close()
+          setState({message: 'Received an unsafe OAuth URL from the daemon', type: 'error'})
+          setLoggingIn(false)
+          return
+        }
+
+        if (popup && !popup.closed) {
+          popup.location.href = response.authUrl
+          setState({authUrl: response.authUrl, type: 'waiting'})
+        } else {
+          // Popup was blocked or closed before navigation. Fall back to an
+          // explicit user-initiated open via the action button below.
+          setState({authUrl: response.authUrl, type: 'blocked'})
+        }
+      } catch (error) {
+        if (cancelled) return
+        setLoggingIn(false)
+        setState({
+          message: error instanceof Error ? error.message : 'Unable to start login',
+          type: 'error',
+        })
+      }
+    }
+
+    start().catch(() => {
+      // error already surfaced via state
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [popup, setLoggingIn])
 
   // Auto-continue once auth flips to authorized (from LOGIN_COMPLETED or poll).
   useEffect(() => {
@@ -52,7 +123,6 @@ export function LoginPromptStep({onAuthenticated, onBack}: LoginPromptStepProps)
     return unsubscribe
   }, [queryClient, setLoggingIn, state.type])
 
-  // Fallback poll in case LOGIN_COMPLETED is missed.
   useEffect(() => {
     if (state.type !== 'waiting') return
 
@@ -78,36 +148,10 @@ export function LoginPromptStep({onAuthenticated, onBack}: LoginPromptStepProps)
     }
   }, [queryClient, setLoggingIn, state.type])
 
-  async function handleSignIn() {
-    setLoggingIn(true)
-    // Open the popup synchronously to keep the user-gesture context — browsers
-    // block window.open() if it lands inside an async callback. `noopener` is
-    // intentionally omitted so we get a window reference and can navigate it
-    // once the auth URL arrives.
-    const popup = window.open('about:blank', '_blank')
+  function retry() {
+    // Clear the guard so the effect runs again on next render.
+    didStartRef.current = false
     setState({type: 'starting'})
-
-    try {
-      const response = await login()
-      if (!isSafeHttpUrl(response.authUrl)) {
-        popup?.close()
-        throw new Error('Received an unsafe OAuth URL from the daemon')
-      }
-
-      if (popup && !popup.closed) {
-        popup.location.href = response.authUrl
-      } else {
-        window.open(response.authUrl, '_blank', 'noopener,noreferrer')
-      }
-
-      setState({authUrl: response.authUrl, type: 'waiting'})
-    } catch (error) {
-      setLoggingIn(false)
-      setState({
-        message: error instanceof Error ? error.message : 'Unable to start login',
-        type: 'error',
-      })
-    }
   }
 
   return (
@@ -117,27 +161,22 @@ export function LoginPromptStep({onAuthenticated, onBack}: LoginPromptStepProps)
           <button className="hover:bg-muted rounded p-0.5 transition-colors" onClick={onBack} type="button">
             <ChevronLeft className="size-5" />
           </button>
-          Sign in to ByteRover
+          Signing in to ByteRover
         </DialogTitle>
       </DialogHeader>
 
       <div className="flex flex-col gap-4">
-        <p className="text-muted-foreground text-sm">
-          ByteRover requires authentication before it can be used as a provider. Sign in to your{' '}
-          <span className="text-foreground">byterover.dev</span> account to continue.
-        </p>
-
         {state.type === 'starting' && (
-          <div className="flex items-center gap-2 rounded-lg border border-blue-500/20 bg-blue-500/5 p-3 text-sm text-blue-700">
-            <LoaderCircle className="size-4 animate-spin" />
-            Starting authentication…
+          <div className="border-primary/30 bg-primary/5 flex items-center gap-2 rounded-lg border p-3 text-sm">
+            <LoaderCircle className="text-primary-foreground size-4 animate-spin" />
+            Preparing sign-in…
           </div>
         )}
 
         {state.type === 'waiting' && (
-          <div className="flex flex-col gap-1 rounded-lg border bg-card p-3">
+          <div className="border-primary/30 bg-primary/5 flex flex-col gap-1 rounded-lg border p-3">
             <div className="flex items-center gap-2 text-sm">
-              <LoaderCircle className="text-primary size-4 animate-spin" />
+              <LoaderCircle className="text-primary-foreground size-4 animate-spin" />
               Finish signing in in the new tab.
             </div>
             <div className="text-muted-foreground pl-6 text-xs">
@@ -150,6 +189,13 @@ export function LoginPromptStep({onAuthenticated, onBack}: LoginPromptStepProps)
           </div>
         )}
 
+        {state.type === 'blocked' && (
+          <div className="border-border bg-muted text-foreground flex items-center gap-2 rounded-lg border p-3 text-sm">
+            <ExternalLink className="size-4 shrink-0" />
+            Your browser blocked the sign-in popup.
+          </div>
+        )}
+
         {state.type === 'error' && (
           <div className="text-destructive bg-destructive/10 rounded-lg px-4 py-2.5 text-sm">{state.message}</div>
         )}
@@ -157,14 +203,22 @@ export function LoginPromptStep({onAuthenticated, onBack}: LoginPromptStepProps)
 
       <DialogFooter className="mt-auto">
         <Button onClick={onBack} variant="secondary">
-          Cancel
+          Use a different provider
         </Button>
-        {state.type === 'error' ? (
-          <Button onClick={() => setState({type: 'idle'})}>Try again</Button>
-        ) : (
-          <Button disabled={state.type === 'starting' || state.type === 'waiting'} onClick={handleSignIn}>
-            {state.type === 'waiting' ? 'Waiting…' : 'Sign in'}
+        {state.type === 'error' && <Button onClick={retry}>Retry sign-in</Button>}
+        {state.type === 'blocked' && (
+          <Button
+            onClick={() => {
+              window.open(state.authUrl, '_blank', 'noopener,noreferrer')
+              setState({authUrl: state.authUrl, type: 'waiting'})
+            }}
+          >
+            <ExternalLink className="size-3.5" />
+            Open sign-in page
           </Button>
+        )}
+        {(state.type === 'starting' || state.type === 'waiting') && (
+          <Button disabled>Waiting…</Button>
         )}
       </DialogFooter>
     </div>

--- a/src/webui/features/provider/components/provider-flow/login-prompt-step.tsx
+++ b/src/webui/features/provider/components/provider-flow/login-prompt-step.tsx
@@ -51,6 +51,7 @@ export function LoginPromptStep({onAuthenticated, onBack, popup}: LoginPromptSte
   const isAuthorized = useAuthStore((s) => s.isAuthorized)
   const setLoggingIn = useAuthStore((s) => s.setLoggingIn)
   const [state, setState] = useState<InnerState>({type: 'starting'})
+  const [retryCount, setRetryCount] = useState(0)
   const didStartRef = useRef(false)
 
   // Kick off the OAuth request as soon as the step mounts. The popup was
@@ -97,7 +98,9 @@ export function LoginPromptStep({onAuthenticated, onBack, popup}: LoginPromptSte
     return () => {
       cancelled = true
     }
-  }, [popup, setLoggingIn])
+    // `retryCount` is a trigger, not read inside the effect — it forces a
+    // re-run when the user hits "Retry sign-in" after a failure.
+  }, [popup, setLoggingIn, retryCount])
 
   // Auto-continue once auth flips to authorized (from LOGIN_COMPLETED or poll).
   useEffect(() => {
@@ -149,9 +152,11 @@ export function LoginPromptStep({onAuthenticated, onBack, popup}: LoginPromptSte
   }, [queryClient, setLoggingIn, state.type])
 
   function retry() {
-    // Clear the guard so the effect runs again on next render.
+    // Clear the guard and bump `retryCount` so the start effect re-runs —
+    // state alone isn't in its deps list, so setState isn't enough.
     didStartRef.current = false
     setState({type: 'starting'})
+    setRetryCount((n) => n + 1)
   }
 
   return (

--- a/src/webui/features/provider/components/provider-flow/provider-flow-dialog.tsx
+++ b/src/webui/features/provider/components/provider-flow/provider-flow-dialog.tsx
@@ -1,30 +1,38 @@
-import { Dialog, DialogContent } from '@campfirein/byterover-packages/components/dialog'
-import { LoaderCircle } from 'lucide-react'
-import { useCallback, useRef, useState } from 'react'
-import { toast } from 'sonner'
+import {Dialog, DialogContent} from '@campfirein/byterover-packages/components/dialog'
+import {LoaderCircle} from 'lucide-react'
+import {useCallback, useRef, useState} from 'react'
+import {toast} from 'sonner'
 
 import type {ModelDTO, ProviderDTO} from '../../../../../shared/transport/events'
 
-import { formatError } from '../../../../lib/error-messages'
-import { useAuthStore } from '../../../auth/stores/auth-store'
-import { useSetActiveModel } from '../../../model/api/set-active-model'
+import {formatError} from '../../../../lib/error-messages'
+import {useAuthStore} from '../../../auth/stores/auth-store'
+import {useSetActiveModel} from '../../../model/api/set-active-model'
 import {TourStepBadge} from '../../../onboarding/components/tour-step-badge'
-import { useAwaitOAuthCallback } from '../../api/await-oauth-callback'
-import { useConnectProvider } from '../../api/connect-provider'
-import { useDisconnectProvider } from '../../api/disconnect-provider'
-import { useGetProviders } from '../../api/get-providers'
-import { useSetActiveProvider } from '../../api/set-active-provider'
-import { useStartOAuth } from '../../api/start-oauth'
-import { useValidateApiKey } from '../../api/validate-api-key'
-import { ApiKeyStep } from './api-key-step'
-import { AuthMethodStep } from './auth-method-step'
-import { BaseUrlStep } from './base-url-step'
-import { LoginPromptStep } from './login-prompt-step'
-import { ModelSelectStep } from './model-select-step'
-import { type ProviderActionId, ProviderActionStep } from './provider-action-step'
-import { ProviderSelectStep } from './provider-select-step'
+import {useAwaitOAuthCallback} from '../../api/await-oauth-callback'
+import {useConnectProvider} from '../../api/connect-provider'
+import {useDisconnectProvider} from '../../api/disconnect-provider'
+import {useGetProviders} from '../../api/get-providers'
+import {useSetActiveProvider} from '../../api/set-active-provider'
+import {useStartOAuth} from '../../api/start-oauth'
+import {useValidateApiKey} from '../../api/validate-api-key'
+import {ApiKeyStep} from './api-key-step'
+import {AuthMethodStep} from './auth-method-step'
+import {BaseUrlStep} from './base-url-step'
+import {LoginPromptStep} from './login-prompt-step'
+import {ModelSelectStep} from './model-select-step'
+import {type ProviderActionId, ProviderActionStep} from './provider-action-step'
+import {ProviderSelectStep} from './provider-select-step'
 
-type FlowStep = 'api_key' | 'auth_method' | 'base_url' | 'connecting' | 'login_prompt' | 'model_select' | 'provider_actions' | 'select'
+type FlowStep =
+  | 'api_key'
+  | 'auth_method'
+  | 'base_url'
+  | 'connecting'
+  | 'login_prompt'
+  | 'model_select'
+  | 'provider_actions'
+  | 'select'
 
 const BYTEROVER_PROVIDER_ID = 'byterover'
 
@@ -188,58 +196,63 @@ export function ProviderFlowDialog({onOpenChange, onProviderActivated, open, tou
         return
       }
 
-    // No key needed → connect directly → model select
-    setStep('connecting')
-    try {
-      await connectMutation.mutateAsync({ providerId: provider.id })
-      setIsNewConnection(true)
-      setStep('model_select')
-    } catch (error_) {
-      toast.error(formatError(error_, 'Connection failed'))
-      setStep('select')
-    }
-  }, [connectByteRover, connectMutation, isAuthorized, onProviderActivated, resetAndClose])
-
-  const handleOAuth = useCallback(async (provider: ProviderDTO) => {
-    setStep('connecting')
-    try {
-      const result = await startOAuthMutation.mutateAsync({providerId: provider.id})
-      if (!result.success) {
-        toast.error(result.error ?? 'Failed to start OAuth')
-        setStep('select')
-        return
-      }
-
-      const callbackResult = await awaitOAuthMutation.mutateAsync({ providerId: provider.id })
-      if (callbackResult.success) {
+      // No key needed → connect directly → model select
+      setStep('connecting')
+      try {
+        await connectMutation.mutateAsync({providerId: provider.id})
         setIsNewConnection(true)
         setStep('model_select')
-      } else {
-        toast.error(callbackResult.error ?? 'OAuth failed')
+      } catch (error_) {
+        toast.error(formatError(error_, 'Connection failed'))
         setStep('select')
       }
-    } catch (error_) {
-      toast.error(formatError(error_, 'OAuth failed'))
-      setStep('select')
-    }
-  }, [awaitOAuthMutation, startOAuthMutation])
+    },
+    [connectByteRover, connectMutation, isAuthorized, onProviderActivated, resetAndClose],
+  )
+
+  const handleOAuth = useCallback(
+    async (provider: ProviderDTO) => {
+      setStep('connecting')
+      try {
+        const result = await startOAuthMutation.mutateAsync({providerId: provider.id})
+        if (!result.success) {
+          toast.error(result.error ?? 'Failed to start OAuth')
+          setStep('select')
+          return
+        }
+
+        const callbackResult = await awaitOAuthMutation.mutateAsync({providerId: provider.id})
+        if (callbackResult.success) {
+          setIsNewConnection(true)
+          setStep('model_select')
+        } else {
+          toast.error(callbackResult.error ?? 'OAuth failed')
+          setStep('select')
+        }
+      } catch (error_) {
+        toast.error(formatError(error_, 'OAuth failed'))
+        setStep('select')
+      }
+    },
+    [awaitOAuthMutation, startOAuthMutation],
+  )
 
   const handleAction = useCallback(
     async (actionId: ProviderActionId) => {
       if (!selectedProvider) return
 
-    switch (actionId) {
-      case 'activate': {
-        setStep('connecting')
-        try {
-          await setActiveMutation.mutateAsync({ providerId: selectedProvider.id })
-          toast.success(`Activated ${selectedProvider.name}`)
-          onProviderActivated?.()
-          resetAndClose()
-        } catch (error_) {
-          setError(formatError(error_, 'Failed'))
-          setStep('provider_actions')
-        }
+      switch (actionId) {
+        case 'activate': {
+          setStep('connecting')
+          try {
+            await setActiveMutation.mutateAsync({providerId: selectedProvider.id})
+            toast.success(`Activated ${selectedProvider.name}`)
+            onProviderActivated?.()
+            resetAndClose()
+          } catch (error_) {
+            setError(formatError(error_, 'Failed'))
+            setStep('provider_actions')
+          }
 
           break
         }
@@ -249,18 +262,18 @@ export function ProviderFlowDialog({onOpenChange, onProviderActivated, open, tou
           break
         }
 
-      case 'disconnect': {
-        setStep('connecting')
-        try {
-          await disconnectMutation.mutateAsync({ providerId: selectedProvider.id })
-          toast.success(`Disconnected ${selectedProvider.name}`)
-          setStep('select')
-          setSelectedProvider(undefined)
-          setError(undefined)
-        } catch (error_) {
-          setError(formatError(error_, 'Failed'))
-          setStep('provider_actions')
-        }
+        case 'disconnect': {
+          setStep('connecting')
+          try {
+            await disconnectMutation.mutateAsync({providerId: selectedProvider.id})
+            toast.success(`Disconnected ${selectedProvider.name}`)
+            setStep('select')
+            setSelectedProvider(undefined)
+            setError(undefined)
+          } catch (error_) {
+            setError(formatError(error_, 'Failed'))
+            setStep('provider_actions')
+          }
 
           break
         }
@@ -293,34 +306,36 @@ export function ProviderFlowDialog({onOpenChange, onProviderActivated, open, tou
     async (apiKey: string) => {
       if (!selectedProvider) return
 
-    // Validate first (skip for openai-compatible)
-    if (selectedProvider.id !== 'openai-compatible' && apiKey) {
-      try {
-        const result = await validateMutation.mutateAsync({ apiKey, providerId: selectedProvider.id })
-        if (!result.isValid) {
-          setError(result.error ?? 'Invalid API key')
+      // Validate first (skip for openai-compatible)
+      if (selectedProvider.id !== 'openai-compatible' && apiKey) {
+        try {
+          const result = await validateMutation.mutateAsync({apiKey, providerId: selectedProvider.id})
+          if (!result.isValid) {
+            setError(result.error ?? 'Invalid API key')
+            return
+          }
+        } catch (error_) {
+          setError(formatError(error_, 'Validation failed'))
           return
         }
-      } catch (error_) {
-        setError(formatError(error_, 'Validation failed'))
-        return
       }
-    }
 
-    setStep('connecting')
-    try {
-      await connectMutation.mutateAsync({
-        apiKey: apiKey || undefined,
-        baseUrl: baseUrl ?? undefined,
-        providerId: selectedProvider.id,
-      })
-      setIsNewConnection(true)
-      setStep('model_select')
-    } catch (error_) {
-      setError(formatError(error_, 'Connection failed'))
-      setStep('api_key')
-    }
-  }, [baseUrl, connectMutation, selectedProvider, validateMutation])
+      setStep('connecting')
+      try {
+        await connectMutation.mutateAsync({
+          apiKey: apiKey || undefined,
+          baseUrl: baseUrl ?? undefined,
+          providerId: selectedProvider.id,
+        })
+        setIsNewConnection(true)
+        setStep('model_select')
+      } catch (error_) {
+        setError(formatError(error_, 'Connection failed'))
+        setStep('api_key')
+      }
+    },
+    [baseUrl, connectMutation, selectedProvider, validateMutation],
+  )
 
   const handleModelSelect = useCallback(
     async (model: ModelDTO) => {
@@ -333,18 +348,20 @@ export function ProviderFlowDialog({onOpenChange, onProviderActivated, open, tou
           providerId: selectedProvider.id,
         })
 
-      if (isNewConnection) {
-        toast.success(`Connected to ${selectedProvider.name}`)
-        onProviderActivated?.()
-        resetAndClose()
-      } else {
-        toast.success(`Model set to ${model.name}`)
-        setStep('provider_actions')
+        if (isNewConnection) {
+          toast.success(`Connected to ${selectedProvider.name}`)
+          onProviderActivated?.()
+          resetAndClose()
+        } else {
+          toast.success(`Model set to ${model.name}`)
+          setStep('provider_actions')
+        }
+      } catch (error_) {
+        toast.error(formatError(error_, 'Failed to set model'))
       }
-    } catch (error_) {
-      toast.error(formatError(error_, 'Failed to set model'))
-    }
-  }, [isNewConnection, onProviderActivated, resetAndClose, selectedProvider, setActiveModelMutation])
+    },
+    [isNewConnection, onProviderActivated, resetAndClose, selectedProvider, setActiveModelMutation],
+  )
 
   const handleApiKeyBack = useCallback(() => {
     setError(undefined)
@@ -475,7 +492,9 @@ export function ProviderFlowDialog({onOpenChange, onProviderActivated, open, tou
     <Dialog onOpenChange={handleOpenChange} open={open}>
       <DialogContent
         className="flex h-150 flex-col sm:max-w-lg"
-        showCloseButton={step === 'select' || step === 'model_select' || step === 'connecting' || step === 'login_prompt'}
+        showCloseButton={
+          step === 'select' || step === 'model_select' || step === 'connecting' || step === 'login_prompt'
+        }
       >
         {tourStepLabel && <TourStepBadge label={tourStepLabel} />}
         {renderStep()}

--- a/src/webui/features/provider/components/provider-flow/provider-flow-dialog.tsx
+++ b/src/webui/features/provider/components/provider-flow/provider-flow-dialog.tsx
@@ -1,6 +1,6 @@
 import { Dialog, DialogContent } from '@campfirein/byterover-packages/components/dialog'
 import { LoaderCircle } from 'lucide-react'
-import { useCallback, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { toast } from 'sonner'
 
 import type {ModelDTO, ProviderDTO} from '../../../../../shared/transport/events'
@@ -61,6 +61,12 @@ export function ProviderFlowDialog({onOpenChange, onProviderActivated, open, tou
   const [baseUrl, setBaseUrl] = useState<string | undefined>()
   const [error, setError] = useState<string | undefined>()
   const [isNewConnection, setIsNewConnection] = useState(false)
+
+  // Window reference for the ByteRover OAuth popup. Opened synchronously in the
+  // provider row click handler to preserve the user-gesture context (browsers
+  // block popups opened later from effects or awaited promises) and handed off
+  // to LoginPromptStep, which navigates it to the auth URL.
+  const oauthPopupRef = useRef<ReturnType<typeof globalThis.open>>(null)
 
   const isAuthorized = useAuthStore((s) => s.isAuthorized)
   const {data} = useGetProviders()
@@ -135,8 +141,12 @@ export function ProviderFlowDialog({onOpenChange, onProviderActivated, open, tou
       setSelectedProvider(provider)
       setError(undefined)
 
-      // ByteRover requires sign-in first
+      // ByteRover requires sign-in first. Open the OAuth popup synchronously
+      // right here — we're inside the row's click handler, which is still
+      // within the user-gesture window browsers require for window.open().
+      // Opening later (from useEffect or after await) gets blocked.
       if (provider.id === BYTEROVER_PROVIDER_ID && !isAuthorized) {
+        oauthPopupRef.current = window.open('about:blank', '_blank')
         setStep('login_prompt')
         return
       }
@@ -415,6 +425,7 @@ export function ProviderFlowDialog({onOpenChange, onProviderActivated, open, tou
               setStep('select')
               setSelectedProvider(undefined)
             }}
+            popup={oauthPopupRef.current}
           />
         ) : null
       }

--- a/src/webui/features/provider/components/provider-flow/provider-select-step.tsx
+++ b/src/webui/features/provider/components/provider-flow/provider-select-step.tsx
@@ -1,3 +1,4 @@
+import {Badge} from '@campfirein/byterover-packages/components/badge'
 import {DialogDescription, DialogHeader, DialogTitle} from '@campfirein/byterover-packages/components/dialog'
 import {Input} from '@campfirein/byterover-packages/components/input'
 import {cn} from '@campfirein/byterover-packages/lib/utils'
@@ -8,18 +9,31 @@ import type {ProviderDTO} from '../../../../../shared/transport/events'
 
 import {providerIcons} from './provider-icons'
 
+const BYTEROVER_PROVIDER_ID = 'byterover'
+
 interface ProviderSelectStepProps {
   onSelect: (provider: ProviderDTO) => void
   providers: ProviderDTO[]
+}
+
+/**
+ * Sort ByteRover to the top so it shows as the default choice. Everything else
+ * keeps its server-side ordering.
+ */
+function orderProviders(providers: ProviderDTO[]): ProviderDTO[] {
+  const byterover = providers.find((p) => p.id === BYTEROVER_PROVIDER_ID)
+  if (!byterover) return providers
+  return [byterover, ...providers.filter((p) => p.id !== BYTEROVER_PROVIDER_ID)]
 }
 
 export function ProviderSelectStep({onSelect, providers}: ProviderSelectStepProps) {
   const [search, setSearch] = useState('')
 
   const filtered = useMemo(() => {
-    if (!search) return providers
+    const ordered = orderProviders(providers)
+    if (!search) return ordered
     const q = search.toLowerCase()
-    return providers.filter((p) => p.name.toLowerCase().includes(q))
+    return ordered.filter((p) => p.name.toLowerCase().includes(q))
   }, [providers, search])
 
   return (
@@ -41,6 +55,7 @@ export function ProviderSelectStep({onSelect, providers}: ProviderSelectStepProp
           {filtered.map((provider) => {
             const icon = providerIcons[provider.id]
             const isActive = provider.isCurrent
+            const isByteRover = provider.id === BYTEROVER_PROVIDER_ID
 
             return (
               <button
@@ -56,9 +71,19 @@ export function ProviderSelectStep({onSelect, providers}: ProviderSelectStepProp
                 <div className="bg-muted/50 grid size-7 shrink-0 place-items-center overflow-hidden rounded-md">
                   {icon && <img alt="" className="size-5" src={icon} />}
                 </div>
-                <div className="min-w-0 flex-1">
-                  <div className="text-foreground truncate text-sm font-medium">{provider.name}</div>
-                  <div className="text-muted-foreground min-h-[1lh] truncate text-xs">{provider.description}</div>
+                <div className="min-w-0 flex-1 space-y-0.5">
+                  <div className="text-foreground flex flex-wrap items-center gap-1.5 text-sm">
+                    <span className="font-medium truncate">{provider.name}</span>
+                    {isByteRover && (
+                      <Badge
+                        className="border-amber-500/50 bg-amber-500/15 text-amber-400 h-[18px] rounded-sm px-1.5 text-[11px] font-medium leading-none"
+                        variant="outline"
+                      >
+                        Native
+                      </Badge>
+                    )}
+                  </div>
+                  <div className="text-muted-foreground min-h-lh truncate text-xs">{provider.description}</div>
                 </div>
                 <div
                   className={cn(

--- a/src/webui/features/provider/stores/provider-store.ts
+++ b/src/webui/features/provider/stores/provider-store.ts
@@ -4,11 +4,14 @@ import type {ProviderDTO} from '../../../../shared/transport/types/dto'
 
 export interface ProviderState {
   activeProviderId: null | string
+  isDialogOpen: boolean
   isLoading: boolean
   providers: ProviderDTO[]
 }
 
 export interface ProviderActions {
+  closeProviderDialog: () => void
+  openProviderDialog: () => void
   reset: () => void
   setActiveProviderId: (providerId: null | string) => void
   setLoading: (isLoading: boolean) => void
@@ -18,12 +21,17 @@ export interface ProviderActions {
 
 const initialState: ProviderState = {
   activeProviderId: null,
+  isDialogOpen: false,
   isLoading: false,
   providers: [],
 }
 
 export const useProviderStore = create<ProviderActions & ProviderState>()((set) => ({
   ...initialState,
+
+  closeProviderDialog: () => set({isDialogOpen: false}),
+
+  openProviderDialog: () => set({isDialogOpen: true}),
 
   reset: () => set(initialState),
 

--- a/src/webui/features/tasks/components/task-composer-bits.tsx
+++ b/src/webui/features/tasks/components/task-composer-bits.tsx
@@ -25,7 +25,10 @@ export function CurateAttachmentHint() {
 export function PrefillBadge({label}: {label: string}) {
   return (
     <Badge
-      className="text-primary-foreground absolute top-2.5 right-3 gap-1.5 px-2 text-[10px] tracking-[0.08em] uppercase"
+      // Bottom-left so the badge shares the textarea's reserved bottom band
+      // with the keyboard hint (which lives at bottom-right) instead of
+      // overlapping the first line of the prefilled example.
+      className="text-primary-foreground absolute bottom-2 left-3 gap-1.5 px-2 text-[10px] tracking-[0.08em] uppercase"
       variant="secondary"
     >
       <span aria-hidden className="bg-primary-foreground size-1.5 rounded-full" />

--- a/src/webui/features/tasks/components/task-composer-header.tsx
+++ b/src/webui/features/tasks/components/task-composer-header.tsx
@@ -1,3 +1,4 @@
+import {Tooltip, TooltipContent, TooltipTrigger} from '@campfirein/byterover-packages/components/tooltip'
 import {cn} from '@campfirein/byterover-packages/lib/utils'
 
 import type {ComposerType} from './task-composer-types'
@@ -25,7 +26,19 @@ export function ComposerHeader({
           <span className="text-muted-foreground/70 font-normal">New</span>
           <span>{type} task</span>
         </h2>
-        {!inTour && <TypeSlider onChange={onTypeChange} value={type} />}
+        {/*
+          During the tour the slider is shown but locked so users still learn
+          the affordance — it'd otherwise be invisible until they finish the
+          tour. Tooltip explains the disabled state.
+        */}
+        {inTour ? (
+          <Tooltip>
+            <TooltipTrigger render={<TypeSlider disabled onChange={onTypeChange} value={type} />} />
+            <TooltipContent>Locked during the tour — the next step covers the other mode.</TooltipContent>
+          </Tooltip>
+        ) : (
+          <TypeSlider onChange={onTypeChange} value={type} />
+        )}
       </div>
       <p className="text-muted-foreground/70 text-xs">
         {type === 'query' ? 'Searches' : 'Will dispatch to'}{' '}
@@ -35,9 +48,20 @@ export function ComposerHeader({
   )
 }
 
-function TypeSlider({onChange, value}: {onChange: (next: ComposerType) => void; value: ComposerType}) {
+function TypeSlider({
+  disabled = false,
+  onChange,
+  value,
+}: {
+  disabled?: boolean
+  onChange: (next: ComposerType) => void
+  value: ComposerType
+}) {
   return (
-    <div className="border-border bg-muted relative inline-flex rounded-md border p-0.5">
+    <div
+      aria-disabled={disabled}
+      className={cn('border-border bg-muted relative inline-flex rounded-md border p-0.5', disabled && 'opacity-60')}
+    >
       <span
         aria-hidden
         className={cn(
@@ -50,7 +74,9 @@ function TypeSlider({onChange, value}: {onChange: (next: ComposerType) => void; 
           className={cn(
             'relative z-10 px-3 py-1 text-xs font-medium transition-colors',
             option === value ? 'text-foreground' : 'text-muted-foreground hover:text-foreground/80',
+            disabled && 'cursor-not-allowed hover:text-muted-foreground',
           )}
+          disabled={disabled}
           key={option}
           onClick={() => onChange(option)}
           type="button"

--- a/src/webui/features/tasks/components/task-composer-types.ts
+++ b/src/webui/features/tasks/components/task-composer-types.ts
@@ -2,8 +2,8 @@ export type ComposerType = 'curate' | 'query'
 
 export const PLACEHOLDER: Record<ComposerType, string> = {
   curate:
-    'JWT tokens expire after 24h. Refresh window is 7 days. Rotation happens on every successful refresh — old refresh token is invalidated immediately.',
-  query: 'What is our auth token expiration policy?',
+    'List the most important conventions and patterns used in this codebase — naming, file organization, testing approach, and any rules a new contributor should know before making changes.',
+  query: 'What conventions should I follow when making changes?',
 }
 
 export const HELP: Record<ComposerType, string> = {

--- a/src/webui/features/tasks/components/task-detail-header.tsx
+++ b/src/webui/features/tasks/components/task-detail-header.tsx
@@ -56,9 +56,9 @@ function CopyableTaskId({taskId}: {taskId: string}) {
   const copy = async () => {
     try {
       await navigator.clipboard.writeText(taskId)
-      toast.success('Task ID copied', {duration: 2000, position: 'top-center'})
+      toast.success('Task ID copied', {duration: 2000})
     } catch {
-      toast.error('Failed to copy task ID', {duration: 3000, position: 'top-center'})
+      toast.error('Failed to copy task ID', {duration: 3000})
     }
   }
 

--- a/src/webui/features/tasks/components/task-detail-sections.tsx
+++ b/src/webui/features/tasks/components/task-detail-sections.tsx
@@ -1,3 +1,4 @@
+import {Button} from '@campfirein/byterover-packages/components/button'
 import {Card} from '@campfirein/byterover-packages/components/card'
 import {cn} from '@campfirein/byterover-packages/lib/utils'
 import {Folder, Paperclip} from 'lucide-react'
@@ -5,7 +6,9 @@ import {Folder, Paperclip} from 'lucide-react'
 import type {StoredTask} from '../types/stored-task'
 
 import {formatError} from '../../../lib/error-messages'
+import {useProviderStore} from '../../provider/stores/provider-store'
 import {shortTaskId} from '../utils/format-time'
+import {isProviderTaskError} from '../utils/is-provider-task-error'
 import {isActiveStatus} from '../utils/task-status'
 import {AttachmentChip} from './attachment-chip'
 import {MarkdownInline} from './markdown-inline'
@@ -75,7 +78,16 @@ export function ResultSection({content}: {content: string}) {
   )
 }
 
-export function ErrorSection({error}: {error: NonNullable<StoredTask['error']>}) {
+export function ErrorSection({task}: {task: StoredTask}) {
+  const {error} = task
+  const openProviderDialog = useProviderStore((s) => s.openProviderDialog)
+  const showProviderCta = isProviderTaskError({
+    error,
+    hadLlmServiceError: Boolean(task.hadLlmServiceError),
+  })
+
+  if (!error) return null
+
   return (
     <section className="relative pl-8">
       <TerminalDot tone="error" />
@@ -83,6 +95,14 @@ export function ErrorSection({error}: {error: NonNullable<StoredTask['error']>})
       <Card className="bg-red-500/5 p-5 ring-1 ring-red-500/30" size="sm">
         <p className="text-red-400 text-sm">{formatError(error)}</p>
         {error.code && <p className="text-muted-foreground mono mt-1 text-[11px]">{error.code}</p>}
+        {showProviderCta && (
+          <div className="mt-3 flex items-center gap-2">
+            <Button onClick={openProviderDialog} size="sm">
+              Configure provider
+            </Button>
+            <span className="text-xs">Re-auth, switch provider, or update your API key.</span>
+          </div>
+        )}
       </Card>
     </section>
   )

--- a/src/webui/features/tasks/components/task-detail-sections.tsx
+++ b/src/webui/features/tasks/components/task-detail-sections.tsx
@@ -1,12 +1,14 @@
 import {Button} from '@campfirein/byterover-packages/components/button'
 import {Card} from '@campfirein/byterover-packages/components/card'
 import {cn} from '@campfirein/byterover-packages/lib/utils'
-import {Folder, Paperclip} from 'lucide-react'
+import {Folder, Paperclip, RotateCcw} from 'lucide-react'
 
 import type {StoredTask} from '../types/stored-task'
 
 import {formatError} from '../../../lib/error-messages'
 import {useProviderStore} from '../../provider/stores/provider-store'
+import {useComposerRetryStore} from '../stores/composer-retry-store'
+import {composerTypeFromTask} from '../utils/composer-type-from-task'
 import {shortTaskId} from '../utils/format-time'
 import {isProviderTaskError} from '../utils/is-provider-task-error'
 import {isActiveStatus} from '../utils/task-status'
@@ -81,12 +83,17 @@ export function ResultSection({content}: {content: string}) {
 export function ErrorSection({task}: {task: StoredTask}) {
   const {error} = task
   const openProviderDialog = useProviderStore((s) => s.openProviderDialog)
+  const requestRetry = useComposerRetryStore((s) => s.requestRetry)
   const showProviderCta = isProviderTaskError({
     error,
     hadLlmServiceError: Boolean(task.hadLlmServiceError),
   })
 
   if (!error) return null
+
+  function retry() {
+    requestRetry({content: task.content, type: composerTypeFromTask(task.type)})
+  }
 
   return (
     <section className="relative pl-8">
@@ -95,14 +102,18 @@ export function ErrorSection({task}: {task: StoredTask}) {
       <Card className="bg-red-500/5 p-5 ring-1 ring-red-500/30" size="sm">
         <p className="text-red-400 text-sm">{formatError(error)}</p>
         {error.code && <p className="text-muted-foreground mono mt-1 text-[11px]">{error.code}</p>}
-        {showProviderCta && (
-          <div className="mt-3 flex items-center gap-2">
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          {showProviderCta && (
             <Button onClick={openProviderDialog} size="sm">
               Configure provider
             </Button>
-            <span className="text-xs">Re-auth, switch provider, or update your API key.</span>
-          </div>
-        )}
+          )}
+          <Button onClick={retry} size="sm" variant={showProviderCta ? 'secondary' : 'default'}>
+            <RotateCcw className="size-3.5" />
+            Try again
+          </Button>
+          <span className="text-muted-foreground text-xs">Your prompt is preserved.</span>
+        </div>
       </Card>
     </section>
   )

--- a/src/webui/features/tasks/components/task-detail-view.tsx
+++ b/src/webui/features/tasks/components/task-detail-view.tsx
@@ -62,7 +62,7 @@ export function TaskDetailView({taskId}: TaskDetailViewProps) {
         <EventLogSection now={now} task={task} />
         {showLive && <LiveStreamSection task={task} />}
         {result && <ResultSection content={result} />}
-        {error && <ErrorSection error={error} />}
+        {error && <ErrorSection task={task} />}
         <TourTaskContinueCta task={task} />
       </div>
     </div>

--- a/src/webui/features/tasks/components/task-list-empty.tsx
+++ b/src/webui/features/tasks/components/task-list-empty.tsx
@@ -7,6 +7,7 @@ import {ListTodo, Plus} from 'lucide-react'
 
 import type {StatusFilter} from '../stores/task-store'
 
+import {TourPointer} from '../../onboarding/components/tour-pointer'
 import {STATUS_LABEL} from './task-list-filter-bar'
 
 export function PlaceholderCard({children, withDots}: {children: ReactNode; withDots?: boolean}) {
@@ -27,7 +28,7 @@ export function LoadingState() {
   return <div className="text-muted-foreground flex h-32 items-center justify-center text-sm">Loading tasks…</div>
 }
 
-export function EmptyState({onNewTask}: {onNewTask: () => void}) {
+export function EmptyState({onNewTask, tourCue}: {onNewTask: () => void; tourCue?: string}) {
   return (
     <div className="flex h-full flex-col items-center justify-center gap-4 p-8 text-center">
       <ListTodo className="text-muted-foreground/70 size-8" />
@@ -38,10 +39,12 @@ export function EmptyState({onNewTask}: {onNewTask: () => void}) {
         </p>
       </div>
       <div className="flex items-center gap-2 pt-1">
-        <Button onClick={onNewTask} size="sm" variant="default">
-          <Plus className="size-4" />
-          New task
-        </Button>
+        <TourPointer active={Boolean(tourCue)} label={tourCue ?? ''} side="top">
+          <Button onClick={onNewTask} size="sm" variant="default">
+            <Plus className="size-4" />
+            New task
+          </Button>
+        </TourPointer>
         <span className="text-muted-foreground/60 ml-2 text-sm">or run from the CLI</span>
       </div>
     </div>

--- a/src/webui/features/tasks/components/task-list-filter-bar.tsx
+++ b/src/webui/features/tasks/components/task-list-filter-bar.tsx
@@ -3,6 +3,7 @@ import {Input} from '@campfirein/byterover-packages/components/input'
 import {cn} from '@campfirein/byterover-packages/lib/utils'
 import {Plus, Search} from 'lucide-react'
 
+import {TourPointer} from '../../onboarding/components/tour-pointer'
 import {STATUS_FILTERS, type StatusFilter, type useStatusBreakdown} from '../stores/task-store'
 
 export const STATUS_LABEL: Record<StatusFilter, string> = {
@@ -27,6 +28,7 @@ export function FilterBar({
   onStatusChange,
   searchQuery,
   statusFilter,
+  tourCue,
 }: {
   breakdown: ReturnType<typeof useStatusBreakdown>
   onNewTask: () => void
@@ -34,6 +36,7 @@ export function FilterBar({
   onStatusChange: (filter: StatusFilter) => void
   searchQuery: string
   statusFilter: StatusFilter
+  tourCue?: string
 }) {
   return (
     <div className="flex min-h-9 flex-wrap items-center gap-2">
@@ -73,10 +76,12 @@ export function FilterBar({
           />
         </div>
 
-        <Button onClick={onNewTask} size="sm" variant="default">
-          <Plus className="size-4" />
-          New task
-        </Button>
+        <TourPointer active={Boolean(tourCue)} align="end" label={tourCue ?? ''}>
+          <Button onClick={onNewTask} size="sm" variant="default">
+            <Plus className="size-4" />
+            New task
+          </Button>
+        </TourPointer>
       </div>
     </div>
   )

--- a/src/webui/features/tasks/components/task-list-view.tsx
+++ b/src/webui/features/tasks/components/task-list-view.tsx
@@ -1,11 +1,16 @@
 import {Button} from '@campfirein/byterover-packages/components/button'
 import {Sheet, SheetContent} from '@campfirein/byterover-packages/components/sheet'
-import {useMemo, useState} from 'react'
+import {useEffect, useMemo, useState} from 'react'
 import {useSearchParams} from 'react-router-dom'
 
+import type {ComposerType} from './task-composer-types'
+
 import {useTransportStore} from '../../../stores/transport-store'
+import {CURATE_EXAMPLE, QUERY_EXAMPLE, TOUR_STEP_LABEL} from '../../onboarding/lib/tour-examples'
+import {useOnboardingStore} from '../../onboarding/stores/onboarding-store'
 import {useGetTasks} from '../api/get-tasks'
 import {useTickingNow} from '../hooks/use-ticking-now'
+import {useComposerRetryStore} from '../stores/composer-retry-store'
 import {statusMatchesFilter, taskMatchesQuery, useStatusBreakdown, useTaskStore} from '../stores/task-store'
 import {isTerminalStatus} from '../utils/task-status'
 import {TaskComposerSheet} from './task-composer'
@@ -49,12 +54,51 @@ export function TaskListView() {
   const now = useTickingNow(breakdown.running > 0)
 
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
-  const [composer, setComposer] = useState<{open: boolean}>({open: false})
+  const [composer, setComposer] = useState<{
+    initialContent?: string
+    initialType?: ComposerType
+    open: boolean
+  }>({open: false})
 
-  const openComposer = () => setComposer({open: true})
+  const tourActive = useOnboardingStore((s) => s.tourActive)
+  const tourStep = useOnboardingStore((s) => s.tourStep)
+  const tourTaskId = useOnboardingStore((s) => s.tourTaskId)
+  const setTourTaskId = useOnboardingStore((s) => s.setTourTaskId)
+  const inComposerStep = tourStep === 'curate' || tourStep === 'query'
+  const inTour = tourActive && inComposerStep
+  const tourCueLabel =
+    inTour && !tourTaskId
+      ? tourStep === 'curate'
+        ? 'Click to capture knowledge'
+        : 'Click to ask a question'
+      : undefined
+
+  const openComposer = () => {
+    if (inTour) {
+      const example = tourStep === 'curate' ? CURATE_EXAMPLE : QUERY_EXAMPLE
+      setComposer({initialContent: example, initialType: tourStep, open: true})
+      return
+    }
+
+    setComposer({open: true})
+  }
+
   const closeComposer = () => setComposer({open: false})
 
+  // Pick up retry seeds from the task-detail "Try again" CTA. Both normal and
+  // tour mode use this composer now, so the seed flow is shared.
+  const retrySeed = useComposerRetryStore((s) => s.seed)
+  const consumeRetry = useComposerRetryStore((s) => s.consume)
+
+  useEffect(() => {
+    if (!retrySeed) return
+    setComposer({initialContent: retrySeed.content, initialType: retrySeed.type, open: true})
+    closeTask()
+    consumeRetry()
+  }, [retrySeed, consumeRetry])
+
   const onComposerSubmitted = (taskId: string, openDetail: boolean) => {
+    if (inTour) setTourTaskId(taskId)
     if (openDetail) openTask(taskId)
   }
 
@@ -139,6 +183,9 @@ export function TaskListView() {
           }}
           searchQuery={searchQuery}
           statusFilter={statusFilter}
+          // Coachmark moves between the empty-state CTA and the header CTA so
+          // we never highlight both simultaneously.
+          tourCue={tourCueLabel && tasks.length > 0 ? tourCueLabel : undefined}
         />
       )}
 
@@ -148,7 +195,7 @@ export function TaskListView() {
         </PlaceholderCard>
       ) : tasks.length === 0 ? (
         <PlaceholderCard withDots>
-          <EmptyState onNewTask={openComposer} />
+          <EmptyState onNewTask={openComposer} tourCue={tourCueLabel} />
         </PlaceholderCard>
       ) : (
         <TaskTable
@@ -183,7 +230,15 @@ export function TaskListView() {
         </SheetContent>
       </Sheet>
 
-      <TaskComposerSheet onClose={closeComposer} onSubmitted={onComposerSubmitted} open={composer.open} />
+      <TaskComposerSheet
+        initialContent={composer.initialContent}
+        initialType={composer.initialType}
+        onClose={closeComposer}
+        onSubmitted={onComposerSubmitted}
+        open={composer.open}
+        prefillNotice={inTour ? 'example' : undefined}
+        tourStepLabel={inTour ? TOUR_STEP_LABEL[tourStep] : undefined}
+      />
     </div>
   )
 }

--- a/src/webui/features/tasks/components/task-list-view.tsx
+++ b/src/webui/features/tasks/components/task-list-view.tsx
@@ -95,7 +95,7 @@ export function TaskListView() {
     setComposer({initialContent: retrySeed.content, initialType: retrySeed.type, open: true})
     closeTask()
     consumeRetry()
-  }, [retrySeed, consumeRetry])
+  }, [retrySeed, consumeRetry, closeTask])
 
   const onComposerSubmitted = (taskId: string, openDetail: boolean) => {
     if (inTour) setTourTaskId(taskId)

--- a/src/webui/features/tasks/hooks/use-composer-submit.ts
+++ b/src/webui/features/tasks/hooks/use-composer-submit.ts
@@ -42,13 +42,11 @@ export function useComposerSubmit(args: {
     try {
       await createMutation.mutateAsync(payload)
       const verb = args.type === 'query' ? 'Query' : 'Curate'
-      toast.success(`${verb} task queued`, {position: 'top-center'})
+      toast.success(`${verb} task queued`)
       args.onSubmitted?.(taskId, args.openDetailAfter)
       args.onClose()
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to create task', {
-        position: 'top-center',
-      })
+      toast.error(error instanceof Error ? error.message : 'Failed to create task')
     }
   }
 

--- a/src/webui/features/tasks/hooks/use-task-subscriptions.ts
+++ b/src/webui/features/tasks/hooks/use-task-subscriptions.ts
@@ -79,6 +79,13 @@ interface LlmThinkingPayload {
   taskId?: string
 }
 
+interface LlmErrorPayload {
+  code?: string
+  error: string
+  sessionId?: string
+  taskId?: string
+}
+
 export function useTaskSubscriptions(): void {
   const apiClient = useTransportStore((s) => s.apiClient)
 
@@ -174,6 +181,11 @@ export function useTaskSubscriptions(): void {
           isThinking: true,
           timestamp: Date.now(),
         })
+      }),
+
+      apiClient.on<LlmErrorPayload>(LlmEvents.ERROR, (data) => {
+        if (!data.taskId) return
+        store.markLlmServiceError(data.taskId)
       }),
     )
 

--- a/src/webui/features/tasks/stores/composer-retry-store.ts
+++ b/src/webui/features/tasks/stores/composer-retry-store.ts
@@ -1,0 +1,33 @@
+import {create} from 'zustand'
+
+import type {ComposerType} from '../components/task-composer-types'
+
+/**
+ * Hand-off slot between the task-detail "Try again" CTA and the composer
+ * host. ErrorSection writes a seed; whichever composer host is active
+ * (TaskListView in normal mode, TourHost in tour mode) reads + clears it
+ * and re-opens the composer pre-filled with the failed task's content so
+ * the user doesn't have to retype.
+ */
+export interface ComposerRetrySeed {
+  content: string
+  type: ComposerType
+}
+
+interface ComposerRetryState {
+  consume: () => ComposerRetrySeed | null
+  requestRetry: (seed: ComposerRetrySeed) => void
+  seed: ComposerRetrySeed | null
+}
+
+export const useComposerRetryStore = create<ComposerRetryState>((set, get) => ({
+  consume() {
+    const {seed} = get()
+    if (seed) set({seed: null})
+    return seed
+  },
+
+  requestRetry: (seed) => set({seed}),
+
+  seed: null,
+}))

--- a/src/webui/features/tasks/stores/task-store.ts
+++ b/src/webui/features/tasks/stores/task-store.ts
@@ -57,6 +57,7 @@ interface TaskActions {
     type: 'reasoning' | 'text'
   }) => void
   clearCompleted: () => void
+  markLlmServiceError: (taskId: string) => void
   mergeTasks: (incoming: TaskListItem[]) => void
   removeTask: (taskId: string) => void
   reset: () => void
@@ -109,6 +110,9 @@ export const useTaskStore = create<TaskActions & TaskState>()(
         ),
 
       clearCompleted: () => set((state) => ({tasks: state.tasks.filter((task) => !isTerminalStatus(task.status))})),
+
+      markLlmServiceError: (taskId) =>
+        set((state) => applyToTask(state, taskId, (task) => ({...task, hadLlmServiceError: true})) ?? {}),
 
       mergeTasks: (incoming) => set((state) => ({tasks: mergeTaskList(state.tasks, incoming)})),
 

--- a/src/webui/features/tasks/types/stored-task.ts
+++ b/src/webui/features/tasks/types/stored-task.ts
@@ -27,6 +27,12 @@ export interface ReasoningContentItem {
 }
 
 export interface StoredTask extends TaskListItem {
+  /**
+   * True if we received any `llmservice:error` broadcast for this task.
+   * Used to show a provider-config CTA on the error surface even when the
+   * task:error payload doesn't carry a structured error code.
+   */
+  hadLlmServiceError?: boolean
   isStreaming?: boolean
   reasoningContents?: ReasoningContentItem[]
   /** Set when the agent's response stream resolves (final assistant message). */

--- a/src/webui/features/tasks/utils/composer-type-from-task.ts
+++ b/src/webui/features/tasks/utils/composer-type-from-task.ts
@@ -1,0 +1,11 @@
+import type {ComposerType} from '../components/task-composer-types'
+
+/**
+ * Map a stored task type to the composer's two-way switch. The composer only
+ * knows about `curate` and `query` — server-side `curate-folder` and `search`
+ * collapse onto those for the purposes of refilling the form.
+ */
+export function composerTypeFromTask(taskType: string): ComposerType {
+  if (taskType === 'query' || taskType === 'search') return 'query'
+  return 'curate'
+}

--- a/src/webui/features/tasks/utils/is-provider-task-error.ts
+++ b/src/webui/features/tasks/utils/is-provider-task-error.ts
@@ -1,0 +1,38 @@
+type TaskError = {
+  code?: string
+  message: string
+  name?: string
+}
+
+type Input = {
+  error: TaskError | undefined
+  /** True if an `llmservice:error` broadcast landed for this task (tracked in the task store). */
+  hadLlmServiceError: boolean
+}
+
+/**
+ * Task error codes the daemon emits directly for provider-config issues.
+ */
+const PROVIDER_CODES = new Set([
+  'ERR_LLM_ERROR',
+  'ERR_LLM_RATE_LIMIT',
+  'ERR_OAUTH_REFRESH_FAILED',
+  'ERR_OAUTH_TOKEN_EXPIRED',
+  'ERR_PROVIDER_NOT_CONFIGURED',
+])
+
+/**
+ * A task error is provider-class when either:
+ *   a) the daemon gave us a provider-class error code, or
+ *   b) we observed an `llmservice:error` broadcast for this task.
+ *
+ * The `llmservice:error` fallback exists because the daemon doesn't always
+ * propagate the structured code through `task:error` — `CipherAgent.run()`
+ * unwraps the fatal LlmError into a bare `new Error(message)` before the
+ * TaskError serializer runs.
+ */
+export function isProviderTaskError({error, hadLlmServiceError}: Input): boolean {
+  if (hadLlmServiceError) return true
+  if (error?.code && PROVIDER_CODES.has(error.code)) return true
+  return false
+}

--- a/src/webui/features/vc/api/execute-vc-init.ts
+++ b/src/webui/features/vc/api/execute-vc-init.ts
@@ -5,6 +5,7 @@ import type {MutationConfig} from '../../../lib/react-query'
 import {type IVcInitResponse, VcEvents} from '../../../../shared/transport/events/vc-events'
 import {useTransportStore} from '../../../stores/transport-store'
 import {getVcBranchesQueryOptions} from './get-vc-branches'
+import {getVcRemoteQueryOptions} from './get-vc-remote'
 import {getVcStatusQueryOptions} from './get-vc-status'
 
 export const executeVcInit = (): Promise<IVcInitResponse> => {
@@ -26,6 +27,7 @@ export const useVcInit = ({mutationConfig}: UseVcInitOptions = {}) => {
     onSuccess(...args) {
       queryClient.invalidateQueries({queryKey: getVcStatusQueryOptions().queryKey})
       queryClient.invalidateQueries({queryKey: getVcBranchesQueryOptions().queryKey})
+      queryClient.invalidateQueries({queryKey: getVcRemoteQueryOptions().queryKey})
       onSuccess?.(...args)
     },
     ...rest,

--- a/src/webui/features/vc/api/get-vc-config.ts
+++ b/src/webui/features/vc/api/get-vc-config.ts
@@ -9,20 +9,12 @@ import {
   VcErrorCode,
   VcEvents,
 } from '../../../../shared/transport/events/vc-events'
+import {hasCode} from '../../../lib/transport-error'
 import {useTransportStore} from '../../../stores/transport-store'
 
 export type VcConfigValues = {
   email: string | undefined
   name: string | undefined
-}
-
-function hasCode(error: unknown): error is {code: string} {
-  return (
-    typeof error === 'object' &&
-    error !== null &&
-    'code' in error &&
-    typeof (error as {code: unknown}).code === 'string'
-  )
 }
 
 async function readKey(key: VcConfigKey): Promise<string | undefined> {

--- a/src/webui/features/vc/api/get-vc-config.ts
+++ b/src/webui/features/vc/api/get-vc-config.ts
@@ -1,0 +1,60 @@
+import {queryOptions, useQuery} from '@tanstack/react-query'
+
+import type {QueryConfig} from '../../../lib/react-query'
+
+import {
+  type IVcConfigRequest,
+  type IVcConfigResponse,
+  type VcConfigKey,
+  VcErrorCode,
+  VcEvents,
+} from '../../../../shared/transport/events/vc-events'
+import {useTransportStore} from '../../../stores/transport-store'
+
+export type VcConfigValues = {
+  email: string | undefined
+  name: string | undefined
+}
+
+function hasCode(error: unknown): error is {code: string} {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    typeof (error as {code: unknown}).code === 'string'
+  )
+}
+
+async function readKey(key: VcConfigKey): Promise<string | undefined> {
+  const {apiClient} = useTransportStore.getState()
+  if (!apiClient) throw new Error('Not connected')
+  try {
+    const response = await apiClient.request<IVcConfigResponse, IVcConfigRequest>(VcEvents.CONFIG, {key})
+    return response.value
+  } catch (error) {
+    if (hasCode(error) && error.code === VcErrorCode.CONFIG_KEY_NOT_SET) return undefined
+    throw error
+  }
+}
+
+export const getVcConfig = async (): Promise<VcConfigValues> => {
+  const [name, email] = await Promise.all([readKey('user.name'), readKey('user.email')])
+  return {email, name}
+}
+
+export const getVcConfigQueryOptions = () =>
+  queryOptions({
+    queryFn: getVcConfig,
+    queryKey: ['vc', 'config'],
+    staleTime: 5000,
+  })
+
+type UseGetVcConfigOptions = {
+  queryConfig?: QueryConfig<typeof getVcConfigQueryOptions>
+}
+
+export const useGetVcConfig = ({queryConfig}: UseGetVcConfigOptions = {}) =>
+  useQuery({
+    ...getVcConfigQueryOptions(),
+    ...queryConfig,
+  })

--- a/src/webui/features/vc/api/get-vc-remote.ts
+++ b/src/webui/features/vc/api/get-vc-remote.ts
@@ -8,20 +8,12 @@ import {
   VcErrorCode,
   VcEvents,
 } from '../../../../shared/transport/events/vc-events'
+import {hasCode} from '../../../lib/transport-error'
 import {useTransportStore} from '../../../stores/transport-store'
 
 export type VcRemoteShow = {
   gitInitialized: boolean
   url: string | undefined
-}
-
-function hasCode(error: unknown): error is {code: string} {
-  return (
-    typeof error === 'object' &&
-    error !== null &&
-    'code' in error &&
-    typeof (error as {code: unknown}).code === 'string'
-  )
 }
 
 export const getVcRemote = async (): Promise<VcRemoteShow> => {

--- a/src/webui/features/vc/api/get-vc-remote.ts
+++ b/src/webui/features/vc/api/get-vc-remote.ts
@@ -1,0 +1,60 @@
+import {queryOptions, useQuery} from '@tanstack/react-query'
+
+import type {QueryConfig} from '../../../lib/react-query'
+
+import {
+  type IVcRemoteRequest,
+  type IVcRemoteResponse,
+  VcErrorCode,
+  VcEvents,
+} from '../../../../shared/transport/events/vc-events'
+import {useTransportStore} from '../../../stores/transport-store'
+
+export type VcRemoteShow = {
+  gitInitialized: boolean
+  url: string | undefined
+}
+
+function hasCode(error: unknown): error is {code: string} {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    typeof (error as {code: unknown}).code === 'string'
+  )
+}
+
+export const getVcRemote = async (): Promise<VcRemoteShow> => {
+  const {apiClient} = useTransportStore.getState()
+  if (!apiClient) throw new Error('Not connected')
+
+  try {
+    const response = await apiClient.request<IVcRemoteResponse, IVcRemoteRequest>(VcEvents.REMOTE, {
+      subcommand: 'show',
+    })
+    return {gitInitialized: true, url: response.url}
+  } catch (error) {
+    if (hasCode(error) && error.code === VcErrorCode.GIT_NOT_INITIALIZED) {
+      return {gitInitialized: false, url: undefined}
+    }
+
+    throw error
+  }
+}
+
+export const getVcRemoteQueryOptions = () =>
+  queryOptions({
+    queryFn: getVcRemote,
+    queryKey: ['vc', 'remote'],
+    staleTime: 5000,
+  })
+
+type UseGetVcRemoteOptions = {
+  queryConfig?: QueryConfig<typeof getVcRemoteQueryOptions>
+}
+
+export const useGetVcRemote = ({queryConfig}: UseGetVcRemoteOptions = {}) =>
+  useQuery({
+    ...getVcRemoteQueryOptions(),
+    ...queryConfig,
+  })

--- a/src/webui/features/vc/api/set-vc-config.ts
+++ b/src/webui/features/vc/api/set-vc-config.ts
@@ -1,0 +1,35 @@
+import {useMutation, useQueryClient} from '@tanstack/react-query'
+
+import type {MutationConfig} from '../../../lib/react-query'
+
+import {
+  type IVcConfigRequest,
+  type IVcConfigResponse,
+  VcEvents,
+} from '../../../../shared/transport/events/vc-events'
+import {useTransportStore} from '../../../stores/transport-store'
+import {getVcConfigQueryOptions} from './get-vc-config'
+
+export const setVcConfig = (request: IVcConfigRequest): Promise<IVcConfigResponse> => {
+  const {apiClient} = useTransportStore.getState()
+  if (!apiClient) return Promise.reject(new Error('Not connected'))
+  return apiClient.request<IVcConfigResponse, IVcConfigRequest>(VcEvents.CONFIG, request)
+}
+
+type UseSetVcConfigOptions = {
+  mutationConfig?: MutationConfig<typeof setVcConfig>
+}
+
+export const useSetVcConfig = ({mutationConfig}: UseSetVcConfigOptions = {}) => {
+  const queryClient = useQueryClient()
+  const {onSuccess, ...rest} = mutationConfig ?? {}
+
+  return useMutation({
+    onSuccess(...args) {
+      queryClient.invalidateQueries({queryKey: getVcConfigQueryOptions().queryKey})
+      onSuccess?.(...args)
+    },
+    ...rest,
+    mutationFn: setVcConfig,
+  })
+}

--- a/src/webui/features/vc/api/set-vc-remote.ts
+++ b/src/webui/features/vc/api/set-vc-remote.ts
@@ -1,0 +1,42 @@
+import {useMutation, useQueryClient} from '@tanstack/react-query'
+
+import type {MutationConfig} from '../../../lib/react-query'
+
+import {
+  type IVcRemoteRequest,
+  type IVcRemoteResponse,
+  VcEvents,
+  type VcRemoteSubcommand,
+} from '../../../../shared/transport/events/vc-events'
+import {useTransportStore} from '../../../stores/transport-store'
+import {getVcRemoteQueryOptions} from './get-vc-remote'
+
+export type SetVcRemoteInput = {
+  subcommand: Exclude<VcRemoteSubcommand, 'show'>
+  url: string
+}
+
+export const setVcRemote = (input: SetVcRemoteInput): Promise<IVcRemoteResponse> => {
+  const {apiClient} = useTransportStore.getState()
+  if (!apiClient) return Promise.reject(new Error('Not connected'))
+  const request: IVcRemoteRequest = {subcommand: input.subcommand, url: input.url}
+  return apiClient.request<IVcRemoteResponse, IVcRemoteRequest>(VcEvents.REMOTE, request)
+}
+
+type UseSetVcRemoteOptions = {
+  mutationConfig?: MutationConfig<typeof setVcRemote>
+}
+
+export const useSetVcRemote = ({mutationConfig}: UseSetVcRemoteOptions = {}) => {
+  const queryClient = useQueryClient()
+  const {onSuccess, ...rest} = mutationConfig ?? {}
+
+  return useMutation({
+    onSuccess(...args) {
+      queryClient.invalidateQueries({queryKey: getVcRemoteQueryOptions().queryKey})
+      onSuccess?.(...args)
+    },
+    ...rest,
+    mutationFn: setVcRemote,
+  })
+}

--- a/src/webui/features/vc/api/set-vc-remote.ts
+++ b/src/webui/features/vc/api/set-vc-remote.ts
@@ -6,20 +6,19 @@ import {
   type IVcRemoteRequest,
   type IVcRemoteResponse,
   VcEvents,
-  type VcRemoteSubcommand,
 } from '../../../../shared/transport/events/vc-events'
 import {useTransportStore} from '../../../stores/transport-store'
 import {getVcRemoteQueryOptions} from './get-vc-remote'
 
-export type SetVcRemoteInput = {
-  subcommand: Exclude<VcRemoteSubcommand, 'show'>
-  url: string
-}
+export type SetVcRemoteInput =
+  | {subcommand: 'add' | 'set-url'; url: string}
+  | {subcommand: 'remove'}
 
 export const setVcRemote = (input: SetVcRemoteInput): Promise<IVcRemoteResponse> => {
   const {apiClient} = useTransportStore.getState()
   if (!apiClient) return Promise.reject(new Error('Not connected'))
-  const request: IVcRemoteRequest = {subcommand: input.subcommand, url: input.url}
+  const request: IVcRemoteRequest =
+    input.subcommand === 'remove' ? {subcommand: 'remove'} : {subcommand: input.subcommand, url: input.url}
   return apiClient.request<IVcRemoteResponse, IVcRemoteRequest>(VcEvents.REMOTE, request)
 }
 

--- a/src/webui/features/vc/components/branch-dropdown.tsx
+++ b/src/webui/features/vc/components/branch-dropdown.tsx
@@ -37,8 +37,6 @@ type DialogKind = 'new-branch' | null
 
 type DeleteTarget = {branchName: string}
 
-const TOAST_OPTS = {position: 'top-center'} as const
-
 function triggerLabel(status: ReturnType<typeof useGetVcStatus>['data']): string {
   if (!status) return 'branch'
   if (!status.initialized) return 'No git repo'
@@ -113,10 +111,9 @@ export function BranchDropdown() {
     setOpen(false)
     try {
       await checkout.mutateAsync({branch: branchName})
-      toast.success(message, TOAST_OPTS)
+      toast.success(message)
     } catch (error) {
       toast.error('Failed to switch branch', {
-        ...TOAST_OPTS,
         description: formatError(error),
       })
     }
@@ -147,10 +144,9 @@ export function BranchDropdown() {
         // Tracking will fall back to unset; the user can retry via CLI.
       }
 
-      toast.success(`Switched to ${localName} (tracking ${branch.name})`, TOAST_OPTS)
+      toast.success(`Switched to ${localName} (tracking ${branch.name})`)
     } catch (error) {
       toast.error('Failed to checkout remote branch', {
-        ...TOAST_OPTS,
         description: formatError(error),
       })
     }
@@ -168,7 +164,6 @@ export function BranchDropdown() {
   function handleFetchAll() {
     setOpen(false)
     toast.promise(fetchMut.mutateAsync({}), {
-      ...TOAST_OPTS,
       error: (err: unknown) => ({
         description: formatError(err),
         message: 'Fetch failed',
@@ -181,7 +176,6 @@ export function BranchDropdown() {
   function handlePull() {
     setOpen(false)
     toast.promise(pull.mutateAsync({}), {
-      ...TOAST_OPTS,
       error: (err: unknown) => ({
         description: formatError(err),
         message: 'Pull failed',

--- a/src/webui/features/vc/components/callout-row.tsx
+++ b/src/webui/features/vc/components/callout-row.tsx
@@ -1,0 +1,19 @@
+import type {ReactNode} from 'react'
+
+type Props = {
+  action: ReactNode
+  description: ReactNode
+  title: ReactNode
+}
+
+export function CalloutRow({action, description, title}: Props) {
+  return (
+    <div className="border-border bg-muted/40 flex items-center justify-between gap-3 rounded-md border border-dashed px-3.5 py-2.5">
+      <div className="flex min-w-0 flex-col gap-0.5">
+        <span className="text-foreground text-sm font-medium">{title}</span>
+        <span className="text-muted-foreground truncate text-xs">{description}</span>
+      </div>
+      {action}
+    </div>
+  )
+}

--- a/src/webui/features/vc/components/changes-panel.tsx
+++ b/src/webui/features/vc/components/changes-panel.tsx
@@ -8,6 +8,7 @@ import type { ChangeFile } from '../types'
 
 import successTick from '../../../assets/success-tick.svg'
 import { formatError } from '../../../lib/error-messages'
+import { toastVcError } from '../../../lib/toast-vc-error'
 import { useTransportStore } from '../../../stores/transport-store'
 import { useAuthStore } from '../../auth/stores/auth-store'
 import { useVcAdd } from '../api/execute-vc-add'
@@ -128,7 +129,7 @@ export function ChangesPanel() {
       toast.success('Committed')
       return true
     } catch (error) {
-      toast.error(formatError(error, 'Failed to commit', {projectPath: selectedProject}))
+      toastVcError(error, 'Failed to commit', navigate, {projectPath: selectedProject})
       return false
     }
   }
@@ -139,7 +140,7 @@ export function ChangesPanel() {
       toast.success('Merge committed')
       return true
     } catch (error) {
-      toast.error(formatError(error, 'Failed to commit merge', {projectPath: selectedProject}))
+      toastVcError(error, 'Failed to commit merge', navigate, {projectPath: selectedProject})
       return false
     }
   }
@@ -176,7 +177,7 @@ export function ChangesPanel() {
         setShowStageAllConfirm(false)
       }
     } catch (error) {
-      toast.error(formatError(error, 'Failed to stage & commit', {projectPath: selectedProject}))
+      toastVcError(error, 'Failed to stage & commit', navigate, {projectPath: selectedProject})
     }
   }
 
@@ -185,7 +186,7 @@ export function ChangesPanel() {
       const result = await pushMutation.mutateAsync({ setUpstream: !status.trackingBranch })
       toast.success(result.alreadyUpToDate ? 'Already up to date' : `Pushed ${result.branch}`)
     } catch (error) {
-      toast.error(formatError(error, 'Failed to push'))
+      toastVcError(error, 'Failed to push', navigate)
     }
   }
 
@@ -198,7 +199,7 @@ export function ChangesPanel() {
         toast.success(result.alreadyUpToDate ? 'Already up to date' : `Pulled ${result.branch}`)
       }
     } catch (error) {
-      toast.error(formatError(error, 'Failed to pull'))
+      toastVcError(error, 'Failed to pull', navigate)
     }
   }
 

--- a/src/webui/features/vc/components/delete-branch-dialog.tsx
+++ b/src/webui/features/vc/components/delete-branch-dialog.tsx
@@ -25,12 +25,10 @@ export function DeleteBranchDialog({branchName, onOpenChange, open}: DeleteBranc
     try {
       await del.mutateAsync(branchName)
 
-      toast.success(`Deleted ${branchName}`, {position: 'top-center'})
+      toast.success(`Deleted ${branchName}`)
       onOpenChange(false)
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to delete branch', {
-        position: 'top-center',
-      })
+      toast.error(error instanceof Error ? error.message : 'Failed to delete branch')
     }
   }
 

--- a/src/webui/features/vc/components/identity-panel.tsx
+++ b/src/webui/features/vc/components/identity-panel.tsx
@@ -1,3 +1,4 @@
+import {Avatar, AvatarFallback, AvatarImage} from '@campfirein/byterover-packages/components/avatar'
 import {Button} from '@campfirein/byterover-packages/components/button'
 import {Field, FieldError, FieldLabel} from '@campfirein/byterover-packages/components/field'
 import {Input} from '@campfirein/byterover-packages/components/input'
@@ -10,11 +11,11 @@ import type {UserDTO} from '../../../../shared/transport/types/dto'
 
 import {formatError} from '../../../lib/error-messages'
 import {noop} from '../../../lib/noop'
+import {initials} from '../../../utils/initials'
 import {useAuthStore} from '../../auth/stores/auth-store'
 import {useGetVcConfig} from '../api/get-vc-config'
 import {useSetVcConfig} from '../api/set-vc-config'
 import {isValidEmail} from '../utils/is-valid-email'
-import {CalloutRow} from './callout-row'
 import {SettingsSection} from './settings-section'
 
 type IdentityValues = {
@@ -22,7 +23,12 @@ type IdentityValues = {
   name: string
 }
 
-function NotSetCallout({
+/**
+ * Empty-state row: lead with the suggested account identity instead of a
+ * foreground "Not set" alert. When no account is connected, fall back to a
+ * minimal "Set manually" affordance.
+ */
+function NotSetRow({
   isPending,
   onApplyAccount,
   onSetManually,
@@ -33,37 +39,51 @@ function NotSetCallout({
   onSetManually: () => void
   user: null | UserDTO
 }) {
-  return (
-    <CalloutRow
-      action={
-        <div className="flex gap-1.5">
-          <Button
-            disabled={isPending}
-            onClick={onSetManually}
-            size="sm"
-            variant={user ? 'ghost' : 'secondary'}
-          >
-            Set manually
-          </Button>
-          {user && (
-            <Button disabled={isPending} onClick={onApplyAccount} size="sm">
-              Use account
-            </Button>
-          )}
+  const containerClass =
+    'flex items-center justify-between gap-3 rounded-md border border-dashed border-border bg-muted/40 px-3.5 py-2.5'
+
+  if (!user) {
+    return (
+      <div className={containerClass}>
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <span className="text-foreground text-sm font-medium">Identity not configured</span>
+          <span className="text-muted-foreground truncate text-xs">
+            Optional — used for commit attribution.
+          </span>
         </div>
-      }
-      description={
-        user ? (
-          <>
-            Apply <span className="text-foreground">{user.name ?? user.email}</span> &lt;{user.email}&gt; or configure
-            manually.
-          </>
-        ) : (
-          'Name and email are required to commit.'
-        )
-      }
-      title="Not set"
-    />
+        <Button disabled={isPending} onClick={onSetManually} size="sm" variant="secondary">
+          Set manually
+        </Button>
+      </div>
+    )
+  }
+
+  const displayName = user.name ?? user.email
+  return (
+    <div className={containerClass}>
+      <div className="flex min-w-0 items-center gap-3">
+        <Avatar className="size-7 shrink-0">
+          <AvatarImage alt={displayName} src={user.avatarUrl} />
+          <AvatarFallback className="text-[10px]">{initials(displayName)}</AvatarFallback>
+        </Avatar>
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <span className="text-foreground truncate text-sm font-medium">
+            {displayName} <span className="text-muted-foreground font-normal">&lt;{user.email}&gt;</span>
+          </span>
+          <span className="text-muted-foreground truncate text-xs">
+            From your ByteRover account — optional, used for commit attribution.
+          </span>
+        </div>
+      </div>
+      <div className="flex shrink-0 gap-1.5">
+        <Button disabled={isPending} onClick={onSetManually} size="sm" variant="ghost">
+          Edit
+        </Button>
+        <Button disabled={isPending} onClick={onApplyAccount} size="sm">
+          Apply
+        </Button>
+      </div>
+    </div>
   )
 }
 
@@ -214,7 +234,7 @@ export function IdentityPanel() {
         ) : configured ? (
           <CompactRow email={storedEmail} name={storedName} onEdit={() => setEditing(true)} />
         ) : (
-          <NotSetCallout
+          <NotSetRow
             isPending={setConfig.isPending}
             onApplyAccount={() => applyFromAccount().catch(noop)}
             onSetManually={() => setEditing(true)}

--- a/src/webui/features/vc/components/identity-panel.tsx
+++ b/src/webui/features/vc/components/identity-panel.tsx
@@ -1,0 +1,232 @@
+import {Button} from '@campfirein/byterover-packages/components/button'
+import {Field, FieldError, FieldLabel} from '@campfirein/byterover-packages/components/field'
+import {Input} from '@campfirein/byterover-packages/components/input'
+import {Skeleton} from '@campfirein/byterover-packages/components/skeleton'
+import {LoaderCircle} from 'lucide-react'
+import {type FormEvent, useId, useState} from 'react'
+import {toast} from 'sonner'
+
+import type {UserDTO} from '../../../../shared/transport/types/dto'
+
+import {formatError} from '../../../lib/error-messages'
+import {noop} from '../../../lib/noop'
+import {useAuthStore} from '../../auth/stores/auth-store'
+import {useGetVcConfig} from '../api/get-vc-config'
+import {useSetVcConfig} from '../api/set-vc-config'
+import {isValidEmail} from '../utils/is-valid-email'
+import {CalloutRow} from './callout-row'
+import {SettingsSection} from './settings-section'
+
+type IdentityValues = {
+  email: string
+  name: string
+}
+
+function NotSetCallout({
+  isPending,
+  onApplyAccount,
+  onSetManually,
+  user,
+}: {
+  isPending: boolean
+  onApplyAccount: () => void
+  onSetManually: () => void
+  user: null | UserDTO
+}) {
+  return (
+    <CalloutRow
+      action={
+        <div className="flex gap-1.5">
+          <Button
+            disabled={isPending}
+            onClick={onSetManually}
+            size="sm"
+            variant={user ? 'ghost' : 'secondary'}
+          >
+            Set manually
+          </Button>
+          {user && (
+            <Button disabled={isPending} onClick={onApplyAccount} size="sm">
+              Use account
+            </Button>
+          )}
+        </div>
+      }
+      description={
+        user ? (
+          <>
+            Apply <span className="text-foreground">{user.name ?? user.email}</span> &lt;{user.email}&gt; or configure
+            manually.
+          </>
+        ) : (
+          'Name and email are required to commit.'
+        )
+      }
+      title="Not set"
+    />
+  )
+}
+
+function CompactRow({email, name, onEdit}: {email: string; name: string; onEdit: () => void}) {
+  return (
+    <div className="flex min-h-8 items-center gap-3">
+      <span className="text-foreground min-w-0 flex-1 truncate text-sm">
+        {name} <span className="text-muted-foreground mono">&lt;{email}&gt;</span>
+      </span>
+      <Button onClick={onEdit} size="sm" variant="ghost">
+        Edit
+      </Button>
+    </div>
+  )
+}
+
+type EditFormProps = {
+  initial: IdentityValues
+  isPending: boolean
+  onCancel: () => void
+  onSubmit: (values: IdentityValues) => Promise<void>
+}
+
+function EditForm({initial, isPending, onCancel, onSubmit}: EditFormProps) {
+  const nameId = useId()
+  const emailId = useId()
+  const [name, setName] = useState(initial.name)
+  const [email, setEmail] = useState(initial.email)
+
+  const trimmedName = name.trim()
+  const trimmedEmail = email.trim()
+  const dirty = trimmedName !== initial.name || trimmedEmail !== initial.email
+  const complete = trimmedName.length > 0 && trimmedEmail.length > 0
+  const emailInvalid = trimmedEmail.length > 0 && !isValidEmail(trimmedEmail)
+  // Only surface the error once the user has interacted (dirty) — don't shout
+  // on an initially-empty form.
+  const showEmailError = emailInvalid && dirty
+  const canSubmit = dirty && complete && !emailInvalid && !isPending
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault()
+    if (!canSubmit) return
+    await onSubmit({email: trimmedEmail, name: trimmedName})
+  }
+
+  function fireSubmit(event: FormEvent) {
+    handleSubmit(event).catch(noop)
+  }
+
+  return (
+    <form className="flex flex-col gap-4" onSubmit={fireSubmit}>
+      <Field>
+        <FieldLabel htmlFor={nameId}>Name</FieldLabel>
+        <Input
+          disabled={isPending}
+          id={nameId}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Your name"
+          value={name}
+        />
+      </Field>
+
+      <Field data-invalid={showEmailError}>
+        <FieldLabel htmlFor={emailId}>Email</FieldLabel>
+        <Input
+          aria-invalid={showEmailError}
+          disabled={isPending}
+          id={emailId}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="you@example.com"
+          type="email"
+          value={email}
+        />
+        {showEmailError && <FieldError>Enter a valid email address.</FieldError>}
+      </Field>
+
+      <div className="flex items-center justify-end gap-2">
+        <Button disabled={isPending} onClick={onCancel} type="button" variant="secondary">
+          Cancel
+        </Button>
+        <Button disabled={!canSubmit} type="submit">
+          {isPending ? 'Saving…' : 'Save'}
+        </Button>
+      </div>
+    </form>
+  )
+}
+
+export function IdentityPanel() {
+  const {data: config, error, isError, isLoading, refetch} = useGetVcConfig()
+  const setConfig = useSetVcConfig()
+  const user = useAuthStore((s) => s.user)
+  const [editing, setEditing] = useState(false)
+
+  const storedName = config?.name ?? ''
+  const storedEmail = config?.email ?? ''
+  const configured = Boolean(storedName && storedEmail)
+
+  async function save(values: IdentityValues) {
+    try {
+      // Serial — the daemon's config write is read-merge-write per field,
+      // so concurrent writes race and clobber each other.
+      if (values.name && values.name !== storedName) {
+        await setConfig.mutateAsync({key: 'user.name', value: values.name})
+      }
+
+      if (values.email && values.email !== storedEmail) {
+        await setConfig.mutateAsync({key: 'user.email', value: values.email})
+      }
+
+      toast.success('Git identity saved.')
+      setEditing(false)
+    } catch (error_) {
+      toast.error(formatError(error_, 'Failed to save identity.'))
+      throw error_
+    }
+  }
+
+  async function applyFromAccount() {
+    if (!user) return
+    try {
+      await setConfig.mutateAsync({key: 'user.name', value: user.name ?? user.email})
+      await setConfig.mutateAsync({key: 'user.email', value: user.email})
+      toast.success('Git identity applied from your ByteRover account.')
+    } catch (error_) {
+      toast.error(formatError(error_, 'Failed to apply identity.'))
+    }
+  }
+
+  return (
+    <SettingsSection
+      action={isLoading ? <LoaderCircle className="text-muted-foreground mt-1 size-4 animate-spin" /> : undefined}
+      compact={!editing}
+      description="Recorded on every commit in this project."
+      error={isError ? error : undefined}
+      errorFallback="Failed to load identity"
+      onRetry={() => refetch().catch(noop)}
+      title="Git identity"
+    >
+      {config ? (
+        editing ? (
+          <EditForm
+            initial={{email: storedEmail, name: storedName}}
+            isPending={setConfig.isPending}
+            onCancel={() => setEditing(false)}
+            onSubmit={save}
+          />
+        ) : configured ? (
+          <CompactRow email={storedEmail} name={storedName} onEdit={() => setEditing(true)} />
+        ) : (
+          <NotSetCallout
+            isPending={setConfig.isPending}
+            onApplyAccount={() => applyFromAccount().catch(noop)}
+            onSetManually={() => setEditing(true)}
+            user={user}
+          />
+        )
+      ) : (
+        <div className="flex min-h-8 items-center gap-3">
+          <Skeleton className="h-4 flex-1" />
+          <Skeleton className="h-8 w-12" />
+        </div>
+      )}
+    </SettingsSection>
+  )
+}

--- a/src/webui/features/vc/components/initialize-vc-button.tsx
+++ b/src/webui/features/vc/components/initialize-vc-button.tsx
@@ -10,14 +10,9 @@ export function InitializeVcButton() {
   async function handleInit() {
     try {
       const result = await init.mutateAsync()
-      toast.success(
-        result.reinitialized ? 'Reinitialized version control' : 'Initialized version control',
-        {position: 'top-center'},
-      )
+      toast.success(result.reinitialized ? 'Reinitialized version control' : 'Initialized version control')
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to initialize', {
-        position: 'top-center',
-      })
+      toast.error(error instanceof Error ? error.message : 'Failed to initialize')
     }
   }
 

--- a/src/webui/features/vc/components/new-branch-dialog.tsx
+++ b/src/webui/features/vc/components/new-branch-dialog.tsx
@@ -45,7 +45,6 @@ export function NewBranchDialog({initialName = '', onOpenChange, open, startPoin
       await checkout.mutateAsync({branch: trimmed, create: true, startPoint})
       toast.success(
         startPoint ? `Created ${trimmed} from ${startPoint} and switched to it` : `Created and switched to ${trimmed}`,
-        {position: 'top-center'},
       )
       onOpenChange(false)
     } catch (error) {

--- a/src/webui/features/vc/components/remotes-panel.tsx
+++ b/src/webui/features/vc/components/remotes-panel.tsx
@@ -1,3 +1,12 @@
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@campfirein/byterover-packages/components/alert-dialog'
 import {Button} from '@campfirein/byterover-packages/components/button'
 import {Field, FieldDescription, FieldError, FieldLabel} from '@campfirein/byterover-packages/components/field'
 import {Input} from '@campfirein/byterover-packages/components/input'
@@ -19,7 +28,17 @@ import {SettingsSection} from './settings-section'
 
 const ORIGIN_NAME = 'origin'
 
-function RemoteRow({onEdit, url}: {onEdit: () => void; url: string}) {
+function RemoteRow({
+  isDeleting,
+  onDelete,
+  onEdit,
+  url,
+}: {
+  isDeleting: boolean
+  onDelete: () => void
+  onEdit: () => void
+  url: string
+}) {
   const urlType = detectGitUrlType(url)
   const isReadOnly = urlType === 'ssh' || urlType === 'git'
   return (
@@ -27,9 +46,20 @@ function RemoteRow({onEdit, url}: {onEdit: () => void; url: string}) {
       <div className="flex min-h-8 items-center gap-3">
         <span className="text-foreground w-14 shrink-0 text-sm font-medium">{ORIGIN_NAME}</span>
         <span className="mono text-foreground min-w-0 flex-1 truncate text-sm">{url}</span>
-        <Button onClick={onEdit} size="sm" variant="ghost">
-          Edit
-        </Button>
+        <div className="flex shrink-0 items-center gap-1">
+          <Button disabled={isDeleting} onClick={onEdit} size="sm" variant="ghost">
+            Edit
+          </Button>
+          <Button
+            className="text-destructive hover:text-destructive"
+            disabled={isDeleting}
+            onClick={onDelete}
+            size="sm"
+            variant="ghost"
+          >
+            Delete
+          </Button>
+        </div>
       </div>
       {isReadOnly && (
         <p className="text-muted-foreground text-xs">
@@ -37,6 +67,43 @@ function RemoteRow({onEdit, url}: {onEdit: () => void; url: string}) {
         </p>
       )}
     </div>
+  )
+}
+
+type DeleteRemoteDialogProps = {
+  isPending: boolean
+  onConfirm: () => Promise<void>
+  onOpenChange: (open: boolean) => void
+  open: boolean
+  url: string
+}
+
+function DeleteRemoteDialog({isPending, onConfirm, onOpenChange, open, url}: DeleteRemoteDialogProps) {
+  function fire() {
+    onConfirm().catch(noop)
+  }
+
+  return (
+    <AlertDialog onOpenChange={onOpenChange} open={open}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            Remove <span className="mono">{ORIGIN_NAME}</span>?
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            Removes <code className="mono bg-muted text-foreground rounded px-1.5 py-0.5 text-xs">{url}</code> from this
+            project. Push, pull, and fetch will be disabled until you set a new remote.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+          <Button disabled={isPending} onClick={fire} variant="destructive">
+            {isPending ? 'Removing…' : 'Remove remote'}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   )
 }
 
@@ -156,6 +223,7 @@ export function RemotesPanel() {
   const {data: envConfig} = useGetEnvironmentConfig()
   const setRemote = useSetVcRemote()
   const [editing, setEditing] = useState(false)
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
 
   const url = data?.url
   const gitInitialized = data?.gitInitialized
@@ -167,6 +235,16 @@ export function RemotesPanel() {
     await setRemote.mutateAsync({subcommand: hasRemote ? 'set-url' : 'add', url: next})
     toast.success(hasRemote ? 'Origin replaced.' : 'Remote added.')
     setEditing(false)
+  }
+
+  async function deleteRemote() {
+    try {
+      await setRemote.mutateAsync({subcommand: 'remove'})
+      toast.success('Remote removed.')
+      setDeleteDialogOpen(false)
+    } catch (error_) {
+      toast.error(formatError(error_, 'Failed to remove remote'))
+    }
   }
 
   return (
@@ -203,7 +281,21 @@ export function RemotesPanel() {
             webAppUrl={envConfig?.webAppUrl}
           />
         ) : url ? (
-          <RemoteRow onEdit={() => setEditing(true)} url={url} />
+          <>
+            <RemoteRow
+              isDeleting={setRemote.isPending && deleteDialogOpen}
+              onDelete={() => setDeleteDialogOpen(true)}
+              onEdit={() => setEditing(true)}
+              url={url}
+            />
+            <DeleteRemoteDialog
+              isPending={setRemote.isPending}
+              onConfirm={deleteRemote}
+              onOpenChange={setDeleteDialogOpen}
+              open={deleteDialogOpen}
+              url={url}
+            />
+          </>
         ) : (
           <p className="text-muted-foreground text-sm">
             No remote set. Push and pull need an{' '}

--- a/src/webui/features/vc/components/remotes-panel.tsx
+++ b/src/webui/features/vc/components/remotes-panel.tsx
@@ -1,0 +1,223 @@
+import {Button} from '@campfirein/byterover-packages/components/button'
+import {Field, FieldDescription, FieldError, FieldLabel} from '@campfirein/byterover-packages/components/field'
+import {Input} from '@campfirein/byterover-packages/components/input'
+import {Skeleton} from '@campfirein/byterover-packages/components/skeleton'
+import {ExternalLink} from 'lucide-react'
+import {type ComponentRef, type FormEvent, type KeyboardEvent, useEffect, useId, useRef, useState} from 'react'
+import {toast} from 'sonner'
+
+import {formatError} from '../../../lib/error-messages'
+import {noop} from '../../../lib/noop'
+import {useGetEnvironmentConfig} from '../../config/api/get-environment-config'
+import {useGetVcRemote} from '../api/get-vc-remote'
+import {useSetVcRemote} from '../api/set-vc-remote'
+import {detectGitUrlType} from '../utils/detect-git-url-type'
+import {validateRemoteUrl} from '../utils/validate-remote-url'
+import {CalloutRow} from './callout-row'
+import {InitializeVcButton} from './initialize-vc-button'
+import {SettingsSection} from './settings-section'
+
+const ORIGIN_NAME = 'origin'
+
+function RemoteRow({onEdit, url}: {onEdit: () => void; url: string}) {
+  const urlType = detectGitUrlType(url)
+  const isReadOnly = urlType === 'ssh' || urlType === 'git'
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex min-h-8 items-center gap-3">
+        <span className="text-foreground w-14 shrink-0 text-sm font-medium">{ORIGIN_NAME}</span>
+        <span className="mono text-foreground min-w-0 flex-1 truncate text-sm">{url}</span>
+        <Button onClick={onEdit} size="sm" variant="ghost">
+          Edit
+        </Button>
+      </div>
+      {isReadOnly && (
+        <p className="text-muted-foreground text-xs">
+          Read-only from the web UI. Push and pull require an SSH agent; change to HTTPS to use them here.
+        </p>
+      )}
+    </div>
+  )
+}
+
+type EditFormProps = {
+  initial: string
+  isPending: boolean
+  mode: 'add' | 'edit'
+  onCancel: () => void
+  onSubmit: (url: string) => Promise<void>
+  placeholder: string
+  webAppUrl?: string
+}
+
+function EditForm({initial, isPending, mode, onCancel, onSubmit, placeholder, webAppUrl}: EditFormProps) {
+  const urlId = useId()
+  const [value, setValue] = useState(initial)
+  const [error, setError] = useState<string | undefined>()
+  const inputRef = useRef<ComponentRef<typeof Input>>(null)
+  const dirty = value.trim() !== initial
+  const validationError = validateRemoteUrl(value)
+  const canSubmit = dirty && !validationError && !isPending
+
+  useEffect(() => {
+    inputRef.current?.focus()
+    inputRef.current?.select()
+  }, [])
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault()
+    if (validationError) {
+      setError(validationError)
+      return
+    }
+
+    try {
+      await onSubmit(value.trim())
+      setError(undefined)
+    } catch (error_) {
+      setError(formatError(error_, 'Failed to save remote'))
+    }
+  }
+
+  function fireSubmit(event: FormEvent) {
+    handleSubmit(event).catch(noop)
+  }
+
+  function handleKey(event: KeyboardEvent<ComponentRef<typeof Input>>) {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      onCancel()
+    }
+  }
+
+  const showValidationError = error ?? (dirty ? validationError : undefined)
+  const showReplacePreview = mode === 'edit' && !showValidationError && initial !== ''
+
+  return (
+    <form className="flex flex-col gap-4" onSubmit={fireSubmit}>
+      <Field data-invalid={Boolean(showValidationError)}>
+        <div className="flex items-center justify-between gap-2">
+          <FieldLabel htmlFor={urlId}>
+            {mode === 'add' ? 'Adding ' : 'Editing '}
+            <span className="mono text-foreground">{ORIGIN_NAME}</span>
+          </FieldLabel>
+          {mode === 'add' && webAppUrl && (
+            <Button
+              className="hidden sm:inline-flex"
+              onClick={() => window.open(webAppUrl, '_blank', 'noopener,noreferrer')}
+              size="sm"
+              type="button"
+              variant="ghost"
+            >
+              <ExternalLink className="size-3.5" />
+              Find in ByteRover
+            </Button>
+          )}
+        </div>
+        <Input
+          aria-invalid={Boolean(showValidationError)}
+          className="mono"
+          disabled={isPending}
+          id={urlId}
+          onChange={(e) => {
+            setValue(e.target.value)
+            if (error) setError(undefined)
+          }}
+          onKeyDown={handleKey}
+          placeholder={placeholder}
+          ref={inputRef}
+          value={value}
+        />
+        {showValidationError && <FieldError>{showValidationError}</FieldError>}
+        {!showValidationError && mode === 'add' && (
+          <FieldDescription>Only HTTPS URLs are supported right now.</FieldDescription>
+        )}
+        {showReplacePreview && (
+          <FieldDescription>
+            Replaces current URL <span className="mono text-foreground">{initial}</span>
+          </FieldDescription>
+        )}
+      </Field>
+
+      <div className="flex items-center justify-end gap-2">
+        <Button disabled={isPending} onClick={onCancel} type="button" variant="secondary">
+          Cancel
+        </Button>
+        <Button disabled={!canSubmit} type="submit">
+          {isPending ? 'Saving…' : mode === 'add' ? 'Add remote' : 'Replace URL'}
+        </Button>
+      </div>
+    </form>
+  )
+}
+
+export function RemotesPanel() {
+  const {data, error, isError, refetch} = useGetVcRemote()
+  const {data: envConfig} = useGetEnvironmentConfig()
+  const setRemote = useSetVcRemote()
+  const [editing, setEditing] = useState(false)
+
+  const url = data?.url
+  const gitInitialized = data?.gitInitialized
+  const hasRemote = Boolean(url)
+  const showAddAction = gitInitialized === true && !hasRemote && !editing
+  const urlPlaceholder = `${envConfig?.gitRemoteBaseUrl ?? 'https://example.com'}/team/space.git`
+
+  async function submit(next: string) {
+    await setRemote.mutateAsync({subcommand: hasRemote ? 'set-url' : 'add', url: next})
+    toast.success(hasRemote ? 'Origin replaced.' : 'Remote added.')
+    setEditing(false)
+  }
+
+  return (
+    <SettingsSection
+      action={
+        showAddAction && (
+          <Button onClick={() => setEditing(true)} size="sm" variant="outline">
+            Add remote
+          </Button>
+        )
+      }
+      compact={!editing}
+      description="Used for push, pull, and fetch."
+      error={isError ? error : undefined}
+      errorFallback="Failed to load remote"
+      onRetry={() => refetch().catch(noop)}
+      title="Remotes"
+    >
+      {data ? (
+        gitInitialized === false ? (
+          <CalloutRow
+            action={<InitializeVcButton />}
+            description="Initialize version control before adding a remote."
+            title="Not initialized"
+          />
+        ) : editing ? (
+          <EditForm
+            initial={url ?? ''}
+            isPending={setRemote.isPending}
+            mode={hasRemote ? 'edit' : 'add'}
+            onCancel={() => setEditing(false)}
+            onSubmit={submit}
+            placeholder={urlPlaceholder}
+            webAppUrl={envConfig?.webAppUrl}
+          />
+        ) : url ? (
+          <RemoteRow onEdit={() => setEditing(true)} url={url} />
+        ) : (
+          <p className="text-muted-foreground text-sm">
+            No remote set. Push and pull need an{' '}
+            <code className="mono bg-muted text-foreground rounded px-1 py-0.5 text-xs">origin</code> URL.
+          </p>
+        )
+      ) : (
+        <div className="flex min-h-8 items-center gap-3">
+          <Skeleton className="h-4 w-14" />
+          <Skeleton className="h-5 w-12 rounded-full" />
+          <Skeleton className="h-4 flex-1" />
+          <Skeleton className="h-8 w-12" />
+        </div>
+      )}
+    </SettingsSection>
+  )
+}

--- a/src/webui/features/vc/components/settings-section.tsx
+++ b/src/webui/features/vc/components/settings-section.tsx
@@ -1,0 +1,57 @@
+import type {ReactNode} from 'react'
+
+import {formatError} from '../../../lib/error-messages'
+
+type Props = {
+  action?: ReactNode
+  children?: ReactNode
+  compact?: boolean
+  description: string
+  error?: unknown
+  errorFallback?: string
+  onRetry?: () => void
+  title: string
+}
+
+export function SettingsSection({
+  action,
+  children,
+  compact = false,
+  description,
+  error,
+  errorFallback = 'Failed to load',
+  onRetry,
+  title,
+}: Props) {
+  const cardClass = compact
+    ? 'bg-card flex flex-col gap-3 rounded-xl border px-4.5 py-3.5'
+    : 'bg-card flex flex-col gap-4 rounded-xl border px-5 py-4'
+
+  return (
+    <div className="flex w-full flex-col gap-3.5">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex min-w-0 flex-col">
+          <h2 className="text-foreground text-[0.95rem] font-semibold leading-tight">{title}</h2>
+          <p className="text-muted-foreground mt-0.5 text-[0.8125rem] leading-snug">{description}</p>
+        </div>
+        {action}
+      </div>
+
+      {error ? (
+        <p className="text-destructive text-sm">
+          ✗ {formatError(error, errorFallback)}
+          {onRetry && (
+            <>
+              {' · '}
+              <button className="underline underline-offset-2" onClick={onRetry} type="button">
+                retry
+              </button>
+            </>
+          )}
+        </p>
+      ) : (
+        children && <div className={cardClass}>{children}</div>
+      )}
+    </div>
+  )
+}

--- a/src/webui/features/vc/utils/detect-git-url-type.ts
+++ b/src/webui/features/vc/utils/detect-git-url-type.ts
@@ -1,0 +1,13 @@
+export type GitUrlType = 'git' | 'https' | 'ssh' | 'unknown'
+
+const SCP_STYLE_RE = /^[a-zA-Z0-9_.-]+@[a-zA-Z0-9_.-]+:[^/].*$/
+
+export function detectGitUrlType(value: string): GitUrlType {
+  const trimmed = value.trim()
+  if (trimmed === '') return 'unknown'
+  if (trimmed.startsWith('https://') || trimmed.startsWith('http://')) return 'https'
+  if (trimmed.startsWith('ssh://')) return 'ssh'
+  if (trimmed.startsWith('git://')) return 'git'
+  if (SCP_STYLE_RE.test(trimmed)) return 'ssh'
+  return 'unknown'
+}

--- a/src/webui/features/vc/utils/detect-git-url-type.ts
+++ b/src/webui/features/vc/utils/detect-git-url-type.ts
@@ -1,11 +1,12 @@
-export type GitUrlType = 'git' | 'https' | 'ssh' | 'unknown'
+export type GitUrlType = 'git' | 'http' | 'https' | 'ssh' | 'unknown'
 
 const SCP_STYLE_RE = /^[a-zA-Z0-9_.-]+@[a-zA-Z0-9_.-]+:[^/].*$/
 
 export function detectGitUrlType(value: string): GitUrlType {
   const trimmed = value.trim()
   if (trimmed === '') return 'unknown'
-  if (trimmed.startsWith('https://') || trimmed.startsWith('http://')) return 'https'
+  if (trimmed.startsWith('https://')) return 'https'
+  if (trimmed.startsWith('http://')) return 'http'
   if (trimmed.startsWith('ssh://')) return 'ssh'
   if (trimmed.startsWith('git://')) return 'git'
   if (SCP_STYLE_RE.test(trimmed)) return 'ssh'

--- a/src/webui/features/vc/utils/is-valid-email.ts
+++ b/src/webui/features/vc/utils/is-valid-email.ts
@@ -1,0 +1,7 @@
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+export function isValidEmail(value: string): boolean {
+  const trimmed = value.trim()
+  if (trimmed === '') return false
+  return EMAIL_RE.test(trimmed)
+}

--- a/src/webui/features/vc/utils/validate-remote-url.ts
+++ b/src/webui/features/vc/utils/validate-remote-url.ts
@@ -1,0 +1,18 @@
+import {detectGitUrlType} from './detect-git-url-type'
+
+/**
+ * Returns undefined if the URL is a valid HTTPS remote the webui can push to,
+ * otherwise returns a human-readable reason. SSH and git:// are intentionally
+ * rejected — the webui's push/pull path uses an HTTPS token, so other schemes
+ * won't work from the browser regardless of what git accepts.
+ */
+export function validateRemoteUrl(value: string): string | undefined {
+  const trimmed = value.trim()
+  if (trimmed === '') return 'URL is required.'
+
+  const urlType = detectGitUrlType(trimmed)
+  if (urlType === 'ssh') return "SSH remotes aren't supported yet — use an HTTPS URL."
+  if (urlType !== 'https') return 'Expected an HTTPS URL (e.g. https://byterover.dev/team/space.git).'
+
+  return undefined
+}

--- a/src/webui/features/vc/utils/validate-remote-url.ts
+++ b/src/webui/features/vc/utils/validate-remote-url.ts
@@ -12,6 +12,7 @@ export function validateRemoteUrl(value: string): string | undefined {
 
   const urlType = detectGitUrlType(trimmed)
   if (urlType === 'ssh') return "SSH remotes aren't supported yet — use an HTTPS URL."
+  if (urlType === 'http') return "Plain HTTP isn't supported — use an HTTPS URL."
   if (urlType !== 'https') return 'Expected an HTTPS URL (e.g. https://byterover.dev/team/space.git).'
 
   return undefined

--- a/src/webui/index.html
+++ b/src/webui/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="./assets/logo.svg" />
-    <title>ByteRover</title>
+    <title>ByteRover - Local</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/webui/layouts/header.tsx
+++ b/src/webui/layouts/header.tsx
@@ -1,10 +1,11 @@
 import {Badge} from '@campfirein/byterover-packages/components/badge'
 import {Button} from '@campfirein/byterover-packages/components/button'
 import {Tooltip, TooltipContent, TooltipTrigger} from '@campfirein/byterover-packages/components/tooltip'
-import {Server} from 'lucide-react'
+import {Plug} from 'lucide-react'
 import {useState} from 'react'
 
 import logo from '../assets/logo-byterover.svg'
+import {StatusDot} from '../components/status-dot'
 import {AuthMenu} from '../features/auth/components/auth-menu'
 import {HelpMenu} from '../features/onboarding/components/help-menu'
 import {ProjectDropdown} from '../features/project/components/project-dropdown'
@@ -58,14 +59,22 @@ export function Header() {
       <div className="flex-1" />
 
       {/* Right: provider/model + docs + login */}
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-3">
         <Tooltip>
           <TooltipTrigger render={<Button onClick={() => setProviderDialogOpen(true)} size="sm" variant="ghost" />}>
-            <Server className="size-3.5 shrink-0 mr-1" />
+            <span className="relative mr-1 inline-flex size-4 shrink-0">
+              <Plug className="size-4" />
+              {activeProvider && (
+                <StatusDot
+                  className="border-background absolute -right-0.5 -bottom-0.5 size-2 border-2"
+                  tone="success"
+                />
+              )}
+            </span>
             {providerLabel}
-            {!activeProvider && <span className="size-1.5 shrink-0 rounded-full bg-amber-500" />}
+            {!activeProvider && <StatusDot pulsing tone="amber" />}
           </TooltipTrigger>
-          {!activeProvider && <TooltipContent>Configure to use curate/query feature</TooltipContent>}
+          <TooltipContent>Configure provider to power curate & query</TooltipContent>
         </Tooltip>
         <ProviderFlowDialog onOpenChange={setProviderDialogOpen} open={providerDialogOpen} />
 

--- a/src/webui/layouts/main-layout.tsx
+++ b/src/webui/layouts/main-layout.tsx
@@ -6,6 +6,7 @@ import {TourBar} from '../features/onboarding/components/tour-bar'
 import {TourHost} from '../features/onboarding/components/tour-host'
 import {WelcomeOverlay} from '../features/onboarding/components/welcome-overlay'
 import {useTourWatchers} from '../features/onboarding/hooks/use-tour-watchers'
+import {GlobalProviderDialog} from '../features/provider/components/global-provider-dialog'
 import {useTaskCounts} from '../features/tasks/stores/task-store'
 import {useGetVcStatus} from '../features/vc/api/get-vc-status'
 import {statusToFiles} from '../features/vc/utils/status-to-files'
@@ -88,6 +89,7 @@ export function MainLayout() {
       <WelcomeOverlay />
       <TourHost />
       <TourBar />
+      <GlobalProviderDialog />
     </div>
   )
 }

--- a/src/webui/layouts/main-layout.tsx
+++ b/src/webui/layouts/main-layout.tsx
@@ -1,11 +1,14 @@
 import {Badge} from '@campfirein/byterover-packages/components/badge'
 import {cn} from '@campfirein/byterover-packages/lib/utils'
-import {NavLink, Outlet} from 'react-router-dom'
+import {NavLink, Outlet, useLocation} from 'react-router-dom'
 
+import {TourBackdrop} from '../features/onboarding/components/tour-backdrop'
 import {TourBar} from '../features/onboarding/components/tour-bar'
 import {TourHost} from '../features/onboarding/components/tour-host'
+import {TourPointer} from '../features/onboarding/components/tour-pointer'
 import {WelcomeOverlay} from '../features/onboarding/components/welcome-overlay'
 import {useTourWatchers} from '../features/onboarding/hooks/use-tour-watchers'
+import {useOnboardingStore} from '../features/onboarding/stores/onboarding-store'
 import {GlobalProviderDialog} from '../features/provider/components/global-provider-dialog'
 import {useTaskCounts} from '../features/tasks/stores/task-store'
 import {useGetVcStatus} from '../features/vc/api/get-vc-status'
@@ -49,6 +52,13 @@ function ChangesBadge() {
 export function MainLayout() {
   const tabs = useTabs()
   useTourWatchers()
+  const tourActive = useOnboardingStore((s) => s.tourActive)
+  const tourStep = useOnboardingStore((s) => s.tourStep)
+  const tourTaskId = useOnboardingStore((s) => s.tourTaskId)
+  const {pathname} = useLocation()
+  const onTasksRoute = pathname.startsWith('/tasks')
+  const showTasksNavCue =
+    tourActive && (tourStep === 'curate' || tourStep === 'query') && !tourTaskId && !onTasksRoute
 
   return (
     <div className="flex h-screen flex-col">
@@ -56,29 +66,40 @@ export function MainLayout() {
 
       {/* Tabs */}
       <nav className="border-border flex gap-2 border-b px-6">
-        {tabs.map((tab) => (
-          <NavLink
-            className={({isActive}) =>
-              cn('flex items-center gap-1.5 border-b-2 px-2 pt-2 pb-3 text-sm transition-colors', {
-                'border-primary-foreground text-primary-foreground font-medium': isActive,
-                'border-transparent text-muted-foreground hover:text-foreground': !isActive,
-              })
-            }
-            key={tab.path}
-            to={tab.path}
-          >
-            <span>{tab.label}</span>
-            {tab.badge && (
-              <Badge className="tabular-nums" variant="secondary">
-                {tab.badgeTone === 'active' && (
-                  <span aria-hidden className="bg-primary-foreground size-1.5 shrink-0 rounded-full" />
-                )}
-                {tab.badge}
-              </Badge>
-            )}
-            {tab.path === '/changes' && <ChangesBadge />}
-          </NavLink>
-        ))}
+        {tabs.map((tab) => {
+          const link = (
+            <NavLink
+              className={({isActive}) =>
+                cn('flex items-center gap-1.5 border-b-2 px-2 pt-2 pb-3 text-sm transition-colors', {
+                  'border-primary-foreground text-primary-foreground font-medium': isActive,
+                  'border-transparent text-muted-foreground hover:text-foreground': !isActive,
+                })
+              }
+              to={tab.path}
+            >
+              <span>{tab.label}</span>
+              {tab.badge && (
+                <Badge className="tabular-nums" variant="secondary">
+                  {tab.badgeTone === 'active' && (
+                    <span aria-hidden className="bg-primary-foreground size-1.5 shrink-0 rounded-full" />
+                  )}
+                  {tab.badge}
+                </Badge>
+              )}
+              {tab.path === '/changes' && <ChangesBadge />}
+            </NavLink>
+          )
+
+          if (tab.path === '/tasks') {
+            return (
+              <TourPointer active={showTasksNavCue} key={tab.path} label="Click here">
+                {link}
+              </TourPointer>
+            )
+          }
+
+          return <span key={tab.path}>{link}</span>
+        })}
       </nav>
 
       {/* Content */}
@@ -88,6 +109,7 @@ export function MainLayout() {
 
       <WelcomeOverlay />
       <TourHost />
+      <TourBackdrop />
       <TourBar />
       <GlobalProviderDialog />
     </div>

--- a/src/webui/lib/error-messages.ts
+++ b/src/webui/lib/error-messages.ts
@@ -1,3 +1,5 @@
+import {VcErrorCode} from '../../shared/transport/events/vc-events'
+
 export interface ErrorContext {
   projectPath?: string
 }
@@ -8,23 +10,21 @@ type OverrideValue = ((ctx: ErrorContext) => string) | string
 const OVERRIDES: Record<string, OverrideValue> = {
   // Auth / providers
   ERR_NOT_AUTHENTICATED: 'Please sign in to continue.',
-
   ERR_PROVIDER_NOT_CONFIGURED: 'No provider is connected, or its credentials are missing or expired.',
+
   // Version control
-  ERR_VC_ALREADY_INITIALIZED: 'Version control is already initialized for this project.',
-  ERR_VC_AUTH_FAILED: 'Authentication failed. Please sign in and try again.',
-  ERR_VC_BRANCH_NOT_FOUND: "Branch not found. You can create a new branch if needed.",
-  ERR_VC_NO_COMMITS: 'Make at least one commit before continuing.',
-  ERR_VC_NO_REMOTE: 'No remote is configured yet. Set one up before using pull, push, or fetch.',
-  ERR_VC_NO_UPSTREAM:
-    "This branch has no upstream configured yet. Use the Push button to publish it and set upstream in one step.",
-  ERR_VC_NON_FAST_FORWARD: 'The remote has changes. Pull first, then try again.',
-  ERR_VC_NOTHING_TO_PUSH: 'Nothing to push — stage and commit your changes first.',
-  ERR_VC_REMOTE_ALREADY_EXISTS: "A remote named 'origin' already exists. Remove or rename it before adding a new one.",
-  ERR_VC_USER_NOT_CONFIGURED: ({projectPath}) =>
-    projectPath
-      ? `Please run \`brv vc config\` in "${projectPath}" to set your commit author before committing.`
-      : 'Please run `brv vc config` inside your project to set commit author before committing.',
+  [VcErrorCode.ALREADY_INITIALIZED]: 'Version control is already initialized for this project.',
+  [VcErrorCode.AUTH_FAILED]: 'Authentication failed. Please sign in and try again.',
+  [VcErrorCode.BRANCH_NOT_FOUND]: 'Branch not found. You can create a new branch if needed.',
+  [VcErrorCode.NO_COMMITS]: 'Make at least one commit before continuing.',
+  [VcErrorCode.NO_REMOTE]: 'No remote configured for this project.',
+  [VcErrorCode.NO_UPSTREAM]:
+    'This branch has no upstream configured yet. Use the Push button to publish it and set upstream in one step.',
+  [VcErrorCode.NON_FAST_FORWARD]: 'The remote has changes. Pull first, then try again.',
+  [VcErrorCode.NOTHING_TO_PUSH]: 'Nothing to push — stage and commit your changes first.',
+  [VcErrorCode.REMOTE_ALREADY_EXISTS]:
+    "A remote named 'origin' already exists. Remove or rename it before adding a new one.",
+  [VcErrorCode.USER_NOT_CONFIGURED]: 'Commit author is not configured.',
 }
 
 const DEFAULT_FALLBACK = 'Something went wrong'

--- a/src/webui/lib/noop.ts
+++ b/src/webui/lib/noop.ts
@@ -1,0 +1,2 @@
+/** Shared no-op; use as the argument to `.catch()` when the error is already surfaced elsewhere. */
+export const noop = () => {}

--- a/src/webui/lib/toast-vc-error.ts
+++ b/src/webui/lib/toast-vc-error.ts
@@ -1,0 +1,50 @@
+import type {NavigateFunction} from 'react-router-dom'
+
+import {toast} from 'sonner'
+
+import {VcErrorCode} from '../../shared/transport/events/vc-events'
+import {type ErrorContext, formatError} from './error-messages'
+
+type ConfigCta = {
+  label: string
+  target: string
+}
+
+const CONFIG_CTA: Record<string, ConfigCta> = {
+  [VcErrorCode.CONFIG_KEY_NOT_SET]: {label: 'Set identity', target: '/configuration#identity'},
+  [VcErrorCode.NO_REMOTE]: {label: 'Set remote', target: '/configuration#remotes'},
+  [VcErrorCode.USER_NOT_CONFIGURED]: {label: 'Set identity', target: '/configuration#identity'},
+}
+
+function errorCode(error: unknown): string | undefined {
+  if (typeof error !== 'object' || error === null || !('code' in error)) return undefined
+  const {code} = error as {code: unknown}
+  return typeof code === 'string' ? code : undefined
+}
+
+/**
+ * Surface a VC error as a toast. The message always comes from `formatError`
+ * (single source of truth); when the error code maps to a Configuration panel,
+ * a one-click CTA is attached that deep-links the user to that section.
+ */
+export function toastVcError(
+  error: unknown,
+  fallback: string,
+  navigate: NavigateFunction,
+  context: ErrorContext = {},
+): void {
+  const message = formatError(error, fallback, context)
+  const cta = CONFIG_CTA[errorCode(error) ?? '']
+
+  if (cta) {
+    toast.error(message, {
+      action: {
+        label: cta.label,
+        onClick: () => navigate(cta.target),
+      },
+    })
+    return
+  }
+
+  toast.error(message)
+}

--- a/src/webui/lib/toast-vc-error.ts
+++ b/src/webui/lib/toast-vc-error.ts
@@ -11,9 +11,9 @@ type ConfigCta = {
 }
 
 const CONFIG_CTA: Record<string, ConfigCta> = {
-  [VcErrorCode.CONFIG_KEY_NOT_SET]: {label: 'Set identity', target: '/configuration#identity'},
-  [VcErrorCode.NO_REMOTE]: {label: 'Set remote', target: '/configuration#remotes'},
-  [VcErrorCode.USER_NOT_CONFIGURED]: {label: 'Set identity', target: '/configuration#identity'},
+  [VcErrorCode.CONFIG_KEY_NOT_SET]: {label: 'Set identity', target: '/configuration'},
+  [VcErrorCode.NO_REMOTE]: {label: 'Set remote', target: '/configuration'},
+  [VcErrorCode.USER_NOT_CONFIGURED]: {label: 'Set identity', target: '/configuration'},
 }
 
 function errorCode(error: unknown): string | undefined {

--- a/src/webui/lib/transport-error.ts
+++ b/src/webui/lib/transport-error.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared helpers for inspecting errors that come off the transport layer.
+ *
+ * The daemon serializes errors as plain objects with an optional `code` field
+ * (see `serializeTaskError` / `VcError.toJSON()`), and socket.io passes them
+ * through to the client unchanged — they're NOT Error instances on arrival.
+ * Callers that need to branch on `error.code` should use this guard instead
+ * of open-coding the shape check.
+ */
+export function hasCode(error: unknown): error is {code: string} {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    typeof (error as {code: unknown}).code === 'string'
+  )
+}

--- a/src/webui/pages/configuration-page.tsx
+++ b/src/webui/pages/configuration-page.tsx
@@ -1,33 +1,14 @@
-import {useEffect} from 'react'
-import {useLocation} from 'react-router-dom'
-
 import {ConnectorsPanel} from '../features/connectors/components/connectors-panel'
 import {IdentityPanel} from '../features/vc/components/identity-panel'
 import {RemotesPanel} from '../features/vc/components/remotes-panel'
 
 export function ConfigurationPage() {
-  const {hash} = useLocation()
-
-  useEffect(() => {
-    if (!hash) return
-    // Hash values are hard-coded below (#identity / #remotes / #connectors), so
-    // using it directly as a selector is safe — no escaping needed.
-    const el = document.querySelector(hash)
-    if (el) el.scrollIntoView({behavior: 'smooth', block: 'start'})
-  }, [hash])
-
   return (
     <div className="flex flex-col items-center pt-8">
       <div className="flex w-full flex-col gap-6 md:gap-12 sm:max-w-lg md:max-w-xl lg:max-w-2xl">
-        <section className="scroll-mt-4" id="identity">
-          <IdentityPanel />
-        </section>
-        <section className="scroll-mt-4" id="remotes">
-          <RemotesPanel />
-        </section>
-        <section className="scroll-mt-4" id="connectors">
-          <ConnectorsPanel />
-        </section>
+        <IdentityPanel />
+        <RemotesPanel />
+        <ConnectorsPanel />
       </div>
     </div>
   )

--- a/src/webui/pages/configuration-page.tsx
+++ b/src/webui/pages/configuration-page.tsx
@@ -1,7 +1,34 @@
-import { ConnectorsPanel } from '../features/connectors/components/connectors-panel'
+import {useEffect} from 'react'
+import {useLocation} from 'react-router-dom'
+
+import {ConnectorsPanel} from '../features/connectors/components/connectors-panel'
+import {IdentityPanel} from '../features/vc/components/identity-panel'
+import {RemotesPanel} from '../features/vc/components/remotes-panel'
 
 export function ConfigurationPage() {
-  return <div className='flex flex-col items-center pt-8'>
-    <ConnectorsPanel />
-  </div>
+  const {hash} = useLocation()
+
+  useEffect(() => {
+    if (!hash) return
+    // Hash values are hard-coded below (#identity / #remotes / #connectors), so
+    // using it directly as a selector is safe — no escaping needed.
+    const el = document.querySelector(hash)
+    if (el) el.scrollIntoView({behavior: 'smooth', block: 'start'})
+  }, [hash])
+
+  return (
+    <div className="flex flex-col items-center pt-8">
+      <div className="flex w-full flex-col gap-6 md:gap-12 sm:max-w-lg md:max-w-xl lg:max-w-2xl">
+        <section className="scroll-mt-4" id="identity">
+          <IdentityPanel />
+        </section>
+        <section className="scroll-mt-4" id="remotes">
+          <RemotesPanel />
+        </section>
+        <section className="scroll-mt-4" id="connectors">
+          <ConnectorsPanel />
+        </section>
+      </div>
+    </div>
+  )
 }

--- a/test/unit/infra/transport/handlers/locations-handler.test.ts
+++ b/test/unit/infra/transport/handlers/locations-handler.test.ts
@@ -85,10 +85,12 @@ describe('LocationsHandler', () => {
   }
 
   describe('setup', () => {
-    it('should register locations:get handler', () => {
+    it('should register locations:get and locations:reveal handlers', () => {
       createHandler()
-      expect(transport.onRequest.calledOnce).to.be.true
-      expect(transport.onRequest.firstCall.args[0]).to.equal(LocationsEvents.GET)
+      expect(transport.onRequest.calledTwice).to.be.true
+      const registeredEvents = transport.onRequest.getCalls().map((call) => call.args[0])
+      expect(registeredEvents).to.include(LocationsEvents.GET)
+      expect(registeredEvents).to.include(LocationsEvents.REVEAL)
     })
   })
 

--- a/test/unit/infra/transport/reveal-command.test.ts
+++ b/test/unit/infra/transport/reveal-command.test.ts
@@ -1,0 +1,30 @@
+import {expect} from 'chai'
+
+import {resolveRevealCommand} from '../../../../src/server/infra/transport/handlers/reveal-command.js'
+
+describe('resolveRevealCommand', () => {
+  const path = '/Users/wzlng/Documents/work/byterover-cli'
+
+  it('returns the macOS "open" command on darwin', () => {
+    expect(resolveRevealCommand('darwin', path)).to.deep.equal({args: [path], command: 'open'})
+  })
+
+  it('returns Windows "explorer" on win32', () => {
+    expect(resolveRevealCommand('win32', path)).to.deep.equal({args: [path], command: 'explorer'})
+  })
+
+  it('falls back to xdg-open on linux', () => {
+    expect(resolveRevealCommand('linux', path)).to.deep.equal({args: [path], command: 'xdg-open'})
+  })
+
+  it('falls back to xdg-open on freebsd and other POSIX-like platforms', () => {
+    expect(resolveRevealCommand('freebsd', path)).to.deep.equal({args: [path], command: 'xdg-open'})
+    expect(resolveRevealCommand('openbsd', path)).to.deep.equal({args: [path], command: 'xdg-open'})
+  })
+
+  it('passes the target path through as the first argument without interpolation', () => {
+    const hostile = '/tmp/dir with spaces/$(whoami)'
+    const result = resolveRevealCommand('darwin', hostile)
+    expect(result.args).to.deep.equal([hostile])
+  })
+})

--- a/test/unit/infra/webui/webui-middleware.test.ts
+++ b/test/unit/infra/webui/webui-middleware.test.ts
@@ -8,6 +8,7 @@ import {createWebUiMiddleware} from '../../../../src/server/infra/webui/webui-mi
 
 interface HttpResult {
   body: string
+  headers: IncomingMessage['headers']
   status: number
 }
 
@@ -17,7 +18,11 @@ async function httpRequest(url: string): Promise<HttpResult> {
       const chunks: Buffer[] = []
       res.on('data', (chunk: Buffer) => chunks.push(chunk))
       res.on('end', () => {
-        resolve({body: Buffer.concat(chunks).toString('utf8'), status: res.statusCode ?? 0})
+        resolve({
+          body: Buffer.concat(chunks).toString('utf8'),
+          headers: res.headers,
+          status: res.statusCode ?? 0,
+        })
       })
       res.on('error', reject)
     }).on('error', reject)
@@ -109,6 +114,21 @@ describe('createWebUiMiddleware', () => {
 
     expect(response.status).to.equal(200)
     expect(response.body).to.equal(indexHtml)
+  })
+
+  it('should allow https images in Content-Security-Policy for OAuth provider avatars', async () => {
+    const distRoot = join(testDir, 'dist', 'webui')
+    mkdirSync(distRoot, {recursive: true})
+    writeFileSync(join(distRoot, 'index.html'), '<!doctype html>', 'utf8')
+
+    const port = await startServer(distRoot)
+    const response = await httpRequest(`http://127.0.0.1:${port}/`)
+
+    const csp = response.headers['content-security-policy']
+    expect(csp).to.be.a('string')
+    const imgSrc = (csp as string).split(';').map((d) => d.trim()).find((d) => d.startsWith('img-src'))
+    expect(imgSrc, 'img-src directive should be present').to.exist
+    expect(imgSrc).to.include('https:')
   })
 
   it('should not register static or SPA routes when webuiDistDir does not exist', async () => {

--- a/test/unit/webui/features/tasks/stores/composer-retry-store.test.ts
+++ b/test/unit/webui/features/tasks/stores/composer-retry-store.test.ts
@@ -1,0 +1,36 @@
+import {expect} from 'chai'
+
+import {useComposerRetryStore} from '../../../../../../src/webui/features/tasks/stores/composer-retry-store.js'
+
+describe('useComposerRetryStore', () => {
+  beforeEach(() => {
+    useComposerRetryStore.setState({seed: null})
+  })
+
+  it('starts with a null seed', () => {
+    expect(useComposerRetryStore.getState().seed).to.equal(null)
+  })
+
+  it('records the latest seed via requestRetry', () => {
+    useComposerRetryStore.getState().requestRetry({content: 'list conventions', type: 'curate'})
+    expect(useComposerRetryStore.getState().seed).to.deep.equal({content: 'list conventions', type: 'curate'})
+  })
+
+  it('overwrites the previous seed when requestRetry is called again', () => {
+    useComposerRetryStore.getState().requestRetry({content: 'first', type: 'curate'})
+    useComposerRetryStore.getState().requestRetry({content: 'second', type: 'query'})
+    expect(useComposerRetryStore.getState().seed).to.deep.equal({content: 'second', type: 'query'})
+  })
+
+  it('consume returns the seed and clears it', () => {
+    useComposerRetryStore.getState().requestRetry({content: 'hi', type: 'query'})
+    const taken = useComposerRetryStore.getState().consume()
+    expect(taken).to.deep.equal({content: 'hi', type: 'query'})
+    expect(useComposerRetryStore.getState().seed).to.equal(null)
+  })
+
+  it('consume returns null and is a no-op when there is no pending seed', () => {
+    expect(useComposerRetryStore.getState().consume()).to.equal(null)
+    expect(useComposerRetryStore.getState().seed).to.equal(null)
+  })
+})

--- a/test/unit/webui/features/tasks/utils/composer-type-from-task.test.ts
+++ b/test/unit/webui/features/tasks/utils/composer-type-from-task.test.ts
@@ -1,0 +1,20 @@
+import {expect} from 'chai'
+
+import {composerTypeFromTask} from '../../../../../../src/webui/features/tasks/utils/composer-type-from-task.js'
+
+describe('composerTypeFromTask', () => {
+  it('maps query and search to query', () => {
+    expect(composerTypeFromTask('query')).to.equal('query')
+    expect(composerTypeFromTask('search')).to.equal('query')
+  })
+
+  it('maps curate and curate-folder to curate', () => {
+    expect(composerTypeFromTask('curate')).to.equal('curate')
+    expect(composerTypeFromTask('curate-folder')).to.equal('curate')
+  })
+
+  it('falls back to curate for unknown types so the composer still opens', () => {
+    expect(composerTypeFromTask('something-new')).to.equal('curate')
+    expect(composerTypeFromTask('')).to.equal('curate')
+  })
+})

--- a/test/unit/webui/features/tasks/utils/is-provider-task-error.test.ts
+++ b/test/unit/webui/features/tasks/utils/is-provider-task-error.test.ts
@@ -1,0 +1,46 @@
+import {expect} from 'chai'
+
+import {isProviderTaskError} from '../../../../../../src/webui/features/tasks/utils/is-provider-task-error'
+
+describe('isProviderTaskError', () => {
+  it('returns false for undefined error and no llmservice:error flag', () => {
+    expect(isProviderTaskError({error: undefined, hadLlmServiceError: false})).to.be.false
+  })
+
+  it('matches on provider-class task error codes', () => {
+    const codes = [
+      'ERR_PROVIDER_NOT_CONFIGURED',
+      'ERR_LLM_ERROR',
+      'ERR_LLM_RATE_LIMIT',
+      'ERR_OAUTH_REFRESH_FAILED',
+      'ERR_OAUTH_TOKEN_EXPIRED',
+    ]
+    for (const code of codes) {
+      expect(
+        isProviderTaskError({error: {code, message: 'x'}, hadLlmServiceError: false}),
+        `code=${code}`,
+      ).to.be.true
+    }
+  })
+
+  it('returns false for unrelated codes without llmservice:error', () => {
+    expect(isProviderTaskError({error: {code: 'ERR_TASK_TIMEOUT', message: 'x'}, hadLlmServiceError: false})).to.be
+      .false
+    expect(isProviderTaskError({error: {code: 'ERR_AGENT_DISCONNECTED', message: 'x'}, hadLlmServiceError: false})).to
+      .be.false
+  })
+
+  it('returns true when hadLlmServiceError is set, regardless of code or message', () => {
+    expect(isProviderTaskError({error: {message: 'anything at all'}, hadLlmServiceError: true})).to.be.true
+    expect(isProviderTaskError({error: undefined, hadLlmServiceError: true})).to.be.true
+  })
+
+  it('does not match on message text alone (no pattern heuristics)', () => {
+    expect(
+      isProviderTaskError({
+        error: {message: 'Generation failed: rate limit — provider refused'},
+        hadLlmServiceError: false,
+      }),
+    ).to.be.false
+  })
+})

--- a/test/unit/webui/features/vc/utils/detect-git-url-type.test.ts
+++ b/test/unit/webui/features/vc/utils/detect-git-url-type.test.ts
@@ -7,8 +7,8 @@ describe('detectGitUrlType', () => {
     expect(detectGitUrlType('https://github.com/wzlng/byterover-cli.git')).to.equal('https')
   })
 
-  it('detects http urls', () => {
-    expect(detectGitUrlType('http://self-hosted.internal/repo.git')).to.equal('https')
+  it('detects http urls distinctly from https', () => {
+    expect(detectGitUrlType('http://self-hosted.internal/repo.git')).to.equal('http')
   })
 
   it('detects ssh scheme urls', () => {

--- a/test/unit/webui/features/vc/utils/detect-git-url-type.test.ts
+++ b/test/unit/webui/features/vc/utils/detect-git-url-type.test.ts
@@ -1,0 +1,34 @@
+import {expect} from 'chai'
+
+import {detectGitUrlType} from '../../../../../../src/webui/features/vc/utils/detect-git-url-type'
+
+describe('detectGitUrlType', () => {
+  it('detects https urls', () => {
+    expect(detectGitUrlType('https://github.com/wzlng/byterover-cli.git')).to.equal('https')
+  })
+
+  it('detects http urls', () => {
+    expect(detectGitUrlType('http://self-hosted.internal/repo.git')).to.equal('https')
+  })
+
+  it('detects ssh scheme urls', () => {
+    expect(detectGitUrlType('ssh://git@github.com/wzlng/byterover-cli.git')).to.equal('ssh')
+  })
+
+  it('detects git@host:path scp-style urls as ssh', () => {
+    expect(detectGitUrlType('git@github.com:wzlng/byterover-cli.git')).to.equal('ssh')
+  })
+
+  it('detects git:// urls', () => {
+    expect(detectGitUrlType('git://github.com/wzlng/byterover-cli.git')).to.equal('git')
+  })
+
+  it('returns unknown for empty / malformed strings', () => {
+    expect(detectGitUrlType('')).to.equal('unknown')
+    expect(detectGitUrlType('not-a-url')).to.equal('unknown')
+  })
+
+  it('trims surrounding whitespace before detecting', () => {
+    expect(detectGitUrlType('  git@github.com:foo/bar.git  ')).to.equal('ssh')
+  })
+})

--- a/test/unit/webui/features/vc/utils/is-valid-email.test.ts
+++ b/test/unit/webui/features/vc/utils/is-valid-email.test.ts
@@ -1,0 +1,30 @@
+import {expect} from 'chai'
+
+import {isValidEmail} from '../../../../../../src/webui/features/vc/utils/is-valid-email'
+
+describe('isValidEmail', () => {
+  it('accepts a typical email', () => {
+    expect(isValidEmail('john@byterover.dev')).to.be.true
+  })
+
+  it('accepts plus addressing and subdomains', () => {
+    expect(isValidEmail('john+commits@mail.byterover.dev')).to.be.true
+  })
+
+  it('rejects strings without an @', () => {
+    expect(isValidEmail('john-byterover.dev')).to.be.false
+  })
+
+  it('rejects strings without a TLD', () => {
+    expect(isValidEmail('john@localhost')).to.be.false
+  })
+
+  it('rejects empty strings and whitespace', () => {
+    expect(isValidEmail('')).to.be.false
+    expect(isValidEmail('   ')).to.be.false
+  })
+
+  it('trims surrounding whitespace before validating', () => {
+    expect(isValidEmail('  john@byterover.dev  ')).to.be.true
+  })
+})

--- a/test/unit/webui/features/vc/utils/validate-remote-url.test.ts
+++ b/test/unit/webui/features/vc/utils/validate-remote-url.test.ts
@@ -7,8 +7,10 @@ describe('validateRemoteUrl', () => {
     expect(validateRemoteUrl('https://github.com/wzlng/repo.git')).to.be.undefined
   })
 
-  it('accepts http URLs (self-hosted installs)', () => {
-    expect(validateRemoteUrl('http://self-hosted.internal/repo.git')).to.be.undefined
+  it('rejects plain http URLs with a specific message', () => {
+    expect(validateRemoteUrl('http://self-hosted.internal/repo.git')).to.equal(
+      "Plain HTTP isn't supported — use an HTTPS URL.",
+    )
   })
 
   it('trims surrounding whitespace before validating', () => {

--- a/test/unit/webui/features/vc/utils/validate-remote-url.test.ts
+++ b/test/unit/webui/features/vc/utils/validate-remote-url.test.ts
@@ -1,0 +1,46 @@
+import {expect} from 'chai'
+
+import {validateRemoteUrl} from '../../../../../../src/webui/features/vc/utils/validate-remote-url'
+
+describe('validateRemoteUrl', () => {
+  it('accepts a bare https URL', () => {
+    expect(validateRemoteUrl('https://github.com/wzlng/repo.git')).to.be.undefined
+  })
+
+  it('accepts http URLs (self-hosted installs)', () => {
+    expect(validateRemoteUrl('http://self-hosted.internal/repo.git')).to.be.undefined
+  })
+
+  it('trims surrounding whitespace before validating', () => {
+    expect(validateRemoteUrl('  https://github.com/wzlng/repo.git  ')).to.be.undefined
+  })
+
+  it('rejects empty/whitespace-only input', () => {
+    expect(validateRemoteUrl('')).to.equal('URL is required.')
+    expect(validateRemoteUrl('   ')).to.equal('URL is required.')
+  })
+
+  it('rejects scp-style ssh urls with a specific message', () => {
+    expect(validateRemoteUrl('git@github.com:wzlng/repo.git')).to.equal(
+      "SSH remotes aren't supported yet — use an HTTPS URL.",
+    )
+  })
+
+  it('rejects ssh:// urls with a specific message', () => {
+    expect(validateRemoteUrl('ssh://git@github.com/wzlng/repo.git')).to.equal(
+      "SSH remotes aren't supported yet — use an HTTPS URL.",
+    )
+  })
+
+  it('rejects git:// urls', () => {
+    expect(validateRemoteUrl('git://github.com/wzlng/repo.git')).to.equal(
+      'Expected an HTTPS URL (e.g. https://byterover.dev/team/space.git).',
+    )
+  })
+
+  it('rejects malformed non-URL strings', () => {
+    expect(validateRemoteUrl('foo/bar/repo')).to.equal(
+      'Expected an HTTPS URL (e.g. https://byterover.dev/team/space.git).',
+    )
+  })
+})

--- a/test/unit/webui/lib/error-messages.test.ts
+++ b/test/unit/webui/lib/error-messages.test.ts
@@ -39,21 +39,22 @@ describe('formatError', () => {
     expect(formatError({})).to.equal('Something went wrong')
   })
 
-  describe('context-aware overrides', () => {
-    it('includes the project path in the USER_NOT_CONFIGURED override when context is provided', () => {
+  describe('USER_NOT_CONFIGURED override', () => {
+    // The override is now a plain string: the webui Configuration page is the
+    // remediation surface, so we don't interpolate project paths or reference
+    // `brv vc config` anymore.
+    it('returns the web-friendly message regardless of context', () => {
       const error = {code: 'ERR_VC_USER_NOT_CONFIGURED', message: 'raw server message'}
-      const result = formatError(error, 'fallback copy', {projectPath: '/Users/thien/my-proj'})
+      const withCtx = formatError(error, 'fallback copy', {projectPath: '/Users/thien/my-proj'})
+      const withoutCtx = formatError(error)
 
-      expect(result).to.include('/Users/thien/my-proj')
-      expect(result).to.include('brv vc config')
+      expect(withCtx).to.equal('Commit author is not configured.')
+      expect(withoutCtx).to.equal('Commit author is not configured.')
     })
 
-    it('falls back to a generic USER_NOT_CONFIGURED override when no project path is supplied', () => {
+    it('does not leak `undefined` when no context is supplied', () => {
       const error = {code: 'ERR_VC_USER_NOT_CONFIGURED', message: 'raw server message'}
-      const result = formatError(error)
-
-      expect(result).to.include('brv vc config')
-      expect(result).to.not.include('undefined')
+      expect(formatError(error)).to.not.include('undefined')
     })
 
     it('ignores context for non-function overrides', () => {

--- a/test/unit/webui/lib/toast-vc-error.test.ts
+++ b/test/unit/webui/lib/toast-vc-error.test.ts
@@ -1,0 +1,70 @@
+import type {NavigateFunction} from 'react-router-dom'
+
+import {expect} from 'chai'
+import {restore, type SinonStub, stub} from 'sinon'
+import {toast} from 'sonner'
+
+import {VcErrorCode} from '../../../../src/shared/transport/events/vc-events.js'
+import {toastVcError} from '../../../../src/webui/lib/toast-vc-error.js'
+
+type ToastAction = {
+  label: string
+  onClick: () => void
+}
+
+function actionOf(call: SinonStub['firstCall']): ToastAction | undefined {
+  // toast.error(message, options?) — we only care about options.action here.
+  const options = call.args[1] as undefined | {action?: ToastAction}
+  return options?.action
+}
+
+describe('toastVcError', () => {
+  let toastErrorStub: SinonStub
+  let navigate: NavigateFunction & SinonStub
+
+  beforeEach(() => {
+    toastErrorStub = stub(toast, 'error')
+    navigate = stub() as unknown as NavigateFunction & SinonStub
+  })
+
+  afterEach(() => {
+    restore()
+  })
+
+  it('attaches a "Set identity" action for ERR_VC_CONFIG_KEY_NOT_SET', () => {
+    toastVcError(
+      {code: VcErrorCode.CONFIG_KEY_NOT_SET, message: 'raw'},
+      'fallback copy',
+      navigate,
+    )
+
+    expect(toastErrorStub.calledOnce).to.be.true
+    const action = actionOf(toastErrorStub.firstCall)
+    expect(action?.label).to.equal('Set identity')
+
+    action?.onClick()
+    expect((navigate as unknown as SinonStub).calledOnceWith('/configuration')).to.be.true
+  })
+
+  it('attaches a "Set remote" action for ERR_VC_NO_REMOTE', () => {
+    toastVcError({code: VcErrorCode.NO_REMOTE, message: 'raw'}, 'fallback copy', navigate)
+
+    expect(toastErrorStub.calledOnce).to.be.true
+    const action = actionOf(toastErrorStub.firstCall)
+    expect(action?.label).to.equal('Set remote')
+
+    action?.onClick()
+    expect((navigate as unknown as SinonStub).calledOnceWith('/configuration')).to.be.true
+  })
+
+  it('calls toast.error with no action for an unknown error code', () => {
+    toastVcError({code: 'ERR_SOMETHING_ELSE', message: 'unrecognised'}, 'fallback copy', navigate)
+
+    expect(toastErrorStub.calledOnce).to.be.true
+    // Second arg should be either undefined or a plain options object without
+    // an `action` field — there's nothing to navigate to.
+    const options = toastErrorStub.firstCall.args[1] as undefined | {action?: ToastAction}
+    expect(options?.action).to.be.undefined
+    expect((navigate as unknown as SinonStub).called).to.be.false
+  })
+})


### PR DESCRIPTION
Configuration page
- Git identity panel: get/set user.name & user.email via the daemon, one-click seed from the signed-in ByteRover account.
- Remote panel: single `origin`, HTTPS-only validation, replace preview, Initialize VC CTA when git is uninitialized, "Find in ByteRover" link.
- Shared SettingsSection + CalloutRow primitives; `bg-card` alignment with ConnectorsPanel; skeleton loading rows.

Provider onboarding
- ByteRover pinned to top of the selector with an amber "Native" pill.
- OAuth popup opens on row click (drops the redundant login-prompt confirmation); 800ms minimum visible delay before popup navigates.
- ProviderFlowDialog mountable globally via provider-store so any surface can open it (task error CTA, etc.).

Error routing
- toastVcError maps VC config gaps to a toast action that deep-links to /configuration#identity or #remotes.
- Task ErrorSection shows "Configure provider" for provider-class errors; checks llmservice:error broadcast (task:error isn't always structured).
- formatError overrides aligned with Configuration page copy.

Header
- Responsive: Local badge hides <lg, HelpMenu/BranchDropdown/version collapse at narrower sizes, provider label truncates by breakpoint.
- StatusDot primitive (tone + pulsing) — pulsing amber when unconfigured, green corner dot on the Plug when active.
- `brv vc init` invalidates the remote query so panel auto-refreshes.

Other
- ProjectDropdown: "Open local folder" opens OS file manager via new locations:reveal transport event (registry-guarded, no shell interp).
- Global toast position = top-center; removed per-call overrides.
- CSP: allow img-src https: for OAuth provider avatars.
- BRV_GIT_REMOTE_BASE_URL surfaced via config:getEnvironment for the Remote URL input placeholder.

Tests
- Pure util tests: detect-git-url-type, is-valid-email, validate-remote-url, is-provider-task-error, reveal-command.