### PR TITLE
fix: [ENG-2469] update Google default model to gemini-3-flash-preview

### DIFF
--- a/src/agent/infra/llm/providers/google.ts
+++ b/src/agent/infra/llm/providers/google.ts
@@ -21,7 +21,7 @@ export const googleProvider: ProviderModule = {
       model: provider(config.model),
     })
   },
-  defaultModel: 'gemini-2.5-flash',
+  defaultModel: 'gemini-3-flash-preview',
   description: 'Gemini models by Google',
   envVars: ['GOOGLE_API_KEY', 'GEMINI_API_KEY'],
   id: 'google',

--- a/src/server/core/domain/entities/provider-registry.ts
+++ b/src/server/core/domain/entities/provider-registry.ts
@@ -161,7 +161,7 @@ export const PROVIDER_REGISTRY: Readonly<Record<string, ProviderDefinition>> = {
     apiKeyUrl: 'https://aistudio.google.com/apikey',
     baseUrl: '',
     category: 'popular',
-    defaultModel: 'gemini-2.5-flash',
+    defaultModel: 'gemini-3-flash-preview',
     description: 'Gemini models by Google',
     envVars: ['GOOGLE_API_KEY', 'GEMINI_API_KEY'],
     headers: {},


### PR DESCRIPTION
The previous default `gemini-2.5-flash` returns thinking-only responses when tools are present, which the agent loop cannot consume — every curate fails validation immediately.

Switch the default surfaced by both the provider registry and the Google provider config to `gemini-3-flash-preview`, matching the docs recommendation list.

## Summary

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [ ] Agent / Tools
- [ ] LLM Providers
- [ ] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes #
- Related #

## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause:
- Why this was not caught earlier:

## Test plan

- Coverage added:
  - [ ] Unit test
  - [ ] Integration test
  - [ ] Manual verification only
- Test file(s):
- Key scenario(s) covered:

## User-visible changes

List user-visible changes (including defaults, config, or CLI output).
If none, write `None`.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording

## Checklist

- [ ] Tests added or updated and passing (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Type check passes (`npm run typecheck`)
- [ ] Build succeeds (`npm run build`)
- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or clearly documented above)
- [ ] Branch is up to date with `main`

## Risks and mitigations

List real risks for this PR. If none, write `None`.

- Risk:
  - Mitigation:
