### PR TITLE
feat: [ENG-2483] fix self-kill under 4-level wrapper chain

### DIFF
--- a/src/oclif/commands/restart.ts
+++ b/src/oclif/commands/restart.ts
@@ -290,7 +290,7 @@ The daemon will restart automatically on the next brv command.`
         '-Command',
         'Get-CimInstance Win32_Process | ForEach-Object { "$($_.ProcessId),$($_.ParentProcessId)" }',
       ],
-      {encoding: 'utf8', windowsHide: true},
+      {encoding: 'utf8', timeout: 10_000, windowsHide: true},
     )
     if (result.status !== 0) return new Map()
     return Restart.parseWindowsProcessTable(result.stdout)
@@ -314,7 +314,11 @@ The daemon will restart automatically on the next brv command.`
    *   macOS:                      ps -A scan
    *   Windows:                    PowerShell Get-CimInstance — available Windows 8+ / PS 3.0+
    */
-  private static patternKill(patterns: string[], skipProtected = false): void {
+  private static patternKill(
+    patterns: string[],
+    skipProtected = false,
+    getPpidOf: (pid: number) => number | undefined = Restart.createDefaultGetPpidOf(),
+  ): void {
     // Self-exclusion: walk the full ancestor chain (getPpidOf is platform-aware —
     // Linux /proc, macOS ps, Windows PowerShell CIM). process.pid + process.ppid
     // are kept as explicit fallbacks in case the walker regresses or returns empty
@@ -322,12 +326,12 @@ The daemon will restart automatically on the next brv command.`
     const excludePids = new Set<number>([
       process.pid,
       process.ppid,
-      ...Restart.ancestorPids(process.pid),
+      ...Restart.ancestorPids(process.pid, getPpidOf),
     ])
 
     if (process.platform === 'win32') {
       const script = Restart.buildWindowsKillScript(patterns, excludePids, skipProtected)
-      spawnSync('powershell', ['-NoProfile', '-NonInteractive', '-Command', script], {stdio: 'ignore', windowsHide: true})
+      spawnSync('powershell', ['-NoProfile', '-NonInteractive', '-Command', script], {stdio: 'ignore', timeout: 10_000, windowsHide: true})
     } else if (process.platform === 'linux') {
       Restart.killByProcScan(patterns, excludePids, skipProtected)
     } else {
@@ -385,13 +389,18 @@ The daemon will restart automatically on the next brv command.`
   async run(): Promise<void> {
     const dataDir = getGlobalDataDir()
 
+    // Resolve the platform getPpidOf once. On Windows this loads the full
+    // Win32_Process table via PowerShell; share it across Phase 1 and Phase 3
+    // so the spawn happens only once instead of twice.
+    const getPpidOf = Restart.createDefaultGetPpidOf()
+
     // Phase 1: Kill all client processes first (TUI, MCP, headless commands).
     // Must happen BEFORE daemon kill — clients have reconnectors that will
     // respawn the daemon via ensureDaemonRunning() if they detect disconnection.
     // Self excluded by process.pid / process.ppid.
     // Protected commands (e.g. `brv update`) are spared.
     this.log('Stopping clients...')
-    Restart.patternKill(Restart.buildCliPatterns(), true)
+    Restart.patternKill(Restart.buildCliPatterns(), true, getPpidOf)
     await Restart.sleep(KILL_SETTLE_MS)
 
     // Phase 2: Graceful daemon kill via daemon.json PID.
@@ -418,7 +427,7 @@ The daemon will restart automatically on the next brv command.`
     }
 
     // Phase 3: Kill orphaned server/agent processes not tracked in daemon.json.
-    Restart.patternKill(Restart.SERVER_AGENT_PATTERNS)
+    Restart.patternKill(Restart.SERVER_AGENT_PATTERNS, false, getPpidOf)
     await Restart.sleep(KILL_SETTLE_MS)
 
     // Phase 4: Clean state files.

--- a/src/oclif/commands/restart.ts
+++ b/src/oclif/commands/restart.ts
@@ -327,7 +327,7 @@ The daemon will restart automatically on the next brv command.`
 
     if (process.platform === 'win32') {
       const script = Restart.buildWindowsKillScript(patterns, excludePids, skipProtected)
-      spawnSync('powershell', ['-Command', script], {stdio: 'ignore', windowsHide: true})
+      spawnSync('powershell', ['-NoProfile', '-NonInteractive', '-Command', script], {stdio: 'ignore', windowsHide: true})
     } else if (process.platform === 'linux') {
       Restart.killByProcScan(patterns, excludePids, skipProtected)
     } else {

--- a/src/oclif/commands/restart.ts
+++ b/src/oclif/commands/restart.ts
@@ -28,6 +28,34 @@ The daemon will restart automatically on the next brv command.`
   private static readonly SERVER_AGENT_PATTERNS = ['brv-server.js', 'agent-process.js']
 
   /**
+   * Returns the process + ancestor chain up to (but not including) pid 1.
+   *
+   * Needed to protect every bash-wrapper layer when the oclif + plugin-update chain
+   * is: outer bash (tarball) → redirect shim → inner bash (client) → node. Each layer
+   * has `bin/brv` in its cmdline and would self-kill if not excluded. `process.ppid`
+   * alone only covers the direct parent — grandparents and beyond need this walker.
+   *
+   * `getPpidOf` is injected for testability; the default queries the OS.
+   */
+  static ancestorPids(
+    startPid: number,
+    getPpidOf: (pid: number) => number | undefined = Restart.createDefaultGetPpidOf(),
+  ): number[] {
+    const chain: number[] = []
+    const visited = new Set<number>()
+    let pid = startPid
+    while (pid > 1 && !visited.has(pid)) {
+      chain.push(pid)
+      visited.add(pid)
+      const ppid = getPpidOf(pid)
+      if (ppid === undefined || ppid === pid || ppid <= 1) break
+      pid = ppid
+    }
+
+    return chain
+  }
+
+  /**
    * Builds the list of CLI script patterns used to identify brv client processes.
    *
    * All patterns are absolute paths or specific filenames to avoid false-positive matches
@@ -59,6 +87,109 @@ The daemon will restart automatically on the next brv command.`
   }
 
   /**
+   * Builds the Windows PowerShell kill script for `patternKill`.
+   *
+   * Extracted for testability — the actual spawn is a side-effect on win32. Non-finite
+   * pids (NaN/Infinity) are dropped so a stray undefined in the exclude set cannot
+   * collapse to `$_.ProcessId -ne NaN` (PowerShell-true for every row, silent skip).
+   * `$true` fallback keeps the emitted script syntactically valid when the exclude set
+   * is empty or fully non-finite — prevents a trailing `-and` from breaking PS parsing.
+   */
+  static buildWindowsKillScript(patterns: string[], excludePids: Iterable<number>, skipProtected: boolean): string {
+    const whereClause = patterns.map((p) => `$_.CommandLine -like '*${p.replaceAll("'", "''")}*'`).join(' -or ')
+    const excludeClause =
+      [...excludePids]
+        .filter((p) => Number.isFinite(p))
+        .map((p) => `$_.ProcessId -ne ${p}`)
+        .join(' -and ') || '$true'
+    const protectedClause = skipProtected
+      ? ` -and ${Restart.PROTECTED_COMMANDS.map((cmd) => `$_.CommandLine -notlike '* ${cmd} *' -and $_.CommandLine -notlike '* ${cmd}'`).join(' -and ')}`
+      : ''
+    return `Get-CimInstance Win32_Process | Where-Object { (${whereClause}) -and ${excludeClause}${protectedClause} } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }`
+  }
+
+  /**
+   * Parses a Linux `/proc/<pid>/stat` line into the ppid, or undefined if malformed.
+   *
+   * The stat format is `<pid> (<comm>) <state> <ppid> <pgrp> ...`. The comm field can
+   * contain spaces and parens, so we anchor on the last `)` — everything after
+   * `") "` is space-delimited and `ppid` is the second token.
+   *
+   * Extracted as a pure function for testability — the surrounding `getPpidOf` does
+   * a filesystem read that's awkward to mock.
+   */
+  static parseProcStat(stat: string): number | undefined {
+    const lastParen = stat.lastIndexOf(')')
+    if (lastParen === -1) return undefined
+    const rest = stat.slice(lastParen + 2).split(' ')
+    if (rest.length < 2) return undefined
+    const n = Number.parseInt(rest[1], 10)
+    return Number.isNaN(n) ? undefined : n
+  }
+
+  /**
+   * Parses `"<pid>,<ppid>\n..."` stdout from the PowerShell process-table query into
+   * a Map. Tolerates header rows, blank lines, CRLF endings, and malformed rows (any
+   * row whose pid or ppid is non-numeric is dropped silently).
+   */
+  static parseWindowsProcessTable(stdout: string): Map<number, number> {
+    const table = new Map<number, number>()
+    for (const line of stdout.split(/\r?\n/)) {
+      const [pidStr, ppidStr] = line.split(',')
+      const pid = Number.parseInt(pidStr, 10)
+      const ppid = Number.parseInt(ppidStr, 10)
+      if (Number.isFinite(pid) && Number.isFinite(ppid)) {
+        table.set(pid, ppid)
+      }
+    }
+
+    return table
+  }
+
+  /**
+   * Builds the default `getPpidOf` for the current platform.
+   *
+   * On Windows, preloads the full Win32_Process table with a single PowerShell
+   * invocation (~200 ms cold start) and returns a Map-backed closure — replaces the
+   * prior per-pid PowerShell spawn, which was O(ancestors × PS startup) per
+   * `ancestorPids` call. On Linux/macOS/other Unix, falls through to per-pid
+   * `getPpidOf` (cheap — `/proc` read or `ps -o ppid=`).
+   */
+  private static createDefaultGetPpidOf(): (pid: number) => number | undefined {
+    if (process.platform === 'win32') {
+      const table = Restart.loadWindowsProcessTable()
+      return (pid) => table.get(pid)
+    }
+
+    return (pid) => Restart.getPpidOf(pid)
+  }
+
+  /**
+   * Returns the parent PID of a given PID, or undefined if the process is gone.
+   *
+   * Windows is handled via the batched `loadWindowsProcessTable` path in
+   * `createDefaultGetPpidOf` — this function only covers Unix-family platforms:
+   *   linux         : /proc/<pid>/stat, parsed via `parseProcStat`
+   *   darwin (macOS): ps -p <pid> -o ppid=
+   *   other Unix    : same ps command as darwin
+   */
+  private static getPpidOf(pid: number): number | undefined {
+    if (process.platform === 'linux') {
+      try {
+        return Restart.parseProcStat(readFileSync(join('/proc', String(pid), 'stat'), 'utf8'))
+      } catch {
+        return undefined
+      }
+    }
+
+    // darwin (macOS) + other Unix (FreeBSD, etc.) — POSIX ps.
+    const result = spawnSync('ps', ['-p', String(pid), '-o', 'ppid='], {encoding: 'utf8'})
+    if (result.status !== 0) return undefined
+    const n = Number.parseInt(result.stdout.trim(), 10)
+    return Number.isNaN(n) ? undefined : n
+  }
+
+  /**
    * Returns true if the cmdline contains a protected command as an argument.
    * Handles both /proc null-byte delimiters (Linux) and space delimiters (macOS ps).
    */
@@ -82,7 +213,7 @@ The daemon will restart automatically on the next brv command.`
   private static killByPid(pid: number): void {
     try {
       if (process.platform === 'win32') {
-        spawnSync('taskkill', ['/pid', String(pid), '/f', '/t'], {stdio: 'ignore'})
+        spawnSync('taskkill', ['/pid', String(pid), '/f', '/t'], {stdio: 'ignore', windowsHide: true})
       } else {
         process.kill(pid, 'SIGKILL')
       }
@@ -147,11 +278,32 @@ The daemon will restart automatically on the next brv command.`
   }
 
   /**
+   * Loads the full Windows process table (pid → ppid) via one PowerShell invocation.
+   * Returns an empty map if PowerShell fails or is unavailable.
+   */
+  private static loadWindowsProcessTable(): Map<number, number> {
+    const result = spawnSync(
+      'powershell',
+      [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        'Get-CimInstance Win32_Process | ForEach-Object { "$($_.ProcessId),$($_.ParentProcessId)" }',
+      ],
+      {encoding: 'utf8', windowsHide: true},
+    )
+    if (result.status !== 0) return new Map()
+    return Restart.parseWindowsProcessTable(result.stdout)
+  }
+
+  /**
    * Pattern-kill brv processes matching the given patterns.
    *
-   * Self-exclusion: own PID and parent PID are always filtered out.
-   * The parent PID exclusion protects the oclif bin/brv bash wrapper
-   * on bundled installs (it does not use exec, so bash remains as parent).
+   * Self-exclusion covers the full ancestor chain (self → parent → grandparent → …).
+   * Required because a `brv restart` under the oclif bash wrapper + plugin-update
+   * redirect chain has up to four ancestors (outer tarball wrapper → redirect shim →
+   * inner client wrapper → node), every one of which contains `bin/brv` in its
+   * cmdline. Excluding only `process.ppid` leaves grandparents open to self-kill.
    *
    * When skipProtected is true, processes running protected commands
    * (e.g. `brv update`) are spared — prevents `brv restart` from killing
@@ -163,15 +315,19 @@ The daemon will restart automatically on the next brv command.`
    *   Windows:                    PowerShell Get-CimInstance — available Windows 8+ / PS 3.0+
    */
   private static patternKill(patterns: string[], skipProtected = false): void {
-    const excludePids = new Set([process.pid, process.ppid])
+    // Self-exclusion: walk the full ancestor chain (getPpidOf is platform-aware —
+    // Linux /proc, macOS ps, Windows PowerShell CIM). process.pid + process.ppid
+    // are kept as explicit fallbacks in case the walker regresses or returns empty
+    // on an unexpected platform — Set dedups so there's no cost.
+    const excludePids = new Set<number>([
+      process.pid,
+      process.ppid,
+      ...Restart.ancestorPids(process.pid),
+    ])
 
     if (process.platform === 'win32') {
-      const whereClause = patterns.map((p) => `$_.CommandLine -like '*${p.replaceAll("'", "''")}*'`).join(' -or ')
-      const protectedClause = skipProtected
-        ? ` -and ${Restart.PROTECTED_COMMANDS.map((cmd) => `$_.CommandLine -notlike '* ${cmd} *' -and $_.CommandLine -notlike '* ${cmd}'`).join(' -and ')}`
-        : ''
-      const script = `Get-CimInstance Win32_Process | Where-Object { (${whereClause}) -and $_.ProcessId -ne ${process.pid} -and $_.ProcessId -ne ${process.ppid}${protectedClause} } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }`
-      spawnSync('powershell', ['-Command', script], {stdio: 'ignore'})
+      const script = Restart.buildWindowsKillScript(patterns, excludePids, skipProtected)
+      spawnSync('powershell', ['-Command', script], {stdio: 'ignore', windowsHide: true})
     } else if (process.platform === 'linux') {
       Restart.killByProcScan(patterns, excludePids, skipProtected)
     } else {

--- a/test/commands/restart.test.ts
+++ b/test/commands/restart.test.ts
@@ -110,6 +110,20 @@ describe('Restart Command', () => {
     expect(command.cleanupCalls).to.have.length(1)
   })
 
+  it('passes a single shared getPpidOf to both patternKill calls', async () => {
+    // Phase 1 and Phase 3 must reuse the same getPpidOf closure so that on
+    // Windows the Win32_Process table is loaded once per restart, not twice.
+    const command = createCommand({pid: 9999, port: 50_000})
+
+    await command.run()
+
+    const phase1Call = patternKillStub.getCall(0)
+    const phase3Call = patternKillStub.getCall(1)
+    expect(phase1Call.args[2]).to.be.a('function')
+    expect(phase3Call.args[2]).to.be.a('function')
+    expect(phase1Call.args[2]).to.equal(phase3Call.args[2])
+  })
+
   describe('Phase 2: daemon kill', () => {
     it('sends SIGTERM to daemon PID when daemon info exists', async () => {
       const command = createCommand({pid: 1234, port: 50_000})
@@ -177,7 +191,7 @@ describe('Restart Command', () => {
       const phase1Call = patternKillStub.getCall(0)
       const phase3Call = patternKillStub.getCall(1)
       expect(phase1Call.args[1]).to.be.true
-      expect(phase3Call.args[1]).to.be.undefined
+      expect(phase3Call.args[1]).to.be.false
     })
 
     it('isProtectedCommand detects update in null-byte delimited cmdline (Linux)', () => {
@@ -204,6 +218,8 @@ describe('Restart Command', () => {
       expect(isProtected('node /usr/lib/byterover-cli/bin/run.js restart')).to.be.false
       // Negative: "update" as part of a path or different argument
       expect(isProtected('node /home/user/update-project/bin/run.js restart')).to.be.false
+      // Negative: "update" as a prefix of a flag at end-of-line
+      expect(isProtected('node /usr/lib/byterover-cli/bin/run.js restart --update-foo')).to.be.false
     })
   })
 

--- a/test/commands/restart.test.ts
+++ b/test/commands/restart.test.ts
@@ -6,6 +6,8 @@ import {match, restore, type SinonStub, stub} from 'sinon'
 
 import Restart from '../../src/oclif/commands/restart.js'
 
+const {buildWindowsKillScript, parseProcStat, parseWindowsProcessTable} = Restart
+
 // ==================== TestableRestartCommand ====================
 
 class TestableRestartCommand extends Restart {
@@ -236,6 +238,149 @@ describe('Restart Command', () => {
       const patterns = Restart.buildCliPatterns()
       const unique = new Set(patterns)
       expect(patterns.length).to.equal(unique.size)
+    })
+  })
+
+  describe('Restart.ancestorPids()', () => {
+    it('returns [self] when parent is pid 1 (init/launchd)', () => {
+      const chain = Restart.ancestorPids(100, (pid) => (pid === 100 ? 1 : undefined))
+      expect(chain).to.deep.equal([100])
+    })
+
+    it('walks a three-level chain (self → parent → grandparent)', () => {
+      const tree: Record<number, number> = {30: 1, 40: 30, 50: 40}
+      const chain = Restart.ancestorPids(50, (pid) => tree[pid])
+      expect(chain).to.deep.equal([50, 40, 30])
+    })
+
+    it('walks a four-level chain (self → inner → shim → outer)', () => {
+      // Mirrors brv-after-plugin-update process chain: node → inner bash → redirect shim → outer bash → zsh (exits chain)
+      const tree: Record<number, number> = {99: 1, 100: 99, 200: 100, 300: 200, 400: 300}
+      const chain = Restart.ancestorPids(400, (pid) => tree[pid])
+      expect(chain).to.deep.equal([400, 300, 200, 100, 99])
+    })
+
+    it('stops when getPpidOf returns undefined (process exited mid-walk)', () => {
+      const tree: Record<number, number | undefined> = {60: undefined, 70: 60}
+      const chain = Restart.ancestorPids(70, (pid) => tree[pid])
+      expect(chain).to.deep.equal([70, 60])
+    })
+
+    it('stops when a pid appears twice (defensive cycle guard)', () => {
+      const chain = Restart.ancestorPids(10, (pid) => (pid === 10 ? 20 : pid === 20 ? 10 : undefined))
+      expect(chain).to.deep.equal([10, 20])
+    })
+
+    it('does not include pid 1 itself (init is not a brv ancestor)', () => {
+      const chain = Restart.ancestorPids(5, (pid) => (pid === 5 ? 1 : undefined))
+      expect(chain).to.not.include(1)
+    })
+  })
+
+  describe('buildWindowsKillScript()', () => {
+    it('emits -ne <pid> for every excluded ancestor pid', () => {
+      const script = buildWindowsKillScript(['bin/brv'], [100, 200, 300], false)
+      expect(script).to.include('$_.ProcessId -ne 100')
+      expect(script).to.include('$_.ProcessId -ne 200')
+      expect(script).to.include('$_.ProcessId -ne 300')
+    })
+
+    it('filters out non-finite values (NaN, Infinity, undefined-cast) from the exclude clause', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const script = buildWindowsKillScript(['bin/brv'], [100, Number.NaN, 200, Number.POSITIVE_INFINITY] as any, false)
+      expect(script).to.include('$_.ProcessId -ne 100')
+      expect(script).to.include('$_.ProcessId -ne 200')
+      expect(script).to.not.include('NaN')
+      expect(script).to.not.include('Infinity')
+      expect(script).to.not.include('undefined')
+    })
+
+    it('escapes single quotes in patterns to avoid PS string breakouts', () => {
+      const script = buildWindowsKillScript(["path/with'quote"], [100], false)
+      expect(script).to.include("path/with''quote")
+    })
+
+    it('appends protected-command filter when skipProtected=true', () => {
+      const script = buildWindowsKillScript(['bin/brv'], [100], true)
+      expect(script).to.include("-notlike '* update *'")
+      expect(script).to.include("-notlike '* update'")
+    })
+
+    it('omits protected-command filter when skipProtected=false', () => {
+      const script = buildWindowsKillScript(['bin/brv'], [100], false)
+      expect(script).to.not.include('update')
+    })
+
+    it('emits $true fallback when excludePids is empty', () => {
+      const script = buildWindowsKillScript(['bin/brv'], [], false)
+      // Guard against a trailing dangling "-and" that breaks PS parsing
+      expect(script).to.not.match(/-and\s*[}\s]*$/)
+      expect(script).to.include('$true')
+    })
+
+    it('emits $true fallback when every excludePid is non-finite', () => {
+      const script = buildWindowsKillScript(['bin/brv'], [Number.NaN, Number.POSITIVE_INFINITY], false)
+      expect(script).to.not.match(/-and\s*[}\s]*$/)
+      expect(script).to.include('$true')
+      expect(script).to.not.include('NaN')
+      expect(script).to.not.include('Infinity')
+    })
+  })
+
+  describe('Restart.parseProcStat()', () => {
+    it('parses ppid from a standard /proc/<pid>/stat line', () => {
+      expect(parseProcStat('1234 (node) R 5678 1234 1234 0 -1 ...')).to.equal(5678)
+    })
+
+    it('handles comm containing spaces and parens', () => {
+      expect(parseProcStat('1234 (my weird (cmd) name) R 5678 1234 ...')).to.equal(5678)
+    })
+
+    it('returns undefined when input has no close paren', () => {
+      expect(parseProcStat('1234 node R 5678')).to.be.undefined
+    })
+
+    it('returns undefined when ppid field is missing', () => {
+      expect(parseProcStat('1234 (node)')).to.be.undefined
+    })
+
+    it('returns undefined when ppid is non-numeric', () => {
+      expect(parseProcStat('1234 (node) R notanumber 1234')).to.be.undefined
+    })
+
+    it('returns ppid 1 (init) correctly', () => {
+      expect(parseProcStat('100 (bash) S 1 100 100 0')).to.equal(1)
+    })
+  })
+
+  describe('Restart.parseWindowsProcessTable()', () => {
+    it('parses two-column ProcessId,ParentProcessId output', () => {
+      const table = parseWindowsProcessTable('100,1\n200,100\n300,200\n')
+      expect(table.get(100)).to.equal(1)
+      expect(table.get(200)).to.equal(100)
+      expect(table.get(300)).to.equal(200)
+    })
+
+    it('skips header lines and blank lines', () => {
+      const table = parseWindowsProcessTable('ProcessId,ParentProcessId\n\n100,1\n\n')
+      expect(table.get(100)).to.equal(1)
+      expect(table.size).to.equal(1)
+    })
+
+    it('skips malformed lines where either column is non-numeric', () => {
+      const table = parseWindowsProcessTable('foo,bar\n100,1\nalpha,200\n')
+      expect(table.size).to.equal(1)
+      expect(table.get(100)).to.equal(1)
+    })
+
+    it('tolerates CRLF line endings', () => {
+      const table = parseWindowsProcessTable('100,1\r\n200,100\r\n')
+      expect(table.get(100)).to.equal(1)
+      expect(table.get(200)).to.equal(100)
+    })
+
+    it('returns empty map for empty input', () => {
+      expect(parseWindowsProcessTable('').size).to.equal(0)
     })
   })
 })


### PR DESCRIPTION
## Summary

- **Problem:** `brv restart` self-killed and hung the terminal when invoked through the oclif bundled tarball + `@oclif/plugin-update` redirect chain (4 bash-wrapper layers).
- **Why it matters:** This made `brv update` unusable for any user on the bundled tarball install path. Two prior fix attempts over 4 days missed the root cause.
- **What changed:** `patternKill()` now excludes the entire process ancestor chain (self, parent, grandparent, ...) instead of only `process.pid` + `process.ppid`. Windows kill script extracted, hardened against non-finite pid leaks and empty exclude sets. Every Windows `spawnSync` now sets `windowsHide: true`. Adds 9 bash e2e scripts that reproduce the exact 4-level wrapper scenario.
- **What did NOT change (scope boundary):**
  - Daemon-side shutdown logic (`ShutdownHandler`, agent pool teardown, transport release) is untouched.
  - The `brv update` postrun hook is untouched (already correct).
  - Phase 2 daemon SIGTERM-then-SIGKILL flow is unchanged.
  - No public API changes, no config changes, no behavior change for `brv restart` outside the wrapper-chain bug.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [x] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [ ] Agent / Tools
- [ ] LLM Providers
- [ ] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [x] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes #2483
- Related: ENG-1592 (prior partial fix), ENG-1384 (original report)

## Root cause

- **Root cause:** `patternKill()` excluded only `process.pid` + `process.ppid` from the kill set. Under the bundled tarball + plugin-update redirect chain, the process tree is `zsh → outer bash (tarball wrapper) → redirect shim → inner bash (client wrapper) → node`. Every wrapper layer has `bin/brv` in its cmdline and matched the kill pattern. Excluding only the direct parent left the grandparent and great-grandparent bash wrappers exposed to SIGKILL, which collapsed the pipeline (exit 137) and left the terminal stuck.
- **Why this was not caught earlier:** Prior fixes (ENG-1592, ENG-1384) treated the symptom (one wrapper) instead of the topology (N wrappers). No e2e coverage existed for the redirect-chain scenario, so unit tests passed while the real install path stayed broken. This PR adds `test/e2e/restart/04-oclif-tarball.sh` to materialize the redirect shim and reproduce the exact failure before validating the fix.

## Test plan

- Coverage added:
  - [x] Unit test
  - [x] Integration test
  - [x] Manual verification only

- Test file(s):
  - `test/commands/restart.test.ts` (24 new unit tests, 41 total)
  - `test/e2e/restart/_common.sh`, `01-source-direct.sh`, `02-npm-link.sh`, `03-npm-pack.sh`, `04-oclif-tarball.sh`, `05-kill-completeness.sh`, `check-all-clean.sh`, `setup-manual-test.sh`, `cleanup-manual-test.sh`, `run-all.sh`

- Key scenarios covered:
  - 3-level and 4-level ancestor chain walks (matches the actual redirect topology)
  - Cycle guard, mid-walk process death, pid 1 exclusion
  - Windows PowerShell kill script: NaN/Infinity filtering, `$true` fallback for empty exclude set, single-quote escaping, protected-command filter on/off
  - `/proc/<pid>/stat` parsing including comm with embedded parens
  - Phase ordering (clients then daemon then orphans then cleanup)
  - Daemon kill: SIGTERM happy path, SIGTERM timeout fallback to SIGKILL, ESRCH already-dead, no-daemon-info skip
  - Protected-command exclusion in null-byte and space-delimited cmdlines (Linux + macOS + Windows)
  - E2E reproduction of the 4-level wrapper chain (`04-oclif-tarball.sh` Test 4c)
  - E2E proof that MCP, TUI, and daemon process types are all individually killed (`05-kill-completeness.sh`)

## User-visible changes

None. Behavior is identical for users on installs that already worked. Users on the bundled tarball + plugin-update path stop hitting `exit 137` and stuck terminals after `brv update` triggers `brv restart`.

## Evidence

E2E results on macOS darwin-arm64 (2026-04-24, this branch):

```
=== Test 4c: brv restart through 4-level chain (USER'S REPORTED BUG) ===
    exit=0
PASS: no self-kill in 4c (exit=0)
PASS: clean completion in 4c stdout
PASS: completion last line in 4c stdout
PASS: all-clean check (4c (4-level chain))
04 oclif-tarball: PASS

=== Verify each DEAD after restart ===
PASS: MCP (91457) dead
PASS: TUI (91459) dead
PASS: daemon (91484) dead
PASS: no self-kill in restart exit=0
05 kill-completeness: PASS
```

Unit test results:

```
$ npx mocha --forbid-only "test/commands/restart.test.ts"
  41 passing (1s)
```

## Checklist

- [x] Tests added or updated and passing (`npm test` for restart suite: 41/41)
- [x] Lint passes (`npx eslint src/oclif/commands/restart.ts test/commands/restart.test.ts`)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (verified during e2e setup: `npm run build` in `04-oclif-tarball.sh`)
- [x] Commits follow Conventional Commits format
- [ ] Documentation updated (N/A: no public API or config change)
- [x] No breaking changes
- [x] Branch is up to date with `main`

## Risks and mitigations

- **Risk:** Windows behavior is structurally verified by unit tests but not run on a live Windows host (no Windows CI). Possible drift between mocked PowerShell script generation and real PowerShell behavior on a customer machine.
  - **Mitigation:** All 3 Windows `spawnSync` paths (taskkill, PowerShell process-table load, PowerShell kill script) carry `windowsHide: true`. Kill script structurally tested for empty exclude sets, NaN/Infinity, single-quote escaping, and protected-command filter. Pre-release: run a manual smoke on a Windows VM with the npm-global install, confirm `brv restart` terminates a running TUI and the next `brv` boots a fresh daemon.

- **Risk:** Concurrent `brv restart` instances (two terminals at once) are siblings, not ancestors, so `skipProtected` (which only protects `update`) does not protect a peer `restart`. Each could kill the other.
  - **Mitigation:** This was the same in the prior code, so it is not a new regression. Single-instance assumption is standard for restart commands. Documented in [agent-tmp/restart-ship-criteria.md](agent-tmp/restart-ship-criteria.md) as AC-16 known caveat. Not user-facing.

- **Risk:** Worst-case wall time is `KILL_SETTLE_MS` × 2 + `SIGTERM_BUDGET_MS` + `KILL_VERIFY_TIMEOUT_MS` = 14 seconds. If a daemon has many agents and shutdown happens sequentially, ShutdownHandler may exceed the 8-second SIGTERM budget and the daemon falls back to SIGKILL.
  - **Mitigation:** SIGKILL fallback path is unit-tested. Worst case the daemon dies hard (still correct) instead of cleaning up gracefully. State files are still cleaned by Phase 4 regardless.
