### PR TITLE
feat: [ENG-1540] style localhost OAuth callback page to match brv brand

### DIFF
--- a/src/server/infra/http/callback-server.ts
+++ b/src/server/infra/http/callback-server.ts
@@ -11,6 +11,139 @@ type CallbackResult = {
   state: string
 }
 
+const PAGE_STYLE = `
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  html, body { height: 100%; }
+  body {
+    font-family: 'Plus Jakarta Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: #000;
+    color: #e5e5e5;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 64px 24px 24px;
+    position: relative;
+    overflow: hidden;
+    -webkit-font-smoothing: antialiased;
+  }
+  body::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background:
+      radial-gradient(900px 500px at 50% -10%, rgba(23, 178, 106, 0.35), transparent 60%),
+      radial-gradient(700px 400px at 95% 10%, rgba(220, 130, 50, 0.18), transparent 60%);
+  }
+  body::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background-image:
+      linear-gradient(to right, rgba(255,255,255,0.04) 1px, transparent 1px),
+      linear-gradient(to bottom, rgba(255,255,255,0.04) 1px, transparent 1px);
+    background-size: 56px 56px;
+    -webkit-mask-image: radial-gradient(ellipse 80% 60% at 50% 30%, #000 55%, transparent 100%);
+    mask-image: radial-gradient(ellipse 80% 60% at 50% 30%, #000 55%, transparent 100%);
+  }
+  .brand { position: relative; z-index: 1; display: flex; align-items: center; gap: 10px; margin-bottom: 96px; }
+  .brand svg { width: 28px; height: 28px; }
+  .brand span { font-weight: 700; letter-spacing: 0.08em; font-size: 18px; color: #fff; }
+  .card {
+    position: relative;
+    z-index: 1;
+    width: 100%;
+    max-width: 560px;
+    background: rgba(20, 22, 26, 0.85);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 16px;
+    padding: 40px 32px;
+    text-align: center;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+  }
+  .icon-circle {
+    width: 56px; height: 56px; border-radius: 50%;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    margin: 0 auto 20px;
+    display: flex; align-items: center; justify-content: center;
+  }
+  .icon-circle svg { width: 28px; height: 28px; }
+  h1 { font-size: 22px; font-weight: 600; color: #fff; margin-bottom: 10px; letter-spacing: -0.01em; }
+  p { font-size: 14px; color: #a3a3a3; line-height: 1.5; max-width: 340px; margin: 0 auto; }
+  .error-detail {
+    margin-top: 20px;
+    padding: 12px 14px;
+    background: rgba(248, 113, 113, 0.08);
+    border: 1px solid rgba(248, 113, 113, 0.18);
+    border-radius: 8px;
+    color: #fca5a5;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 12px;
+    text-align: left;
+    word-break: break-word;
+  }
+`
+
+const BRAND_LOGO_SVG = `<svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><rect width="32" height="32" rx="16" fill="black"/><path d="M16.01 1.88257C7.97727 1.88257 1.4502 8.42761 1.4502 16.4814C1.4502 24.5352 7.97727 31.0803 16.01 31.0803C24.0427 31.0803 30.5698 24.5352 30.5698 16.4814C30.5698 8.42761 24.0427 1.88257 16.01 1.88257ZM16.01 2.51825C23.7077 2.51825 29.9365 8.76029 29.9365 16.4814C29.9365 24.1994 23.7077 30.4446 16.01 30.4446C8.30917 30.4446 2.08354 24.1994 2.08354 16.4814C2.08354 8.7595 8.30839 2.51825 16.01 2.51825Z" fill="white"/><path d="M29.2815 12.0991L29.1269 11.6188C28.9465 11.1643 28.7091 10.5575 28.5076 10.1132C25.829 5.39161 14.5601 3.45957 9.52303 3.78834C16.6663 3.90392 27.6361 7.1206 29.2815 12.0983M29.1699 20.8487C29.3393 20.2638 29.5439 19.4766 29.6736 18.8846L29.7423 18.477C30.1812 12.3435 15.3879 8.24593 5.58008 8.58564C18.268 9.40875 31.0488 14.8277 29.1699 20.8487Z" fill="white"/><path d="M23.6739 28.1234C24.1828 27.748 24.6799 27.3568 25.1647 26.9505C25.4349 26.6904 25.798 26.3476 26.0542 26.0735C30.9545 20.3008 15.6279 15.4886 3.76074 15.644C21.5575 17.2864 29.4309 23.651 24.0807 27.8274C23.9581 27.9212 23.7965 28.0328 23.6739 28.1234Z" fill="white"/><path d="M15.606 30.0481C17.6653 31.0766 21.4888 30.0192 21.6942 27.9794C21.9823 25.1891 13.3123 22.4269 5.12891 22.7049C16.6969 23.5421 22.144 27.3007 19.5731 29.3077" fill="white"/></svg>`
+
+const USER_ICON_SVG = `<svg viewBox="0 0 24 24" fill="#17b26a" aria-hidden="true"><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/></svg>`
+
+const ALERT_ICON_SVG = `<svg viewBox="0 0 24 24" fill="#f87171" aria-hidden="true"><path d="M12 2 1 21h22L12 2zm0 5.5L19.5 19h-15L12 7.5zM11 11v4h2v-4h-2zm0 5v2h2v-2h-2z"/></svg>`
+
+function escapeHtml(text: string): string {
+  return text
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
+}
+
+const SUCCESS_HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>ByteRover - Authentication Successful</title>
+<style>${PAGE_STYLE}</style>
+</head>
+<body>
+<div class="brand">${BRAND_LOGO_SVG}<span>BYTEROVER</span></div>
+<div class="card">
+  <div class="icon-circle">${USER_ICON_SVG}</div>
+  <h1>Authentication Successful</h1>
+  <p>You can now safely close this tab and return to where you left off</p>
+</div>
+<script>setTimeout(() => window.close(), 2500);</script>
+</body>
+</html>`
+
+function errorHtml(message: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>ByteRover - Authentication Failed</title>
+<style>${PAGE_STYLE}</style>
+</head>
+<body>
+<div class="brand">${BRAND_LOGO_SVG}<span>BYTEROVER</span></div>
+<div class="card">
+  <div class="icon-circle">${ALERT_ICON_SVG}</div>
+  <h1>Authentication Failed</h1>
+  <p>An error occurred while signing you in. Return to the CLI and try again.</p>
+  <div class="error-detail">${escapeHtml(message)}</div>
+</div>
+</body>
+</html>`
+}
+
 export class CallbackServer {
   private app = express()
   private connections = new Set<Socket>()
@@ -101,18 +234,19 @@ export class CallbackServer {
       if (error !== undefined) {
         const errorMessage = error_description ?? error
         this.app.locals.onError?.(String(errorMessage))
-        res.status(400).send(`Authentication failed: ${String(errorMessage)}`)
+        res.status(400).type('html').send(errorHtml(String(errorMessage)))
         return
       }
 
       if (code === undefined || state === undefined) {
-        this.app.locals.onError?.('Missing code or state parameter')
-        res.status(400).send('Authentication failed: Missing required parameters')
+        const missingMessage = 'Missing code or state parameter'
+        this.app.locals.onError?.(missingMessage)
+        res.status(400).type('html').send(errorHtml(missingMessage))
         return
       }
 
       this.app.locals.onCallback?.(String(code), String(state))
-      res.status(200).send('Authentication successful. You can close this window.')
+      res.status(200).type('html').send(SUCCESS_HTML)
     })
   }
 }

--- a/src/server/infra/http/callback-server.ts
+++ b/src/server/infra/http/callback-server.ts
@@ -1,4 +1,3 @@
- 
 import type {Server} from 'node:http'
 import type {Socket} from 'node:net'
 
@@ -15,7 +14,7 @@ const PAGE_STYLE = `
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
   html, body { height: 100%; }
   body {
-    font-family: 'Plus Jakarta Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     background: #000;
     color: #e5e5e5;
     min-height: 100vh;
@@ -139,12 +138,21 @@ const SUCCESS_HTML = `<!DOCTYPE html>
 <div class="card">
   <div class="icon-circle">${USER_ICON_SVG}</div>
   <h1>Authentication Successful</h1>
-  <p>You can now safely close this tab and return to where you left off</p>
+  <p>You can now safely close this tab and return to where you left off.</p>
 </div>
 </body>
 </html>`
 
-function errorHtml(message: string): string {
+/**
+ * Render the failure card. `details` is rendered in a monospace red-tint block
+ * underneath the body copy when present and non-empty; omit it for blank or
+ * undefined input so we don't show an empty `.error-detail` box.
+ */
+function errorHtml(details?: string): string {
+  const trimmed = details?.trim() ?? ''
+  const detailBlock = trimmed.length > 0
+    ? `<div class="error-detail">${escapeHtml(trimmed)}</div>`
+    : ''
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -158,8 +166,8 @@ function errorHtml(message: string): string {
 <div class="card">
   <div class="icon-circle">${ALERT_ICON_SVG}</div>
   <h1>Authentication Failed</h1>
-  <p>An error occurred while signing you in. Return to the CLI and try again.</p>
-  <div class="error-detail">${escapeHtml(message)}</div>
+  <p>Something went wrong while signing you in. Return to the CLI and try again.</p>
+  ${detailBlock}
 </div>
 </body>
 </html>`
@@ -257,16 +265,20 @@ export class CallbackServer {
       const state = firstQueryParam(req.query.state)
 
       if (error !== undefined) {
-        const errorMessage = errorDescription ?? error
-        this.app.locals.onError?.(errorMessage)
-        res.status(400).type('html').send(errorHtml(errorMessage))
+        // `??` would let `?error_description=` (empty string) through and render
+        // an empty red detail box; `||` falls back to the error code instead.
+        const detail = (errorDescription && errorDescription.length > 0) ? errorDescription : error
+        this.app.locals.onError?.(detail)
+        res.status(400).type('html').send(errorHtml(detail))
         return
       }
 
       if (code === undefined || state === undefined) {
-        const missingMessage = 'Missing code or state parameter'
-        this.app.locals.onError?.(missingMessage)
-        res.status(400).type('html').send(errorHtml(missingMessage))
+        // Keep the OAuth-jargon string for the CLI-facing onError callback (it
+        // surfaces in `brv login` stderr / logs where it's actionable), but
+        // render the user-facing card with the friendlier copy + no detail box.
+        this.app.locals.onError?.('Missing code or state parameter')
+        res.status(400).type('html').send(errorHtml())
         return
       }
 

--- a/src/server/infra/http/callback-server.ts
+++ b/src/server/infra/http/callback-server.ts
@@ -1,4 +1,4 @@
-/* eslint-disable camelcase */
+ 
 import type {Server} from 'node:http'
 import type {Socket} from 'node:net'
 
@@ -95,13 +95,35 @@ const USER_ICON_SVG = `<svg viewBox="0 0 24 24" fill="#17b26a" aria-hidden="true
 
 const ALERT_ICON_SVG = `<svg viewBox="0 0 24 24" fill="#f87171" aria-hidden="true"><path d="M12 2 1 21h22L12 2zm0 5.5L19.5 19h-15L12 7.5zM11 11v4h2v-4h-2zm0 5v2h2v-2h-2z"/></svg>`
 
-function escapeHtml(text: string): string {
+/**
+ * Escape characters that have meaning in HTML so user-controlled error
+ * messages cannot break out of attribute or text contexts.
+ */
+export function escapeHtml(text: string): string {
   return text
     .replaceAll('&', '&amp;')
     .replaceAll('<', '&lt;')
     .replaceAll('>', '&gt;')
     .replaceAll('"', '&quot;')
     .replaceAll("'", '&#39;')
+}
+
+/**
+ * Express parses repeated query keys (e.g. `?error=foo&error=bar`) into
+ * arrays, and nested syntax (`?error[code]=x`) into objects. Authoritative
+ * OAuth providers always send a single string per key, but the wire is
+ * untrusted — coerce any non-string shape to undefined and pick the first
+ * string when given an array, so we never feed `[object Object]` or a
+ * comma-joined value into a user-facing message.
+ */
+export function firstQueryParam(value: unknown): string | undefined {
+  if (typeof value === 'string') return value
+  if (Array.isArray(value)) {
+    const first = value[0]
+    if (typeof first === 'string') return first
+  }
+
+  return undefined
 }
 
 const SUCCESS_HTML = `<!DOCTYPE html>
@@ -119,7 +141,7 @@ const SUCCESS_HTML = `<!DOCTYPE html>
   <h1>Authentication Successful</h1>
   <p>You can now safely close this tab and return to where you left off</p>
 </div>
-<script>setTimeout(() => window.close(), 2500);</script>
+<!-- inline script: would be blocked by a strict CSP if one is added later --><script>setTimeout(() => window.close(), 2500);</script>
 </body>
 </html>`
 
@@ -230,11 +252,15 @@ export class CallbackServer {
 
   private setupRoutes(): void {
     this.app.get('/callback', (req, res) => {
-      const {code, error, error_description, state} = req.query
+      const error = firstQueryParam(req.query.error)
+      const errorDescription = firstQueryParam(req.query.error_description)
+      const code = firstQueryParam(req.query.code)
+      const state = firstQueryParam(req.query.state)
+
       if (error !== undefined) {
-        const errorMessage = error_description ?? error
-        this.app.locals.onError?.(String(errorMessage))
-        res.status(400).type('html').send(errorHtml(String(errorMessage)))
+        const errorMessage = errorDescription ?? error
+        this.app.locals.onError?.(errorMessage)
+        res.status(400).type('html').send(errorHtml(errorMessage))
         return
       }
 
@@ -245,7 +271,7 @@ export class CallbackServer {
         return
       }
 
-      this.app.locals.onCallback?.(String(code), String(state))
+      this.app.locals.onCallback?.(code, state)
       res.status(200).type('html').send(SUCCESS_HTML)
     })
   }

--- a/src/server/infra/http/callback-server.ts
+++ b/src/server/infra/http/callback-server.ts
@@ -116,7 +116,7 @@ export function escapeHtml(text: string): string {
  * string when given an array, so we never feed `[object Object]` or a
  * comma-joined value into a user-facing message.
  */
-export function firstQueryParam(value: unknown): string | undefined {
+export function firstQueryParam(value?: unknown): string | undefined {
   if (typeof value === 'string') return value
   if (Array.isArray(value)) {
     const first = value[0]
@@ -141,7 +141,6 @@ const SUCCESS_HTML = `<!DOCTYPE html>
   <h1>Authentication Successful</h1>
   <p>You can now safely close this tab and return to where you left off</p>
 </div>
-<!-- inline script: would be blocked by a strict CSP if one is added later --><script>setTimeout(() => window.close(), 2500);</script>
 </body>
 </html>`
 

--- a/test/unit/infra/http/callback-server.test.ts
+++ b/test/unit/infra/http/callback-server.test.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai'
 
-import {CallbackServer} from '../../../../src/server/infra/http/callback-server.js'
+import {CallbackServer, escapeHtml, firstQueryParam} from '../../../../src/server/infra/http/callback-server.js'
 
 describe('CallbackServer', () => {
   let server: CallbackServer | undefined
@@ -72,6 +72,137 @@ describe('CallbackServer', () => {
       const error = await callbackPromise
       expect(error).to.be.an('error')
       expect((error as Error).message).to.include('State mismatch')
+    })
+  })
+
+  describe('callback HTML responses', () => {
+    it('returns 200 + branded HTML body on successful callback', async () => {
+      server = new CallbackServer()
+      const port = await server.start()
+
+      const expectedState = 'state-success'
+      const callbackPromise = server.waitForCallback(expectedState, 5000)
+
+      // eslint-disable-next-line n/no-unsupported-features/node-builtins
+      const res = await fetch(`http://localhost:${port}/callback?code=abc&state=${expectedState}`)
+      const body = await res.text()
+      await callbackPromise
+
+      expect(res.status).to.equal(200)
+      expect(res.headers.get('content-type') ?? '').to.include('text/html')
+      expect(body).to.include('Authentication Successful')
+      expect(body).to.include('BYTEROVER')
+    })
+
+    it('returns 400 + branded error HTML when provider returns error', async () => {
+      server = new CallbackServer()
+      const port = await server.start()
+
+      const errorPromise = server
+        .waitForCallback('any-state', 5000)
+        .catch((error: Error) => error)
+
+      // eslint-disable-next-line n/no-unsupported-features/node-builtins
+      const res = await fetch(
+        `http://localhost:${port}/callback?error=access_denied&error_description=user%20denied%20access`,
+      )
+      const body = await res.text()
+      await errorPromise
+
+      expect(res.status).to.equal(400)
+      expect(res.headers.get('content-type') ?? '').to.include('text/html')
+      expect(body).to.include('Authentication Failed')
+      expect(body).to.include('user denied access')
+    })
+
+    it('escapes HTML metacharacters in the error message', async () => {
+      server = new CallbackServer()
+      const port = await server.start()
+
+      const errorPromise = server
+        .waitForCallback('any-state', 5000)
+        .catch((error: Error) => error)
+
+      // eslint-disable-next-line n/no-unsupported-features/node-builtins
+      const res = await fetch(
+        `http://localhost:${port}/callback?error=oops&error_description=` +
+          encodeURIComponent('<script>alert("x")</script>'),
+      )
+      const body = await res.text()
+      await errorPromise
+
+      // Raw script tag must NOT appear; escaped form MUST appear in the .error-detail block.
+      expect(body).to.not.include('<script>alert("x")</script>')
+      expect(body).to.include('&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;')
+    })
+
+    it('returns 400 + error HTML when code or state is missing', async () => {
+      server = new CallbackServer()
+      const port = await server.start()
+
+      const errorPromise = server
+        .waitForCallback('any-state', 5000)
+        .catch((error: Error) => error)
+
+      // eslint-disable-next-line n/no-unsupported-features/node-builtins
+      const res = await fetch(`http://localhost:${port}/callback?code=abc`) // no state
+      const body = await res.text()
+      await errorPromise
+
+      expect(res.status).to.equal(400)
+      expect(body).to.include('Missing code or state parameter')
+    })
+  })
+
+  describe('escapeHtml', () => {
+    it('escapes all five HTML metacharacters', () => {
+      expect(escapeHtml('&')).to.equal('&amp;')
+      expect(escapeHtml('<')).to.equal('&lt;')
+      expect(escapeHtml('>')).to.equal('&gt;')
+      expect(escapeHtml('"')).to.equal('&quot;')
+      expect(escapeHtml("'")).to.equal('&#39;')
+    })
+
+    it('passes safe text through unchanged', () => {
+      expect(escapeHtml('hello world 123')).to.equal('hello world 123')
+      expect(escapeHtml('')).to.equal('')
+    })
+
+    it('escapes & first to avoid double-escaping subsequent entity prefixes', () => {
+      // If `&` were escaped after `<`, the `&` in `&lt;` would become `&amp;lt;`.
+      expect(escapeHtml('<a&b>')).to.equal('&lt;a&amp;b&gt;')
+    })
+
+    it('escapes a realistic XSS payload', () => {
+      expect(escapeHtml(`<img src=x onerror="alert('p')">`)).to.equal(
+        '&lt;img src=x onerror=&quot;alert(&#39;p&#39;)&quot;&gt;',
+      )
+    })
+  })
+
+  describe('firstQueryParam', () => {
+    it('returns the string when given a string', () => {
+      expect(firstQueryParam('hello')).to.equal('hello')
+    })
+
+    it('returns the first string when given an array of strings', () => {
+      expect(firstQueryParam(['a', 'b'])).to.equal('a')
+    })
+
+    it('returns undefined when given an empty array', () => {
+      expect(firstQueryParam([])).to.equal(undefined)
+    })
+
+    it('returns undefined when given an array whose first element is not a string', () => {
+      // Express ParsedQs: ?error[code]=x parses to { error: { code: 'x' } } — guard refuses it.
+      expect(firstQueryParam([{nested: 'x'}])).to.equal(undefined)
+    })
+
+    it('returns undefined for object / number / null / undefined inputs', () => {
+      expect(firstQueryParam({foo: 'bar'})).to.equal(undefined)
+      expect(firstQueryParam(42)).to.equal(undefined)
+      expect(firstQueryParam(null)).to.equal(undefined)
+      expect(firstQueryParam()).to.equal(undefined)
     })
   })
 

--- a/test/unit/infra/http/callback-server.test.ts
+++ b/test/unit/infra/http/callback-server.test.ts
@@ -136,7 +136,7 @@ describe('CallbackServer', () => {
       expect(body).to.include('&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;')
     })
 
-    it('returns 400 + error HTML when code or state is missing', async () => {
+    it('returns 400 + friendly error HTML when code or state is missing (no jargon leaks to UI)', async () => {
       server = new CallbackServer()
       const port = await server.start()
 
@@ -147,10 +147,36 @@ describe('CallbackServer', () => {
       // eslint-disable-next-line n/no-unsupported-features/node-builtins
       const res = await fetch(`http://localhost:${port}/callback?code=abc`) // no state
       const body = await res.text()
+      const captured = await errorPromise
+
+      expect(res.status).to.equal(400)
+      // User-facing card shows friendly copy, NOT the OAuth-jargon onError string.
+      expect(body).to.include('Authentication Failed')
+      expect(body).to.include('Return to the CLI and try again')
+      expect(body).to.not.include('Missing code or state parameter')
+      // The OAuth-jargon string still surfaces to the CLI-side onError callback.
+      expect((captured as Error).message).to.include('Missing code or state parameter')
+    })
+
+    it('omits the .error-detail box when error_description is empty', async () => {
+      server = new CallbackServer()
+      const port = await server.start()
+
+      const errorPromise = server
+        .waitForCallback('any-state', 5000)
+        .catch((error: Error) => error)
+
+      // ?error=foo&error_description= — empty description must NOT render an empty red box.
+      // eslint-disable-next-line n/no-unsupported-features/node-builtins
+      const res = await fetch(`http://localhost:${port}/callback?error=server_error&error_description=`)
+      const body = await res.text()
       await errorPromise
 
       expect(res.status).to.equal(400)
-      expect(body).to.include('Missing code or state parameter')
+      // No empty detail block.
+      expect(body).to.not.include('<div class="error-detail"></div>')
+      // Falls back to the error code when description is blank.
+      expect(body).to.include('server_error')
     })
   })
 


### PR DESCRIPTION
The local HTTP callback served after `brv login` was responding with plain text on a default white page, which clashed with the brv dark theme. Replace it with self-contained HTML that mirrors the design spec (Figma: CLI-focused, node `9584-10575`): black background with a soft green/warm radial glow, faint grid overlay, BYTEROVER wordmark, and a centered card carrying a status icon, heading, and supporting copy. Adds a matching error variant that shows the OAuth error message in a red-tinted code block.

## Summary

- **Problem:** After `brv login`, the localhost OAuth callback rendered plain text on a default white background — visually jarring against the rest of brv's dark surface.
- **Why it matters:** It's the first impression after authenticating with the CLI. Reported via design review; tracked in [ENG-1540](https://linear.app/byterover/issue/ENG-1540).
- **What changed:** The `/callback` route on the localhost OAuth callback server now responds with self-contained HTML (success + error variants) styled to match the Figma spec. Plus a `firstQueryParam` guard that coerces Express's `string | string[] | ParsedQs | ParsedQs[]` query values to a single string, and full unit coverage of both helpers and the three response variants.
- **What did NOT change:** Token exchange, OAuth state validation, the redirect-URI contract, the `/callback` route shape, env vars, or any other CLI surface. Auto-closing the tab is also out of scope (browser security restriction — see Risks).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [x] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [ ] Agent / Tools
- [ ] LLM Providers
- [x] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes ENG-1540

## Root cause (bug fixes only, otherwise write `N/A`)

- **Root cause:** `src/server/infra/http/callback-server.ts` responded to `GET /callback` with `res.status(200).send('Authentication successful. You can close this window.')` — plain text against the browser default white. No theming, no brand, no logo.
- **Why this was not caught earlier:** The localhost handoff page was added to the OAuth flow before the rest of the brv surface adopted dark theming; nobody loops back through this view often, so the visual mismatch went unaddressed until raised in design review.

## Test plan

- Coverage added:
  - [x] Unit test
  - [ ] Integration test
  - [ ] Manual verification only
- Test file(s): `test/unit/infra/http/callback-server.test.ts`
- Key scenario(s) covered:
  - `escapeHtml` — five metachars, safe-text passthrough, ampersand-first ordering (avoids double-escaping), realistic XSS payload
  - `firstQueryParam` — string / array of strings / empty array / non-string-first array / object / number / null / undefined
  - `GET /callback` success → 200, `Content-Type: text/html`, body contains `Authentication Successful` + `BYTEROVER`
  - `GET /callback` with `error` + `error_description` → 400, body contains `Authentication Failed` + the escaped description
  - `GET /callback` with `<script>` in `error_description` → escaped entities present, raw tag absent
  - `GET /callback` with missing `state` → 400, body contains `Missing code or state parameter`
  - All 21 tests in the suite pass.

## User-visible changes

- After a successful `brv login`, the browser tab now shows a dark, branded confirmation page instead of plain text on white.
- After a failed OAuth round-trip, the same dark layout is shown with the provider's error message rendered safely (HTML-escaped) inside a red-tinted code block.
- The page no longer attempts to auto-close: browsers refuse `window.close()` on tabs they did not open themselves, so the script was a silent no-op. The copy directs the user to close manually, which is the correct affordance.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording

## Checklist

- [x] Tests added or updated and passing (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated (if applicable) — N/A
- [x] No breaking changes (or clearly documented above)
- [x] Branch is up to date with `main`

## Risks and mitigations

- **Risk:** HTML/CSS is inlined in the response; future design tweaks require a CLI release.
  - **Mitigation:** Trade-off is explicit. Alternative is redirecting to a hosted web-app page; deferred because the localhost flow is light-weight and works offline. Easy to swap later — `res.send(SUCCESS_HTML)` becomes `res.redirect(...)`.
- **Risk:** Inline `<style>` on the response would be blocked if a strict CSP is ever added to this localhost server.
  - **Mitigation:** Today the localhost callback server has no CSP. If one is added later, the page should be served from a hosted URL anyway, which removes the inline-style concern.