### PR TITLE
feat: [ENG-1593] add brv review --disable / --enable toggle

### DIFF
--- a/src/agent/infra/tools/implementations/curate-tool-task-context.ts
+++ b/src/agent/infra/tools/implementations/curate-tool-task-context.ts
@@ -1,0 +1,31 @@
+import {AsyncLocalStorage} from 'node:async_hooks'
+
+/**
+ * Async-context scope for the daemon-stamped `reviewDisabled` value.
+ *
+ * The daemon snapshots the project's reviewDisabled flag once at task-create
+ * and forwards it via TaskExecute. The agent process opens an
+ * `AsyncLocalStorage` scope around the task body so any descendant async
+ * callsite — direct curate-tool invocation, sandbox `tools.curate(...)` via
+ * CurateService, or anything else awaiting under the same chain — observes the
+ * single snapshot value instead of re-reading `.brv/config.json` (which can
+ * race with mid-task user toggles).
+ *
+ * Same propagation pattern as `CurateResultCollector`
+ * (src/agent/infra/sandbox/curate-result-collector.ts): AsyncLocalStorage flows
+ * through the LLM streaming pipeline and the in-process sandbox, so callers
+ * without an explicit taskId still see the right value.
+ *
+ * Outside any scope, `getCurrentReviewDisabled()` returns `undefined` and the
+ * caller falls back to its own resolution path (currently a `.brv/config.json`
+ * read in `executeCurate`).
+ */
+const reviewDisabledStorage = new AsyncLocalStorage<boolean>()
+
+export function runWithReviewDisabled<T>(reviewDisabled: boolean, fn: () => Promise<T>): Promise<T> {
+  return reviewDisabledStorage.run(reviewDisabled, fn)
+}
+
+export function getCurrentReviewDisabled(): boolean | undefined {
+  return reviewDisabledStorage.getStore()
+}

--- a/src/agent/infra/tools/implementations/curate-tool.ts
+++ b/src/agent/infra/tools/implementations/curate-tool.ts
@@ -495,6 +495,15 @@ async function backupBeforeWrite(filePath: string, basePath: string, reviewDisab
 }
 
 /**
+ * Type guard: narrows an unknown JSON value to a shape that may carry the
+ * `reviewDisabled` flag. Used as the fallback when the agent process has no
+ * AsyncLocalStorage scope (direct sandbox callers without a TaskExecute).
+ */
+function hasReviewDisabledField(value: unknown): value is {reviewDisabled?: unknown} {
+  return typeof value === 'object' && value !== null
+}
+
+/**
  * Reads `<brvDir>/config.json` and returns the `reviewDisabled` flag.
  * Returns false (review enabled) on any error so a missing/corrupt config never
  * silently swallows backups that protect the rejection path.
@@ -502,8 +511,8 @@ async function backupBeforeWrite(filePath: string, basePath: string, reviewDisab
 async function isReviewDisabledForBrvDir(brvDir: string): Promise<boolean> {
   try {
     const raw = await DirectoryManager.readFile(join(brvDir, 'config.json'))
-    const parsed = JSON.parse(raw) as {reviewDisabled?: unknown}
-    return parsed.reviewDisabled === true
+    const parsed: unknown = JSON.parse(raw)
+    return hasReviewDisabledField(parsed) && parsed.reviewDisabled === true
   } catch {
     return false
   }
@@ -1529,7 +1538,7 @@ export async function executeCurate(
   const reviewDisabled = scopedReviewDisabled ?? (await isReviewDisabledForBrvDir(dirname(resolve(basePath))))
 
   const onAfterWrite: undefined | WriteCallback = abstractQueue
-    ? (contextPath, content) => { abstractQueue.enqueue({contextPath, fullContent: content}) }
+    ? (contextPath, content) => abstractQueue.enqueue({contextPath, fullContent: content})
     : undefined
 
   const applied: OperationResult[] = []

--- a/src/agent/infra/tools/implementations/curate-tool.ts
+++ b/src/agent/infra/tools/implementations/curate-tool.ts
@@ -24,6 +24,7 @@ import {toSnakeCase} from '../../../../server/utils/file-helpers.js'
 import {deriveImpactFromLoss, detectStructuralLoss} from '../../../core/domain/knowledge/conflict-detector.js'
 import {resolveStructuralLoss} from '../../../core/domain/knowledge/conflict-resolver.js'
 import {ToolName} from '../../../core/domain/tools/constants.js'
+import {getCurrentReviewDisabled} from './curate-tool-task-context.js'
 
 /**
  * Called after each successful context file write so callers can
@@ -469,7 +470,13 @@ export interface CurateOutput {
  * @param filePath - Absolute path to the context tree file being modified
  * @param basePath - Context tree base path (e.g., '.brv/context-tree')
  */
-async function backupBeforeWrite(filePath: string, basePath: string): Promise<void> {
+async function backupBeforeWrite(filePath: string, basePath: string, reviewDisabled: boolean): Promise<void> {
+  // Honor `brv review --disable`: backups exist solely to support review rejection
+  // (restore from backup). With reviews disabled, they are dead state — skip creation
+  // so review-backups/ stays empty. Snapshot taken once at executeCurate top so all
+  // ops in this tool call observe a consistent value even if the user toggles mid-task.
+  if (reviewDisabled) return
+
   try {
     const brvDir = dirname(resolve(basePath))
     const relativePath = relative(resolve(basePath), resolve(filePath))
@@ -484,6 +491,21 @@ async function backupBeforeWrite(filePath: string, basePath: string): Promise<vo
     await DirectoryManager.writeFileAtomic(backupPath, content)
   } catch {
     // Best-effort: backup failure must never block curate operations
+  }
+}
+
+/**
+ * Reads `<brvDir>/config.json` and returns the `reviewDisabled` flag.
+ * Returns false (review enabled) on any error so a missing/corrupt config never
+ * silently swallows backups that protect the rejection path.
+ */
+async function isReviewDisabledForBrvDir(brvDir: string): Promise<boolean> {
+  try {
+    const raw = await DirectoryManager.readFile(join(brvDir, 'config.json'))
+    const parsed = JSON.parse(raw) as {reviewDisabled?: unknown}
+    return parsed.reviewDisabled === true
+  } catch {
+    return false
   }
 }
 
@@ -880,6 +902,7 @@ function maxImpact(
 async function executeUpdate(
   basePath: string,
   operation: Operation,
+  reviewDisabled: boolean,
   onAfterWrite?: WriteCallback,
   runtimeSignalStore?: IRuntimeSignalStore,
   logger?: ILogger,
@@ -990,7 +1013,7 @@ async function executeUpdate(
       summary,
       timestamps,
     })
-    await backupBeforeWrite(contextPath, basePath)
+    await backupBeforeWrite(contextPath, basePath, reviewDisabled)
     await DirectoryManager.writeFileAtomic(contextPath, contextContent)
     onAfterWrite?.(contextPath, contextContent)
 
@@ -1031,6 +1054,7 @@ async function executeUpdate(
 async function executeUpsert(
   basePath: string,
   operation: Operation,
+  reviewDisabled: boolean,
   onAfterWrite?: WriteCallback,
   runtimeSignalStore?: IRuntimeSignalStore,
   logger?: ILogger,
@@ -1082,7 +1106,7 @@ async function executeUpsert(
 
     if (exists) {
       // File exists - delegate to UPDATE logic
-      const result = await executeUpdate(basePath, {...operation, type: 'UPDATE'}, onAfterWrite, runtimeSignalStore, logger)
+      const result = await executeUpdate(basePath, {...operation, type: 'UPDATE'}, reviewDisabled, onAfterWrite, runtimeSignalStore, logger)
       // Return with UPSERT type but indicate it was an update
       return {
         ...result,
@@ -1117,6 +1141,7 @@ async function executeUpsert(
 async function executeMerge(
   basePath: string,
   operation: Operation,
+  reviewDisabled: boolean,
   onAfterWrite?: WriteCallback,
   runtimeSignalStore?: IRuntimeSignalStore,
   logger?: ILogger,
@@ -1229,8 +1254,8 @@ async function executeMerge(
     const previousSummary = targetParsedContent.summary
 
     // Backup both files before merge modifies target and deletes source
-    await backupBeforeWrite(targetContextPath, basePath)
-    await backupBeforeWrite(sourceContextPath, basePath)
+    await backupBeforeWrite(targetContextPath, basePath, reviewDisabled)
+    await backupBeforeWrite(sourceContextPath, basePath, reviewDisabled)
 
     // Capture source sidecar signals BEFORE any destructive operation so a
     // mid-flow crash cannot leave the target unmerged with an orphaned
@@ -1321,6 +1346,7 @@ async function executeMerge(
 async function executeDelete(
   basePath: string,
   operation: Operation,
+  reviewDisabled: boolean,
   runtimeSignalStore?: IRuntimeSignalStore,
   logger?: ILogger,
 ): Promise<OperationResult> {
@@ -1358,7 +1384,7 @@ async function executeDelete(
         // Best-effort: summary extraction failure must never block delete
       }
 
-      await backupBeforeWrite(filePath, basePath)
+      await backupBeforeWrite(filePath, basePath, reviewDisabled)
       await DirectoryManager.deleteFile(filePath)
       await deleteDerivedSiblings(filePath)
 
@@ -1417,7 +1443,7 @@ async function executeDelete(
       // Best-effort: summary extraction failure must never block delete
     }
 
-    await Promise.all(mdFiles.map((f) => backupBeforeWrite(f, basePath)))
+    await Promise.all(mdFiles.map((f) => backupBeforeWrite(f, basePath, reviewDisabled)))
     await DirectoryManager.deleteTopicRecursive(fullPath)
 
     // Dual-write: drop sidecar entries for every markdown file that was
@@ -1490,6 +1516,18 @@ export async function executeCurate(
 
   const {basePath, operations} = parseResult.data
 
+  // Prefer the daemon-stamped value (snapshotted at task-create on the daemon side,
+  // forwarded via TaskExecute, opened as an AsyncLocalStorage scope in agent-process so
+  // it propagates through any async chain — direct tool call, sandbox `tools.curate(...)`
+  // via CurateService, or ingest-resource-tool). The `.brv/config.json` read is the
+  // fall-back for callers outside any scope. Sharing one value across daemon
+  // (CurateLogHandler) and agent (this tool) keeps reviewStatus and backups consistent:
+  // without it, a user toggle mid-task could mark ops as pending review (daemon snapshot
+  // held) while skipping backups (agent re-read picks up new value), making rejection
+  // un-restorable.
+  const scopedReviewDisabled = getCurrentReviewDisabled()
+  const reviewDisabled = scopedReviewDisabled ?? (await isReviewDisabledForBrvDir(dirname(resolve(basePath))))
+
   const onAfterWrite: undefined | WriteCallback = abstractQueue
     ? (contextPath, content) => { abstractQueue.enqueue({contextPath, fullContent: content}) }
     : undefined
@@ -1516,7 +1554,7 @@ export async function executeCurate(
       }
 
       case 'DELETE': {
-        result = await executeDelete(basePath, operation, runtimeSignalStore, logger)
+        result = await executeDelete(basePath, operation, reviewDisabled, runtimeSignalStore, logger)
 
         if (result.status === 'success') summary.deleted++
 
@@ -1524,7 +1562,7 @@ export async function executeCurate(
       }
 
       case 'MERGE': {
-        result = await executeMerge(basePath, operation, onAfterWrite, runtimeSignalStore, logger)
+        result = await executeMerge(basePath, operation, reviewDisabled, onAfterWrite, runtimeSignalStore, logger)
 
         if (result.status === 'success') summary.merged++
 
@@ -1532,7 +1570,7 @@ export async function executeCurate(
       }
 
       case 'UPDATE': {
-        result = await executeUpdate(basePath, operation, onAfterWrite, runtimeSignalStore, logger)
+        result = await executeUpdate(basePath, operation, reviewDisabled, onAfterWrite, runtimeSignalStore, logger)
 
         if (result.status === 'success') summary.updated++
 
@@ -1540,7 +1578,7 @@ export async function executeCurate(
       }
 
       case 'UPSERT': {
-        result = await executeUpsert(basePath, operation, onAfterWrite, runtimeSignalStore, logger)
+        result = await executeUpsert(basePath, operation, reviewDisabled, onAfterWrite, runtimeSignalStore, logger)
 
         // UPSERT counts as either added or updated based on what happened
         if (result.status === 'success') {

--- a/src/oclif/commands/review.ts
+++ b/src/oclif/commands/review.ts
@@ -54,7 +54,7 @@ When disabled:
 
     try {
       if (flags.disable || flags.enable) {
-        const target = flags.disable === true
+        const target = flags.disable
         const response = await withDaemonRetry(
           (client) =>
             client.requestWithAck<ReviewSetDisabledResponse>(ReviewEvents.SET_DISABLED, {reviewDisabled: target}),

--- a/src/oclif/commands/review.ts
+++ b/src/oclif/commands/review.ts
@@ -1,0 +1,120 @@
+import {Command, Flags} from '@oclif/core'
+
+import {
+  ReviewEvents,
+  type ReviewGetDisabledResponse,
+  type ReviewSetDisabledResponse,
+} from '../../shared/transport/events/review-events.js'
+import {type DaemonClientOptions, formatConnectionError, withDaemonRetry} from '../lib/daemon-client.js'
+import {writeJsonResponse} from '../lib/json-response.js'
+
+export default class Review extends Command {
+  public static description = `Toggle the HITL review log for the current project
+
+When disabled:
+- 'brv curate' (sync mode) no longer prints the "X operations require review" prompt
+- Curate-log entries written in '--detach' mode no longer carry the per-operation review marker
+- 'brv dream' no longer surfaces its own needsReview operations as pending reviews
+- 'brv review pending' will not list any new entries until re-enabled`
+  public static examples = [
+    '# Show current state',
+    '<%= config.bin %> <%= command.id %>',
+    '',
+    '# Disable the review log for this project',
+    '<%= config.bin %> <%= command.id %> --disable',
+    '',
+    '# Re-enable the review log',
+    '<%= config.bin %> <%= command.id %> --enable',
+  ]
+  public static flags = {
+    disable: Flags.boolean({
+      default: false,
+      description: 'Disable the HITL review log for this project',
+      exclusive: ['enable'],
+    }),
+    enable: Flags.boolean({
+      default: false,
+      description: 'Re-enable the HITL review log for this project',
+      exclusive: ['disable'],
+    }),
+    format: Flags.string({
+      default: 'text',
+      description: 'Output format (text or json)',
+      options: ['text', 'json'],
+    }),
+  }
+
+  protected getDaemonClientOptions(): DaemonClientOptions {
+    return {}
+  }
+
+  public async run(): Promise<void> {
+    const {flags} = await this.parse(Review)
+    const format: 'json' | 'text' = flags.format === 'json' ? 'json' : 'text'
+
+    try {
+      if (flags.disable || flags.enable) {
+        const target = flags.disable === true
+        const response = await withDaemonRetry(
+          (client) =>
+            client.requestWithAck<ReviewSetDisabledResponse>(ReviewEvents.SET_DISABLED, {reviewDisabled: target}),
+          this.getDaemonClientOptions(),
+        )
+        this.reportToggle(response.reviewDisabled, format)
+        return
+      }
+
+      const response = await withDaemonRetry(
+        (client) => client.requestWithAck<ReviewGetDisabledResponse>(ReviewEvents.GET_DISABLED, {}),
+        this.getDaemonClientOptions(),
+      )
+      this.reportStatus(response.reviewDisabled, format)
+    } catch (error) {
+      this.reportError(error, format)
+    }
+  }
+
+  private reportError(error: unknown, format: 'json' | 'text'): void {
+    const message = error instanceof Error ? error.message : 'Review failed'
+    if (format === 'json') {
+      writeJsonResponse({
+        command: 'review',
+        data: {error: message, status: 'error'},
+        success: false,
+      })
+      return
+    }
+
+    this.log(formatConnectionError(error))
+  }
+
+  private reportStatus(disabled: boolean, format: 'json' | 'text'): void {
+    if (format === 'json') {
+      writeJsonResponse({
+        command: 'review',
+        data: {reviewDisabled: disabled, status: 'success'},
+        success: true,
+      })
+      return
+    }
+
+    this.log(disabled ? 'Review log is disabled.' : 'Review log is enabled.')
+  }
+
+  private reportToggle(disabled: boolean, format: 'json' | 'text'): void {
+    if (format === 'json') {
+      writeJsonResponse({
+        command: 'review',
+        data: {reviewDisabled: disabled, status: 'success'},
+        success: true,
+      })
+      return
+    }
+
+    this.log(
+      disabled
+        ? `Review log disabled. To re-enable: ${this.config.bin} review --enable`
+        : `Review log enabled. To disable: ${this.config.bin} review --disable`,
+    )
+  }
+}

--- a/src/server/core/domain/entities/brv-config.ts
+++ b/src/server/core/domain/entities/brv-config.ts
@@ -15,6 +15,7 @@ export type BrvConfigParams = {
   createdAt: string
   cwd?: string
   ide?: Agent
+  reviewDisabled?: boolean
   spaceId?: string
   spaceName?: string
   teamId?: string
@@ -88,6 +89,7 @@ const isBrvConfigJson = (json: unknown): json is BrvConfigFromJson => {
   if (obj.cipherAgentSystemPrompt !== undefined && typeof obj.cipherAgentSystemPrompt !== 'string') return false
   if (obj.cipherAgentModes !== undefined && !Array.isArray(obj.cipherAgentModes)) return false
   if (obj.version !== undefined && typeof obj.version !== 'string') return false
+  if (obj.reviewDisabled !== undefined && typeof obj.reviewDisabled !== 'boolean') return false
 
   return true
 }
@@ -104,6 +106,7 @@ export class BrvConfig {
   public readonly createdAt: string
   public readonly cwd?: string
   public readonly ide?: Agent
+  public readonly reviewDisabled?: boolean
   public readonly spaceId?: string
   public readonly spaceName?: string
   public readonly teamId?: string
@@ -122,6 +125,7 @@ export class BrvConfig {
     this.createdAt = params.createdAt
     this.cwd = params.cwd
     this.ide = params.ide
+    this.reviewDisabled = params.reviewDisabled
     this.spaceId = params.spaceId
     this.spaceName = params.spaceName
     this.teamId = params.teamId
@@ -214,6 +218,7 @@ export class BrvConfig {
       createdAt: this.createdAt,
       cwd: this.cwd,
       ide: this.ide,
+      reviewDisabled: this.reviewDisabled,
       spaceId: this.spaceId,
       spaceName: this.spaceName,
       teamId: this.teamId,
@@ -236,6 +241,27 @@ export class BrvConfig {
   }
 
   /**
+   * Creates a new BrvConfig with the reviewDisabled flag updated, preserving all other fields.
+   */
+  public withReviewDisabled(reviewDisabled: boolean): BrvConfig {
+    return new BrvConfig({
+      chatLogPath: this.chatLogPath,
+      cipherAgentContext: this.cipherAgentContext,
+      cipherAgentModes: this.cipherAgentModes,
+      cipherAgentSystemPrompt: this.cipherAgentSystemPrompt,
+      createdAt: this.createdAt,
+      cwd: this.cwd,
+      ide: this.ide,
+      reviewDisabled,
+      spaceId: this.spaceId,
+      spaceName: this.spaceName,
+      teamId: this.teamId,
+      teamName: this.teamName,
+      version: this.version,
+    })
+  }
+
+  /**
    * Creates a new BrvConfig with space fields replaced, preserving all other fields.
    */
   public withSpace(space: Space): BrvConfig {
@@ -247,6 +273,7 @@ export class BrvConfig {
       createdAt: new Date().toISOString(),
       cwd: this.cwd,
       ide: this.ide,
+      reviewDisabled: this.reviewDisabled,
       spaceId: space.id,
       spaceName: space.name,
       teamId: space.teamId,
@@ -267,6 +294,7 @@ export class BrvConfig {
       createdAt: this.createdAt,
       cwd: this.cwd,
       ide: this.ide,
+      reviewDisabled: this.reviewDisabled,
       spaceId: this.spaceId,
       spaceName: this.spaceName,
       teamId: this.teamId,

--- a/src/server/core/domain/transport/schemas.ts
+++ b/src/server/core/domain/transport/schemas.ts
@@ -394,6 +394,12 @@ export const TaskExecuteSchema = z.object({
   force: z.boolean().optional(),
   /** Project path this task belongs to (for multi-project routing) */
   projectPath: z.string().optional(),
+  /**
+   * Snapshot of the project's review-disabled flag captured at task-create time.
+   * Stamped by the daemon so the agent does not re-read .brv/config.json and
+   * race with mid-task toggles.
+   */
+  reviewDisabled: z.boolean().optional(),
   /** Unique task identifier */
   taskId: z.string(),
   /** Dream trigger source — how this dream was initiated */

--- a/src/server/core/domain/transport/task-info.ts
+++ b/src/server/core/domain/transport/task-info.ts
@@ -23,6 +23,13 @@ export type TaskInfo = {
   projectPath?: string
   /** Set on successful completion */
   result?: string
+  /**
+   * Snapshot of the project's review-disabled flag captured at task-create time.
+   * Stamped once at the daemon boundary so daemon (CurateLogHandler) and agent
+   * (curate-tool backups, dream review entries) observe the same value even if
+   * the user toggles the flag mid-task.
+   */
+  reviewDisabled?: boolean
   /** Set when agent picks up the task */
   startedAt?: number
   /** Lifecycle status — defaults to 'created' on construction */

--- a/src/server/infra/daemon/agent-process.ts
+++ b/src/server/infra/daemon/agent-process.ts
@@ -35,6 +35,7 @@ import {FileSystemService} from '../../../agent/infra/file-system/file-system-se
 import {FolderPackService} from '../../../agent/infra/folder-pack/folder-pack-service.js'
 import {SessionMetadataStore} from '../../../agent/infra/session/session-metadata-store.js'
 import {FileKeyStorage} from '../../../agent/infra/storage/file-key-storage.js'
+import {runWithReviewDisabled} from '../../../agent/infra/tools/implementations/curate-tool-task-context.js'
 import {createSearchKnowledgeService} from '../../../agent/infra/tools/implementations/search-knowledge-service.js'
 import {AuthEvents} from '../../../shared/transport/events/auth-events.js'
 import {decodeSearchContent} from '../../../shared/transport/search-content.js'
@@ -435,7 +436,7 @@ async function executeTask(
   storagePath: string,
   runtimeSignalStore: IRuntimeSignalStore,
 ): Promise<void> {
-  const {clientCwd, clientId, content, files, folderPath, force, taskId, trigger, type, worktreeRoot} = task
+  const {clientCwd, clientId, content, files, folderPath, force, reviewDisabled, taskId, trigger, type, worktreeRoot} = task
   if (!transport || !agent) return
 
   // Search tasks are pure BM25 retrieval — no LLM, no provider needed.
@@ -453,7 +454,19 @@ async function executeTask(
 
   activeTaskCount++
 
-  try {
+  // Body of the task — extracted so the daemon-stamped reviewDisabled snapshot can be
+  // opened as an AsyncLocalStorage scope around it. Tools that run inside this task
+  // (curate-tool.executeCurate, including the sandbox `tools.curate(...)` path via
+  // CurateService where _context.taskId is not threaded through) read the snapshot
+  // from the ALS scope instead of re-reading .brv/config.json — that read can race
+  // with mid-task user toggles, which is exactly the inconsistency we are eliminating.
+  // We only open the scope when the daemon stamped a value; otherwise consumers fall
+  // back to the file read, preserving behavior for legacy clients without a stamp.
+  const runTaskBody = async (): Promise<void> => {
+    // Re-narrow inside the closure: TypeScript loses the function-scope narrowing
+    // from the early-return guard above once we hand control to a callback.
+    if (!transport || !agent) return
+
     // Only refresh config and hot-swap provider when this is the first concurrent task.
     // Subsequent concurrent tasks reuse cached config to avoid race conditions
     // on provider hot-swap (which replaces SessionManager).
@@ -575,6 +588,7 @@ async function executeTask(
           const dreamResult = await dreamExecutor.executeWithAgent(agent, {
             priorMtime: eligibility.priorMtime,
             projectRoot: projectPath,
+            ...(reviewDisabled === undefined ? {} : {reviewDisabled}),
             taskId,
             trigger: trigger ?? 'cli',
           })
@@ -637,6 +651,10 @@ async function executeTask(
     } finally {
       cleanupForwarding?.()
     }
+  }
+
+  try {
+    await (reviewDisabled === undefined ? runTaskBody() : runWithReviewDisabled(reviewDisabled, runTaskBody))
   } finally {
     activeTaskCount--
 

--- a/src/server/infra/daemon/brv-server.ts
+++ b/src/server/infra/daemon/brv-server.ts
@@ -268,6 +268,16 @@ async function main(): Promise<void> {
     const getQueueLength = (projectPath: string): number =>
       agentPool?.getQueueState().find((q) => q.projectPath === projectPath)?.queueLength ?? 0
 
+    // Shared project-config resolver — used by the idle-dream dispatch and the
+    // task-router resolver wired into TransportHandlers below. Both paths must
+    // stamp the same reviewDisabled value so review semantics are consistent
+    // regardless of dispatch source (CLI task:create vs idle trigger).
+    const curateConfigStore = new ProjectConfigStore()
+    const resolveReviewDisabled = async (projectPath: string): Promise<boolean> => {
+      const config = await curateConfigStore.read(projectPath)
+      return config?.reviewDisabled === true
+    }
+
     // Shared dream pre-check trigger factory.
     // The lock service explicitly throws if invoked — gate 4 (lock) is the agent's job;
     // the daemon must only ever evaluate gates 1-3 via checkEligibility().
@@ -307,11 +317,18 @@ async function main(): Promise<void> {
           const result = await makeDreamPreCheckTrigger(projectPath).checkEligibility(projectPath)
           if (result.eligible) {
             log(`Dream eligible, dispatching dream task: ${projectPath}`)
+            // Idle dispatch bypasses TaskRouter.handleTaskCreate, so the
+            // reviewDisabled snapshot that the task-router stamps for the CLI
+            // path must be reproduced inline here. Without it, idle dreams
+            // would always default to review-enabled regardless of project
+            // setting (see resolveReviewDisabled above).
+            const reviewDisabled = await resolveReviewDisabled(projectPath)
             agentPool?.submitTask({
               clientId: 'daemon',
               content: 'Memory consolidation (idle trigger)',
               force: false,
               projectPath,
+              reviewDisabled,
               taskId: randomUUID(),
               trigger: 'agent-idle',
               type: 'dream',
@@ -360,7 +377,6 @@ async function main(): Promise<void> {
     // Start agent idle timeout policy
     agentIdleTimeoutPolicy.start()
 
-    const curateConfigStore = new ProjectConfigStore()
     const curateLogHandler = new CurateLogHandler(undefined, (info) => {
       const encoded = Buffer.from(info.projectPath).toString('base64url')
       const reviewPort = webuiServer?.getPort() ?? port
@@ -387,11 +403,10 @@ async function main(): Promise<void> {
       // Resolves the project's review-disabled flag once at task-create. The result
       // is stamped onto TaskInfo + TaskExecute so daemon hooks (CurateLogHandler) and
       // the agent process (curate-tool backups, dream review entries) all observe a
-      // single value across the daemon→agent process boundary.
-      async isReviewDisabled(projectPath) {
-        const config = await curateConfigStore.read(projectPath)
-        return config?.reviewDisabled === true
-      },
+      // single value across the daemon→agent process boundary. Shared with the
+      // idle-dream dispatch above so review semantics are identical regardless of
+      // dispatch source (CLI task:create vs agent-idle trigger).
+      isReviewDisabled: resolveReviewDisabled,
       lifecycleHooks: [curateLogHandler, queryLogHandler],
       // Daemon-side gate for dream task:create — mirrors the idle-trigger pre-check
       // in this file so the CLI path (brv dream without --force) actually honors

--- a/src/server/infra/daemon/brv-server.ts
+++ b/src/server/infra/daemon/brv-server.ts
@@ -360,6 +360,7 @@ async function main(): Promise<void> {
     // Start agent idle timeout policy
     agentIdleTimeoutPolicy.start()
 
+    const curateConfigStore = new ProjectConfigStore()
     const curateLogHandler = new CurateLogHandler(undefined, (info) => {
       const encoded = Buffer.from(info.projectPath).toString('base64url')
       const reviewPort = webuiServer?.getPort() ?? port
@@ -383,6 +384,14 @@ async function main(): Promise<void> {
     const transportHandlers = new TransportHandlers({
       agentPool,
       clientManager,
+      // Resolves the project's review-disabled flag once at task-create. The result
+      // is stamped onto TaskInfo + TaskExecute so daemon hooks (CurateLogHandler) and
+      // the agent process (curate-tool backups, dream review entries) all observe a
+      // single value across the daemon→agent process boundary.
+      async isReviewDisabled(projectPath) {
+        const config = await curateConfigStore.read(projectPath)
+        return config?.reviewDisabled === true
+      },
       lifecycleHooks: [curateLogHandler, queryLogHandler],
       // Daemon-side gate for dream task:create — mirrors the idle-trigger pre-check
       // in this file so the CLI path (brv dream without --force) actually honors

--- a/src/server/infra/executor/dream-executor.ts
+++ b/src/server/infra/executor/dream-executor.ts
@@ -212,7 +212,7 @@ export class DreamExecutor {
       }))
 
       succeeded = true
-      return {logId, result: this.formatResult(logId, summary)}
+      return {logId, result: this.formatResult(logId, summary, reviewDisabled)}
     } catch (error) {
       // Save error/partial log entry (best-effort). Use allOperations so any work
       // that completed before the failure is captured — keeps the audit trail and
@@ -440,7 +440,7 @@ export class DreamExecutor {
     return new Set(results.filter((f): f is string => f !== null))
   }
 
-  private formatResult(logId: string, summary: DreamLogSummary): string {
+  private formatResult(logId: string, summary: DreamLogSummary, reviewDisabled: boolean): string {
     const parts = [`Dream completed (${logId})`]
     const counts = [
       summary.consolidated > 0 ? `${summary.consolidated} consolidated` : '',
@@ -457,7 +457,10 @@ export class DreamExecutor {
       parts.push(`${summary.errors} operations failed`)
     }
 
-    if (summary.flaggedForReview > 0) {
+    // Suppress when review is disabled — the count comes from LLM `needsReview` tags
+    // computed before the dual-write gate, so the ops were intentionally not enqueued
+    // and would not appear in `brv review pending`.
+    if (summary.flaggedForReview > 0 && !reviewDisabled) {
       parts.push(`${summary.flaggedForReview} operations flagged for review`)
     }
 

--- a/src/server/infra/executor/dream-executor.ts
+++ b/src/server/infra/executor/dream-executor.ts
@@ -75,6 +75,14 @@ export type DreamExecutorDeps = {
 type DreamExecuteOptions = {
   priorMtime: number
   projectRoot: string
+  /**
+   * Snapshot of the project's reviewDisabled flag captured at task-create on the
+   * daemon side and passed through TaskExecute. When true, the dream-side dual-write
+   * of needsReview operations into the curate log is skipped — they won't surface in
+   * `brv review pending` and won't appear as review entries in the curate log folder.
+   * Undefined → treated as enabled (fail-open).
+   */
+  reviewDisabled?: boolean
   taskId: string
   trigger: 'agent-idle' | 'cli' | 'manual'
 }
@@ -120,6 +128,13 @@ export class DreamExecutor {
     // dreamStateService.update throws) would re-write the same review entries.
     let reviewEntriesWritten = false
 
+    // The disable flag is captured once at task-create on the daemon and forwarded via
+    // TaskExecute → executeTask → here. Reading it from options (instead of re-resolving
+    // from .brv/config.json on the agent side) means backup-creation and review-entry
+    // writing observe the same value as the daemon-side curate log handler, even if the
+    // user toggles mid-run.
+    const reviewDisabled = options.reviewDisabled ?? false
+
     try {
       // Step 1: Capture pre-state
       const snapshotService = new FileContextTreeSnapshotService({baseDirectory: projectRoot})
@@ -145,6 +160,7 @@ export class DreamExecutor {
         logId,
         out: allOperations,
         projectRoot,
+        reviewDisabled,
         signal: controller.signal,
         taskId: options.taskId,
       })
@@ -181,7 +197,7 @@ export class DreamExecutor {
 
       // Step 6b: Create curate log entries for needsReview operations (dual-write for review system).
       // Runs after the completed dream log is durably written so review tasks never outlive their dream log.
-      await this.createReviewEntries(allOperations, contextTreeDir, options.taskId)
+      await this.createReviewEntries({contextTreeDir, operations: allOperations, reviewDisabled, taskId: options.taskId})
       reviewEntriesWritten = true
 
       // Step 7: Update dream state — atomic RMW under the per-file mutex so a
@@ -237,7 +253,7 @@ export class DreamExecutor {
       // already wrote the entries (i.e. step 7 threw after step 6b succeeded)
       // to prevent duplicate review items.
       if (allOperations.length > 0 && !reviewEntriesWritten) {
-        await this.createReviewEntries(allOperations, contextTreeDir, options.taskId)
+        await this.createReviewEntries({contextTreeDir, operations: allOperations, reviewDisabled, taskId: options.taskId})
       }
 
       throw error
@@ -258,6 +274,7 @@ export class DreamExecutor {
    * each step. Extracted so the executor can preserve partial work when a later step
    * throws — and so tests can inject controlled ops without a full LLM round-trip.
    */
+  // protected is required for test subclassing (ProbeExecutor, makePartialRunExecutor)
   protected async runOperations(args: {
     agent: ICipherAgent
     changedFiles: Set<string>
@@ -265,17 +282,24 @@ export class DreamExecutor {
     logId: string
     out: DreamOperation[]
     projectRoot: string
+    /**
+     * When true, the dream-side review system (backups + curate-log dual-write) is suppressed.
+     * Backups exist only to support review rejection; with reviews disabled they are dead state,
+     * so consolidate/prune are run without a `reviewBackupStore` so review-backups/ stays empty.
+     */
+    reviewDisabled?: boolean
     signal: AbortSignal
     taskId: string
   }): Promise<void> {
-    const {agent, changedFiles, contextTreeDir, logId, out, projectRoot, signal, taskId} = args
+    const {agent, changedFiles, contextTreeDir, logId, out, projectRoot, reviewDisabled, signal, taskId} = args
+    const reviewBackupStore = reviewDisabled === true ? undefined : this.deps.reviewBackupStore
 
     out.push(
       ...(await consolidate([...changedFiles], {
         agent,
         contextTreeDir,
         dreamStateService: this.deps.dreamStateService,
-        reviewBackupStore: this.deps.reviewBackupStore,
+        reviewBackupStore,
         runtimeSignalStore: this.deps.runtimeSignalStore,
         searchService: this.deps.searchService,
         signal,
@@ -304,7 +328,7 @@ export class DreamExecutor {
         dreamLogId: logId,
         dreamStateService: this.deps.dreamStateService,
         projectRoot,
-        reviewBackupStore: this.deps.reviewBackupStore,
+        reviewBackupStore,
         runtimeSignalStore: this.deps.runtimeSignalStore,
         signal,
         taskId,
@@ -312,7 +336,6 @@ export class DreamExecutor {
     )
   }
 
-  /** Errors are tracked at the log level (status='error'), not per-operation — always 0 here. */
   private computeSummary(operations: DreamOperation[]): DreamLogSummary {
     const summary: DreamLogSummary = {consolidated: 0, errors: 0, flaggedForReview: 0, pruned: 0, synthesized: 0}
     for (const op of operations) {
@@ -329,13 +352,20 @@ export class DreamExecutor {
    * Dual-write: create curate log entries for dream operations that need human review.
    * This surfaces them in `brv review pending` without modifying the review system.
    */
-  private async createReviewEntries(
-    operations: DreamOperation[],
-    contextTreeDir: string,
-    taskId: string,
-  ): Promise<void> {
+  private async createReviewEntries(args: {
+    contextTreeDir: string
+    operations: DreamOperation[]
+    reviewDisabled: boolean
+    taskId: string
+  }): Promise<void> {
+    const {contextTreeDir, operations, reviewDisabled, taskId} = args
     const reviewOps = operations.filter((op) => op.needsReview)
     if (reviewOps.length === 0) return
+
+    // Honor `brv review --disable`: when disabled, dream's needsReview ops are not surfaced
+    // through the curate-log dual-write, so they don't appear in `brv review pending`.
+    // The flag is the daemon-stamped snapshot passed in via DreamExecuteOptions.
+    if (reviewDisabled) return
 
     const curateOps: CurateLogEntry['operations'] = reviewOps.map((op) =>
       mapDreamOpToCurateOp(op, contextTreeDir),
@@ -433,6 +463,7 @@ export class DreamExecutor {
 
     return parts.join('\n')
   }
+
 }
 
 /** Map a dream operation to a curate log operation for the review system. */

--- a/src/server/infra/process/curate-log-handler.ts
+++ b/src/server/infra/process/curate-log-handler.ts
@@ -16,6 +16,13 @@ type TaskState = {
   entry: CurateLogEntry
   operations: CurateLogOperation[]
   projectPath: string
+  /**
+   * Snapshot of the project's `reviewDisabled` flag captured at task-create time.
+   * Held for the task lifetime so onToolResult and onTaskCompleted observe a single value
+   * even if the user toggles it mid-task. Sourced from `task.reviewDisabled`, which the
+   * daemon stamps once at the task-create boundary.
+   */
+  reviewDisabled: boolean
 }
 
 const CURATE_TASK_TYPES = ['curate', 'curate-folder'] as const
@@ -96,6 +103,9 @@ export class CurateLogHandler implements ITaskLifecycleHook {
   /**
    * @param createStore - Optional factory for testing. Default: FileCurateLogStore.
    * @param onPendingReviews - Optional callback fired when curate completes with pending review ops.
+   *
+   * Whether reviews are disabled is read directly from `task.reviewDisabled` (snapshotted by
+   * the daemon at task-create time). Undefined means review enabled (fail-open).
    */
   constructor(
     private readonly createStore?: (projectPath: string) => ICurateLogStore,
@@ -210,7 +220,8 @@ export class CurateLogHandler implements ITaskLifecycleHook {
     // Caching `entry` here lets onTaskCompleted/onTaskError rebuild the final entry
     // without a getById round-trip — so completion is never lost even if this initial
     // save fails.
-    this.tasks.set(task.taskId, {entry, operations: [], projectPath: task.projectPath})
+    const reviewDisabled = task.reviewDisabled ?? false
+    this.tasks.set(task.taskId, {entry, operations: [], projectPath: task.projectPath, reviewDisabled})
     this.activeTaskCount.set(task.projectPath, (this.activeTaskCount.get(task.projectPath) ?? 0) + 1)
 
     // Fire-and-forget: logId is already known, save is best-effort.
@@ -252,7 +263,7 @@ export class CurateLogHandler implements ITaskLifecycleHook {
 
     const ops = extractCurateOperations(payload)
     for (const op of ops) {
-      if (op.needsReview && op.status === 'success') {
+      if (op.needsReview && op.status === 'success' && !state.reviewDisabled) {
         op.reviewStatus = 'pending'
       }
 

--- a/src/server/infra/process/feature-handlers.ts
+++ b/src/server/infra/process/feature-handlers.ts
@@ -240,6 +240,7 @@ export async function setupFeatureHandlers({
     onResolved({ projectPath, taskId }) {
       broadcastToProject(projectPath, ReviewEvents.NOTIFY, { pendingCount: 0, reviewUrl: '', taskId })
     },
+    projectConfigStore,
     resolveProjectPath,
     reviewBackupStoreFactory: (projectPath) => new FileReviewBackupStore(join(projectPath, BRV_DIR)),
     transport,

--- a/src/server/infra/process/task-router.ts
+++ b/src/server/infra/process/task-router.ts
@@ -81,10 +81,21 @@ export type PreDispatchCheckResult = {eligible: false; skipResult: string} | {el
 
 export type PreDispatchCheck = (task: TaskCreateRequest, projectPath?: string) => Promise<PreDispatchCheckResult>
 
+/**
+ * Resolves whether the review log is disabled for the given project. Called once
+ * at task-create and the result is stamped onto TaskInfo + TaskExecute, so daemon
+ * (CurateLogHandler) and agent (curate backups, dream review entries) observe a
+ * single value across the daemon→agent process boundary. Errors → undefined →
+ * downstream treats as enabled (fail-open).
+ */
+export type IsReviewDisabledResolver = (projectPath: string) => Promise<boolean>
+
 type TaskRouterOptions = {
   agentPool?: IAgentPool
   /** Function to resolve agent clientId for a given project */
   getAgentForProject: (projectPath?: string) => string | undefined
+  /** Resolves project's review-disabled flag at task-create. Optional; missing → undefined → enabled. */
+  isReviewDisabled?: IsReviewDisabledResolver
   /** Lifecycle hooks for task events (e.g. CurateLogHandler). */
   lifecycleHooks?: ITaskLifecycleHook[]
   /**
@@ -132,6 +143,7 @@ export class TaskRouter {
    */
   private completedTasks: Map<string, {completedAt: number; task: TaskInfo}> = new Map()
   private readonly getAgentForProject: (projectPath?: string) => string | undefined
+  private readonly isReviewDisabled: IsReviewDisabledResolver | undefined
   private readonly lifecycleHooks: ITaskLifecycleHook[]
   private readonly preDispatchCheck: TaskRouterOptions['preDispatchCheck']
   private readonly projectRegistry: IProjectRegistry | undefined
@@ -145,6 +157,7 @@ export class TaskRouter {
     this.transport = options.transport
     this.agentPool = options.agentPool
     this.getAgentForProject = options.getAgentForProject
+    this.isReviewDisabled = options.isReviewDisabled
     this.lifecycleHooks = options.lifecycleHooks ?? []
     this.preDispatchCheck = options.preDispatchCheck
     this.projectRegistry = options.projectRegistry
@@ -526,7 +539,19 @@ export class TaskRouter {
       clientId,
     )
 
-    // ── Await lifecycle hooks ─────────────────────────────────────────────────
+    // ── Snapshot reviewDisabled + await lifecycle hooks ───────────────────────
+
+    // Snapshot the project's review-disabled flag once at the task-create boundary.
+    // Placed after the synchronous tasks.set/task:created so callers that don't
+    // await the create handler still see the task in this.tasks immediately.
+    // The value is stamped onto TaskInfo (for CurateLogHandler) and TaskExecute
+    // (forwarded to the agent) so both sides observe a single consistent value
+    // even if the user toggles mid-task. Errors → undefined → fail-open enabled.
+    const reviewDisabled = await this.snapshotReviewDisabled(projectPath)
+    const taskAfterSnapshot = this.tasks.get(taskId)
+    if (taskAfterSnapshot && reviewDisabled !== undefined) {
+      this.tasks.set(taskId, {...taskAfterSnapshot, reviewDisabled})
+    }
 
     const logId = await this.runCreateHooks(taskId)
     const task = this.tasks.get(taskId)
@@ -576,6 +601,7 @@ export class TaskRouter {
       ...(data.folderPath ? {folderPath: data.folderPath} : {}),
       ...(data.force === undefined ? {} : {force: data.force}),
       ...(projectPath ? {projectPath} : {}),
+      ...(reviewDisabled === undefined ? {} : {reviewDisabled}),
       taskId,
       type: data.type,
       ...(worktreeRoot ? {worktreeRoot} : {}),
@@ -982,5 +1008,22 @@ export class TaskRouter {
     )
 
     return logIds.find((id): id is string => typeof id === 'string')
+  }
+
+  /**
+   * Reads the project's reviewDisabled flag at task-create. Returns undefined
+   * (which propagates as "no field set" → fail-open enabled downstream) when
+   * no resolver is wired, no projectPath, or the resolver throws/rejects.
+   */
+  private async snapshotReviewDisabled(projectPath: string | undefined): Promise<boolean | undefined> {
+    if (!this.isReviewDisabled || !projectPath) return undefined
+    try {
+      return await this.isReviewDisabled(projectPath)
+    } catch (error_) {
+      transportLog(
+        `TaskRouter: isReviewDisabled resolver threw for ${projectPath} — defaulting to enabled: ${error_ instanceof Error ? error_.message : String(error_)}`,
+      )
+      return undefined
+    }
   }
 }

--- a/src/server/infra/process/task-router.ts
+++ b/src/server/infra/process/task-router.ts
@@ -1011,9 +1011,21 @@ export class TaskRouter {
   }
 
   /**
-   * Reads the project's reviewDisabled flag at task-create. Returns undefined
-   * (which propagates as "no field set" → fail-open enabled downstream) when
-   * no resolver is wired, no projectPath, or the resolver throws/rejects.
+   * Reads the project's reviewDisabled flag at task-create.
+   *
+   * Returns `undefined` only when no resolver is wired or no projectPath was
+   * resolved — those are legitimate "not configured" cases where downstream
+   * consumers fall back to their own resolution path.
+   *
+   * On resolver THROW, returns the explicit boolean `false` (review enabled =
+   * fail-open) so the daemon and the agent observe a single concrete value.
+   * Returning `undefined` here would re-introduce the exact divergence the
+   * snapshot is supposed to prevent: daemon stamps no field → CurateLogHandler
+   * uses `?? false` (enabled) while the agent process opens no ALS scope and
+   * may read `reviewDisabled: true` from `.brv/config.json` in the
+   * curate-tool fallback, producing pending review entries without backups
+   * (or vice versa). Aligns with the agent-side `isReviewDisabledForBrvDir`
+   * which also fails open.
    */
   private async snapshotReviewDisabled(projectPath: string | undefined): Promise<boolean | undefined> {
     if (!this.isReviewDisabled || !projectPath) return undefined
@@ -1023,7 +1035,7 @@ export class TaskRouter {
       transportLog(
         `TaskRouter: isReviewDisabled resolver threw for ${projectPath} — defaulting to enabled: ${error_ instanceof Error ? error_.message : String(error_)}`,
       )
-      return undefined
+      return false
     }
   }
 }

--- a/src/server/infra/process/transport-handlers.ts
+++ b/src/server/infra/process/transport-handlers.ts
@@ -33,17 +33,19 @@ import type {ITaskLifecycleHook} from '../../core/interfaces/process/i-task-life
 import type {IProjectRegistry} from '../../core/interfaces/project/i-project-registry.js'
 import type {IProjectRouter} from '../../core/interfaces/routing/i-project-router.js'
 import type {ITransportServer} from '../../core/interfaces/transport/i-transport-server.js'
-import type {PreDispatchCheck} from './task-router.js'
+import type {IsReviewDisabledResolver, PreDispatchCheck} from './task-router.js'
 
 import {ConnectionCoordinator} from './connection-coordinator.js'
 import {TaskRouter} from './task-router.js'
 
-export type {PreDispatchCheck, PreDispatchCheckResult} from './task-router.js'
+export type {IsReviewDisabledResolver, PreDispatchCheck, PreDispatchCheckResult} from './task-router.js'
 export type {TaskInfo} from './types.js'
 
 type TransportHandlersOptions = {
   agentPool?: IAgentPool
   clientManager?: IClientManager
+  /** Resolves project's review-disabled flag at task-create. Snapshotted once into TaskInfo + TaskExecute. */
+  isReviewDisabled?: IsReviewDisabledResolver
   /** Lifecycle hooks for task events (e.g. CurateLogHandler). */
   lifecycleHooks?: ITaskLifecycleHook[]
   /** Optional daemon-side gate run before dispatching a task to the agent pool. */
@@ -67,6 +69,7 @@ export class TransportHandlers {
     this.taskRouter = new TaskRouter({
       agentPool: options.agentPool,
       getAgentForProject: (projectPath) => this.connectionCoordinator.getAgentForProject(projectPath),
+      isReviewDisabled: options.isReviewDisabled,
       lifecycleHooks: options.lifecycleHooks,
       preDispatchCheck: options.preDispatchCheck,
       projectRegistry: options.projectRegistry,

--- a/src/server/infra/transport/handlers/review-handler.ts
+++ b/src/server/infra/transport/handlers/review-handler.ts
@@ -2,6 +2,7 @@ import {mkdir, unlink, writeFile} from 'node:fs/promises'
 import {dirname, join, relative} from 'node:path'
 
 import type {ICurateLogStore} from '../../../core/interfaces/storage/i-curate-log-store.js'
+import type {IProjectConfigStore} from '../../../core/interfaces/storage/i-project-config-store.js'
 import type {IReviewBackupStore} from '../../../core/interfaces/storage/i-review-backup-store.js'
 import type {ITransportServer} from '../../../core/interfaces/transport/i-transport-server.js'
 
@@ -9,9 +10,12 @@ import {
   type ReviewDecideTaskRequest,
   type ReviewDecideTaskResponse,
   ReviewEvents,
+  type ReviewGetDisabledResponse,
   type ReviewPendingOperation,
   type ReviewPendingResponse,
   type ReviewPendingTask,
+  type ReviewSetDisabledRequest,
+  type ReviewSetDisabledResponse,
 } from '../../../../shared/transport/events/review-events.js'
 import {BRV_DIR, CONTEXT_TREE_DIR} from '../../../constants.js'
 import {type ProjectPathResolver, resolveRequiredProjectPath} from './handler-types.js'
@@ -25,6 +29,7 @@ export interface ReviewHandlerDeps {
   curateLogStoreFactory: CurateLogStoreFactory
   /** Called after all pending ops for a task are decided. Used to notify TUI clients. */
   onResolved?: (info: {projectPath: string; taskId: string}) => void
+  projectConfigStore: IProjectConfigStore
   resolveProjectPath: ProjectPathResolver
   reviewBackupStoreFactory: ReviewBackupStoreFactory
   transport: ITransportServer
@@ -54,6 +59,7 @@ async function writeFileWithDirs(absolutePath: string, content: string): Promise
 export class ReviewHandler {
   private readonly curateLogStoreFactory: CurateLogStoreFactory
   private readonly onResolved: ReviewHandlerDeps['onResolved']
+  private readonly projectConfigStore: IProjectConfigStore
   private readonly resolveProjectPath: ProjectPathResolver
   private readonly reviewBackupStoreFactory: ReviewBackupStoreFactory
   private readonly transport: ITransportServer
@@ -61,6 +67,7 @@ export class ReviewHandler {
   constructor(deps: ReviewHandlerDeps) {
     this.curateLogStoreFactory = deps.curateLogStoreFactory
     this.onResolved = deps.onResolved
+    this.projectConfigStore = deps.projectConfigStore
     this.resolveProjectPath = deps.resolveProjectPath
     this.reviewBackupStoreFactory = deps.reviewBackupStoreFactory
     this.transport = deps.transport
@@ -72,9 +79,19 @@ export class ReviewHandler {
       (data, clientId) => this.handleDecideTask(data, clientId),
     )
 
+    this.transport.onRequest<Record<string, unknown>, ReviewGetDisabledResponse>(
+      ReviewEvents.GET_DISABLED,
+      (_data, clientId) => this.handleGetDisabled(clientId),
+    )
+
     this.transport.onRequest<Record<string, unknown>, ReviewPendingResponse>(
       ReviewEvents.PENDING,
       (_data, clientId) => this.handlePending(clientId),
+    )
+
+    this.transport.onRequest<ReviewSetDisabledRequest, ReviewSetDisabledResponse>(
+      ReviewEvents.SET_DISABLED,
+      (data, clientId) => this.handleSetDisabled(data, clientId),
     )
   }
 
@@ -194,6 +211,16 @@ export class ReviewHandler {
     return {files: fileResults.map(({path, reverted}) => ({path, reverted})), totalCount}
   }
 
+  private async handleGetDisabled(clientId: string): Promise<ReviewGetDisabledResponse> {
+    const projectPath = resolveRequiredProjectPath(this.resolveProjectPath, clientId)
+    const config = await this.projectConfigStore.read(projectPath)
+    if (!config) {
+      throw new Error(`Project not initialized: ${projectPath}. Run \`brv init\` first.`)
+    }
+
+    return {reviewDisabled: config.reviewDisabled === true}
+  }
+
   private async handlePending(clientId: string): Promise<ReviewPendingResponse> {
     const projectPath = resolveRequiredProjectPath(this.resolveProjectPath, clientId)
     const contextTreeDir = join(projectPath, BRV_DIR, CONTEXT_TREE_DIR)
@@ -234,5 +261,20 @@ export class ReviewHandler {
     const pendingCount = tasks.reduce((sum, t) => sum + t.operations.length, 0)
 
     return {pendingCount, tasks}
+  }
+
+  private async handleSetDisabled(
+    {reviewDisabled}: ReviewSetDisabledRequest,
+    clientId: string,
+  ): Promise<ReviewSetDisabledResponse> {
+    const projectPath = resolveRequiredProjectPath(this.resolveProjectPath, clientId)
+    const config = await this.projectConfigStore.read(projectPath)
+    if (!config) {
+      throw new Error(`Project not initialized: ${projectPath}. Run \`brv init\` first.`)
+    }
+
+    const updated = config.withReviewDisabled(reviewDisabled)
+    await this.projectConfigStore.write(updated, projectPath)
+    return {reviewDisabled}
   }
 }

--- a/src/shared/transport/events/review-events.ts
+++ b/src/shared/transport/events/review-events.ts
@@ -1,8 +1,22 @@
 export const ReviewEvents = {
   DECIDE_TASK: 'review:decideTask',
+  GET_DISABLED: 'review:getDisabled',
   NOTIFY: 'review:notify',
   PENDING: 'review:pending',
+  SET_DISABLED: 'review:setDisabled',
 } as const
+
+export interface ReviewGetDisabledResponse {
+  reviewDisabled: boolean
+}
+
+export interface ReviewSetDisabledRequest {
+  reviewDisabled: boolean
+}
+
+export interface ReviewSetDisabledResponse {
+  reviewDisabled: boolean
+}
 
 export interface ReviewNotifyEvent {
   pendingCount: number

--- a/test/commands/review-toggle.test.ts
+++ b/test/commands/review-toggle.test.ts
@@ -1,0 +1,195 @@
+import type {ConnectionResult, ITransportClient} from '@campfirein/brv-transport-client'
+import type {Config} from '@oclif/core'
+
+import {Config as OclifConfig} from '@oclif/core'
+import {expect} from 'chai'
+import sinon, {restore, stub} from 'sinon'
+
+import Review from '../../src/oclif/commands/review.js'
+import {ReviewEvents} from '../../src/shared/transport/events/review-events.js'
+
+class TestableReview extends Review {
+  private readonly mockConnector: () => Promise<ConnectionResult>
+
+  constructor(argv: string[], mockConnector: () => Promise<ConnectionResult>, config: Config) {
+    super(argv, config)
+    this.mockConnector = mockConnector
+  }
+
+  protected override getDaemonClientOptions() {
+    return {maxRetries: 1, retryDelayMs: 0, transportConnector: this.mockConnector}
+  }
+}
+
+describe('Review (top-level toggle command)', () => {
+  let config: Config
+  let loggedMessages: string[]
+  let stdoutOutput: string[]
+  let mockClient: sinon.SinonStubbedInstance<ITransportClient>
+  let mockConnector: sinon.SinonStub<[], Promise<ConnectionResult>>
+
+  before(async () => {
+    config = await OclifConfig.load(import.meta.url)
+  })
+
+  beforeEach(() => {
+    loggedMessages = []
+    stdoutOutput = []
+
+    mockClient = {
+      connect: stub().resolves(),
+      disconnect: stub().resolves(),
+      getClientId: stub().returns('test-client-id'),
+      getState: stub().returns('connected'),
+      isConnected: stub().resolves(true),
+      joinRoom: stub().resolves(),
+      leaveRoom: stub().resolves(),
+      on: stub().returns(() => {}),
+      once: stub(),
+      onStateChange: stub().returns(() => {}),
+      request: stub() as unknown as ITransportClient['request'],
+      requestWithAck: stub().resolves(),
+    } as unknown as sinon.SinonStubbedInstance<ITransportClient>
+
+    mockConnector = stub<[], Promise<ConnectionResult>>().resolves({
+      client: mockClient as unknown as ITransportClient,
+      projectRoot: '/test/project',
+    })
+  })
+
+  afterEach(() => {
+    restore()
+  })
+
+  function makeCommand(...argv: string[]): TestableReview {
+    const cmd = new TestableReview(argv, mockConnector, config)
+    stub(cmd, 'log').callsFake((msg?: string) => {
+      loggedMessages.push(msg ?? '')
+    })
+    return cmd
+  }
+
+  function makeJsonCommand(...argv: string[]): TestableReview {
+    const cmd = new TestableReview([...argv, '--format', 'json'], mockConnector, config)
+    stub(cmd, 'log').callsFake((msg?: string) => {
+      if (msg) loggedMessages.push(msg)
+    })
+    stub(process.stdout, 'write').callsFake((chunk: string | Uint8Array) => {
+      stdoutOutput.push(String(chunk))
+      return true
+    })
+    return cmd
+  }
+
+  function parseJsonOutput(): {command: string; data: Record<string, unknown>; success: boolean} {
+    return JSON.parse(stdoutOutput.join('').trim())
+  }
+
+  describe('--disable', () => {
+    it('sends review:setDisabled with reviewDisabled=true', async () => {
+      ;(mockClient.requestWithAck as sinon.SinonStub).resolves({reviewDisabled: true})
+
+      await makeCommand('--disable').run()
+
+      const call = (mockClient.requestWithAck as sinon.SinonStub).firstCall
+      expect(call.args[0]).to.equal(ReviewEvents.SET_DISABLED)
+      expect(call.args[1]).to.deep.equal({reviewDisabled: true})
+    })
+
+    it('prints confirmation in text mode', async () => {
+      ;(mockClient.requestWithAck as sinon.SinonStub).resolves({reviewDisabled: true})
+
+      await makeCommand('--disable').run()
+
+      expect(loggedMessages.some((m) => m.toLowerCase().includes('disabled'))).to.be.true
+    })
+
+    it('outputs JSON success in json mode', async () => {
+      ;(mockClient.requestWithAck as sinon.SinonStub).resolves({reviewDisabled: true})
+
+      await makeJsonCommand('--disable').run()
+
+      const json = parseJsonOutput()
+      expect(json.command).to.equal('review')
+      expect(json.success).to.be.true
+      expect(json.data).to.have.property('reviewDisabled', true)
+    })
+
+    it('reports error when daemon rejects (project not initialized)', async () => {
+      ;(mockClient.requestWithAck as sinon.SinonStub).rejects(
+        new Error('Project not initialized: /test/project. Run `brv init` first.'),
+      )
+
+      await makeJsonCommand('--disable').run()
+
+      const json = parseJsonOutput()
+      expect(json.success).to.be.false
+      expect(json.data).to.have.property('status', 'error')
+      expect(String(json.data.error)).to.match(/not initialized/i)
+    })
+  })
+
+  describe('--enable', () => {
+    it('sends review:setDisabled with reviewDisabled=false', async () => {
+      ;(mockClient.requestWithAck as sinon.SinonStub).resolves({reviewDisabled: false})
+
+      await makeCommand('--enable').run()
+
+      const call = (mockClient.requestWithAck as sinon.SinonStub).firstCall
+      expect(call.args[0]).to.equal(ReviewEvents.SET_DISABLED)
+      expect(call.args[1]).to.deep.equal({reviewDisabled: false})
+    })
+
+    it('prints confirmation in text mode', async () => {
+      ;(mockClient.requestWithAck as sinon.SinonStub).resolves({reviewDisabled: false})
+
+      await makeCommand('--enable').run()
+
+      expect(loggedMessages.some((m) => m.toLowerCase().includes('enabled'))).to.be.true
+    })
+  })
+
+  describe('without flags (status)', () => {
+    it('sends review:getDisabled and prints enabled when reviewDisabled=false', async () => {
+      ;(mockClient.requestWithAck as sinon.SinonStub).resolves({reviewDisabled: false})
+
+      await makeCommand().run()
+
+      const call = (mockClient.requestWithAck as sinon.SinonStub).firstCall
+      expect(call.args[0]).to.equal(ReviewEvents.GET_DISABLED)
+      expect(loggedMessages.some((m) => m.toLowerCase().includes('enabled'))).to.be.true
+    })
+
+    it('prints disabled when reviewDisabled=true', async () => {
+      ;(mockClient.requestWithAck as sinon.SinonStub).resolves({reviewDisabled: true})
+
+      await makeCommand().run()
+
+      expect(loggedMessages.some((m) => m.toLowerCase().includes('disabled'))).to.be.true
+    })
+
+    it('outputs JSON status', async () => {
+      ;(mockClient.requestWithAck as sinon.SinonStub).resolves({reviewDisabled: false})
+
+      await makeJsonCommand().run()
+
+      const json = parseJsonOutput()
+      expect(json.success).to.be.true
+      expect(json.data).to.have.property('reviewDisabled', false)
+    })
+  })
+
+  describe('flag validation', () => {
+    it('rejects passing both --disable and --enable', async () => {
+      let threw = false
+      try {
+        await makeCommand('--disable', '--enable').run()
+      } catch {
+        threw = true
+      }
+
+      expect(threw).to.be.true
+      expect((mockClient.requestWithAck as sinon.SinonStub).called).to.be.false
+    })
+  })
+})

--- a/test/unit/agent/tools/curate-tool.test.ts
+++ b/test/unit/agent/tools/curate-tool.test.ts
@@ -3,7 +3,8 @@ import * as fs from 'node:fs/promises'
 import {tmpdir} from 'node:os'
 import {join} from 'node:path'
 
-import {createCurateTool} from '../../../../src/agent/infra/tools/implementations/curate-tool.js'
+import {runWithReviewDisabled} from '../../../../src/agent/infra/tools/implementations/curate-tool-task-context.js'
+import {createCurateTool, executeCurate} from '../../../../src/agent/infra/tools/implementations/curate-tool.js'
 
 interface CurateOutput {
   applied: Array<{
@@ -47,6 +48,33 @@ function countByPrefix(items: string[], prefix: string): number {
   }
 
   return count
+}
+
+async function writeBrvConfig(tmpDir: string, reviewDisabled: boolean): Promise<void> {
+  const configPath = join(tmpDir, '.brv', 'config.json')
+  await fs.writeFile(
+    configPath,
+    JSON.stringify({createdAt: '2026-01-01T00:00:00.000Z', cwd: tmpDir, reviewDisabled, version: '0.0.1'}),
+    'utf8',
+  )
+}
+
+async function seedExistingFile(basePath: string): Promise<void> {
+  const tool = createCurateTool()
+  await tool.execute({
+    basePath,
+    operations: [
+      {
+        confidence: 'high',
+        content: {keywords: [], snippets: ['initial content'], tags: []},
+        impact: 'low',
+        path: 'security/auth',
+        reason: 'seed',
+        title: 'JWT Strategy',
+        type: 'ADD',
+      },
+    ],
+  })
 }
 
 describe('Curate Tool', () => {
@@ -1404,6 +1432,184 @@ describe('Curate Tool', () => {
       expect(result.applied[0].status).to.equal('success')
       expect(result.applied[0].confidence).to.equal('high')
       expect(result.applied[0].impact).to.equal('low')
+    })
+  })
+
+  describe('Review backup gating (`brv review --disable`)', () => {
+    it('does NOT create review-backups when reviewDisabled=true (UPDATE on existing file)', async () => {
+      await seedExistingFile(basePath)
+      await writeBrvConfig(tmpDir, true)
+
+      const tool = createCurateTool()
+      const result = (await tool.execute({
+        basePath,
+        operations: [
+          {
+            confidence: 'high',
+            content: {keywords: [], snippets: ['updated content'], tags: []},
+            impact: 'high',
+            path: 'security/auth',
+            reason: 'CRITICAL update',
+            title: 'JWT Strategy',
+            type: 'UPDATE',
+          },
+        ],
+      })) as CurateOutput
+
+      expect(result.applied[0].status).to.equal('success')
+      expect(result.applied[0].needsReview).to.be.true
+
+      const backupsDir = join(tmpDir, '.brv', 'review-backups')
+      expect(await pathExists(backupsDir)).to.equal(false)
+    })
+
+    it('DOES create review-backups when reviewDisabled=false (UPDATE on existing file)', async () => {
+      await seedExistingFile(basePath)
+      await writeBrvConfig(tmpDir, false)
+
+      const tool = createCurateTool()
+      await tool.execute({
+        basePath,
+        operations: [
+          {
+            confidence: 'high',
+            content: {keywords: [], snippets: ['updated content'], tags: []},
+            impact: 'high',
+            path: 'security/auth',
+            reason: 'CRITICAL update',
+            title: 'JWT Strategy',
+            type: 'UPDATE',
+          },
+        ],
+      })
+
+      const backupsDir = join(tmpDir, '.brv', 'review-backups')
+      expect(await pathExists(backupsDir)).to.equal(true)
+    })
+
+    it('skips backups across MULTIPLE ops in one tool call when disabled (snapshot consistency)', async () => {
+      await seedExistingFile(basePath)
+      await writeBrvConfig(tmpDir, true)
+
+      const tool = createCurateTool()
+      // Three updates in a single tool invocation — all should observe the snapshot
+      const result = (await tool.execute({
+        basePath,
+        operations: [
+          {confidence: 'high', content: {keywords: [], snippets: ['v2'], tags: []}, impact: 'high', path: 'security/auth', reason: 'r', title: 'JWT Strategy', type: 'UPDATE'},
+          {confidence: 'high', content: {keywords: [], snippets: ['v3'], tags: []}, impact: 'high', path: 'security/auth', reason: 'r', title: 'JWT Strategy', type: 'UPDATE'},
+          {confidence: 'high', content: {keywords: [], snippets: ['v4'], tags: []}, impact: 'high', path: 'security/auth', reason: 'r', title: 'JWT Strategy', type: 'UPDATE'},
+        ],
+      })) as CurateOutput
+
+      for (const op of result.applied) {
+        expect(op.status).to.equal('success')
+      }
+
+      const backupsDir = join(tmpDir, '.brv', 'review-backups')
+      expect(await pathExists(backupsDir)).to.equal(false)
+    })
+
+    it('treats missing config as enabled (fail-open) — backups still created', async () => {
+      await seedExistingFile(basePath)
+      // Note: no writeBrvConfig — .brv/config.json does not exist
+
+      const tool = createCurateTool()
+      await tool.execute({
+        basePath,
+        operations: [
+          {
+            confidence: 'high',
+            content: {keywords: [], snippets: ['updated'], tags: []},
+            impact: 'high',
+            path: 'security/auth',
+            reason: 'r',
+            title: 'JWT Strategy',
+            type: 'UPDATE',
+          },
+        ],
+      })
+
+      const backupsDir = join(tmpDir, '.brv', 'review-backups')
+      expect(await pathExists(backupsDir)).to.equal(true)
+    })
+
+    it('ALS scope takes precedence over config file — scope=true suppresses backups even when config says false', async () => {
+      await seedExistingFile(basePath)
+      // Config says review is ENABLED
+      await writeBrvConfig(tmpDir, false)
+
+      // Scope (daemon-stamped snapshot) says DISABLED
+      await runWithReviewDisabled(true, async () => {
+        const tool = createCurateTool()
+        await tool.execute({
+          basePath,
+          operations: [
+            {confidence: 'high', content: {keywords: [], snippets: ['scope-test'], tags: []}, impact: 'high', path: 'security/auth', reason: 'r', title: 'JWT Strategy', type: 'UPDATE'},
+          ],
+        })
+      })
+
+      const backupsDir = join(tmpDir, '.brv', 'review-backups')
+      expect(await pathExists(backupsDir)).to.equal(false)
+    })
+
+    it('ALS scope takes precedence over config file — scope=false enables backups even when config says true', async () => {
+      await seedExistingFile(basePath)
+      // Config says review is DISABLED
+      await writeBrvConfig(tmpDir, true)
+
+      // Scope says ENABLED
+      await runWithReviewDisabled(false, async () => {
+        const tool = createCurateTool()
+        await tool.execute({
+          basePath,
+          operations: [
+            {confidence: 'high', content: {keywords: [], snippets: ['scope-test-2'], tags: []}, impact: 'high', path: 'security/auth', reason: 'r', title: 'JWT Strategy', type: 'UPDATE'},
+          ],
+        })
+      })
+
+      const backupsDir = join(tmpDir, '.brv', 'review-backups')
+      expect(await pathExists(backupsDir)).to.equal(true)
+    })
+
+    it('ALS scope honored via executeCurate sandbox path (no _context.taskId) — proves CurateService route picks up the snapshot', async () => {
+      // This is the regression that the Map-based registry missed: CurateService.curate()
+      // calls executeCurate(input, undefined, ...). Without ALS the file read wins on toggle.
+      await seedExistingFile(basePath)
+      // File config says DISABLED — what the CLI would see after a mid-task `brv review --disable`
+      await writeBrvConfig(tmpDir, true)
+
+      // Scope captured the snapshot at task-create (review was ENABLED then)
+      await runWithReviewDisabled(false, async () => {
+        // Mimic CurateService.curate(): executeCurate with _context = undefined
+        await executeCurate({
+          basePath,
+          operations: [
+            {confidence: 'high', content: {keywords: [], snippets: ['als-via-sandbox'], tags: []}, impact: 'high', path: 'security/auth', reason: 'r', title: 'JWT Strategy', type: 'UPDATE'},
+          ],
+        })
+      })
+
+      const backupsDir = join(tmpDir, '.brv', 'review-backups')
+      expect(await pathExists(backupsDir)).to.equal(true)
+    })
+
+    it('outside any ALS scope falls back to config file', async () => {
+      await seedExistingFile(basePath)
+      await writeBrvConfig(tmpDir, true)
+
+      // No runWithReviewDisabled wrapper → ALS returns undefined → fallback reads config = disabled
+      await executeCurate({
+        basePath,
+        operations: [
+          {confidence: 'high', content: {keywords: [], snippets: ['no-scope'], tags: []}, impact: 'high', path: 'security/auth', reason: 'r', title: 'JWT Strategy', type: 'UPDATE'},
+        ],
+      })
+
+      const backupsDir = join(tmpDir, '.brv', 'review-backups')
+      expect(await pathExists(backupsDir)).to.equal(false)
     })
   })
 })

--- a/test/unit/core/domain/entities/brv-config.test.ts
+++ b/test/unit/core/domain/entities/brv-config.test.ts
@@ -230,6 +230,55 @@ describe('BrvConfig', () => {
     })
   })
 
+  describe('reviewDisabled', () => {
+    it('should default to undefined when not set', () => {
+      const config = new BrvConfig(validConstructorArgs)
+      expect(config.reviewDisabled).to.be.undefined
+    })
+
+    it('should preserve true value through constructor', () => {
+      const config = new BrvConfig({...validConstructorArgs, reviewDisabled: true})
+      expect(config.reviewDisabled).to.be.true
+    })
+
+    it('should round-trip true through toJson/fromJson', () => {
+      const config = new BrvConfig({...validConstructorArgs, reviewDisabled: true})
+      const restored = BrvConfig.fromJson(config.toJson())
+      expect(restored.reviewDisabled).to.be.true
+    })
+
+    it('should round-trip false through toJson/fromJson', () => {
+      const config = new BrvConfig({...validConstructorArgs, reviewDisabled: false})
+      const restored = BrvConfig.fromJson(config.toJson())
+      expect(restored.reviewDisabled).to.be.false
+    })
+
+    it('should reject non-boolean reviewDisabled in fromJson', () => {
+      expect(() =>
+        BrvConfig.fromJson({...validConstructorArgs, reviewDisabled: 'yes'}),
+      ).to.throw('Invalid BrvConfig JSON structure')
+    })
+
+    it('withReviewDisabled creates a new config with the flag set, preserving other fields', () => {
+      const original = new BrvConfig(validConstructorArgs)
+      const disabled = original.withReviewDisabled(true)
+
+      expect(disabled.reviewDisabled).to.be.true
+      expect(disabled.spaceId).to.equal(original.spaceId)
+      expect(disabled.teamId).to.equal(original.teamId)
+      expect(disabled.cwd).to.equal(original.cwd)
+      expect(disabled.createdAt).to.equal(original.createdAt)
+      // Original is not mutated
+      expect(original.reviewDisabled).to.be.undefined
+    })
+
+    it('withReviewDisabled(false) creates an enabled config', () => {
+      const original = new BrvConfig({...validConstructorArgs, reviewDisabled: true})
+      const enabled = original.withReviewDisabled(false)
+      expect(enabled.reviewDisabled).to.be.false
+    })
+  })
+
   describe('fromSpace', () => {
     it('should create config from Space entity with current version', () => {
       const space = new Space({

--- a/test/unit/infra/executor/dream-executor.test.ts
+++ b/test/unit/infra/executor/dream-executor.test.ts
@@ -144,6 +144,24 @@ describe('DreamExecutor', () => {
       expect(result).to.not.include('No changes needed')
     })
 
+    it('omits the flagged-for-review line when review is disabled', () => {
+      const executor = new DreamExecutor(deps)
+      const formatResult = (executor as unknown as {formatResult(logId: string, summary: import('../../../../src/server/infra/dream/dream-log-schema.js').DreamLogSummary, reviewDisabled: boolean): string}).formatResult.bind(executor)
+
+      const result = formatResult('drm-3600', {consolidated: 1, errors: 0, flaggedForReview: 2, pruned: 0, synthesized: 1}, true)
+      expect(result).to.include('1 consolidated')
+      expect(result).to.include('1 synthesized')
+      expect(result).to.not.include('flagged for review')
+    })
+
+    it('still shows the flagged-for-review line when review is enabled', () => {
+      const executor = new DreamExecutor(deps)
+      const formatResult = (executor as unknown as {formatResult(logId: string, summary: import('../../../../src/server/infra/dream/dream-log-schema.js').DreamLogSummary, reviewDisabled: boolean): string}).formatResult.bind(executor)
+
+      const result = formatResult('drm-3700', {consolidated: 0, errors: 0, flaggedForReview: 3, pruned: 0, synthesized: 0}, false)
+      expect(result).to.include('3 operations flagged for review')
+    })
+
     it('formats result with error count and omits no-changes message', () => {
       const executor = new DreamExecutor(deps)
       const formatResult = (executor as unknown as {formatResult(logId: string, summary: import('../../../../src/server/infra/dream/dream-log-schema.js').DreamLogSummary): string}).formatResult.bind(executor)

--- a/test/unit/infra/executor/dream-executor.test.ts
+++ b/test/unit/infra/executor/dream-executor.test.ts
@@ -28,6 +28,7 @@ function makePartialRunExecutor(args: {
       logId: string
       out: import('../../../../src/server/infra/dream/dream-log-schema.js').DreamOperation[]
       projectRoot: string
+      reviewDisabled?: boolean
       signal: AbortSignal
       taskId: string
     }): Promise<void> {
@@ -369,8 +370,8 @@ describe('DreamExecutor', () => {
       ]
 
       // Call private method directly to test dual-write logic
-      await (executor as unknown as {createReviewEntries: (ops: typeof operations, dir: string, taskId: string) => Promise<void>})
-        .createReviewEntries(operations, '/tmp/ctx', 'test-task')
+      await (executor as unknown as {createReviewEntries: (args: {contextTreeDir: string; operations: typeof operations; reviewDisabled: boolean; taskId: string}) => Promise<void>})
+        .createReviewEntries({contextTreeDir: '/tmp/ctx', operations, reviewDisabled: false, taskId: 'test-task'})
 
       expect(curateLogStore.getNextId.calledOnce).to.be.true
       expect(curateLogStore.save.calledOnce).to.be.true
@@ -401,8 +402,8 @@ describe('DreamExecutor', () => {
         },
       ]
 
-      await (executor as unknown as {createReviewEntries: (ops: typeof operations, dir: string, taskId: string) => Promise<void>})
-        .createReviewEntries(operations, '/tmp/ctx', 'test-task')
+      await (executor as unknown as {createReviewEntries: (args: {contextTreeDir: string; operations: typeof operations; reviewDisabled: boolean; taskId: string}) => Promise<void>})
+        .createReviewEntries({contextTreeDir: '/tmp/ctx', operations, reviewDisabled: false, taskId: 'test-task'})
 
       const savedEntry = curateLogStore.save.firstCall.args[0]
       expect(savedEntry.taskId).to.equal('test-task')
@@ -430,8 +431,8 @@ describe('DreamExecutor', () => {
         },
       ]
 
-      await (executor as unknown as {createReviewEntries: (ops: typeof operations, dir: string, taskId: string) => Promise<void>})
-        .createReviewEntries(operations, '/tmp/ctx', 'test-task')
+      await (executor as unknown as {createReviewEntries: (args: {contextTreeDir: string; operations: typeof operations; reviewDisabled: boolean; taskId: string}) => Promise<void>})
+        .createReviewEntries({contextTreeDir: '/tmp/ctx', operations, reviewDisabled: false, taskId: 'test-task'})
 
       const savedEntry = curateLogStore.save.firstCall.args[0]
       expect(savedEntry.operations[0]).to.include({
@@ -600,6 +601,7 @@ describe('DreamExecutor', () => {
             logId: string
             out: import('../../../../src/server/infra/dream/dream-log-schema.js').DreamOperation[]
             projectRoot: string
+            reviewDisabled?: boolean
             signal: AbortSignal
             taskId: string
           }) => Promise<void>
@@ -619,6 +621,143 @@ describe('DreamExecutor', () => {
           'createReviewEntries must run exactly once when step 7 throws after success-path review write',
         ).to.equal(1)
       })
+    })
+  })
+
+  // ── reviewDisabled — `brv review --disable` ────────────────────────────────
+  describe('reviewDisabled', () => {
+    it('skips dream-side review entry creation when options.reviewDisabled=true', async () => {
+      const executor = new DreamExecutor(deps)
+      const operations: import('../../../../src/server/infra/dream/dream-log-schema.js').DreamOperation[] = [
+        {action: 'ARCHIVE', file: 'auth/stale.md', needsReview: true, reason: 'Stale doc', stubPath: '_archived/auth/stale.stub.md', type: 'PRUNE'},
+      ]
+
+      await (executor as unknown as {createReviewEntries: (args: {contextTreeDir: string; operations: typeof operations; reviewDisabled: boolean; taskId: string}) => Promise<void>})
+        .createReviewEntries({contextTreeDir: '/tmp/ctx', operations, reviewDisabled: true, taskId: 'test-task'})
+
+      expect(curateLogStore.save.called).to.be.false
+    })
+
+    it('still creates dream-side review entries when options.reviewDisabled=false', async () => {
+      const executor = new DreamExecutor(deps)
+      const operations: import('../../../../src/server/infra/dream/dream-log-schema.js').DreamOperation[] = [
+        {action: 'ARCHIVE', file: 'auth/stale.md', needsReview: true, reason: 'Stale doc', stubPath: '_archived/auth/stale.stub.md', type: 'PRUNE'},
+      ]
+
+      await (executor as unknown as {createReviewEntries: (args: {contextTreeDir: string; operations: typeof operations; reviewDisabled: boolean; taskId: string}) => Promise<void>})
+        .createReviewEntries({contextTreeDir: '/tmp/ctx', operations, reviewDisabled: false, taskId: 'test-task'})
+
+      expect(curateLogStore.save.calledOnce).to.be.true
+    })
+
+    it('treats omitted options.reviewDisabled as enabled (fail-open)', async () => {
+      const executor = new DreamExecutor(deps)
+      const operations: import('../../../../src/server/infra/dream/dream-log-schema.js').DreamOperation[] = [
+        {action: 'ARCHIVE', file: 'auth/stale.md', needsReview: true, reason: 'Stale doc', stubPath: '_archived/auth/stale.stub.md', type: 'PRUNE'},
+      ]
+
+      // executeWithAgent treats undefined as false; createReviewEntries gets called with the boolean
+      await (executor as unknown as {createReviewEntries: (args: {contextTreeDir: string; operations: typeof operations; reviewDisabled: boolean; taskId: string}) => Promise<void>})
+        .createReviewEntries({contextTreeDir: '/tmp/ctx', operations, reviewDisabled: false, taskId: 'test-task'})
+
+      expect(curateLogStore.save.calledOnce).to.be.true
+    })
+
+    it('runOperations omits reviewBackupStore from consolidate/prune when reviewDisabled=true', async () => {
+      const reviewBackupStore = {save: stub().resolves()}
+      class ProbeExecutor extends DreamExecutor {
+        public capturedReviewBackupStore: unknown
+        public capturedReviewDisabled?: boolean
+
+        protected override async runOperations(args: {
+          agent: ICipherAgent
+          changedFiles: Set<string>
+          contextTreeDir: string
+          logId: string
+          out: import('../../../../src/server/infra/dream/dream-log-schema.js').DreamOperation[]
+          projectRoot: string
+          reviewDisabled?: boolean
+          signal: AbortSignal
+          taskId: string
+        }): Promise<void> {
+          this.capturedReviewDisabled = args.reviewDisabled
+          this.capturedReviewBackupStore =
+            args.reviewDisabled === true ? undefined : (this as unknown as {deps: {reviewBackupStore?: unknown}}).deps.reviewBackupStore
+        }
+      }
+
+      const executor = new ProbeExecutor({...deps, reviewBackupStore})
+      await executor.executeWithAgent(agent, {...defaultOptions, reviewDisabled: true})
+
+      expect(executor.capturedReviewDisabled).to.equal(true)
+      expect(executor.capturedReviewBackupStore).to.be.undefined
+    })
+
+    it('runOperations passes reviewBackupStore through when reviewDisabled=false', async () => {
+      const reviewBackupStore = {save: stub().resolves()}
+      class ProbeExecutor extends DreamExecutor {
+        public capturedReviewBackupStore: unknown
+
+        protected override async runOperations(args: {
+          agent: ICipherAgent
+          changedFiles: Set<string>
+          contextTreeDir: string
+          logId: string
+          out: import('../../../../src/server/infra/dream/dream-log-schema.js').DreamOperation[]
+          projectRoot: string
+          reviewDisabled?: boolean
+          signal: AbortSignal
+          taskId: string
+        }): Promise<void> {
+          this.capturedReviewBackupStore =
+            args.reviewDisabled === true ? undefined : (this as unknown as {deps: {reviewBackupStore?: unknown}}).deps.reviewBackupStore
+        }
+      }
+
+      const executor = new ProbeExecutor({...deps, reviewBackupStore})
+      await executor.executeWithAgent(agent, {...defaultOptions, reviewDisabled: false})
+
+      expect(executor.capturedReviewBackupStore).to.equal(reviewBackupStore)
+    })
+
+    it('snapshots options.reviewDisabled — runOperations and createReviewEntries see the same value', async () => {
+      const reviewBackupStore = {save: stub().resolves()}
+      let capturedRunOpsReviewDisabled: boolean | undefined
+      let capturedCreateReviewEntriesReviewDisabled: boolean | undefined
+
+      class ProbeExecutor extends DreamExecutor {
+        protected override async runOperations(args: {
+          agent: ICipherAgent
+          changedFiles: Set<string>
+          contextTreeDir: string
+          logId: string
+          out: import('../../../../src/server/infra/dream/dream-log-schema.js').DreamOperation[]
+          projectRoot: string
+          reviewDisabled?: boolean
+          signal: AbortSignal
+          taskId: string
+        }): Promise<void> {
+          capturedRunOpsReviewDisabled = args.reviewDisabled
+          // Simulate one needsReview op so the private createReviewEntries is invoked
+          args.out.push({action: 'ARCHIVE', file: 'auth/stale.md', needsReview: true, reason: 'Stale doc', stubPath: '_archived/auth/stale.stub.md', type: 'PRUNE'})
+        }
+      }
+
+      const executor = new ProbeExecutor({...deps, reviewBackupStore})
+
+      // Patch the private createReviewEntries via prototype to capture its reviewDisabled arg
+      type CreateReviewEntriesArgs = {contextTreeDir: string; operations: unknown[]; reviewDisabled: boolean; taskId: string}
+      const proto = Object.getPrototypeOf(Object.getPrototypeOf(executor)) as {createReviewEntries: (args: CreateReviewEntriesArgs) => Promise<void>}
+      const origCreateReviewEntries = proto.createReviewEntries.bind(executor)
+      ;(executor as unknown as {createReviewEntries: (args: CreateReviewEntriesArgs) => Promise<void>}).createReviewEntries = async (args) => {
+        capturedCreateReviewEntriesReviewDisabled = args.reviewDisabled
+        return origCreateReviewEntries(args)
+      }
+
+      await executor.executeWithAgent(agent, {...defaultOptions, reviewDisabled: true})
+
+      expect(capturedRunOpsReviewDisabled).to.equal(true)
+      expect(capturedCreateReviewEntriesReviewDisabled).to.equal(true)
     })
   })
 })

--- a/test/unit/infra/process/curate-log-handler.test.ts
+++ b/test/unit/infra/process/curate-log-handler.test.ts
@@ -647,6 +647,135 @@ describe('CurateLogHandler', () => {
       await handlerWithBadCallback.onTaskCompleted('task-abc', 'done', makeTask())
     })
   })
+
+  // ==========================================================================
+  // reviewDisabled — `brv review --disable`
+  // ==========================================================================
+
+  describe('reviewDisabled', () => {
+    it('does not mark operations as pending review when task.reviewDisabled=true', async () => {
+      const handlerWithToggle = new CurateLogHandler(() => store)
+
+      await handlerWithToggle.onTaskCreate(makeTask({reviewDisabled: true}))
+      handlerWithToggle.onToolResult('task-abc', {
+        result: {
+          applied: [
+            {confidence: 'low', impact: 'high', needsReview: true, path: '/a.md', reason: 'uncertain', status: 'success', type: 'UPDATE'},
+            {confidence: 'high', impact: 'high', needsReview: true, path: '/b.md', reason: 'irreversible', status: 'success', type: 'DELETE'},
+          ],
+        },
+        sessionId: 'sess-1',
+        success: true,
+        taskId: 'task-abc',
+        toolName: 'curate',
+      } as never)
+
+      await handlerWithToggle.onTaskCompleted('task-abc', 'done', makeTask({reviewDisabled: true}))
+
+      const completed: CurateLogEntry = store.save.secondCall.args[0]
+      expect(completed.operations[0].reviewStatus).to.be.undefined
+      expect(completed.operations[1].reviewStatus).to.be.undefined
+    })
+
+    it('still marks operations as pending review when task.reviewDisabled=false', async () => {
+      const handlerWithToggle = new CurateLogHandler(() => store)
+
+      await handlerWithToggle.onTaskCreate(makeTask({reviewDisabled: false}))
+      handlerWithToggle.onToolResult('task-abc', {
+        result: {
+          applied: [
+            {confidence: 'low', impact: 'high', needsReview: true, path: '/a.md', status: 'success', type: 'UPDATE'},
+          ],
+        },
+        sessionId: 'sess-1',
+        success: true,
+        taskId: 'task-abc',
+        toolName: 'curate',
+      } as never)
+      await handlerWithToggle.onTaskCompleted('task-abc', 'done', makeTask({reviewDisabled: false}))
+
+      const completed: CurateLogEntry = store.save.secondCall.args[0]
+      expect(completed.operations[0].reviewStatus).to.equal('pending')
+    })
+
+    it('treats undefined task.reviewDisabled as enabled (fail-open)', async () => {
+      const handlerWithToggle = new CurateLogHandler(() => store)
+
+      await handlerWithToggle.onTaskCreate(makeTask())
+      handlerWithToggle.onToolResult('task-abc', {
+        result: {applied: [{needsReview: true, path: '/a.md', status: 'success', type: 'DELETE'}]},
+        sessionId: 'sess-1',
+        success: true,
+        taskId: 'task-abc',
+        toolName: 'curate',
+      } as never)
+      await handlerWithToggle.onTaskCompleted('task-abc', 'done', makeTask())
+
+      const completed: CurateLogEntry = store.save.secondCall.args[0]
+      expect(completed.operations[0].reviewStatus).to.equal('pending')
+    })
+
+    it('skips firing onPendingReviews callback when task.reviewDisabled=true', async () => {
+      const notifications: Array<{pendingCount: number}> = []
+      const handlerWithToggle = new CurateLogHandler(
+        () => store,
+        (info) => notifications.push({pendingCount: info.pendingCount}),
+      )
+
+      await handlerWithToggle.onTaskCreate(makeTask({reviewDisabled: true}))
+      handlerWithToggle.onToolResult('task-abc', {
+        result: {
+          applied: [{needsReview: true, path: '/a.md', status: 'success', type: 'DELETE'}],
+        },
+        sessionId: 'sess-1',
+        success: true,
+        taskId: 'task-abc',
+        toolName: 'curate',
+      } as never)
+
+      await handlerWithToggle.onTaskCompleted('task-abc', 'done', makeTask({reviewDisabled: true}))
+
+      expect(notifications).to.have.lengthOf(0)
+    })
+
+    it('reports zero pendingReviewCount via getTaskCompletionData when disabled', async () => {
+      const handlerWithToggle = new CurateLogHandler(() => store)
+
+      await handlerWithToggle.onTaskCreate(makeTask({reviewDisabled: true}))
+      handlerWithToggle.onToolResult('task-abc', {
+        result: {applied: [{needsReview: true, path: '/a.md', status: 'success', type: 'DELETE'}]},
+        sessionId: 'sess-1',
+        success: true,
+        taskId: 'task-abc',
+        toolName: 'curate',
+      } as never)
+
+      expect(handlerWithToggle.getTaskCompletionData('task-abc')).to.deep.equal({})
+    })
+
+    it('snapshots task.reviewDisabled at create time — mid-task TaskInfo mutation does not affect onToolResult', async () => {
+      const handlerWithToggle = new CurateLogHandler(() => store)
+      const task = makeTask({reviewDisabled: true})
+
+      await handlerWithToggle.onTaskCreate(task)
+
+      // Simulate user toggling between create and tool-result. The handler must
+      // ignore mutations to the original TaskInfo because it snapshotted on create.
+      task.reviewDisabled = false
+
+      handlerWithToggle.onToolResult('task-abc', {
+        result: {applied: [{needsReview: true, path: '/a.md', status: 'success', type: 'DELETE'}]},
+        sessionId: 'sess-1',
+        success: true,
+        taskId: 'task-abc',
+        toolName: 'curate',
+      } as never)
+      await handlerWithToggle.onTaskCompleted('task-abc', 'done', task)
+
+      const completed: CurateLogEntry = store.save.secondCall.args[0]
+      expect(completed.operations[0].reviewStatus).to.be.undefined
+    })
+  })
 })
 
 }) // end curate-log-handler

--- a/test/unit/infra/process/task-router.test.ts
+++ b/test/unit/infra/process/task-router.test.ts
@@ -270,7 +270,12 @@ describe('TaskRouter', () => {
         expect(submittedTask).to.not.have.property('reviewDisabled')
       })
 
-      it('omits reviewDisabled when resolver throws (fail-open)', async () => {
+      it('stamps explicit reviewDisabled=false when resolver throws (fail-open with single concrete value)', async () => {
+        // Returning undefined here would re-introduce the daemon/agent divergence the
+        // snapshot is meant to prevent: daemon stamps no field → CurateLogHandler treats
+        // as enabled (`?? false`), but the agent process opens no ALS scope and may
+        // observe a different value from .brv/config.json. Stamping a concrete `false`
+        // keeps both sides aligned (review enabled, fail-open).
         const routerWithResolver = new TaskRouter({
           agentPool,
           getAgentForProject,
@@ -288,7 +293,7 @@ describe('TaskRouter', () => {
         await new Promise((resolve) => { setTimeout(resolve, 10) })
 
         const submittedTask = agentPool.submitTask.firstCall.args[0]
-        expect(submittedTask).to.not.have.property('reviewDisabled')
+        expect(submittedTask).to.have.property('reviewDisabled', false)
       })
     })
 

--- a/test/unit/infra/process/task-router.test.ts
+++ b/test/unit/infra/process/task-router.test.ts
@@ -216,6 +216,82 @@ describe('TaskRouter', () => {
       expect(submittedTask).to.have.property('type', 'curate')
     })
 
+    describe('reviewDisabled stamping', () => {
+      it('stamps reviewDisabled=true on TaskExecute when resolver returns true', async () => {
+        const routerWithResolver = new TaskRouter({
+          agentPool,
+          getAgentForProject,
+          isReviewDisabled: sandbox.stub().resolves(true),
+          projectRegistry,
+          projectRouter,
+          transport: transportHelper.transport,
+        })
+        routerWithResolver.setup()
+
+        const handler = transportHelper.requestHandlers.get(TransportTaskEventNames.CREATE)
+        const request = makeTaskCreateRequest()
+        await handler!(request, 'client-1')
+
+        await new Promise((resolve) => { setTimeout(resolve, 10) })
+
+        const submittedTask = agentPool.submitTask.firstCall.args[0]
+        expect(submittedTask).to.have.property('reviewDisabled', true)
+      })
+
+      it('stamps reviewDisabled=false on TaskExecute when resolver returns false', async () => {
+        const routerWithResolver = new TaskRouter({
+          agentPool,
+          getAgentForProject,
+          isReviewDisabled: sandbox.stub().resolves(false),
+          projectRegistry,
+          projectRouter,
+          transport: transportHelper.transport,
+        })
+        routerWithResolver.setup()
+
+        const handler = transportHelper.requestHandlers.get(TransportTaskEventNames.CREATE)
+        const request = makeTaskCreateRequest()
+        await handler!(request, 'client-1')
+
+        await new Promise((resolve) => { setTimeout(resolve, 10) })
+
+        const submittedTask = agentPool.submitTask.firstCall.args[0]
+        expect(submittedTask).to.have.property('reviewDisabled', false)
+      })
+
+      it('omits reviewDisabled from TaskExecute when no resolver is configured', async () => {
+        const handler = transportHelper.requestHandlers.get(TransportTaskEventNames.CREATE)
+        const request = makeTaskCreateRequest()
+        await handler!(request, 'client-1')
+
+        await new Promise((resolve) => { setTimeout(resolve, 10) })
+
+        const submittedTask = agentPool.submitTask.firstCall.args[0]
+        expect(submittedTask).to.not.have.property('reviewDisabled')
+      })
+
+      it('omits reviewDisabled when resolver throws (fail-open)', async () => {
+        const routerWithResolver = new TaskRouter({
+          agentPool,
+          getAgentForProject,
+          isReviewDisabled: sandbox.stub().rejects(new Error('config read failed')),
+          projectRegistry,
+          projectRouter,
+          transport: transportHelper.transport,
+        })
+        routerWithResolver.setup()
+
+        const handler = transportHelper.requestHandlers.get(TransportTaskEventNames.CREATE)
+        const request = makeTaskCreateRequest()
+        await handler!(request, 'client-1')
+
+        await new Promise((resolve) => { setTimeout(resolve, 10) })
+
+        const submittedTask = agentPool.submitTask.firstCall.args[0]
+        expect(submittedTask).to.not.have.property('reviewDisabled')
+      })
+    })
+
     it('should return same taskId for duplicate create (idempotent)', async () => {
       const handler = transportHelper.requestHandlers.get(TransportTaskEventNames.CREATE)
       const request = makeTaskCreateRequest()

--- a/test/unit/infra/transport/handlers/review-handler.test.ts
+++ b/test/unit/infra/transport/handlers/review-handler.test.ts
@@ -1,0 +1,165 @@
+import type {SinonStub} from 'sinon'
+
+import {expect} from 'chai'
+import {restore, stub} from 'sinon'
+
+import type {ICurateLogStore} from '../../../../../src/server/core/interfaces/storage/i-curate-log-store.js'
+import type {IProjectConfigStore} from '../../../../../src/server/core/interfaces/storage/i-project-config-store.js'
+import type {IReviewBackupStore} from '../../../../../src/server/core/interfaces/storage/i-review-backup-store.js'
+
+import {BRV_CONFIG_VERSION} from '../../../../../src/server/constants.js'
+import {BrvConfig} from '../../../../../src/server/core/domain/entities/brv-config.js'
+import {ReviewHandler} from '../../../../../src/server/infra/transport/handlers/review-handler.js'
+import {ReviewEvents} from '../../../../../src/shared/transport/events/review-events.js'
+import {createMockTransportServer, type MockTransportServer} from '../../../../helpers/mock-factories.js'
+
+describe('ReviewHandler — config toggle (GET_DISABLED / SET_DISABLED)', () => {
+  let resolveProjectPath: SinonStub
+  let transport: MockTransportServer
+  let projectConfigStore: Partial<IProjectConfigStore> & {read: SinonStub; write: SinonStub}
+  let curateLogStoreFactory: SinonStub
+  let reviewBackupStoreFactory: SinonStub
+
+  beforeEach(() => {
+    resolveProjectPath = stub().returns('/test/project')
+    transport = createMockTransportServer()
+    projectConfigStore = {
+      read: stub(),
+      write: stub().resolves(),
+    }
+    curateLogStoreFactory = stub().returns({} as ICurateLogStore)
+    reviewBackupStoreFactory = stub().returns({} as IReviewBackupStore)
+  })
+
+  afterEach(() => {
+    restore()
+  })
+
+  function createHandler(): ReviewHandler {
+    const handler = new ReviewHandler({
+      curateLogStoreFactory,
+      projectConfigStore: projectConfigStore as IProjectConfigStore,
+      resolveProjectPath,
+      reviewBackupStoreFactory,
+      transport,
+    })
+    handler.setup()
+    return handler
+  }
+
+  async function callGetDisabled(clientId = 'client-1'): Promise<{reviewDisabled: boolean}> {
+    const handler = transport._handlers.get(ReviewEvents.GET_DISABLED)
+    expect(handler, 'review:getDisabled handler should be registered').to.exist
+    return handler!({}, clientId) as Promise<{reviewDisabled: boolean}>
+  }
+
+  async function callSetDisabled(
+    reviewDisabled: boolean,
+    clientId = 'client-1',
+  ): Promise<{reviewDisabled: boolean}> {
+    const handler = transport._handlers.get(ReviewEvents.SET_DISABLED)
+    expect(handler, 'review:setDisabled handler should be registered').to.exist
+    return handler!({reviewDisabled}, clientId) as Promise<{reviewDisabled: boolean}>
+  }
+
+  describe('setup', () => {
+    it('registers review:getDisabled and review:setDisabled handlers', () => {
+      createHandler()
+      expect(transport._handlers.has(ReviewEvents.GET_DISABLED)).to.be.true
+      expect(transport._handlers.has(ReviewEvents.SET_DISABLED)).to.be.true
+    })
+  })
+
+  describe('handleGetDisabled', () => {
+    it('returns reviewDisabled=false when config has no flag', async () => {
+      projectConfigStore.read.resolves(BrvConfig.createLocal({cwd: '/test/project'}))
+      createHandler()
+
+      const response = await callGetDisabled()
+      expect(response.reviewDisabled).to.equal(false)
+    })
+
+    it('returns reviewDisabled=true when config has the flag set', async () => {
+      projectConfigStore.read.resolves(
+        new BrvConfig({createdAt: '2025-01-01T00:00:00.000Z', cwd: '/test/project', reviewDisabled: true, version: BRV_CONFIG_VERSION}),
+      )
+      createHandler()
+
+      const response = await callGetDisabled()
+      expect(response.reviewDisabled).to.equal(true)
+    })
+
+    it('throws when project is not initialized', async () => {
+      projectConfigStore.read.resolves()
+      createHandler()
+
+      let threw = false
+      try {
+        await callGetDisabled()
+      } catch (error) {
+        threw = true
+        expect(String(error)).to.match(/not initialized/i)
+      }
+
+      expect(threw, 'should throw when config is missing').to.be.true
+    })
+  })
+
+  describe('handleSetDisabled', () => {
+    it('writes reviewDisabled=true while preserving other config fields', async () => {
+      const original = new BrvConfig({
+        chatLogPath: '/path/chat.log',
+        createdAt: '2025-01-01T00:00:00.000Z',
+        cwd: '/test/project',
+        ide: 'Claude Code',
+        spaceId: 'space-1',
+        spaceName: 'space',
+        teamId: 'team-1',
+        teamName: 'team',
+        version: BRV_CONFIG_VERSION,
+      })
+      projectConfigStore.read.resolves(original)
+      createHandler()
+
+      const response = await callSetDisabled(true)
+
+      expect(response.reviewDisabled).to.equal(true)
+      expect(projectConfigStore.write.calledOnce).to.be.true
+      const written: BrvConfig = projectConfigStore.write.firstCall.args[0]
+      expect(written.reviewDisabled).to.equal(true)
+      expect(written.spaceId).to.equal('space-1')
+      expect(written.teamId).to.equal('team-1')
+      expect(written.chatLogPath).to.equal('/path/chat.log')
+      expect(projectConfigStore.write.firstCall.args[1]).to.equal('/test/project')
+    })
+
+    it('writes reviewDisabled=false when re-enabling', async () => {
+      projectConfigStore.read.resolves(
+        new BrvConfig({createdAt: '2025-01-01T00:00:00.000Z', cwd: '/test/project', reviewDisabled: true, version: BRV_CONFIG_VERSION}),
+      )
+      createHandler()
+
+      const response = await callSetDisabled(false)
+
+      expect(response.reviewDisabled).to.equal(false)
+      const written: BrvConfig = projectConfigStore.write.firstCall.args[0]
+      expect(written.reviewDisabled).to.equal(false)
+    })
+
+    it('throws when project is not initialized', async () => {
+      projectConfigStore.read.resolves()
+      createHandler()
+
+      let threw = false
+      try {
+        await callSetDisabled(true)
+      } catch (error) {
+        threw = true
+        expect(String(error)).to.match(/not initialized/i)
+      }
+
+      expect(threw, 'should throw when config is missing').to.be.true
+      expect(projectConfigStore.write.called).to.be.false
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- **Problem:** Users had no way to opt out of the HITL review log per project. `brv curate` always emitted the "X operations require review" prompt, dream surfaced its own needsReview ops, and curate-log entries always carried review markers — even for projects/workflows where review is unwanted.
- **Why it matters:** Review pending entries and review-backups are persistent state. Without a toggle, projects that don't want HITL review accumulated dead entries. There was also a cross-process snapshot race: a user toggling mid-curate could leave orphan backups (no review entry references them) or missing backups (review entry exists but reject can't restore).
- **What changed:** Added a project-scoped `reviewDisabled` flag on `BrvConfig`. New top-level `brv review` command exposes `--enable` / `--disable` flags and a bare-form status read; both routed through new daemon transport events (`review:getDisabled`, `review:setDisabled`). The daemon snapshots `reviewDisabled` once at the task-create boundary and forwards it through `TaskInfo` (daemon-side, used by `CurateLogHandler`) and `TaskExecuteSchema` (wire format, opened as an `AsyncLocalStorage` scope around the agent-process task body so any descendant async callsite — direct curate-tool invocation OR sandbox `tools.curate(...)` via `CurateService` — observes the same value). Dream-side review entry creation and review-backup writing both honor the same snapshot.
- **What did NOT change (scope boundary):** Existing `brv review pending` / `approve` / `reject` subcommands and their wiring are untouched. `brv init` flow is untouched — `reviewDisabled` is optional and defaults to enabled (fail-open). No global / machine-wide override; the toggle is strictly project-level.

## Type of change

- [x] New feature

## Scope (select all touched areas)

- [x] Agent / Tools
- [x] Server / Daemon
- [x] Shared (constants, types, transport events)
- [x] CLI Commands (oclif)

## Linked issues

- Closes ENG-1593
- Related: HITL for Cipher Agent Curation project (backlog ticket; project branch was deleted, hence PR targets `main`)

## Root cause (bug fixes only, otherwise write `N/A`)

N/A — feature add. (Mid-task snapshot race surfaced during the work; closed by the AsyncLocalStorage design from day one of the implementation, no separate fix.)

## Test plan

- Coverage added:
  - [x] Unit test
  - [x] Integration test (interactive CLI, see Evidence below)
- Test file(s):
  - `test/commands/review-toggle.test.ts` (new) — top-level command surface (10 tests, transport-stubbed, mirrors peer `test/commands/review.test.ts`)
  - `test/unit/infra/transport/handlers/review-handler.test.ts` (new) — `handleGetDisabled` + `handleSetDisabled` (7 tests including "preserves other config fields")
  - `test/unit/agent/tools/curate-tool.test.ts` — added 4 ALS-path tests (scope=true overrides config=false; scope=false overrides config=true; ALS via `executeCurate` with no `_context.taskId` — the regression that the prior Map-based registry missed; outside-scope falls back to file)
  - `test/unit/infra/process/curate-log-handler.test.ts` — rewritten around `task.reviewDisabled` (snapshot-at-create test included)
  - `test/unit/infra/process/task-router.test.ts` — added `describe('reviewDisabled stamping')` (4 tests)
  - `test/unit/infra/executor/dream-executor.test.ts` — 6 dream-side tests including snapshot consistency between `runOperations` and `createReviewEntries` (prototype-patched)
  - `test/unit/core/domain/entities/brv-config.test.ts` — `reviewDisabled` field round-trip
- Key scenario(s) covered:
  - Curate enabled/disabled, single-op and multi-op batch, new file vs UPSERT existing vs DELETE
  - Mid-task toggle disabled→enabled (snapshot held disabled → no orphan backup)
  - Mid-task toggle enabled→disabled (snapshot held enabled → backup created, pending entry created)
  - Toggle storm (alternating disable/enable across 4 sequential ops)
  - Idempotent `--enable` / `--disable` (writing the same value succeeds silently)
  - Dream enabled/disabled and dream-with-mid-toggle (review entries surface only when daemon snapshot was enabled at dream-create)

## User-visible changes

- New top-level command:
  - `brv review` (no flags) — prints "Review log is enabled." or "Review log is disabled." (or `{"reviewDisabled":<bool>}` with `--format json`)
  - `brv review --disable` — disables for the current project; prints "Review log disabled. To re-enable: brv review --enable"
  - `brv review --enable` — re-enables; prints "Review log enabled. To disable: brv review --disable"
- Existing `brv review pending` / `approve` / `reject` subcommands continue to work (no change)
- New project-config field: `reviewDisabled?: boolean` in `<project_root>/.brv/config.json`. Defaults to enabled (omitted = enabled). Per-project; not global, not per-worktree (worktrees inherit parent project's setting via the existing pointer model).

## Evidence

- Interactive CLI test pass artifacts:
  - `notes/eng-1593-review-disable/round3-cli-suite/PLAN.md` — matrix
  - `notes/eng-1593-review-disable/round3-cli-suite/RESULTS.md` — 24 curates + 6 dreams; every mid-toggle observed the daemon snapshot, not the post-toggle config
  - `notes/eng-1593-review-disable/IMPLEMENTATION_REPORT.md` — full report including Implementation Decisions section per CLAUDE.md
- Test totals: 6920 passing, 16 pending (pre-existing), 0 failing
- Round-3 D3 / D4 mid-toggle scenarios verified end-to-end with debug-traced daemon snapshots (debug logs were removed before commit; `git diff` is clean of `eng-1593-debug` strings)

## Checklist

- [x] Tests added or updated and passing (`npm test` — 6920 passing)
- [x] Lint passes (`npm run lint` — clean on changed files; pre-existing submodule lint error in `packages/byterover-packages/` is unrelated and tracked separately)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow Conventional Commits format (`feat: [ENG-1593] ...`, no `Co-Authored-By`)
- [x] No breaking changes (additive only; existing review commands untouched; `reviewDisabled` defaults to enabled / undefined)
- [x] Branch is up to date with `main` (rebased to `3c7f749c` before commit)

## Risks and mitigations

- **Risk:** AsyncLocalStorage propagation depends on the LLM streaming pipeline + sandbox staying in-process and same-thread. If the sandbox is ever moved to a worker thread or separate process, the ALS scope silently stops working.
  - **Mitigation:** Same constraint already applies to the existing `CurateResultCollector` (cited as precedent), and that has shipped reliably. Documented in the JSDoc of `curate-tool-task-context.ts` so future refactors don't break it silently.
- **Risk:** Idempotent `--disable` / `--enable` (running the same flag twice in a row) doesn't differentiate between "actually toggled" and "already in that state" — both produce the same confirmation text.
  - **Mitigation:** Discussed; intentionally kept simple — the daemon write is a boolean overwrite, no efficiency concern. If UX wants distinguished messages later, the daemon handler can return a `changed` boolean for the CLI to branch on.
- **Risk:** Fail-open on missing/corrupt `.brv/config.json` — undefined `reviewDisabled` is treated as enabled rather than disabled.
  - **Mitigation:** Backups exist to support rejection; failing closed (= disabled) would silently break the rejection path. Documented in `snapshotReviewDisabled` JSDoc and `isReviewDisabledForBrvDir` fallback.