### PR TITLE
fix: [ENG-2513] bump byterover-packages to 1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@ai-sdk/xai": "^2.0.57",
         "@anthropic-ai/sdk": "^0.70.1",
         "@campfirein/brv-transport-client": "github:campfirein/brv-transport-client#1.0.0",
-        "@campfirein/byterover-packages": "github:campfirein/byterover-packages#1.0.1",
+        "@campfirein/byterover-packages": "github:campfirein/byterover-packages#1.0.2",
         "@google/genai": "^1.29.0",
         "@inkjs/ui": "^2.0.0",
         "@inquirer/prompts": "^7.9.0",
@@ -3337,7 +3337,7 @@
     },
     "node_modules/@campfirein/byterover-packages": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/campfirein/byterover-packages.git#50a9d9a396dcf8dbd97238fbc566ad24a2e1473b",
+      "resolved": "git+ssh://git@github.com/campfirein/byterover-packages.git#bbd9b8854cd951d47a9e26d8a0b1ad7119307f25",
       "inBundle": true,
       "dependencies": {
         "@base-ui/react": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@ai-sdk/xai": "^2.0.57",
     "@anthropic-ai/sdk": "^0.70.1",
     "@campfirein/brv-transport-client": "github:campfirein/brv-transport-client#1.0.0",
-    "@campfirein/byterover-packages": "github:campfirein/byterover-packages#1.0.1",
+    "@campfirein/byterover-packages": "github:campfirein/byterover-packages#1.0.2",
     "@google/genai": "^1.29.0",
     "@inkjs/ui": "^2.0.0",
     "@inquirer/prompts": "^7.9.0",


### PR DESCRIPTION
## Summary

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [ ] Agent / Tools
- [ ] LLM Providers
- [ ] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes #
- Related #

## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause:
- Why this was not caught earlier:

## Test plan

- Coverage added:
  - [ ] Unit test
  - [ ] Integration test
  - [ ] Manual verification only
- Test file(s):
- Key scenario(s) covered:

## User-visible changes

List user-visible changes (including defaults, config, or CLI output).
If none, write `None`.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording

## Checklist

- [ ] Tests added or updated and passing (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Type check passes (`npm run typecheck`)
- [ ] Build succeeds (`npm run build`)
- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or clearly documented above)
- [ ] Branch is up to date with `main`

## Risks and mitigations

List real risks for this PR. If none, write `None`.

- Risk:
  - Mitigation:
