### PR TITLE
fix: [ENG-2484] validate openai-compatible URL and defer provider activation

### DIFF
--- a/src/server/core/domain/entities/provider-registry.ts
+++ b/src/server/core/domain/entities/provider-registry.ts
@@ -258,7 +258,6 @@ export const PROVIDER_REGISTRY: Readonly<Record<string, ProviderDefinition>> = {
   'openai-compatible': {
     baseUrl: '',
     category: 'other',
-    defaultModel: 'llama3',
     description: 'OpenAI-compatible endpoint (Ollama, LM Studio, etc.)',
     envVars: ['OPENAI_COMPATIBLE_API_KEY'],
     headers: {},

--- a/src/server/core/interfaces/i-provider-config-store.ts
+++ b/src/server/core/interfaces/i-provider-config-store.ts
@@ -9,7 +9,10 @@ export interface IProviderConfigStore {
    * Marks a provider as connected.
    *
    * @param providerId The provider ID to mark as connected
-   * @param options Optional settings like default model
+   * @param options Optional settings like default model. Pass `setAsActive: false`
+   *   to skip flipping the active provider (used when the provider has no
+   *   active model yet — activating it would put the app in a half-configured
+   *   state that the welcome view interprets as "needs setup").
    */
   connectProvider: (
     providerId: string,
@@ -18,6 +21,7 @@ export interface IProviderConfigStore {
       authMethod?: 'api-key' | 'oauth'
       baseUrl?: string
       oauthAccountId?: string
+      setAsActive?: boolean
     },
   ) => Promise<void>
 

--- a/src/server/infra/storage/file-provider-config-store.ts
+++ b/src/server/infra/storage/file-provider-config-store.ts
@@ -53,7 +53,9 @@ export class FileProviderConfigStore implements IProviderConfigStore {
   }
 
   /**
-   * Marks a provider as connected.
+   * Marks a provider as connected. Defaults to also marking it as active —
+   * pass `setAsActive: false` to skip the activate step (used when the
+   * provider has no usable model yet).
    */
   public async connectProvider(
     providerId: string,
@@ -62,10 +64,12 @@ export class FileProviderConfigStore implements IProviderConfigStore {
       authMethod?: 'api-key' | 'oauth'
       baseUrl?: string
       oauthAccountId?: string
+      setAsActive?: boolean
     },
   ): Promise<void> {
     const config = await this.read()
-    const newConfig = config.withProviderConnected(providerId, options).withActiveProvider(providerId)
+    const connected = config.withProviderConnected(providerId, options)
+    const newConfig = options?.setAsActive === false ? connected : connected.withActiveProvider(providerId)
     await this.write(newConfig)
   }
 

--- a/src/server/infra/transport/handlers/provider-handler.ts
+++ b/src/server/infra/transport/handlers/provider-handler.ts
@@ -42,6 +42,7 @@ import {TransportDaemonEventNames} from '../../../core/domain/transport/schemas.
 import {getErrorMessage} from '../../../utils/error-helpers.js'
 import {processLog} from '../../../utils/process-logger.js'
 import {validateApiKey as validateApiKeyViaFetcher} from '../../http/provider-model-fetcher-registry.js'
+import {OpenAICompatibleModelFetcher} from '../../http/provider-model-fetchers.js'
 import {
   computeExpiresAt,
   exchangeCodeForTokens as defaultExchangeCodeForTokens,
@@ -50,6 +51,14 @@ import {
   ProviderCallbackServer,
   ProviderCallbackTimeoutError,
 } from '../../provider-oauth/index.js'
+
+async function defaultValidateOpenAICompatibleEndpoint(params: {
+  apiKey: string
+  baseUrl: string
+}): Promise<{error?: string; isValid: boolean}> {
+  const fetcher = new OpenAICompatibleModelFetcher(params.baseUrl, 'OpenAI Compatible')
+  return fetcher.validateApiKey(params.apiKey)
+}
 
 type OAuthFlowState = {
   awaitInProgress?: boolean
@@ -72,6 +81,11 @@ export interface ProviderHandlerDeps {
   providerKeychainStore: IProviderKeychainStore
   providerOAuthTokenStore: IProviderOAuthTokenStore
   transport: ITransportServer
+  /** Validator for openai-compatible base URL (injectable for testing) */
+  validateOpenAICompatibleEndpoint?: (params: {
+    apiKey: string
+    baseUrl: string
+  }) => Promise<{error?: string; isValid: boolean}>
 }
 
 /**
@@ -89,6 +103,10 @@ export class ProviderHandler {
   private readonly providerKeychainStore: IProviderKeychainStore
   private readonly providerOAuthTokenStore: IProviderOAuthTokenStore
   private readonly transport: ITransportServer
+  private readonly validateOpenAICompatibleEndpoint: (params: {
+    apiKey: string
+    baseUrl: string
+  }) => Promise<{error?: string; isValid: boolean}>
 
   constructor(deps: ProviderHandlerDeps) {
     this.authStateStore = deps.authStateStore
@@ -100,6 +118,8 @@ export class ProviderHandler {
     this.providerKeychainStore = deps.providerKeychainStore
     this.providerOAuthTokenStore = deps.providerOAuthTokenStore
     this.transport = deps.transport
+    this.validateOpenAICompatibleEndpoint =
+      deps.validateOpenAICompatibleEndpoint ?? defaultValidateOpenAICompatibleEndpoint
   }
 
   setup(): void {
@@ -240,16 +260,37 @@ export class ProviderHandler {
         return {error: 'ByteRover Provider requires authentication. Run /login or brv login to sign in', success: false}
       }
 
+      // Verify openai-compatible endpoint is reachable before persisting anything —
+      // a failed setup must not leave a placeholder config that masquerades as connected.
+      if (providerId === 'openai-compatible' && baseUrl) {
+        const validation = await this.validateOpenAICompatibleEndpoint({apiKey: apiKey ?? '', baseUrl})
+        if (!validation.isValid) {
+          const detail = validation.error ? `: ${validation.error}` : ''
+          return {
+            error: `Could not reach OpenAI-compatible endpoint at ${baseUrl}${detail}`,
+            success: false,
+          }
+        }
+      }
+
       // Store API key if provided (supports optional keys for openai-compatible)
       if (apiKey) {
         await this.providerKeychainStore.setApiKey(providerId, apiKey)
       }
 
       const provider = getProviderById(providerId)
+      // Skip activating the provider when it ends up with no active model —
+      // the welcome view treats `activeProvider w/o activeModel` as
+      // "needs setup" and unmounts any in-flight setup flow on the home
+      // page. The model:setActive handler activates the provider when the
+      // user picks a model, which is the right moment.
+      const existingActiveModel = await this.providerConfigStore.getActiveModel(providerId)
+      const willHaveActiveModel = Boolean(provider?.defaultModel ?? existingActiveModel)
       await this.providerConfigStore.connectProvider(providerId, {
         activeModel: provider?.defaultModel,
         authMethod: apiKey ? 'api-key' : undefined,
         baseUrl,
+        setAsActive: willHaveActiveModel,
       })
 
       this.transport.broadcast(TransportDaemonEventNames.PROVIDER_UPDATED, {})
@@ -300,6 +341,7 @@ export class ProviderHandler {
           const authMethod = providerConfig?.authMethod
 
           return {
+            activeModel: providerConfig?.activeModel,
             apiKeyUrl: def.apiKeyUrl,
             authMethod,
             category: def.category,

--- a/src/server/infra/transport/handlers/provider-handler.ts
+++ b/src/server/infra/transport/handlers/provider-handler.ts
@@ -261,13 +261,29 @@ export class ProviderHandler {
       }
 
       // Verify openai-compatible endpoint is reachable before persisting anything —
-      // a failed setup must not leave a placeholder config that masquerades as connected.
-      if (providerId === 'openai-compatible' && baseUrl) {
-        const validation = await this.validateOpenAICompatibleEndpoint({apiKey: apiKey ?? '', baseUrl})
+      // a failed setup must not leave a placeholder config that masquerades as
+      // connected. Falls back to existing baseUrl/keychain key on reconfigure
+      // when the request omits them, so a partial reconfigure (e.g. only changing
+      // the URL) still validates with the user's stored credentials.
+      if (providerId === 'openai-compatible') {
+        const existingBaseUrl = await this.providerConfigStore.read().then((c) => c.getBaseUrl(providerId))
+        const effectiveBaseUrl = baseUrl ?? existingBaseUrl
+        if (!effectiveBaseUrl) {
+          return {
+            error: 'A base URL is required for OpenAI-compatible providers (e.g. http://localhost:11434/v1)',
+            success: false,
+          }
+        }
+
+        const effectiveApiKey = apiKey ?? (await this.providerKeychainStore.getApiKey(providerId)) ?? ''
+        const validation = await this.validateOpenAICompatibleEndpoint({
+          apiKey: effectiveApiKey,
+          baseUrl: effectiveBaseUrl,
+        })
         if (!validation.isValid) {
           const detail = validation.error ? `: ${validation.error}` : ''
           return {
-            error: `Could not reach OpenAI-compatible endpoint at ${baseUrl}${detail}`,
+            error: `Could not reach OpenAI-compatible endpoint at ${effectiveBaseUrl}${detail}`,
             success: false,
           }
         }
@@ -284,8 +300,8 @@ export class ProviderHandler {
       // "needs setup" and unmounts any in-flight setup flow on the home
       // page. The model:setActive handler activates the provider when the
       // user picks a model, which is the right moment.
-      const existingActiveModel = await this.providerConfigStore.getActiveModel(providerId)
-      const willHaveActiveModel = Boolean(provider?.defaultModel ?? existingActiveModel)
+      const willHaveActiveModel = Boolean(provider?.defaultModel)
+        || Boolean(await this.providerConfigStore.getActiveModel(providerId))
       await this.providerConfigStore.connectProvider(providerId, {
         activeModel: provider?.defaultModel,
         authMethod: apiKey ? 'api-key' : undefined,

--- a/src/shared/transport/types/dto.ts
+++ b/src/shared/transport/types/dto.ts
@@ -79,6 +79,8 @@ export interface ConnectorDTO {
 // ============================================================================
 
 export interface ProviderDTO {
+  /** Currently selected model for this provider, if any. Absent means connected but model not yet picked. */
+  activeModel?: string
   apiKeyUrl?: string
   authMethod?: 'api-key' | 'oauth'
   category: 'other' | 'popular'

--- a/src/tui/features/provider/components/provider-flow.tsx
+++ b/src/tui/features/provider/components/provider-flow.tsx
@@ -42,6 +42,17 @@ interface ProviderAction {
   name: string
 }
 
+/**
+ * Throws on transport responses that ack with `success: false` so the
+ * existing try/catch surfaces server-side errors instead of silently
+ * marching forward into the next step.
+ */
+function ensureSuccess(response: {error?: string; success: boolean}): void {
+  if (!response.success) {
+    throw new Error(response.error ?? 'Operation failed')
+  }
+}
+
 export interface ProviderFlowProps {
   /** Hide the Cancel keybind in provider selection */
   hideCancelButton?: boolean
@@ -165,9 +176,15 @@ export const ProviderFlow: React.FC<ProviderFlowProps> = ({
       return
     }
 
-    // Already connected → show actions menu
+    // Already connected → show actions menu. Exception: a non-byterover
+    // provider that's the active provider but has no model picked yet
+    // jumps straight to the model picker so the welcome view's user can
+    // finish setup. For non-current half-configured providers we still
+    // show the actions menu so Disconnect / Set as active stay reachable
+    // (the picker would otherwise be a dead-end if the endpoint is down).
     if (provider.isConnected) {
-      setStep('provider_actions')
+      const needsModelPick = provider.id !== 'byterover' && !provider.activeModel && provider.isCurrent
+      setStep(needsModelPick ? 'model_select' : 'provider_actions')
       return
     }
 
@@ -321,15 +338,19 @@ export const ProviderFlow: React.FC<ProviderFlowProps> = ({
 
     setStep('connecting')
     try {
-      await connectMutation.mutateAsync({
+      ensureSuccess(await connectMutation.mutateAsync({
         apiKey: apiKey || undefined,
         baseUrl: baseUrl || undefined,
         providerId: selectedProvider.id,
-      })
+      }))
       setStep('model_select')
     } catch (error_) {
       setError(formatTransportError(error_))
-      setStep('api_key')
+      // Server rejection (e.g. unreachable openai-compatible URL) — return to
+      // the provider list where the error is rendered. The user can re-enter
+      // the flow with a corrected URL or API key.
+      setStep('select')
+      setBaseUrl(null)
     }
   }, [baseUrl, connectMutation, selectedProvider])
 

--- a/src/tui/features/provider/components/provider-flow.tsx
+++ b/src/tui/features/provider/components/provider-flow.tsx
@@ -176,14 +176,17 @@ export const ProviderFlow: React.FC<ProviderFlowProps> = ({
       return
     }
 
-    // Already connected → show actions menu. Exception: a non-byterover
-    // provider that's the active provider but has no model picked yet
-    // jumps straight to the model picker so the welcome view's user can
-    // finish setup. For non-current half-configured providers we still
-    // show the actions menu so Disconnect / Set as active stay reachable
-    // (the picker would otherwise be a dead-end if the endpoint is down).
+    // Already connected → show actions menu. Exception: openai-compatible
+    // is the only provider that can land in a connected-but-no-active-model
+    // state (no canonical defaultModel exists for arbitrary endpoints), so
+    // when it's the current provider we jump straight to the model picker
+    // so the welcome view's user can finish setup. For non-current
+    // half-configured providers we still show the actions menu so
+    // Disconnect / Set as active stay reachable (the picker would otherwise
+    // be a dead-end if the endpoint is down).
     if (provider.isConnected) {
-      const needsModelPick = provider.id !== 'byterover' && !provider.activeModel && provider.isCurrent
+      const needsModelPick =
+        provider.id === 'openai-compatible' && !provider.activeModel && provider.isCurrent
       setStep(needsModelPick ? 'model_select' : 'provider_actions')
       return
     }
@@ -348,8 +351,11 @@ export const ProviderFlow: React.FC<ProviderFlowProps> = ({
       setError(formatTransportError(error_))
       // Server rejection (e.g. unreachable openai-compatible URL) — return to
       // the provider list where the error is rendered. The user can re-enter
-      // the flow with a corrected URL or API key.
+      // the flow with a corrected URL or API key. Mirror the other failure
+      // paths (e.g. handleSelect at the byterover branch) by clearing the
+      // selected provider too.
       setStep('select')
+      setSelectedProvider(null)
       setBaseUrl(null)
     }
   }, [baseUrl, connectMutation, selectedProvider])

--- a/test/unit/core/domain/entities/provider-registry.test.ts
+++ b/test/unit/core/domain/entities/provider-registry.test.ts
@@ -97,6 +97,11 @@ describe('Provider Registry', () => {
       expect(provider?.oauth).to.be.undefined
     })
 
+    it('should not have a defaultModel for openai-compatible (no sensible placeholder for self-hosted endpoints)', () => {
+      const provider = getProviderById('openai-compatible')
+      expect(provider?.defaultModel).to.be.undefined
+    })
+
     it('should not have oauth config for byterover', () => {
       const provider = getProviderById('byterover')
       expect(provider?.oauth).to.be.undefined

--- a/test/unit/infra/transport/handlers/model-handler.test.ts
+++ b/test/unit/infra/transport/handlers/model-handler.test.ts
@@ -94,6 +94,38 @@ describe('ModelHandler', () => {
       expect(providerConfigStore.setActiveModel.calledBefore(transport.broadcast)).to.be.true
     })
 
+    it('should activate the provider when picking a model (load-bearing for openai-compatible deferred-activation)', async () => {
+      // The openai-compatible connect path passes setAsActive: false when no
+      // active model will be set. The provider only becomes active once a
+      // model is picked here — so this call MUST flip activeProvider, or
+      // the openai-compatible setup flow ends up "connected but never
+      // active". A regression that drops this call would silently break it.
+      providerConfigStore.read.resolves(
+        ProviderConfig.fromJson({
+          activeProvider: '',
+          providers: {
+            'openai-compatible': {
+              authMethod: 'api-key',
+              baseUrl: 'http://localhost:11434/v1',
+              connectedAt: new Date().toISOString(),
+              favoriteModels: [],
+              recentModels: [],
+            },
+          },
+        }),
+      )
+
+      createHandler()
+
+      const handler = transport._handlers.get(ModelEvents.SET_ACTIVE)
+      const result = await handler!({modelId: 'qwen3.5-9b', providerId: 'openai-compatible'}, 'client-1')
+
+      expect(result).to.deep.equal({success: true})
+      expect(providerConfigStore.setActiveProvider.calledWith('openai-compatible')).to.be.true
+      expect(providerConfigStore.setActiveModel.calledWith('openai-compatible', 'qwen3.5-9b')).to.be.true
+      expect(providerConfigStore.setActiveProvider.calledBefore(providerConfigStore.setActiveModel)).to.be.true
+    })
+
     it('should reject when provider is not connected', async () => {
       createHandler()
 

--- a/test/unit/infra/transport/handlers/provider-handler.test.ts
+++ b/test/unit/infra/transport/handlers/provider-handler.test.ts
@@ -99,6 +99,28 @@ describe('ProviderHandler', () => {
     return handler
   }
 
+  function createHandlerWithValidator(
+    validateOpenAICompatibleEndpoint: (params: {apiKey: string; baseUrl: string}) => Promise<{
+      error?: string
+      isValid: boolean
+    }>,
+  ): ProviderHandler {
+    const handler = new ProviderHandler({
+      authStateStore,
+      browserLauncher,
+      createCallbackServer: () => mockCallbackServer as unknown as ProviderCallbackServer,
+      exchangeCodeForTokens: exchangeCodeStub,
+      generatePkce: generatePkceStub,
+      providerConfigStore,
+      providerKeychainStore,
+      providerOAuthTokenStore,
+      transport,
+      validateOpenAICompatibleEndpoint,
+    })
+    handler.setup()
+    return handler
+  }
+
   describe('setup', () => {
     it('should register all provider event handlers', () => {
       createHandler()
@@ -159,6 +181,143 @@ describe('ProviderHandler', () => {
       await handler!({providerId: 'byterover'}, 'client-1')
 
       expect(providerConfigStore.connectProvider.calledBefore(transport.broadcast)).to.be.true
+    })
+
+    describe('openai-compatible URL validation', () => {
+      it('should validate base URL via injected validator before persisting anything', async () => {
+        const validateStub = stub<
+          [{apiKey: string; baseUrl: string}],
+          Promise<{error?: string; isValid: boolean}>
+        >().resolves({isValid: true})
+        createHandlerWithValidator(validateStub)
+
+        const connectHandler = transport._handlers.get(ProviderEvents.CONNECT)
+        const result = await connectHandler!(
+          {apiKey: 'test-key', baseUrl: 'http://localhost:11434/v1', providerId: 'openai-compatible'},
+          'client-1',
+        )
+
+        expect(result).to.deep.equal({success: true})
+        expect(validateStub.calledOnce).to.be.true
+        expect(validateStub.firstCall.args[0]).to.deep.equal({
+          apiKey: 'test-key',
+          baseUrl: 'http://localhost:11434/v1',
+        })
+        expect(validateStub.calledBefore(providerKeychainStore.setApiKey)).to.be.true
+        expect(validateStub.calledBefore(providerConfigStore.connectProvider)).to.be.true
+      })
+
+      it('should return error and persist nothing when endpoint validation fails', async () => {
+        const validateStub = stub<
+          [{apiKey: string; baseUrl: string}],
+          Promise<{error?: string; isValid: boolean}>
+        >().resolves({error: 'connect ECONNREFUSED', isValid: false})
+        createHandlerWithValidator(validateStub)
+
+        const connectHandler = transport._handlers.get(ProviderEvents.CONNECT)
+        const result = await connectHandler!(
+          {apiKey: 'test-key', baseUrl: 'http://nope', providerId: 'openai-compatible'},
+          'client-1',
+        )
+
+        expect(result.success).to.be.false
+        expect(result.error).to.include('http://nope')
+        expect(result.error).to.include('connect ECONNREFUSED')
+        expect(providerKeychainStore.setApiKey.notCalled).to.be.true
+        expect(providerConfigStore.connectProvider.notCalled).to.be.true
+        expect(transport.broadcast.notCalled).to.be.true
+      })
+
+      it('should not pre-write activeModel for openai-compatible', async () => {
+        const validateStub = stub<
+          [{apiKey: string; baseUrl: string}],
+          Promise<{error?: string; isValid: boolean}>
+        >().resolves({isValid: true})
+        createHandlerWithValidator(validateStub)
+
+        const connectHandler = transport._handlers.get(ProviderEvents.CONNECT)
+        await connectHandler!(
+          {baseUrl: 'http://localhost:11434/v1', providerId: 'openai-compatible'},
+          'client-1',
+        )
+
+        const connectArgs = providerConfigStore.connectProvider.firstCall.args[1] as Record<string, unknown>
+        expect(connectArgs.activeModel).to.be.undefined
+        expect(connectArgs.baseUrl).to.equal('http://localhost:11434/v1')
+      })
+
+      it('should skip validation when baseUrl is missing', async () => {
+        const validateStub = stub<
+          [{apiKey: string; baseUrl: string}],
+          Promise<{error?: string; isValid: boolean}>
+        >().resolves({isValid: true})
+        createHandlerWithValidator(validateStub)
+
+        const connectHandler = transport._handlers.get(ProviderEvents.CONNECT)
+        const result = await connectHandler!({providerId: 'openai-compatible'}, 'client-1')
+
+        expect(result).to.deep.equal({success: true})
+        expect(validateStub.notCalled).to.be.true
+      })
+
+      it('should not validate non-openai-compatible providers', async () => {
+        const validateStub = stub<
+          [{apiKey: string; baseUrl: string}],
+          Promise<{error?: string; isValid: boolean}>
+        >().resolves({isValid: true})
+        createHandlerWithValidator(validateStub)
+
+        const connectHandler = transport._handlers.get(ProviderEvents.CONNECT)
+        await connectHandler!({apiKey: 'test-key', providerId: 'openrouter'}, 'client-1')
+
+        expect(validateStub.notCalled).to.be.true
+      })
+
+      it('should not activate openai-compatible when no active model will be set', async () => {
+        const validateStub = stub<
+          [{apiKey: string; baseUrl: string}],
+          Promise<{error?: string; isValid: boolean}>
+        >().resolves({isValid: true})
+        providerConfigStore.getActiveModel.withArgs('openai-compatible').resolves()
+        createHandlerWithValidator(validateStub)
+
+        const connectHandler = transport._handlers.get(ProviderEvents.CONNECT)
+        await connectHandler!(
+          {baseUrl: 'http://localhost:11434/v1', providerId: 'openai-compatible'},
+          'client-1',
+        )
+
+        const connectArgs = providerConfigStore.connectProvider.firstCall.args[1] as Record<string, unknown>
+        expect(connectArgs.setAsActive).to.equal(false)
+      })
+
+      it('should activate openai-compatible when an existing active model will be preserved', async () => {
+        const validateStub = stub<
+          [{apiKey: string; baseUrl: string}],
+          Promise<{error?: string; isValid: boolean}>
+        >().resolves({isValid: true})
+        providerConfigStore.getActiveModel.withArgs('openai-compatible').resolves('qwen3.5-9b')
+        createHandlerWithValidator(validateStub)
+
+        const connectHandler = transport._handlers.get(ProviderEvents.CONNECT)
+        await connectHandler!(
+          {baseUrl: 'http://localhost:11434/v1', providerId: 'openai-compatible'},
+          'client-1',
+        )
+
+        const connectArgs = providerConfigStore.connectProvider.firstCall.args[1] as Record<string, unknown>
+        expect(connectArgs.setAsActive).to.equal(true)
+      })
+    })
+
+    it('should activate non-openai-compatible providers (registry has a defaultModel)', async () => {
+      createHandler()
+
+      const handler = transport._handlers.get(ProviderEvents.CONNECT)
+      await handler!({apiKey: 'test-key', providerId: 'openrouter'}, 'client-1')
+
+      const connectArgs = providerConfigStore.connectProvider.firstCall.args[1] as Record<string, unknown>
+      expect(connectArgs.setAsActive).to.equal(true)
     })
   })
 

--- a/test/unit/infra/transport/handlers/provider-handler.test.ts
+++ b/test/unit/infra/transport/handlers/provider-handler.test.ts
@@ -184,6 +184,13 @@ describe('ProviderHandler', () => {
     })
 
     describe('openai-compatible URL validation', () => {
+      beforeEach(() => {
+        // setupConnect now reads existing config to fall back on stored
+        // baseUrl/apiKey when the request omits them — give the mock a
+        // sensible default so each test doesn't have to wire it up.
+        providerConfigStore.read.resolves(ProviderConfig.createDefault())
+      })
+
       it('should validate base URL via injected validator before persisting anything', async () => {
         const validateStub = stub<
           [{apiKey: string; baseUrl: string}],
@@ -246,18 +253,59 @@ describe('ProviderHandler', () => {
         expect(connectArgs.baseUrl).to.equal('http://localhost:11434/v1')
       })
 
-      it('should skip validation when baseUrl is missing', async () => {
+      it('should reject with friendly error when no baseUrl is provided and none is stored', async () => {
         const validateStub = stub<
           [{apiKey: string; baseUrl: string}],
           Promise<{error?: string; isValid: boolean}>
         >().resolves({isValid: true})
+        providerConfigStore.read.resolves(ProviderConfig.createDefault())
+        createHandlerWithValidator(validateStub)
+
+        const connectHandler = transport._handlers.get(ProviderEvents.CONNECT)
+        const result = await connectHandler!({providerId: 'openai-compatible'}, 'client-1')
+
+        expect(result.success).to.be.false
+        expect(result.error).to.include('base URL is required')
+        expect(validateStub.notCalled).to.be.true
+        expect(providerConfigStore.connectProvider.notCalled).to.be.true
+      })
+
+      it('should validate with the stored baseUrl when the request omits it', async () => {
+        const validateStub = stub<
+          [{apiKey: string; baseUrl: string}],
+          Promise<{error?: string; isValid: boolean}>
+        >().resolves({isValid: true})
+        const stored = ProviderConfig.createDefault().withProviderConnected('openai-compatible', {
+          baseUrl: 'http://stored:11434/v1',
+        })
+        providerConfigStore.read.resolves(stored)
         createHandlerWithValidator(validateStub)
 
         const connectHandler = transport._handlers.get(ProviderEvents.CONNECT)
         const result = await connectHandler!({providerId: 'openai-compatible'}, 'client-1')
 
         expect(result).to.deep.equal({success: true})
-        expect(validateStub.notCalled).to.be.true
+        expect(validateStub.firstCall.args[0]).to.deep.include({baseUrl: 'http://stored:11434/v1'})
+      })
+
+      it('should validate with the stored API key when the request omits it', async () => {
+        const validateStub = stub<
+          [{apiKey: string; baseUrl: string}],
+          Promise<{error?: string; isValid: boolean}>
+        >().resolves({isValid: true})
+        providerKeychainStore.getApiKey.withArgs('openai-compatible').resolves('stored-key')
+        createHandlerWithValidator(validateStub)
+
+        const connectHandler = transport._handlers.get(ProviderEvents.CONNECT)
+        await connectHandler!(
+          {baseUrl: 'http://localhost:11434/v1', providerId: 'openai-compatible'},
+          'client-1',
+        )
+
+        expect(validateStub.firstCall.args[0]).to.deep.equal({
+          apiKey: 'stored-key',
+          baseUrl: 'http://localhost:11434/v1',
+        })
       })
 
       it('should not validate non-openai-compatible providers', async () => {

--- a/test/unit/infra/transport/handlers/provider-handler.test.ts
+++ b/test/unit/infra/transport/handlers/provider-handler.test.ts
@@ -917,6 +917,22 @@ describe('ProviderHandler', () => {
       expect(openaiProvider?.authMethod).to.equal('oauth')
       expect(openaiProvider?.requiresApiKey).to.be.false
     })
+
+    it('should expose activeModel as undefined for openai-compatible connected without a model', async () => {
+      const config = ProviderConfig.createDefault().withProviderConnected('openai-compatible', {
+        baseUrl: 'http://localhost:11434/v1',
+      })
+      providerConfigStore.read.resolves(config)
+      providerConfigStore.isProviderConnected.withArgs('openai-compatible').resolves(true)
+      createHandler()
+
+      const handler = transport._handlers.get(ProviderEvents.LIST)
+      const result = await handler!(undefined, 'client-1')
+
+      const openaiCompat = result.providers.find((p: {id: string}) => p.id === 'openai-compatible')
+      expect(openaiCompat?.isConnected).to.be.true
+      expect(openaiCompat?.activeModel).to.be.undefined
+    })
   })
 
   describe('provider:cancelOAuth', () => {


### PR DESCRIPTION
## Summary

- Problem: First-time onboarding for the OpenAI-compatible provider silently set `llama3` as the active model — a placeholder that doesn't exist on most users' Ollama/LM Studio setups. A bad base URL was accepted as "connected" with no validation, and the resulting half-configured state could hang the REPL after a disconnect/reconnect cycle.
- Why it matters: Linear ENG-2484 reports the visible symptom (agent uses a non-existent model on first connect). The follow-on issues — TUI hang, welcome-page-mid-flow detour — are deterministic regressions from the same root design (writing a placeholder + flipping `activeProvider` before the user has a usable model).
- What changed:
  - Removed `defaultModel: 'llama3'` from the `openai-compatible` registry entry (no sensible canonical default exists).
  - Added server-side `/models` validation in `setupConnect` for openai-compatible — bad URL → `{success: false}` with a friendly message; no keychain or config write.
  - Added `setAsActive?: boolean` option to `connectProvider`. `setupConnect` now skips `withActiveProvider` when no `activeModel` will be set, preventing the welcome-page-mid-flow detour that unmounted the slash command's `ProviderFlow` and hung the REPL.
  - Exposed `activeModel` on `ProviderDTO` so the TUI can route a connected-but-no-model provider to the model picker directly (only when the provider is current — non-current half-configured providers still reach the actions menu so Disconnect stays accessible).
  - TUI's `handleApiKeySuccess` now checks `response.success` and surfaces the server's error inline at the provider list (previously swallowed silently).
- What did NOT change (scope boundary): Other providers' connect/disconnect/setActive flows. ByteRover's special-cased flows. The `ApiKeyDialog` validation contract for non-openai-compatible providers. The picker UI itself. The `model:setActive` handler.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [x] TUI / REPL
- [ ] Agent / Tools
- [x] LLM Providers
- [x] Server / Daemon
- [x] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes ENG-2484
- Related N/A

## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause: `setupConnect` always wrote `activeModel: provider?.defaultModel` and called `withActiveProvider` unconditionally. For openai-compatible, `defaultModel: 'llama3'` was a placeholder that almost never matched the user's actual server. Combined with no URL validation, this meant any connect attempt — successful or not — committed `{activeProvider: 'openai-compatible', activeModel: 'llama3'}` to disk. The picker step in the TUI either fetched empty models from a wrong URL or showed a model the user hadn't picked. Removing the placeholder without also gating `withActiveProvider` introduced a different bug: the half-configured state (`activeProvider` set, `activeModel` undefined) was interpreted by `useAppViewMode` as `'config-provider'`, causing the welcome page to mount mid-flow and unmount the slash command's `ProviderFlow` before its `onComplete` could fire — leaving the REPL stuck.
- Why this was not caught earlier: The original placeholder masked the "active provider with no active model" state from `useAppViewMode`, so the welcome-page-mid-flow detour was only possible after the placeholder was removed. The first iteration of this fix removed the placeholder without addressing the activation contract, exposing the second bug deterministically. Tests now pin both behaviors.

## Test plan

- Coverage added:
  - [x] Unit test
  - [ ] Integration test
  - [x] Manual verification only
- Test file(s):
  - `test/unit/core/domain/entities/provider-registry.test.ts` — pins `openai-compatible.defaultModel === undefined`.
  - `test/unit/infra/transport/handlers/provider-handler.test.ts` — 8 new tests covering URL validation, no-pre-write of `activeModel`, `setAsActive` decisions across openai-compatible (no-existing-model and existing-model paths) and non-openai-compatible providers.
- Key scenario(s) covered:
  - Bad/unreachable openai-compatible URL → `{success: false}`, no keychain write, no config write, no broadcast.
  - Good URL → `{success: true}`, no `activeModel` placeholder, `setAsActive` reflects whether a model will end up set.
  - Reconfigure preserves existing `activeModel` → activation re-enabled.
  - Non-openai-compatible providers untouched (still activate via `defaultModel`).
- Manual verification:
  - CLI repro of the deterministic hang scenario (disconnect openai-compatible from non-current state, reconnect to mock URL): `activeProvider` correctly remained at the prior provider; openai-compatible was connected without `activeModel`; no welcome-page detour.
  - TUI verified end-to-end by the requester: disconnect/reconnect on openai-compatible no longer hangs; bad URL surfaces inline at the provider list; picker shows real models from the user's Ollama; non-current half-configured providers reach the actions menu (Disconnect accessible).

## User-visible changes

- Bad base URL on openai-compatible now produces an inline error at the provider list (`Could not reach OpenAI-compatible endpoint at <URL>: <details>`) instead of silently committing a broken config.
- A successful first-time connect to openai-compatible no longer pre-selects a model. The picker is rendered with the user's actual `/models` listing, and the user must select one for the provider to become active.
- Disconnect/reconnect of openai-compatible from the home page no longer hangs the REPL.
- For openai-compatible specifically: if the provider is connected but no model has been picked yet, picking it from the welcome page jumps straight to the model picker; from `/providers` (non-current case) the actions menu is shown with Disconnect reachable.

## Evidence

- 6881 unit tests pass (`npm test`); typecheck clean; build succeeds.
- CLI verification: `brv providers connect openai-compatible --base-url http://localhost:1/nope` returns `{"success":false,"error":"Could not reach OpenAI-compatible endpoint at http://localhost:1/nope: API error: "}` with no state pollution. Good-URL connect produces config without `activeModel`.
- TUI deterministic repro (disconnect openai-compatible while another provider is current → reconnect → pick model): `activeProvider` preserved during connect, slash command flow stays mounted, no hang.

## Checklist

- [x] Tests added or updated and passing (`npm test`) — 6881 passing
- [ ] Lint passes (`npm run lint`) — full lint blocked by pre-existing submodule config issue (`@workspace/typescript-config/react-library.json` not found in `packages/byterover-packages/ui/`); confirmed by stashing changes. Targeted lint on changed files is clean.
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated (if applicable) — N/A
- [x] No breaking changes
- [x] Branch is up to date with `main`

## Risks and mitigations

- Risk: Other consumers of `connectProvider` (currently only the OAuth callback handler) might rely on the implicit `withActiveProvider`. Mitigation: `setAsActive` defaults to `true`, so callers that don't pass it preserve existing behavior. The OAuth handler always supplies a `defaultModel`, so its `setAsActive` would be `true` regardless. Verified: existing OAuth tests still pass.
- Risk: Users with stale post-original-fix state (`activeProvider: 'openai-compatible'` with no `activeModel`) land on the welcome page on first launch. Mitigation: the TUI auto-route in `handleSelect` jumps to the model picker when the user picks the current half-configured provider, so they can finish setup in one screen.
- Risk: If the openai-compatible endpoint responds `200 OK` to `/models` but isn't actually OpenAI-compatible (returns garbage), validation passes and the picker may show empty/garbage. Mitigation: explicitly disclosed as a narrow edge case; user can recover via Disconnect or `brv providers disconnect`. Out of scope for this ticket.