### PR TITLE
fix: [ENG-2100] share parent taskId across summary regenerations

### DIFF
--- a/src/server/core/interfaces/context-tree/i-context-tree-summary-service.ts
+++ b/src/server/core/interfaces/context-tree/i-context-tree-summary-service.ts
@@ -18,8 +18,17 @@ export interface IContextTreeSummaryService {
    * Generate or regenerate the _index.md summary for a directory.
    * Uses three-tier escalation: normal → aggressive → deterministic fallback.
    * Fail-open: returns { actionTaken: false } on any error.
+   *
+   * @param parentTaskId When supplied, summary LLM calls adopt this taskId as
+   * their session grouping key on the wire so the billing service treats them
+   * as part of the caller's operation rather than as standalone work.
    */
-  generateSummary(directoryPath: string, agent: ICipherAgent, directory?: string): Promise<SummaryGenerationResult>
+  generateSummary(
+    directoryPath: string,
+    agent: ICipherAgent,
+    directory?: string,
+    parentTaskId?: string,
+  ): Promise<SummaryGenerationResult>
 
   /** Check whether a directory has an existing _index.md summary. */
   hasSummary(directoryPath: string, directory?: string): Promise<boolean>
@@ -28,10 +37,14 @@ export interface IContextTreeSummaryService {
    * Propagate staleness upward from changed paths.
    * Processes bottom-up: regenerates stale summaries from deepest to shallowest.
    * Stops climbing on LLM/IO errors; continues on empty directories.
+   *
+   * @param parentTaskId Threaded into `generateSummary` so every regeneration
+   * triggered by one caller operation shares one billing group on the server.
    */
   propagateStaleness(
     changedPaths: string[],
     agent: ICipherAgent,
     directory?: string,
+    parentTaskId?: string,
   ): Promise<SummaryGenerationResult[]>
 }

--- a/src/server/infra/context-tree/file-context-tree-summary-service.ts
+++ b/src/server/infra/context-tree/file-context-tree-summary-service.ts
@@ -113,10 +113,7 @@ export class FileContextTreeSummaryService implements IContextTreeSummaryService
       // Step 4: Total input tokens
       const totalInputTokens = children.reduce((sum, c) => sum + c.tokens, 0)
 
-      // Step 5: Three-tier escalation via CipherAgent.
-      // When the caller supplies parentTaskId, use it verbatim so the billing
-      // service groups summary LLM calls under the caller's session. Standalone
-      // invocations fall back to the per-directory label.
+      // Step 5: Three-tier escalation via CipherAgent
       const taskId = parentTaskId ?? `summary_${directoryPath.replaceAll('/', '_') || 'root'}`
       const childEntries = children.map((c) => ({content: c.content, name: c.name}))
       let summaryText: string

--- a/src/server/infra/context-tree/file-context-tree-summary-service.ts
+++ b/src/server/infra/context-tree/file-context-tree-summary-service.ts
@@ -85,6 +85,7 @@ export class FileContextTreeSummaryService implements IContextTreeSummaryService
     directoryPath: string,
     agent: ICipherAgent,
     directory?: string,
+    parentTaskId?: string,
   ): Promise<SummaryGenerationResult> {
     const baseDir = directory ?? process.cwd()
     const contextTreeDir = join(baseDir, BRV_DIR, CONTEXT_TREE_DIR)
@@ -112,8 +113,11 @@ export class FileContextTreeSummaryService implements IContextTreeSummaryService
       // Step 4: Total input tokens
       const totalInputTokens = children.reduce((sum, c) => sum + c.tokens, 0)
 
-      // Step 5: Three-tier escalation via CipherAgent
-      const taskId = `summary_${directoryPath.replaceAll('/', '_') || 'root'}`
+      // Step 5: Three-tier escalation via CipherAgent.
+      // When the caller supplies parentTaskId, use it verbatim so the billing
+      // service groups summary LLM calls under the caller's session. Standalone
+      // invocations fall back to the per-directory label.
+      const taskId = parentTaskId ?? `summary_${directoryPath.replaceAll('/', '_') || 'root'}`
       const childEntries = children.map((c) => ({content: c.content, name: c.name}))
       let summaryText: string
       try {
@@ -172,6 +176,7 @@ export class FileContextTreeSummaryService implements IContextTreeSummaryService
     changedPaths: string[],
     agent: ICipherAgent,
     directory?: string,
+    parentTaskId?: string,
   ): Promise<SummaryGenerationResult[]> {
     if (changedPaths.length === 0) return []
 
@@ -207,7 +212,7 @@ export class FileContextTreeSummaryService implements IContextTreeSummaryService
       const staleness = await this.checkStaleness(dirPath, directory)
       if (!staleness.isStale) continue
 
-      const result = await this.generateSummary(dirPath, agent, directory)
+      const result = await this.generateSummary(dirPath, agent, directory, parentTaskId)
       results.push(result)
 
       if (!result.actionTaken) {

--- a/src/server/infra/executor/curate-executor.ts
+++ b/src/server/infra/executor/curate-executor.ts
@@ -139,7 +139,7 @@ export class CurateExecutor implements ICurateExecutor {
           const changedPaths = diffStates(preState, postState)
           if (changedPaths.length > 0) {
             const summaryService = new FileContextTreeSummaryService()
-            const results = await summaryService.propagateStaleness(changedPaths, agent, baseDir)
+            const results = await summaryService.propagateStaleness(changedPaths, agent, baseDir, taskId)
 
             // Opportunistic manifest rebuild (pre-warm for next query)
             if (results.some((r) => r.actionTaken)) {

--- a/src/server/infra/executor/dream-executor.ts
+++ b/src/server/infra/executor/dream-executor.ts
@@ -156,7 +156,7 @@ export class DreamExecutor {
           const changedPaths = diffStates(preState, postState)
           if (changedPaths.length > 0) {
             const summaryService = new FileContextTreeSummaryService()
-            await summaryService.propagateStaleness(changedPaths, agent, projectRoot)
+            await summaryService.propagateStaleness(changedPaths, agent, projectRoot, options.taskId)
             const manifestService = new FileContextTreeManifestService({baseDirectory: projectRoot})
             await manifestService.buildManifest(projectRoot)
           }

--- a/src/server/infra/executor/folder-pack-executor.ts
+++ b/src/server/infra/executor/folder-pack-executor.ts
@@ -93,7 +93,7 @@ export class FolderPackExecutor implements IFolderPackExecutor {
         const changedPaths = diffStates(preState, postState)
         if (changedPaths.length > 0) {
           const summaryService = new FileContextTreeSummaryService()
-          const results = await summaryService.propagateStaleness(changedPaths, agent, tempFileDir)
+          const results = await summaryService.propagateStaleness(changedPaths, agent, tempFileDir, taskId)
 
           if (results.some((result) => result.actionTaken)) {
             const manifestService = new FileContextTreeManifestService({baseDirectory: tempFileDir})

--- a/test/unit/infra/context-tree/file-context-tree-summary-service.test.ts
+++ b/test/unit/infra/context-tree/file-context-tree-summary-service.test.ts
@@ -334,4 +334,60 @@ describe('FileContextTreeSummaryService', () => {
       expect(results.some((result) => result.path === 'auth' && result.actionTaken)).to.equal(true)
     })
   })
+
+  describe('parentTaskId threading', () => {
+    it('uses parentTaskId for createTaskSession when provided', async () => {
+      const capturedTaskIds: string[] = []
+      const trackingAgent = createMockAgent('Summary.')
+      trackingAgent.createTaskSession = async (taskId: string) => {
+        capturedTaskIds.push(taskId)
+        return 'mock-session'
+      }
+
+      const authDir = join(contextTreeDir, 'auth')
+      await mkdir(authDir, {recursive: true})
+      await writeFile(join(authDir, 'jwt.md'), '# JWT\nToken handling.')
+
+      await service.generateSummary('auth', trackingAgent, testDir, 'curate-op-abc123')
+      expect(capturedTaskIds).to.include('curate-op-abc123')
+      expect(capturedTaskIds.every((id) => !id.startsWith('summary_'))).to.equal(true)
+    })
+
+    it('falls back to summary_<dir> taskId when parentTaskId is absent', async () => {
+      const capturedTaskIds: string[] = []
+      const trackingAgent = createMockAgent('Summary.')
+      trackingAgent.createTaskSession = async (taskId: string) => {
+        capturedTaskIds.push(taskId)
+        return 'mock-session'
+      }
+
+      const authDir = join(contextTreeDir, 'auth')
+      await mkdir(authDir, {recursive: true})
+      await writeFile(join(authDir, 'jwt.md'), '# JWT\nToken handling.')
+
+      await service.generateSummary('auth', trackingAgent, testDir)
+      expect(capturedTaskIds).to.include('summary_auth')
+    })
+
+    it('propagateStaleness threads parentTaskId through every generateSummary call', async () => {
+      const capturedTaskIds: string[] = []
+      const trackingAgent = createMockAgent('Summary.')
+      trackingAgent.createTaskSession = async (taskId: string) => {
+        capturedTaskIds.push(taskId)
+        return 'mock-session'
+      }
+
+      const topicDir = join(contextTreeDir, 'auth', 'jwt')
+      await mkdir(topicDir, {recursive: true})
+      await writeFile(join(topicDir, 'refresh.md'), '# Refresh')
+
+      const parentTaskId = 'curate-op-xyz789'
+      await service.propagateStaleness(['auth/jwt/refresh.md'], trackingAgent, testDir, parentTaskId)
+
+      // Every walk-up level (auth/jwt, auth) MUST share the parent id so the
+      // billing service groups them into one operation.
+      expect(capturedTaskIds.length).to.be.greaterThan(1)
+      expect(capturedTaskIds.every((id) => id === parentTaskId)).to.equal(true)
+    })
+  })
 })

--- a/test/unit/infra/executor/curate-executor.test.ts
+++ b/test/unit/infra/executor/curate-executor.test.ts
@@ -15,6 +15,9 @@ import type {ICipherAgent} from '../../../../src/agent/core/interfaces/i-cipher-
 
 import {LocalSandbox} from '../../../../src/agent/infra/sandbox/local-sandbox.js'
 import {FileValidationError} from '../../../../src/server/core/domain/errors/task-error.js'
+import {FileContextTreeManifestService} from '../../../../src/server/infra/context-tree/file-context-tree-manifest-service.js'
+import {FileContextTreeSnapshotService} from '../../../../src/server/infra/context-tree/file-context-tree-snapshot-service.js'
+import {FileContextTreeSummaryService} from '../../../../src/server/infra/context-tree/file-context-tree-summary-service.js'
 import {CurateExecutor} from '../../../../src/server/infra/executor/curate-executor.js'
 
 describe('CurateExecutor (regression)', () => {
@@ -244,6 +247,57 @@ describe('CurateExecutor (regression)', () => {
       })
 
       expect(result).to.equal('done')
+    })
+  })
+
+  describe('summary propagation taskId threading (ENG-2100)', () => {
+    it('passes the curate operation taskId to propagateStaleness so summary LLM calls share one billing session', async () => {
+      const agent = {
+        cancel: stub().resolves(false),
+        createTaskSession: stub().resolves('session-id'),
+        deleteSandboxVariable: stub(),
+        deleteSandboxVariableOnSession: stub(),
+        deleteSession: stub().resolves(true),
+        deleteTaskSession: stub().resolves(),
+        execute: stub().resolves(''),
+        executeOnSession: stub().resolves('curated'),
+        generate: stub().resolves({content: '', toolCalls: [], usage: {inputTokens: 0, outputTokens: 0}}),
+        getSessionMetadata: stub().resolves(),
+        getState: stub().returns({currentIteration: 0, executionHistory: [], executionState: 'idle', toolCallsExecuted: 0}),
+        listPersistedSessions: stub().resolves([]),
+        reset: stub(),
+        setSandboxVariable: stub(),
+        setSandboxVariableOnSession: stub(),
+        start: stub().resolves(),
+        stream: stub().resolves({[Symbol.asyncIterator]: () => ({next: () => Promise.resolve({done: true, value: undefined})})}),
+      } as unknown as ICipherAgent
+
+      // pre-state empty, post-state has one new file → diffStates yields one changed path
+      stub(FileContextTreeSnapshotService.prototype, 'getCurrentState')
+        .onFirstCall()
+        .resolves(new Map())
+        .onSecondCall()
+        .resolves(new Map([['auth/jwt.md', {hash: 'h', size: 1}]]))
+      const propagateStalenessStub = stub(
+        FileContextTreeSummaryService.prototype,
+        'propagateStaleness',
+      ).resolves([])
+      stub(FileContextTreeManifestService.prototype, 'buildManifest').resolves()
+
+      const taskId = 'curate-op-uuid-1'
+      const projectRoot = '/projects/myapp'
+      const executor = new CurateExecutor()
+      await executor.executeWithAgent(agent, {
+        clientCwd: projectRoot,
+        content: 'capture auth knowledge',
+        projectRoot,
+        taskId,
+      })
+
+      expect(propagateStalenessStub.calledOnce).to.be.true
+      // 4th arg must be the curate's taskId so the billing service groups
+      // summary regenerations into the same session as the parent operation.
+      expect(propagateStalenessStub.firstCall.args[3]).to.equal(taskId)
     })
   })
 })

--- a/test/unit/infra/executor/dream-executor.test.ts
+++ b/test/unit/infra/executor/dream-executor.test.ts
@@ -6,6 +6,9 @@ import {restore, type SinonStub, stub} from 'sinon'
 
 import type {ICipherAgent} from '../../../../src/agent/core/interfaces/i-cipher-agent.js'
 
+import {FileContextTreeManifestService} from '../../../../src/server/infra/context-tree/file-context-tree-manifest-service.js'
+import {FileContextTreeSnapshotService} from '../../../../src/server/infra/context-tree/file-context-tree-snapshot-service.js'
+import {FileContextTreeSummaryService} from '../../../../src/server/infra/context-tree/file-context-tree-summary-service.js'
 import {EMPTY_DREAM_STATE} from '../../../../src/server/infra/dream/dream-state-schema.js'
 import {DreamExecutor, type DreamExecutorDeps} from '../../../../src/server/infra/executor/dream-executor.js'
 
@@ -618,6 +621,30 @@ describe('DreamExecutor', () => {
           createReviewEntries.callCount,
           'createReviewEntries must run exactly once when step 7 throws after success-path review write',
         ).to.equal(1)
+      })
+    })
+
+    describe('summary propagation taskId threading (ENG-2100)', () => {
+      it('passes the dream operation taskId to propagateStaleness so summary LLM calls share one billing session', async () => {
+        // pre-state empty, post-state has one new file → diffStates yields one changed path
+        stub(FileContextTreeSnapshotService.prototype, 'getCurrentState')
+          .onFirstCall()
+          .resolves(new Map())
+          .onSecondCall()
+          .resolves(new Map([['auth/jwt.md', {hash: 'h', size: 1}]]))
+        const propagateStalenessStub = stub(
+          FileContextTreeSummaryService.prototype,
+          'propagateStaleness',
+        ).resolves([])
+        stub(FileContextTreeManifestService.prototype, 'buildManifest').resolves()
+
+        const executor = new DreamExecutor(deps)
+        await executor.executeWithAgent(agent, defaultOptions)
+
+        expect(propagateStalenessStub.calledOnce).to.be.true
+        // 4th arg must be the dream's taskId so the billing service groups
+        // summary regenerations into the same session as the parent operation.
+        expect(propagateStalenessStub.firstCall.args[3]).to.equal(defaultOptions.taskId)
       })
     })
   })

--- a/test/unit/infra/executor/folder-pack-executor.test.ts
+++ b/test/unit/infra/executor/folder-pack-executor.test.ts
@@ -252,7 +252,7 @@ describe('FolderPackExecutor', () => {
     expect(executeIterativeStub.calledOnce).to.be.true
     expect(executeIterativeStub.firstCall.args[3]).to.equal(path.resolve(clientCwd, 'src'))
     expect(executeIterativeStub.firstCall.args[5]).to.equal(clientCwd)
-    expect(propagateStalenessStub.calledOnceWithExactly(['auth/jwt.md'], agent, clientCwd)).to.be.true
+    expect(propagateStalenessStub.calledOnceWithExactly(['auth/jwt.md'], agent, clientCwd, 'task-123')).to.be.true
     expect(buildManifestStub.calledOnceWithExactly(clientCwd)).to.be.true
   })
 


### PR DESCRIPTION
The summary service minted its own per-directory taskId (summary_dir)  which the billing service treated as a distinct session on the wire. A single curate that regenerates N directories of summaries landed as N separate billable operations; fresh free-tier accounts hit 50/50 in a couple of curates.

Thread the caller's taskId through generateSummary / propagateStaleness so every LLM call triggered by one curate/dream/folder-pack shares one session and groups into a single operation server-side. The per-dir label is preserved as a fallback for standalone / background invocations that have no parent operation context.

## Summary

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [ ] Agent / Tools
- [ ] LLM Providers
- [ ] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes #
- Related #

## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause:
- Why this was not caught earlier:

## Test plan

- Coverage added:
  - [ ] Unit test
  - [ ] Integration test
  - [ ] Manual verification only
- Test file(s):
- Key scenario(s) covered:

## User-visible changes

List user-visible changes (including defaults, config, or CLI output).
If none, write `None`.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording

## Checklist

- [ ] Tests added or updated and passing (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Type check passes (`npm run typecheck`)
- [ ] Build succeeds (`npm run build`)
- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or clearly documented above)
- [ ] Branch is up to date with `main`

## Risks and mitigations

List real risks for this PR. If none, write `None`.

- Risk:
  - Mitigation:
