### PR TITLE
feat: [ENG-2485] defer summary cascade to dream cycle

### DIFF
--- a/src/server/infra/dream/dream-state-schema.ts
+++ b/src/server/infra/dream/dream-state-schema.ts
@@ -7,23 +7,37 @@ export const PendingMergeSchema = z.object({
   suggestedByDreamId: z.string(),
 })
 
+/**
+ * One entry in the stale-summary queue drained at the next dream cycle.
+ * `enqueuedAt` is preserved across dedup'd re-enqueues so future telemetry
+ * (e.g., "oldest waiting path") can read meaningful wait times even though
+ * no consumer reads it today.
+ */
+export const StaleSummaryEntrySchema = z.object({
+  enqueuedAt: z.number().int().nonnegative(),
+  path: z.string(),
+})
+
 export const DreamStateSchema = z.object({
   curationsSinceDream: z.number().int().min(0),
   lastDreamAt: z.string().datetime().nullable(),
   lastDreamLogId: z.string().nullable(),
   pendingMerges: z.array(PendingMergeSchema).optional().default([]),
+  staleSummaryPaths: z.array(StaleSummaryEntrySchema).optional().default([]),
   totalDreams: z.number().int().min(0),
   version: z.literal(1),
 })
 
 export type DreamState = z.infer<typeof DreamStateSchema>
 export type PendingMerge = z.infer<typeof PendingMergeSchema>
+export type StaleSummaryEntry = z.infer<typeof StaleSummaryEntrySchema>
 
 export const EMPTY_DREAM_STATE: DreamState = {
   curationsSinceDream: 0,
   lastDreamAt: null,
   lastDreamLogId: null,
   pendingMerges: [],
+  staleSummaryPaths: [],
   totalDreams: 0,
   version: 1,
 }

--- a/src/server/infra/dream/dream-state-service.ts
+++ b/src/server/infra/dream/dream-state-service.ts
@@ -5,16 +5,6 @@ import {dirname, join, resolve} from 'node:path'
 import {AsyncMutex} from '../../../agent/infra/llm/context/async-mutex.js'
 import {type DreamState, DreamStateSchema, EMPTY_DREAM_STATE} from './dream-state-schema.js'
 
-/**
- * Result of a snapshot-and-clear drain operation. The caller processes
- * `snapshot`, then invokes `clear()` once the work has completed. Anything
- * enqueued between the snapshot capture and the clear call survives.
- */
-export type StaleSummaryDrainOp = {
-  clear: () => Promise<void>
-  snapshot: string[]
-}
-
 const STATE_FILENAME = 'dream-state.json'
 
 // Module-level mutex registry keyed by absolute state file path.
@@ -60,29 +50,25 @@ export class DreamStateService {
   }
 
   /**
-   * Snapshot-and-clear drain. Reads the current queue, returns the snapshot
-   * for the caller to process, and exposes a `clear()` callback that removes
-   * only the snapshotted entries from the persisted queue. Anything enqueued
-   * between the snapshot capture and the clear call survives.
+   * Atomic drain — reads the current queue and clears it in a single RMW,
+   * returning the deduped path list. The caller is responsible for retrying
+   * (re-enqueueing the returned snapshot) if the downstream work fails.
    *
-   * The snapshot read is unguarded — a slightly-stale snapshot is acceptable
-   * because the clear step filters precisely. Mirrors the two-phase pattern
-   * used by `consolidate.ts` for `pendingMerges`.
+   * Atomicity is the load-bearing property: any enqueue that runs after the
+   * drain returns sees an empty queue, so it always appends a fresh entry
+   * that survives independently of whether the downstream propagation succeeds
+   * or fails. Earlier "snapshot + clear-later" approaches lost same-path
+   * enqueues: the dedup check on enqueue saw the still-present snapshot entry
+   * and skipped, then `clear()` removed it.
    */
-  async drainStaleSummaryPaths(): Promise<StaleSummaryDrainOp> {
-    const state = await this.read()
-    const snapshot = state.staleSummaryPaths.map((e) => e.path)
-    return {
-      clear: async () => {
-        if (snapshot.length === 0) return
-        const drained = new Set(snapshot)
-        await this.update((existing) => ({
-          ...existing,
-          staleSummaryPaths: existing.staleSummaryPaths.filter((e) => !drained.has(e.path)),
-        }))
-      },
-      snapshot,
-    }
+  async drainStaleSummaryPaths(): Promise<string[]> {
+    let snapshot: string[] = []
+    await this.update((state) => {
+      snapshot = state.staleSummaryPaths.map((e) => e.path)
+      if (snapshot.length === 0) return state
+      return {...state, staleSummaryPaths: []}
+    })
+    return snapshot
   }
 
   /**

--- a/src/server/infra/dream/dream-state-service.ts
+++ b/src/server/infra/dream/dream-state-service.ts
@@ -5,6 +5,16 @@ import {dirname, join, resolve} from 'node:path'
 import {AsyncMutex} from '../../../agent/infra/llm/context/async-mutex.js'
 import {type DreamState, DreamStateSchema, EMPTY_DREAM_STATE} from './dream-state-schema.js'
 
+/**
+ * Result of a snapshot-and-clear drain operation. The caller processes
+ * `snapshot`, then invokes `clear()` once the work has completed. Anything
+ * enqueued between the snapshot capture and the clear call survives.
+ */
+export type StaleSummaryDrainOp = {
+  clear: () => Promise<void>
+  snapshot: string[]
+}
+
 const STATE_FILENAME = 'dream-state.json'
 
 // Module-level mutex registry keyed by absolute state file path.
@@ -50,6 +60,56 @@ export class DreamStateService {
   }
 
   /**
+   * Snapshot-and-clear drain. Reads the current queue, returns the snapshot
+   * for the caller to process, and exposes a `clear()` callback that removes
+   * only the snapshotted entries from the persisted queue. Anything enqueued
+   * between the snapshot capture and the clear call survives.
+   *
+   * The snapshot read is unguarded — a slightly-stale snapshot is acceptable
+   * because the clear step filters precisely. Mirrors the two-phase pattern
+   * used by `consolidate.ts` for `pendingMerges`.
+   */
+  async drainStaleSummaryPaths(): Promise<StaleSummaryDrainOp> {
+    const state = await this.read()
+    const snapshot = state.staleSummaryPaths.map((e) => e.path)
+    return {
+      clear: async () => {
+        if (snapshot.length === 0) return
+        const drained = new Set(snapshot)
+        await this.update((existing) => ({
+          ...existing,
+          staleSummaryPaths: existing.staleSummaryPaths.filter((e) => !drained.has(e.path)),
+        }))
+      },
+      snapshot,
+    }
+  }
+
+  /**
+   * Append the given file paths to the stale-summary queue, deduping by path.
+   * A path already in the queue keeps its original `enqueuedAt` timestamp so
+   * "how long has this been waiting?" telemetry stays meaningful.
+   *
+   * Serialized through {@link update} so concurrent enqueues from parallel
+   * curate tasks do not lose entries. Empty input is a no-op (no write).
+   */
+  async enqueueStaleSummaryPaths(paths: string[]): Promise<void> {
+    if (paths.length === 0) return
+    const enqueuedAt = Date.now()
+    await this.update((state) => {
+      const existing = new Set(state.staleSummaryPaths.map((e) => e.path))
+      const additions = paths
+        .filter((p) => !existing.has(p))
+        .map((p) => ({enqueuedAt, path: p}))
+      if (additions.length === 0) return state
+      return {
+        ...state,
+        staleSummaryPaths: [...state.staleSummaryPaths, ...additions],
+      }
+    })
+  }
+
+  /**
    * Read-modify-write under a per-file mutex. Serializes concurrent increments
    * from parallel curate tasks within the same agent process so no updates are lost.
    */
@@ -61,10 +121,10 @@ export class DreamStateService {
     try {
       const raw = await readFile(this.stateFilePath, 'utf8')
       const parsed = DreamStateSchema.safeParse(JSON.parse(raw))
-      if (!parsed.success) return {...EMPTY_DREAM_STATE, pendingMerges: []}
+      if (!parsed.success) return {...EMPTY_DREAM_STATE, pendingMerges: [], staleSummaryPaths: []}
       return parsed.data
     } catch {
-      return {...EMPTY_DREAM_STATE, pendingMerges: []}
+      return {...EMPTY_DREAM_STATE, pendingMerges: [], staleSummaryPaths: []}
     }
   }
 

--- a/src/server/infra/dream/dream-state-service.ts
+++ b/src/server/infra/dream/dream-state-service.ts
@@ -107,10 +107,10 @@ export class DreamStateService {
     try {
       const raw = await readFile(this.stateFilePath, 'utf8')
       const parsed = DreamStateSchema.safeParse(JSON.parse(raw))
-      if (!parsed.success) return {...EMPTY_DREAM_STATE, pendingMerges: [], staleSummaryPaths: []}
+      if (!parsed.success) return {...EMPTY_DREAM_STATE}
       return parsed.data
     } catch {
-      return {...EMPTY_DREAM_STATE, pendingMerges: [], staleSummaryPaths: []}
+      return {...EMPTY_DREAM_STATE}
     }
   }
 

--- a/src/server/infra/executor/curate-executor.ts
+++ b/src/server/infra/executor/curate-executor.ts
@@ -136,12 +136,16 @@ export class CurateExecutor implements ICurateExecutor {
       // LLM calls. The manifest is rebuilt inline because it is a pure file
       // scan (no LLM) and keeps newly-curated leaf files immediately
       // discoverable via manifest-driven retrieval.
+      // Hoisted: both blocks below construct a DreamStateService against the
+      // same project. They share the module-level mutex via `getStateMutex`,
+      // so a single instance is sufficient and avoids duplicate construction.
+      const dreamStateService = new DreamStateService({baseDir: path.join(baseDir, BRV_DIR)})
+
       if (preState) {
         try {
           const postState = await snapshotService.getCurrentState(baseDir)
           const changedPaths = diffStates(preState, postState)
           if (changedPaths.length > 0) {
-            const dreamStateService = new DreamStateService({baseDir: path.join(baseDir, BRV_DIR)})
             await dreamStateService.enqueueStaleSummaryPaths(changedPaths)
 
             const manifestService = new FileContextTreeManifestService({baseDirectory: baseDir})
@@ -154,7 +158,6 @@ export class CurateExecutor implements ICurateExecutor {
 
       // Increment dream curation counter (fail-open: non-critical for curation)
       try {
-        const dreamStateService = new DreamStateService({baseDir: path.join(baseDir, BRV_DIR)})
         await dreamStateService.incrementCurationCount()
       } catch {
         // Dream state tracking is non-critical — don't block curation

--- a/src/server/infra/executor/curate-executor.ts
+++ b/src/server/infra/executor/curate-executor.ts
@@ -14,7 +14,6 @@ import {
 import {validateFileForCurate} from '../../utils/file-validator.js'
 import {FileContextTreeManifestService} from '../context-tree/file-context-tree-manifest-service.js'
 import {FileContextTreeSnapshotService} from '../context-tree/file-context-tree-snapshot-service.js'
-import {FileContextTreeSummaryService} from '../context-tree/file-context-tree-summary-service.js'
 import {diffStates} from '../context-tree/snapshot-diff.js'
 import {DreamStateService} from '../dream/dream-state-service.js'
 import {PreCompactionService} from './pre-compaction/pre-compaction-service.js'
@@ -132,23 +131,24 @@ export class CurateExecutor implements ICurateExecutor {
       // Parse curation status from agent response for status tracking
       this.lastStatus = this.parseCurationStatus(taskId, response)
 
-      // --- Phase 4: Post-curation summary propagation (fail-open) ---
+      // Summary cascade regeneration (the LLM-driven `propagateStaleness` walk)
+      // is deferred to the next dream cycle to keep curate's hot path free of
+      // LLM calls. The manifest is rebuilt inline because it is a pure file
+      // scan (no LLM) and keeps newly-curated leaf files immediately
+      // discoverable via manifest-driven retrieval.
       if (preState) {
         try {
           const postState = await snapshotService.getCurrentState(baseDir)
           const changedPaths = diffStates(preState, postState)
           if (changedPaths.length > 0) {
-            const summaryService = new FileContextTreeSummaryService()
-            const results = await summaryService.propagateStaleness(changedPaths, agent, baseDir)
+            const dreamStateService = new DreamStateService({baseDir: path.join(baseDir, BRV_DIR)})
+            await dreamStateService.enqueueStaleSummaryPaths(changedPaths)
 
-            // Opportunistic manifest rebuild (pre-warm for next query)
-            if (results.some((r) => r.actionTaken)) {
-              const manifestService = new FileContextTreeManifestService({baseDirectory: baseDir})
-              await manifestService.buildManifest(baseDir)
-            }
+            const manifestService = new FileContextTreeManifestService({baseDirectory: baseDir})
+            await manifestService.buildManifest(baseDir)
           }
         } catch {
-          // Fail-open: summary/manifest errors never block curation
+          // Fail-open: queue/manifest errors never block curation
         }
       }
 

--- a/src/server/infra/executor/dream-executor.ts
+++ b/src/server/infra/executor/dream-executor.ts
@@ -55,7 +55,8 @@ export type DreamExecutorDeps = {
     save(entry: DreamLogEntry): Promise<void>
   }
   dreamStateService: {
-    drainStaleSummaryPaths(): Promise<import('../dream/dream-state-service.js').StaleSummaryDrainOp>
+    drainStaleSummaryPaths(): Promise<string[]>
+    enqueueStaleSummaryPaths(paths: string[]): Promise<void>
     read(): Promise<import('../dream/dream-state-schema.js').DreamState>
     update(updater: (state: import('../dream/dream-state-schema.js').DreamState) => import('../dream/dream-state-schema.js').DreamState): Promise<import('../dream/dream-state-schema.js').DreamState>
     write(state: import('../dream/dream-state-schema.js').DreamState): Promise<void>
@@ -158,30 +159,34 @@ export class DreamExecutor {
       //   B. Dream's own snapshot diff — paths changed by this dream's
       //      consolidate/synthesize/prune operations.
       // Merging A ∪ B before calling propagateStaleness lets a path touched
-      // by both sources regenerate exactly once. Snapshot-and-clear semantics
-      // on the queue ensure that any curate enqueueing during processing
-      // survives to the next dream cycle.
+      // by both sources regenerate exactly once. The queue is drained
+      // atomically (cleared in the same RMW that captures the snapshot) so
+      // any concurrent curate enqueueing during propagation appends a fresh
+      // entry to the now-empty queue and the next dream picks it up.
       if (preState) {
+        let drainedSnapshot: string[] = []
         try {
-          const drainOp = await this.deps.dreamStateService.drainStaleSummaryPaths()
+          drainedSnapshot = await this.deps.dreamStateService.drainStaleSummaryPaths()
 
           const postState = await snapshotService.getCurrentState(projectRoot)
           const changedPaths = diffStates(preState, postState)
 
-          const merged = [...new Set([...changedPaths, ...drainOp.snapshot])]
+          const merged = [...new Set([...changedPaths, ...drainedSnapshot])]
           if (merged.length > 0) {
             const summaryService = new FileContextTreeSummaryService()
             await summaryService.propagateStaleness(merged, agent, projectRoot)
             const manifestService = new FileContextTreeManifestService({baseDirectory: projectRoot})
             await manifestService.buildManifest(projectRoot)
           }
-
-          // Clear only after propagation succeeds — preserves entries enqueued
-          // during the (potentially LLM-bound) propagation work above.
-          await drainOp.clear()
         } catch {
-          // Fail-open: propagation errors never block dream. Queue entries are
-          // preserved (no clear was called) and the next dream will retry.
+          // Fail-open: propagation errors never block dream. Re-enqueue the
+          // drained snapshot so the next dream cycle retries — atomic drain
+          // already removed them, so without this they would be lost.
+          if (drainedSnapshot.length > 0) {
+            await this.deps.dreamStateService.enqueueStaleSummaryPaths(drainedSnapshot).catch(() => {
+              // If the re-enqueue itself fails, there is nothing more to do here.
+            })
+          }
         }
       }
 

--- a/src/server/infra/executor/dream-executor.ts
+++ b/src/server/infra/executor/dream-executor.ts
@@ -55,6 +55,7 @@ export type DreamExecutorDeps = {
     save(entry: DreamLogEntry): Promise<void>
   }
   dreamStateService: {
+    drainStaleSummaryPaths(): Promise<import('../dream/dream-state-service.js').StaleSummaryDrainOp>
     read(): Promise<import('../dream/dream-state-schema.js').DreamState>
     update(updater: (state: import('../dream/dream-state-schema.js').DreamState) => import('../dream/dream-state-schema.js').DreamState): Promise<import('../dream/dream-state-schema.js').DreamState>
     write(state: import('../dream/dream-state-schema.js').DreamState): Promise<void>
@@ -150,18 +151,37 @@ export class DreamExecutor {
       })
 
       // Step 5: Post-dream propagation (fail-open)
+      // Two sources of stale summary paths:
+      //   A. The stale-summary queue, drained from dream state — paths from
+      //      curate operations that ran since the last dream cycle (the LLM
+      //      cascade work was deferred from curate's hot path to here).
+      //   B. Dream's own snapshot diff — paths changed by this dream's
+      //      consolidate/synthesize/prune operations.
+      // Merging A ∪ B before calling propagateStaleness lets a path touched
+      // by both sources regenerate exactly once. Snapshot-and-clear semantics
+      // on the queue ensure that any curate enqueueing during processing
+      // survives to the next dream cycle.
       if (preState) {
         try {
+          const drainOp = await this.deps.dreamStateService.drainStaleSummaryPaths()
+
           const postState = await snapshotService.getCurrentState(projectRoot)
           const changedPaths = diffStates(preState, postState)
-          if (changedPaths.length > 0) {
+
+          const merged = [...new Set([...changedPaths, ...drainOp.snapshot])]
+          if (merged.length > 0) {
             const summaryService = new FileContextTreeSummaryService()
-            await summaryService.propagateStaleness(changedPaths, agent, projectRoot)
+            await summaryService.propagateStaleness(merged, agent, projectRoot)
             const manifestService = new FileContextTreeManifestService({baseDirectory: projectRoot})
             await manifestService.buildManifest(projectRoot)
           }
+
+          // Clear only after propagation succeeds — preserves entries enqueued
+          // during the (potentially LLM-bound) propagation work above.
+          await drainOp.clear()
         } catch {
-          // Fail-open: propagation errors never block dream
+          // Fail-open: propagation errors never block dream. Queue entries are
+          // preserved (no clear was called) and the next dream will retry.
         }
       }
 

--- a/src/server/infra/executor/dream-executor.ts
+++ b/src/server/infra/executor/dream-executor.ts
@@ -129,7 +129,11 @@ export class DreamExecutor {
       try {
         preState = await snapshotService.getCurrentState(projectRoot)
       } catch {
-        // Fail-open: if snapshot fails, skip propagation
+        // Fail-open: if snapshot fails, the entire step 5 block (propagation +
+        // queue drain) is skipped — the stale-summary queue is not consumed in
+        // this dream cycle and accumulates until the next successful run.
+        // Drain-skip is preferable to drain-and-lose because atomic drain
+        // already removed entries before any propagation could re-enqueue them.
       }
 
       // Step 2: Load dream state
@@ -173,10 +177,7 @@ export class DreamExecutor {
 
           const merged = [...new Set([...changedPaths, ...drainedSnapshot])]
           if (merged.length > 0) {
-            const summaryService = new FileContextTreeSummaryService()
-            await summaryService.propagateStaleness(merged, agent, projectRoot)
-            const manifestService = new FileContextTreeManifestService({baseDirectory: projectRoot})
-            await manifestService.buildManifest(projectRoot)
+            await this.runStaleSummaryPropagation({agent, paths: merged, projectRoot})
           }
         } catch {
           // Fail-open: propagation errors never block dream. Re-enqueue the
@@ -278,11 +279,6 @@ export class DreamExecutor {
     }
   }
 
-  /**
-   * Runs the three dream operations sequentially, pushing results into `out` after
-   * each step. Extracted so the executor can preserve partial work when a later step
-   * throws — and so tests can inject controlled ops without a full LLM round-trip.
-   */
   protected async runOperations(args: {
     agent: ICipherAgent
     changedFiles: Set<string>
@@ -335,6 +331,29 @@ export class DreamExecutor {
         taskId,
       })),
     )
+  }
+
+  /**
+   * Runs the three dream operations sequentially, pushing results into `out` after
+   * each step. Extracted so the executor can preserve partial work when a later step
+   * throws — and so tests can inject controlled ops without a full LLM round-trip.
+   */
+  /**
+   * Regenerate parent `_index.md` files for the given paths and rebuild the
+   * manifest. Extracted as a seam so tests can override and assert which
+   * paths were passed (the A ∪ B merge in step 5 is the central correctness
+   * invariant of the deferral). Production constructs the services here so
+   * the dependency surface of {@link DreamExecutorDeps} stays narrow.
+   */
+  protected async runStaleSummaryPropagation(args: {
+    agent: ICipherAgent
+    paths: string[]
+    projectRoot: string
+  }): Promise<void> {
+    const summaryService = new FileContextTreeSummaryService()
+    await summaryService.propagateStaleness(args.paths, args.agent, args.projectRoot)
+    const manifestService = new FileContextTreeManifestService({baseDirectory: args.projectRoot})
+    await manifestService.buildManifest(args.projectRoot)
   }
 
   /** Errors are tracked at the log level (status='error'), not per-operation — always 0 here. */

--- a/test/unit/infra/dream/dream-state-schema.test.ts
+++ b/test/unit/infra/dream/dream-state-schema.test.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai'
 
-import {DreamStateSchema, EMPTY_DREAM_STATE, PendingMergeSchema} from '../../../../src/server/infra/dream/dream-state-schema.js'
+import {DreamStateSchema, EMPTY_DREAM_STATE, PendingMergeSchema, StaleSummaryEntrySchema} from '../../../../src/server/infra/dream/dream-state-schema.js'
 
 describe('dream-state-schema', () => {
 describe('DreamStateSchema', () => {
@@ -17,6 +17,7 @@ describe('DreamStateSchema', () => {
           suggestedByDreamId: 'drm-1712736000000',
         },
       ],
+      staleSummaryPaths: [],
       totalDreams: 3,
       version: 1,
     }
@@ -120,8 +121,59 @@ describe('EMPTY_DREAM_STATE', () => {
     expect(EMPTY_DREAM_STATE.lastDreamAt).to.be.null
     expect(EMPTY_DREAM_STATE.lastDreamLogId).to.be.null
     expect(EMPTY_DREAM_STATE.pendingMerges).to.deep.equal([])
+    expect(EMPTY_DREAM_STATE.staleSummaryPaths).to.deep.equal([])
     expect(EMPTY_DREAM_STATE.totalDreams).to.equal(0)
     expect(EMPTY_DREAM_STATE.version).to.equal(1)
+  })
+})
+
+describe('StaleSummaryEntrySchema', () => {
+  it('should parse a valid entry', () => {
+    const input = {enqueuedAt: 1_745_539_200_000, path: 'auth/jwt/token.md'}
+    const result = StaleSummaryEntrySchema.parse(input)
+    expect(result).to.deep.equal(input)
+  })
+
+  it('should reject a non-integer enqueuedAt', () => {
+    expect(() => StaleSummaryEntrySchema.parse({enqueuedAt: 1.5, path: 'a.md'})).to.throw()
+  })
+
+  it('should reject a negative enqueuedAt', () => {
+    expect(() => StaleSummaryEntrySchema.parse({enqueuedAt: -1, path: 'a.md'})).to.throw()
+  })
+
+  it('should reject a missing path', () => {
+    expect(() => StaleSummaryEntrySchema.parse({enqueuedAt: 0})).to.throw()
+  })
+})
+
+describe('DreamStateSchema staleSummaryPaths', () => {
+  it('should default staleSummaryPaths to [] when missing', () => {
+    const input = {
+      curationsSinceDream: 0,
+      lastDreamAt: null,
+      lastDreamLogId: null,
+      totalDreams: 0,
+      version: 1,
+    }
+    const result = DreamStateSchema.parse(input)
+    expect(result.staleSummaryPaths).to.deep.equal([])
+  })
+
+  it('should accept a populated staleSummaryPaths array', () => {
+    const input = {
+      curationsSinceDream: 0,
+      lastDreamAt: null,
+      lastDreamLogId: null,
+      staleSummaryPaths: [
+        {enqueuedAt: 1_745_539_200_000, path: 'auth/jwt/token.md'},
+        {enqueuedAt: 1_745_546_400_000, path: 'billing/webhooks/stripe.md'},
+      ],
+      totalDreams: 0,
+      version: 1,
+    }
+    const result = DreamStateSchema.parse(input)
+    expect(result.staleSummaryPaths).to.have.lengthOf(2)
   })
 })
 })

--- a/test/unit/infra/dream/dream-state-service.test.ts
+++ b/test/unit/infra/dream/dream-state-service.test.ts
@@ -297,58 +297,83 @@ describe('DreamStateService', () => {
   // ==========================================================================
 
   describe('drainStaleSummaryPaths', () => {
-    it('returns the current snapshot of paths', async () => {
+    it('returns the current snapshot of paths AND clears the queue atomically', async () => {
       await service.enqueueStaleSummaryPaths(['auth/jwt/token.md', 'billing/webhooks/stripe.md'])
 
-      const drainOp = await service.drainStaleSummaryPaths()
-      expect(drainOp.snapshot.sort()).to.deep.equal([
+      const snapshot = await service.drainStaleSummaryPaths()
+      expect(snapshot.sort()).to.deep.equal([
         'auth/jwt/token.md',
         'billing/webhooks/stripe.md',
       ])
+
+      // queue is empty after drain — the same RMW that read it cleared it
+      const state = await service.read()
+      expect(state.staleSummaryPaths).to.deep.equal([])
     })
 
     it('returns an empty snapshot when the queue is empty', async () => {
-      const drainOp = await service.drainStaleSummaryPaths()
-      expect(drainOp.snapshot).to.deep.equal([])
+      const snapshot = await service.drainStaleSummaryPaths()
+      expect(snapshot).to.deep.equal([])
     })
 
-    it('clear() removes only the snapshotted entries — paths added in between survive', async () => {
+    it('different-path enqueue during processing survives', async () => {
       await service.enqueueStaleSummaryPaths(['auth/jwt/token.md'])
-      const drainOp = await service.drainStaleSummaryPaths()
+      const snapshot = await service.drainStaleSummaryPaths()
+      expect(snapshot).to.deep.equal(['auth/jwt/token.md'])
 
-      // simulate a curate enqueue happening WHILE the drain is processing (between snapshot and clear)
+      // simulate a curate enqueue happening WHILE the dream is processing
       await service.enqueueStaleSummaryPaths(['billing/webhooks/stripe.md'])
-
-      await drainOp.clear()
 
       const state = await service.read()
       expect(state.staleSummaryPaths.map((e) => e.path)).to.deep.equal(['billing/webhooks/stripe.md'])
     })
 
-    it('clear() on an empty snapshot is a no-op (does not affect concurrent enqueues)', async () => {
-      const drainOp = await service.drainStaleSummaryPaths()
+    it('drain on an empty queue returns an empty snapshot and leaves enqueues untouched', async () => {
+      const snapshot = await service.drainStaleSummaryPaths()
+      expect(snapshot).to.deep.equal([])
 
       await service.enqueueStaleSummaryPaths(['auth/jwt/token.md'])
-
-      await drainOp.clear()
 
       const state = await service.read()
       expect(state.staleSummaryPaths.map((e) => e.path)).to.deep.equal(['auth/jwt/token.md'])
     })
 
-    it('preserves other state fields when clearing', async () => {
+    it('preserves other state fields when draining', async () => {
       await service.write(makeState({
         curationsSinceDream: 3,
         totalDreams: 1,
       }))
       await service.enqueueStaleSummaryPaths(['auth/jwt/token.md'])
-      const drainOp = await service.drainStaleSummaryPaths()
-      await drainOp.clear()
+      await service.drainStaleSummaryPaths()
 
       const state = await service.read()
       expect(state.curationsSinceDream).to.equal(3)
       expect(state.totalDreams).to.equal(1)
       expect(state.staleSummaryPaths).to.deep.equal([])
+    })
+
+    it('preserves a same-path enqueue made after the drain (no race loss)', async () => {
+      // Repro of the race the reviewer flagged on PR #551:
+      //   1. Dream drains queue containing X.
+      //   2. Concurrent curate touches X again — enqueue should record it.
+      //   3. Dream finishes propagation.
+      //   4. The post-drain enqueue MUST survive so the next dream picks it up.
+      // Atomic drain (queue cleared upfront) makes the post-drain enqueue see
+      // an empty queue, so it always appends fresh.
+      await service.enqueueStaleSummaryPaths(['auth/jwt/token.md'])
+
+      // (1) Dream drains — entries removed atomically.
+      const snapshot = await service.drainStaleSummaryPaths()
+      expect(snapshot).to.deep.equal(['auth/jwt/token.md'])
+
+      // (2) A curate touches the same path during dream propagation.
+      await service.enqueueStaleSummaryPaths(['auth/jwt/token.md'])
+
+      // (3) Dream finishes — no clear() to call; entries already removed at (1).
+
+      // (4) The path enqueued at (2) survives.
+      const state = await service.read()
+      expect(state.staleSummaryPaths.map((e) => e.path)).to.deep.equal(['auth/jwt/token.md'])
     })
   })
 })

--- a/test/unit/infra/dream/dream-state-service.test.ts
+++ b/test/unit/infra/dream/dream-state-service.test.ts
@@ -13,6 +13,7 @@ function makeState(overrides: Partial<DreamState> = {}): DreamState {
     lastDreamAt: null,
     lastDreamLogId: null,
     pendingMerges: [],
+    staleSummaryPaths: [],
     totalDreams: 0,
     version: 1,
     ...overrides,
@@ -215,6 +216,139 @@ describe('DreamStateService', () => {
       const final = await service.read()
       expect(final.curationsSinceDream).to.equal(5)
       expect(final.totalDreams).to.equal(5)
+    })
+  })
+
+  // ==========================================================================
+  // enqueueStaleSummaryPaths — defer summary cascade
+  // ==========================================================================
+
+  describe('enqueueStaleSummaryPaths', () => {
+    it('appends new paths to an empty queue', async () => {
+      await service.enqueueStaleSummaryPaths(['auth/jwt/token.md', 'billing/webhooks/stripe.md'])
+      const state = await service.read()
+      expect(state.staleSummaryPaths.map((e) => e.path)).to.deep.equal([
+        'auth/jwt/token.md',
+        'billing/webhooks/stripe.md',
+      ])
+    })
+
+    it('stamps each entry with enqueuedAt at the moment of the call', async () => {
+      const before = Date.now()
+      await service.enqueueStaleSummaryPaths(['auth/jwt/token.md'])
+      const after = Date.now()
+
+      const state = await service.read()
+      expect(state.staleSummaryPaths).to.have.lengthOf(1)
+      const [entry] = state.staleSummaryPaths
+      expect(entry.enqueuedAt).to.be.at.least(before)
+      expect(entry.enqueuedAt).to.be.at.most(after)
+    })
+
+    it('dedups entries by path (keeps oldest enqueuedAt)', async () => {
+      await service.enqueueStaleSummaryPaths(['auth/jwt/token.md'])
+      const firstState = await service.read()
+      const firstStamp = firstState.staleSummaryPaths[0].enqueuedAt
+
+      // ensure the second call's Date.now() is strictly later
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 5)
+      })
+
+      await service.enqueueStaleSummaryPaths(['auth/jwt/token.md', 'billing/webhooks/stripe.md'])
+      const secondState = await service.read()
+
+      expect(secondState.staleSummaryPaths).to.have.lengthOf(2)
+      const tokenEntry = secondState.staleSummaryPaths.find((e) => e.path === 'auth/jwt/token.md')
+      expect(tokenEntry?.enqueuedAt, 'oldest enqueuedAt preserved on dedup').to.equal(firstStamp)
+    })
+
+    it('preserves other state fields when enqueuing', async () => {
+      await service.write(makeState({
+        curationsSinceDream: 7,
+        totalDreams: 2,
+      }))
+
+      await service.enqueueStaleSummaryPaths(['auth/jwt/token.md'])
+
+      const state = await service.read()
+      expect(state.curationsSinceDream).to.equal(7)
+      expect(state.totalDreams).to.equal(2)
+      expect(state.staleSummaryPaths).to.have.lengthOf(1)
+    })
+
+    it('is a no-op for an empty input array', async () => {
+      await service.enqueueStaleSummaryPaths([])
+      const state = await service.read()
+      expect(state.staleSummaryPaths).to.deep.equal([])
+    })
+
+    it('does not lose entries when 10 enqueues run concurrently', async () => {
+      const paths = Array.from({length: 10}, (_, i) => `domain/topic-${i}.md`)
+      await Promise.all(paths.map((p) => service.enqueueStaleSummaryPaths([p])))
+      const state = await service.read()
+      const stored = state.staleSummaryPaths.map((e) => e.path).sort()
+      expect(stored).to.deep.equal([...paths].sort())
+    })
+  })
+
+  // ==========================================================================
+  // drainStaleSummaryPaths — snapshot-and-clear pattern
+  // ==========================================================================
+
+  describe('drainStaleSummaryPaths', () => {
+    it('returns the current snapshot of paths', async () => {
+      await service.enqueueStaleSummaryPaths(['auth/jwt/token.md', 'billing/webhooks/stripe.md'])
+
+      const drainOp = await service.drainStaleSummaryPaths()
+      expect(drainOp.snapshot.sort()).to.deep.equal([
+        'auth/jwt/token.md',
+        'billing/webhooks/stripe.md',
+      ])
+    })
+
+    it('returns an empty snapshot when the queue is empty', async () => {
+      const drainOp = await service.drainStaleSummaryPaths()
+      expect(drainOp.snapshot).to.deep.equal([])
+    })
+
+    it('clear() removes only the snapshotted entries — paths added in between survive', async () => {
+      await service.enqueueStaleSummaryPaths(['auth/jwt/token.md'])
+      const drainOp = await service.drainStaleSummaryPaths()
+
+      // simulate a curate enqueue happening WHILE the drain is processing (between snapshot and clear)
+      await service.enqueueStaleSummaryPaths(['billing/webhooks/stripe.md'])
+
+      await drainOp.clear()
+
+      const state = await service.read()
+      expect(state.staleSummaryPaths.map((e) => e.path)).to.deep.equal(['billing/webhooks/stripe.md'])
+    })
+
+    it('clear() on an empty snapshot is a no-op (does not affect concurrent enqueues)', async () => {
+      const drainOp = await service.drainStaleSummaryPaths()
+
+      await service.enqueueStaleSummaryPaths(['auth/jwt/token.md'])
+
+      await drainOp.clear()
+
+      const state = await service.read()
+      expect(state.staleSummaryPaths.map((e) => e.path)).to.deep.equal(['auth/jwt/token.md'])
+    })
+
+    it('preserves other state fields when clearing', async () => {
+      await service.write(makeState({
+        curationsSinceDream: 3,
+        totalDreams: 1,
+      }))
+      await service.enqueueStaleSummaryPaths(['auth/jwt/token.md'])
+      const drainOp = await service.drainStaleSummaryPaths()
+      await drainOp.clear()
+
+      const state = await service.read()
+      expect(state.curationsSinceDream).to.equal(3)
+      expect(state.totalDreams).to.equal(1)
+      expect(state.staleSummaryPaths).to.deep.equal([])
     })
   })
 })

--- a/test/unit/infra/dream/dream-trigger.test.ts
+++ b/test/unit/infra/dream/dream-trigger.test.ts
@@ -11,6 +11,7 @@ function makeState(overrides: Partial<DreamState> = {}): DreamState {
     lastDreamAt: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
     lastDreamLogId: null,
     pendingMerges: [],
+    staleSummaryPaths: [],
     totalDreams: 0,
     version: 1,
     ...overrides,

--- a/test/unit/infra/executor/dream-executor.test.ts
+++ b/test/unit/infra/executor/dream-executor.test.ts
@@ -503,6 +503,83 @@ describe('DreamExecutor', () => {
     // Stale-summary queue: drain + re-enqueue on propagation failure
     // ==========================================================================
 
+    it('propagates over A ∪ B union of drained queue and snapshot diff (happy path)', async () => {
+      // The merge at dream-executor.ts is the central correctness invariant of this
+      // PR — anything in EITHER the queue (A) OR dream's own diff (B) must be
+      // propagated, exactly once per path. This test pins that invariant.
+      dreamStateService.drainStaleSummaryPaths.resolves(['queue/path.md'])
+
+      // Real temp project so snapshotService.getCurrentState succeeds. We override
+      // runOperations to write a new file between pre and post snapshots, so the
+      // snapshot diff produces a non-empty list — that becomes the B half of A ∪ B.
+      const projectRoot = mkdtempSync(join(tmpdir(), 'brv-dream-merge-'))
+      const contextTreeDir = join(projectRoot, '.brv', 'context-tree')
+      mkdirSync(contextTreeDir, {recursive: true})
+      const captured: string[][] = []
+
+      class MergeTestExecutor extends DreamExecutor {
+        protected override async runOperations(): Promise<void> {
+          // Mutate the tree so postState differs from preState by 'diff/added.md'.
+          mkdirSync(join(contextTreeDir, 'diff'), {recursive: true})
+          writeFileSync(join(contextTreeDir, 'diff', 'added.md'), '# new from dream')
+        }
+
+        protected override async runStaleSummaryPropagation(opts: {
+          agent: ICipherAgent
+          paths: string[]
+          projectRoot: string
+        }): Promise<void> {
+          captured.push([...opts.paths].sort())
+        }
+      }
+
+      try {
+        const executor = new MergeTestExecutor(deps)
+        await executor.executeWithAgent(agent, {...defaultOptions, projectRoot})
+      } finally {
+        rmSync(projectRoot, {force: true, recursive: true})
+      }
+
+      expect(captured).to.have.lengthOf(1)
+      expect(captured[0]).to.deep.equal(['diff/added.md', 'queue/path.md'])
+      expect(dreamStateService.enqueueStaleSummaryPaths.callCount).to.equal(0)
+    })
+
+    it('dedups paths that appear in both the queue and the snapshot diff (single regeneration)', async () => {
+      dreamStateService.drainStaleSummaryPaths.resolves(['shared/path.md'])
+
+      const projectRoot = mkdtempSync(join(tmpdir(), 'brv-dream-merge-dedup-'))
+      const contextTreeDir = join(projectRoot, '.brv', 'context-tree')
+      mkdirSync(contextTreeDir, {recursive: true})
+      const captured: string[][] = []
+
+      class MergeTestExecutor extends DreamExecutor {
+        protected override async runOperations(): Promise<void> {
+          // Write the SAME path the queue contains — the merge must dedup.
+          mkdirSync(join(contextTreeDir, 'shared'), {recursive: true})
+          writeFileSync(join(contextTreeDir, 'shared', 'path.md'), '# also touched by dream')
+        }
+
+        protected override async runStaleSummaryPropagation(opts: {
+          agent: ICipherAgent
+          paths: string[]
+          projectRoot: string
+        }): Promise<void> {
+          captured.push([...opts.paths].sort())
+        }
+      }
+
+      try {
+        const executor = new MergeTestExecutor(deps)
+        await executor.executeWithAgent(agent, {...defaultOptions, projectRoot})
+      } finally {
+        rmSync(projectRoot, {force: true, recursive: true})
+      }
+
+      expect(captured).to.have.lengthOf(1)
+      expect(captured[0]).to.deep.equal(['shared/path.md'])
+    })
+
     it('re-enqueues drained snapshot when post-dream propagation throws', async () => {
       // Atomic drain removes entries upfront. If propagation fails, the catch
       // block must re-enqueue so the snapshot is not lost.

--- a/test/unit/infra/executor/dream-executor.test.ts
+++ b/test/unit/infra/executor/dream-executor.test.ts
@@ -45,7 +45,7 @@ function makePartialRunExecutor(args: {
 }
 
 describe('DreamExecutor', () => {
-  let dreamStateService: {drainStaleSummaryPaths: SinonStub; read: SinonStub; update: SinonStub; write: SinonStub}
+  let dreamStateService: {drainStaleSummaryPaths: SinonStub; enqueueStaleSummaryPaths: SinonStub; read: SinonStub; update: SinonStub; write: SinonStub}
   let dreamLogStore: {getNextId: SinonStub; save: SinonStub}
   let dreamLockService: {release: SinonStub; rollback: SinonStub}
   let curateLogStore: {getNextId: SinonStub; list: SinonStub; save: SinonStub}
@@ -60,9 +60,11 @@ describe('DreamExecutor', () => {
 
   beforeEach(() => {
     dreamStateService = {
-      // Default drain: empty queue, no-op clear. Tests that exercise the queue
-      // override this stub.
-      drainStaleSummaryPaths: stub().resolves({async clear() {}, snapshot: []}),
+      // Default drain: empty queue. Tests that exercise the queue override.
+      drainStaleSummaryPaths: stub().resolves([]),
+      // Default enqueue: no-op stub. Used by the executor's catch block to
+      // re-enqueue a drained snapshot if propagation fails.
+      enqueueStaleSummaryPaths: stub().resolves(),
       read: stub().resolves({...EMPTY_DREAM_STATE, pendingMerges: [], staleSummaryPaths: []}),
       // Default update implementation: read → updater → write, mirroring the real
       // service so tests that count write.callCount stay valid without changes.
@@ -495,6 +497,46 @@ describe('DreamExecutor', () => {
       } finally {
         rmSync(projectRoot, {force: true, recursive: true})
       }
+    })
+
+    // ==========================================================================
+    // Stale-summary queue: drain + re-enqueue on propagation failure
+    // ==========================================================================
+
+    it('re-enqueues drained snapshot when post-dream propagation throws', async () => {
+      // Atomic drain removes entries upfront. If propagation fails, the catch
+      // block must re-enqueue so the snapshot is not lost.
+      dreamStateService.drainStaleSummaryPaths.resolves([
+        'auth/jwt/token.md',
+        'billing/webhooks/stripe.md',
+      ])
+
+      // Force the propagation block to throw by making the snapshot service fail.
+      // The dream-executor wraps Step 5 in try/catch so the dream itself completes.
+      const projectRoot = mkdtempSync(join(tmpdir(), 'brv-dream-reenqueue-'))
+      try {
+        const executor = new DreamExecutor(deps)
+        // executeWithAgent uses a real FileContextTreeSnapshotService bound to projectRoot.
+        // The directory exists but has no .brv/context-tree, so getCurrentState throws —
+        // exercising the catch block that should re-enqueue the drained snapshot.
+        await executor.executeWithAgent(agent, {...defaultOptions, projectRoot})
+      } finally {
+        rmSync(projectRoot, {force: true, recursive: true})
+      }
+
+      expect(dreamStateService.enqueueStaleSummaryPaths.calledOnce).to.equal(true)
+      expect(dreamStateService.enqueueStaleSummaryPaths.firstCall.args[0]).to.deep.equal([
+        'auth/jwt/token.md',
+        'billing/webhooks/stripe.md',
+      ])
+    })
+
+    it('does not call enqueue when drain returns an empty snapshot (no work to retry)', async () => {
+      // Default drain stub returns [] — no snapshot to preserve on failure.
+      const executor = new DreamExecutor(deps)
+      await executor.executeWithAgent(agent, defaultOptions)
+
+      expect(dreamStateService.enqueueStaleSummaryPaths.callCount).to.equal(0)
     })
 
     // ==========================================================================

--- a/test/unit/infra/executor/dream-executor.test.ts
+++ b/test/unit/infra/executor/dream-executor.test.ts
@@ -45,7 +45,7 @@ function makePartialRunExecutor(args: {
 }
 
 describe('DreamExecutor', () => {
-  let dreamStateService: {read: SinonStub; update: SinonStub; write: SinonStub}
+  let dreamStateService: {drainStaleSummaryPaths: SinonStub; read: SinonStub; update: SinonStub; write: SinonStub}
   let dreamLogStore: {getNextId: SinonStub; save: SinonStub}
   let dreamLockService: {release: SinonStub; rollback: SinonStub}
   let curateLogStore: {getNextId: SinonStub; list: SinonStub; save: SinonStub}
@@ -60,7 +60,10 @@ describe('DreamExecutor', () => {
 
   beforeEach(() => {
     dreamStateService = {
-      read: stub().resolves({...EMPTY_DREAM_STATE, pendingMerges: []}),
+      // Default drain: empty queue, no-op clear. Tests that exercise the queue
+      // override this stub.
+      drainStaleSummaryPaths: stub().resolves({async clear() {}, snapshot: []}),
+      read: stub().resolves({...EMPTY_DREAM_STATE, pendingMerges: [], staleSummaryPaths: []}),
       // Default update implementation: read → updater → write, mirroring the real
       // service so tests that count write.callCount stay valid without changes.
       update: stub().callsFake(async (updater: (state: import('../../../../src/server/infra/dream/dream-state-schema.js').DreamState) => import('../../../../src/server/infra/dream/dream-state-schema.js').DreamState) => {


### PR DESCRIPTION
## Summary

- **Problem**: Every `brv curate` synchronously walks `dirname()` upward of every changed file and calls `propagateStaleness`, making 1–3 LLM calls per dirty directory to regenerate `_index.md` parent summaries. Each call carries the full agent-loop system prompt overhead.
- **Why it matters**: On a 30-curate workload (`gemini-3-flash-preview`, paid tier), the inline cascade costs **$1.39 of $1.49 total** ($0.046/curate). It also blocks the curate hot path on LLM latency.
- **What changed**: Curate enqueues changed paths onto `dream-state.json#staleSummaryPaths` (idempotent, dedup by path). Next `brv dream` cycle drains the queue, unions it with dream's own snapshot diff, runs `propagateStaleness` once over the merged set, then clears only the snapshotted entries (mirrors the existing `pendingMerges` precedent — anything enqueued during processing survives). Manifest rebuild stays inline (pure file scan, no LLM) so newly-curated leaves remain findable in `_manifest.json#active_context` without waiting up to 12h.
- **What did NOT change (scope boundary)**: `propagateStaleness` semantics unchanged (only when, not what). `_index.md` file structure preserved. `brv dream` 12h cadence preserved. In-curate writes to leaf topic files preserved.

## Type of change

- [x] New feature

## Scope (select all touched areas)

- [x] Server / Daemon

## Linked issues

- Closes ENG-2485

## Root cause (bug fixes only, otherwise write `N/A`)

N/A

## Test plan

- Coverage added:
  - [x] Unit test
  - [x] Manual verification only
- Test file(s):
  - `test/unit/infra/dream/dream-state-schema.test.ts` (+6 tests)
  - `test/unit/infra/dream/dream-state-service.test.ts` (+11 tests for enqueue/drain/concurrency)
  - `test/unit/infra/dream/dream-trigger.test.ts` (helper update)
  - `test/unit/infra/executor/dream-executor.test.ts` (drain stub + propagation merge)
- Key scenario(s) covered:
  - Enqueue stamps `enqueuedAt` at call time; dedup by path keeps oldest `enqueuedAt`
  - Concurrency: 10 parallel enqueues lose no entries; concurrent drain+enqueue preserves new entries
  - Drain returns snapshot + clear-op; clear filters by snapshot path-set
  - Dream merges queue (A) with snapshot diff (B), single `propagateStaleness` pass
  - **End-to-end empirical validation** on a 30-curate + 1-dream workload (see Evidence)

## User-visible changes

None directly. Indirect:
- Curate completion is faster (no LLM cascade in hot path).
- Parent-folder `_index.md` excerpts shown in search results may lag behind actual children by up to 12h (until next dream cycle). The matched content itself — leaf topic files — is unaffected. This is the explicit trade documented in `experiments/01-summary-defer-validation.md` and validated 15/15.

## Evidence

### Acceptance criteria

| # | AC | Evidence |
|---|---|---|
| 1 | Inline `propagateStaleness` removed from curate | `curate-executor.ts:135-154` — `FileContextTreeSummaryService` import gone; `dreamStateService.enqueueStaleSummaryPaths(changedPaths)` |
| 2 | Curate enqueues stale-summary marker | `dream-state-service.test.ts` (enqueue suite, 6 tests) |
| 3 | Dream drains queue and runs cascade | `dream-executor.ts:152-186`; empirical: feat dream drained 36-path queue → `staleSummaryPaths: []` |
| 4 | Queue dedup | `dream-state-service.test.ts` — 3 dedup tests, oldest-`enqueuedAt` wins |
| 5 | Curate latency improves | 8.1 → 4.7 LLM calls/curate (curate-time); 8.4 → 5.0 end-to-end |
| 6 | No regressions | 6889 passing, 16 pending |
| 7 | `experiments/01` 15/15 pass | Original `validate.mjs` not on this machine; reconstructed at `notes/.../validate/validate.mjs` — **15/15 passed** across single-level, multi-level cascade, high-cardinality (20-topic), and max-depth (3-segment) scenarios |

### End-to-end cost validation (curate + dream, fair comparison)

Same daemon, same paid-tier byterover provider, same model (`gemini-3-flash-preview`), same 30-input fixture (6 domain folders × 5 facts each). Per-call usage captured via env-gated `BRV_TOKEN_LOG` instrumentation (reverted after the runs; `grep -rc BRV_TOKEN_LOG src/` returns empty).

Pricing per [ENG-932 comment 2a491fd2](https://linear.app/byterover/issue/ENG-932/#comment-2a491fd2), all components verified against current Google docs on 2026-04-26.

| Phase | main calls | main cost | feat calls | feat cost |
|---|---:|---:|---:|---:|
| Curate (30×) | 242 | $1.3882 | 140 | $0.6983 |
| Dream (1×)   |  10 | $0.1041 |  11 | $0.1114 |
| **TOTAL**    | **252** | **$1.4923** | **151** | **$0.8097** |

**Headline: 45.7% end-to-end cost reduction, 40.1% LLM-call reduction.**

The deferred work shows up at dream time, but only adds **$0.0073** on feat — the A ∪ B union dedup in `dream-executor.ts:152-186` collapses the 36-path queue against dream's own snapshot diff, so each parent regenerates exactly once.

Why the headline (45.7%) exceeds the v1 plan estimate (5–15%): cascade depth (3-level), per-call agent-loop overhead, and dedup-beats-inline. Detailed analysis in [Linear ENG-2485 comment](https://linear.app/byterover/issue/ENG-2485/is-01-defer-summary-cascade-to-dream).

### Design decisions (4 settled gaps in the spec)

1. **Manifest rebuild stays inline** — without it, newly-curated leaves wouldn't appear in `_manifest.json` for up to 12h.
2. **Drain location**: merge with dream's existing post-propagation block — A ∪ B regenerates each parent once.
3. **Concurrency**: snapshot-and-clear, mirroring `pendingMerges` precedent.
4. **Queue location**: `dream-state.json#staleSummaryPaths` instead of the spec's separate `.brv/dream-queue/summary-staleness.json` — spec explicitly allowed this; reuses existing `AsyncMutex` registry + `update()` RMW.

## Checklist

- [x] Tests added or updated and passing (`npm test`)
- [x] Lint passes (`npm run lint` — clean on changed files; pre-existing repo-wide lint error in `packages/byterover-packages/ui/...` unrelated to this PR)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow Conventional Commits format
- [x] Documentation updated (if applicable) — N/A (no user-facing docs)
- [x] No breaking changes (or clearly documented above)
- [x] Branch is up to date with `main`

## Risks and mitigations

- **Risk**: Stale parent-summary excerpts in search results during the 12h window between curate and dream.
  - **Mitigation**: Empirically validated in `experiments/01-summary-defer-validation.md` (15/15 reconstructed and re-run). New content remains findable; ranking stability holds (top-5 path overlap = 100% on generic queries). Trade is cosmetic, not correctness.
- **Risk**: If dream is disabled/never runs, summaries never regenerate.
  - **Mitigation**: Pre-existing risk — dream cycle ran fine in this validation. Queue is bounded by distinct paths (dedup), so unbounded growth requires both unique paths AND no dream — improbable in production.
- **Risk**: Concurrent curate+dream race — paths enqueued during dream propagation are dropped.
  - **Mitigation**: Snapshot-and-clear pattern: `clear()` filters by the snapshotted path set, so newly-enqueued entries survive. Tested by `dream-state-service.test.ts` concurrency suite.