### PR TITLE
feat: [ENG-2485] defer summary cascade to dream

### DIFF
--- a/src/server/infra/dream/dream-state-schema.ts
+++ b/src/server/infra/dream/dream-state-schema.ts
@@ -7,23 +7,37 @@ export const PendingMergeSchema = z.object({
   suggestedByDreamId: z.string(),
 })
 
+/**
+ * One entry in the stale-summary queue drained at the next dream cycle.
+ * `enqueuedAt` is preserved across dedup'd re-enqueues so future telemetry
+ * (e.g., "oldest waiting path") can read meaningful wait times even though
+ * no consumer reads it today.
+ */
+export const StaleSummaryEntrySchema = z.object({
+  enqueuedAt: z.number().int().nonnegative(),
+  path: z.string(),
+})
+
 export const DreamStateSchema = z.object({
   curationsSinceDream: z.number().int().min(0),
   lastDreamAt: z.string().datetime().nullable(),
   lastDreamLogId: z.string().nullable(),
   pendingMerges: z.array(PendingMergeSchema).optional().default([]),
+  staleSummaryPaths: z.array(StaleSummaryEntrySchema).optional().default([]),
   totalDreams: z.number().int().min(0),
   version: z.literal(1),
 })
 
 export type DreamState = z.infer<typeof DreamStateSchema>
 export type PendingMerge = z.infer<typeof PendingMergeSchema>
+export type StaleSummaryEntry = z.infer<typeof StaleSummaryEntrySchema>
 
 export const EMPTY_DREAM_STATE: DreamState = {
   curationsSinceDream: 0,
   lastDreamAt: null,
   lastDreamLogId: null,
   pendingMerges: [],
+  staleSummaryPaths: [],
   totalDreams: 0,
   version: 1,
 }

--- a/src/server/infra/dream/dream-state-schema.ts
+++ b/src/server/infra/dream/dream-state-schema.ts
@@ -15,7 +15,10 @@ export const PendingMergeSchema = z.object({
  */
 export const StaleSummaryEntrySchema = z.object({
   enqueuedAt: z.number().int().nonnegative(),
-  path: z.string(),
+  // Empty paths indicate a bug at the call site (a malformed diff entry would
+  // resolve to an empty parent dir); reject them at the schema boundary so
+  // garbage cannot persist into dream-state.json.
+  path: z.string().min(1),
 })
 
 export const DreamStateSchema = z.object({

--- a/src/server/infra/dream/dream-state-service.ts
+++ b/src/server/infra/dream/dream-state-service.ts
@@ -50,6 +50,52 @@ export class DreamStateService {
   }
 
   /**
+   * Atomic drain — reads the current queue and clears it in a single RMW,
+   * returning the deduped path list. The caller is responsible for retrying
+   * (re-enqueueing the returned snapshot) if the downstream work fails.
+   *
+   * Atomicity is the load-bearing property: any enqueue that runs after the
+   * drain returns sees an empty queue, so it always appends a fresh entry
+   * that survives independently of whether the downstream propagation succeeds
+   * or fails. Earlier "snapshot + clear-later" approaches lost same-path
+   * enqueues: the dedup check on enqueue saw the still-present snapshot entry
+   * and skipped, then `clear()` removed it.
+   */
+  async drainStaleSummaryPaths(): Promise<string[]> {
+    let snapshot: string[] = []
+    await this.update((state) => {
+      snapshot = state.staleSummaryPaths.map((e) => e.path)
+      if (snapshot.length === 0) return state
+      return {...state, staleSummaryPaths: []}
+    })
+    return snapshot
+  }
+
+  /**
+   * Append the given file paths to the stale-summary queue, deduping by path.
+   * A path already in the queue keeps its original `enqueuedAt` timestamp so
+   * "how long has this been waiting?" telemetry stays meaningful.
+   *
+   * Serialized through {@link update} so concurrent enqueues from parallel
+   * curate tasks do not lose entries. Empty input is a no-op (no write).
+   */
+  async enqueueStaleSummaryPaths(paths: string[]): Promise<void> {
+    if (paths.length === 0) return
+    const enqueuedAt = Date.now()
+    await this.update((state) => {
+      const existing = new Set(state.staleSummaryPaths.map((e) => e.path))
+      const additions = paths
+        .filter((p) => !existing.has(p))
+        .map((p) => ({enqueuedAt, path: p}))
+      if (additions.length === 0) return state
+      return {
+        ...state,
+        staleSummaryPaths: [...state.staleSummaryPaths, ...additions],
+      }
+    })
+  }
+
+  /**
    * Read-modify-write under a per-file mutex. Serializes concurrent increments
    * from parallel curate tasks within the same agent process so no updates are lost.
    */
@@ -61,10 +107,10 @@ export class DreamStateService {
     try {
       const raw = await readFile(this.stateFilePath, 'utf8')
       const parsed = DreamStateSchema.safeParse(JSON.parse(raw))
-      if (!parsed.success) return {...EMPTY_DREAM_STATE, pendingMerges: []}
+      if (!parsed.success) return {...EMPTY_DREAM_STATE}
       return parsed.data
     } catch {
-      return {...EMPTY_DREAM_STATE, pendingMerges: []}
+      return {...EMPTY_DREAM_STATE}
     }
   }
 

--- a/src/server/infra/dream/dream-state-service.ts
+++ b/src/server/infra/dream/dream-state-service.ts
@@ -81,10 +81,14 @@ export class DreamStateService {
    */
   async enqueueStaleSummaryPaths(paths: string[]): Promise<void> {
     if (paths.length === 0) return
+    // Dedup the input itself before checking against the queue — callers may
+    // pass non-unique arrays (e.g. multiple changed paths within a single
+    // curate that round-trip through the same parent dir).
+    const incoming = [...new Set(paths)]
     const enqueuedAt = Date.now()
     await this.update((state) => {
       const existing = new Set(state.staleSummaryPaths.map((e) => e.path))
-      const additions = paths
+      const additions = incoming
         .filter((p) => !existing.has(p))
         .map((p) => ({enqueuedAt, path: p}))
       if (additions.length === 0) return state

--- a/src/server/infra/dream/dream-trigger.ts
+++ b/src/server/infra/dream/dream-trigger.ts
@@ -79,8 +79,12 @@ export class DreamTrigger {
       }
     }
 
-    // Gate 2: Activity
-    if (state.curationsSinceDream < minCurations) {
+    // Gate 2: Activity. Bypassed when the stale-summary queue has deferred
+    // work — leaving entries indefinitely strands `_index.md` regeneration
+    // in low-activity projects (the very projects ENG-2485 most affects,
+    // since 1–2 curates over a 12h window otherwise sit under minCurations
+    // forever). Dream is the canonical drain point; if it has work, run.
+    if (state.curationsSinceDream < minCurations && state.staleSummaryPaths.length === 0) {
       return {
         eligible: false,
         reason: `Not enough activity (${state.curationsSinceDream} < ${minCurations} curations)`,

--- a/src/server/infra/executor/curate-executor.ts
+++ b/src/server/infra/executor/curate-executor.ts
@@ -141,18 +141,37 @@ export class CurateExecutor implements ICurateExecutor {
       // so a single instance is sufficient and avoids duplicate construction.
       const dreamStateService = new DreamStateService({baseDir: path.join(baseDir, BRV_DIR)})
 
+      // Two independent fail-open concerns: (a) enqueue the deferred
+      // summary-cascade work to dream's queue; (b) rebuild the search
+      // manifest. They share `changedPaths` but otherwise are unrelated —
+      // a transient disk error on the dream-state write must not skip the
+      // pure-filesystem manifest scan that keeps newly-curated leaf files
+      // immediately discoverable. Each runs in its own try block so one
+      // failure cannot mask the other's work.
+      let changedPaths: string[] = []
       if (preState) {
         try {
           const postState = await snapshotService.getCurrentState(baseDir)
-          const changedPaths = diffStates(preState, postState)
-          if (changedPaths.length > 0) {
-            await dreamStateService.enqueueStaleSummaryPaths(changedPaths)
+          changedPaths = diffStates(preState, postState)
+        } catch {
+          // Fail-open: snapshot errors leave changedPaths empty → no enqueue,
+          // no manifest rebuild. Next curate's snapshot will pick up the diff.
+        }
 
+        if (changedPaths.length > 0) {
+          try {
+            await dreamStateService.enqueueStaleSummaryPaths(changedPaths)
+          } catch {
+            // Fail-open: queue write errors never block curation. The next
+            // curate's enqueue will still capture the same paths via diffStates.
+          }
+
+          try {
             const manifestService = new FileContextTreeManifestService({baseDirectory: baseDir})
             await manifestService.buildManifest(baseDir)
+          } catch {
+            // Fail-open: manifest rebuild is best-effort pre-warming.
           }
-        } catch {
-          // Fail-open: queue/manifest errors never block curation
         }
       }
 

--- a/src/server/infra/executor/curate-executor.ts
+++ b/src/server/infra/executor/curate-executor.ts
@@ -14,7 +14,6 @@ import {
 import {validateFileForCurate} from '../../utils/file-validator.js'
 import {FileContextTreeManifestService} from '../context-tree/file-context-tree-manifest-service.js'
 import {FileContextTreeSnapshotService} from '../context-tree/file-context-tree-snapshot-service.js'
-import {FileContextTreeSummaryService} from '../context-tree/file-context-tree-summary-service.js'
 import {diffStates} from '../context-tree/snapshot-diff.js'
 import {DreamStateService} from '../dream/dream-state-service.js'
 import {PreCompactionService} from './pre-compaction/pre-compaction-service.js'
@@ -132,29 +131,33 @@ export class CurateExecutor implements ICurateExecutor {
       // Parse curation status from agent response for status tracking
       this.lastStatus = this.parseCurationStatus(taskId, response)
 
-      // --- Phase 4: Post-curation summary propagation (fail-open) ---
+      // Summary cascade regeneration (the LLM-driven `propagateStaleness` walk)
+      // is deferred to the next dream cycle to keep curate's hot path free of
+      // LLM calls. The manifest is rebuilt inline because it is a pure file
+      // scan (no LLM) and keeps newly-curated leaf files immediately
+      // discoverable via manifest-driven retrieval.
+      // Hoisted: both blocks below construct a DreamStateService against the
+      // same project. They share the module-level mutex via `getStateMutex`,
+      // so a single instance is sufficient and avoids duplicate construction.
+      const dreamStateService = new DreamStateService({baseDir: path.join(baseDir, BRV_DIR)})
+
       if (preState) {
         try {
           const postState = await snapshotService.getCurrentState(baseDir)
           const changedPaths = diffStates(preState, postState)
           if (changedPaths.length > 0) {
-            const summaryService = new FileContextTreeSummaryService()
-            const results = await summaryService.propagateStaleness(changedPaths, agent, baseDir, taskId)
+            await dreamStateService.enqueueStaleSummaryPaths(changedPaths)
 
-            // Opportunistic manifest rebuild (pre-warm for next query)
-            if (results.some((r) => r.actionTaken)) {
-              const manifestService = new FileContextTreeManifestService({baseDirectory: baseDir})
-              await manifestService.buildManifest(baseDir)
-            }
+            const manifestService = new FileContextTreeManifestService({baseDirectory: baseDir})
+            await manifestService.buildManifest(baseDir)
           }
         } catch {
-          // Fail-open: summary/manifest errors never block curation
+          // Fail-open: queue/manifest errors never block curation
         }
       }
 
       // Increment dream curation counter (fail-open: non-critical for curation)
       try {
-        const dreamStateService = new DreamStateService({baseDir: path.join(baseDir, BRV_DIR)})
         await dreamStateService.incrementCurationCount()
       } catch {
         // Dream state tracking is non-critical — don't block curation

--- a/src/server/infra/executor/dream-executor.ts
+++ b/src/server/infra/executor/dream-executor.ts
@@ -129,11 +129,12 @@ export class DreamExecutor {
       try {
         preState = await snapshotService.getCurrentState(projectRoot)
       } catch {
-        // Fail-open: if snapshot fails, the entire step 5 block (propagation +
-        // queue drain) is skipped — the stale-summary queue is not consumed in
-        // this dream cycle and accumulates until the next successful run.
-        // Drain-skip is preferable to drain-and-lose because atomic drain
-        // already removed entries before any propagation could re-enqueue them.
+        // Fail-open: leaving preState undefined skips the entire step 5 block
+        // (queue drain + propagation), so the stale-summary queue is left
+        // intact for the next successful dream cycle. Skipping drain here is
+        // safer than drain-then-fail: the atomic-drain design clears entries
+        // synchronously inside the RMW, so if we drained and then threw
+        // before reaching the catch's re-enqueue, the snapshot would be lost.
       }
 
       // Step 2: Load dream state

--- a/src/server/infra/executor/dream-executor.ts
+++ b/src/server/infra/executor/dream-executor.ts
@@ -55,6 +55,8 @@ export type DreamExecutorDeps = {
     save(entry: DreamLogEntry): Promise<void>
   }
   dreamStateService: {
+    drainStaleSummaryPaths(): Promise<string[]>
+    enqueueStaleSummaryPaths(paths: string[]): Promise<void>
     read(): Promise<import('../dream/dream-state-schema.js').DreamState>
     update(updater: (state: import('../dream/dream-state-schema.js').DreamState) => import('../dream/dream-state-schema.js').DreamState): Promise<import('../dream/dream-state-schema.js').DreamState>
     write(state: import('../dream/dream-state-schema.js').DreamState): Promise<void>
@@ -127,7 +129,11 @@ export class DreamExecutor {
       try {
         preState = await snapshotService.getCurrentState(projectRoot)
       } catch {
-        // Fail-open: if snapshot fails, skip propagation
+        // Fail-open: if snapshot fails, the entire step 5 block (propagation +
+        // queue drain) is skipped — the stale-summary queue is not consumed in
+        // this dream cycle and accumulates until the next successful run.
+        // Drain-skip is preferable to drain-and-lose because atomic drain
+        // already removed entries before any propagation could re-enqueue them.
       }
 
       // Step 2: Load dream state
@@ -150,18 +156,38 @@ export class DreamExecutor {
       })
 
       // Step 5: Post-dream propagation (fail-open)
+      // Two sources of stale summary paths:
+      //   A. The stale-summary queue, drained from dream state — paths from
+      //      curate operations that ran since the last dream cycle (the LLM
+      //      cascade work was deferred from curate's hot path to here).
+      //   B. Dream's own snapshot diff — paths changed by this dream's
+      //      consolidate/synthesize/prune operations.
+      // Merging A ∪ B before calling propagateStaleness lets a path touched
+      // by both sources regenerate exactly once. The queue is drained
+      // atomically (cleared in the same RMW that captures the snapshot) so
+      // any concurrent curate enqueueing during propagation appends a fresh
+      // entry to the now-empty queue and the next dream picks it up.
       if (preState) {
+        let drainedSnapshot: string[] = []
         try {
+          drainedSnapshot = await this.deps.dreamStateService.drainStaleSummaryPaths()
+
           const postState = await snapshotService.getCurrentState(projectRoot)
           const changedPaths = diffStates(preState, postState)
-          if (changedPaths.length > 0) {
-            const summaryService = new FileContextTreeSummaryService()
-            await summaryService.propagateStaleness(changedPaths, agent, projectRoot, options.taskId)
-            const manifestService = new FileContextTreeManifestService({baseDirectory: projectRoot})
-            await manifestService.buildManifest(projectRoot)
+
+          const merged = [...new Set([...changedPaths, ...drainedSnapshot])]
+          if (merged.length > 0) {
+            await this.runStaleSummaryPropagation({agent, parentTaskId: options.taskId, paths: merged, projectRoot})
           }
         } catch {
-          // Fail-open: propagation errors never block dream
+          // Fail-open: propagation errors never block dream. Re-enqueue the
+          // drained snapshot so the next dream cycle retries — atomic drain
+          // already removed them, so without this they would be lost.
+          if (drainedSnapshot.length > 0) {
+            await this.deps.dreamStateService.enqueueStaleSummaryPaths(drainedSnapshot).catch(() => {
+              // If the re-enqueue itself fails, there is nothing more to do here.
+            })
+          }
         }
       }
 
@@ -253,11 +279,6 @@ export class DreamExecutor {
     }
   }
 
-  /**
-   * Runs the three dream operations sequentially, pushing results into `out` after
-   * each step. Extracted so the executor can preserve partial work when a later step
-   * throws — and so tests can inject controlled ops without a full LLM round-trip.
-   */
   protected async runOperations(args: {
     agent: ICipherAgent
     changedFiles: Set<string>
@@ -310,6 +331,30 @@ export class DreamExecutor {
         taskId,
       })),
     )
+  }
+
+  /**
+   * Runs the three dream operations sequentially, pushing results into `out` after
+   * each step. Extracted so the executor can preserve partial work when a later step
+   * throws — and so tests can inject controlled ops without a full LLM round-trip.
+   */
+  /**
+   * Regenerate parent `_index.md` files for the given paths and rebuild the
+   * manifest. Extracted as a seam so tests can override and assert which
+   * paths were passed (the A ∪ B merge in step 5 is the central correctness
+   * invariant of the deferral). Production constructs the services here so
+   * the dependency surface of {@link DreamExecutorDeps} stays narrow.
+   */
+  protected async runStaleSummaryPropagation(args: {
+    agent: ICipherAgent
+    parentTaskId?: string
+    paths: string[]
+    projectRoot: string
+  }): Promise<void> {
+    const summaryService = new FileContextTreeSummaryService()
+    await summaryService.propagateStaleness(args.paths, args.agent, args.projectRoot, args.parentTaskId)
+    const manifestService = new FileContextTreeManifestService({baseDirectory: args.projectRoot})
+    await manifestService.buildManifest(args.projectRoot)
   }
 
   /** Errors are tracked at the log level (status='error'), not per-operation — always 0 here. */

--- a/src/server/infra/executor/dream-executor.ts
+++ b/src/server/infra/executor/dream-executor.ts
@@ -279,6 +279,11 @@ export class DreamExecutor {
     }
   }
 
+  /**
+   * Runs the three dream operations sequentially, pushing results into `out` after
+   * each step. Extracted so the executor can preserve partial work when a later step
+   * throws — and so tests can inject controlled ops without a full LLM round-trip.
+   */
   protected async runOperations(args: {
     agent: ICipherAgent
     changedFiles: Set<string>
@@ -333,11 +338,6 @@ export class DreamExecutor {
     )
   }
 
-  /**
-   * Runs the three dream operations sequentially, pushing results into `out` after
-   * each step. Extracted so the executor can preserve partial work when a later step
-   * throws — and so tests can inject controlled ops without a full LLM round-trip.
-   */
   /**
    * Regenerate parent `_index.md` files for the given paths and rebuild the
    * manifest. Extracted as a seam so tests can override and assert which

--- a/test/unit/infra/dream/dream-state-schema.test.ts
+++ b/test/unit/infra/dream/dream-state-schema.test.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai'
 
-import {DreamStateSchema, EMPTY_DREAM_STATE, PendingMergeSchema} from '../../../../src/server/infra/dream/dream-state-schema.js'
+import {DreamStateSchema, EMPTY_DREAM_STATE, PendingMergeSchema, StaleSummaryEntrySchema} from '../../../../src/server/infra/dream/dream-state-schema.js'
 
 describe('dream-state-schema', () => {
 describe('DreamStateSchema', () => {
@@ -17,6 +17,7 @@ describe('DreamStateSchema', () => {
           suggestedByDreamId: 'drm-1712736000000',
         },
       ],
+      staleSummaryPaths: [],
       totalDreams: 3,
       version: 1,
     }
@@ -120,8 +121,59 @@ describe('EMPTY_DREAM_STATE', () => {
     expect(EMPTY_DREAM_STATE.lastDreamAt).to.be.null
     expect(EMPTY_DREAM_STATE.lastDreamLogId).to.be.null
     expect(EMPTY_DREAM_STATE.pendingMerges).to.deep.equal([])
+    expect(EMPTY_DREAM_STATE.staleSummaryPaths).to.deep.equal([])
     expect(EMPTY_DREAM_STATE.totalDreams).to.equal(0)
     expect(EMPTY_DREAM_STATE.version).to.equal(1)
+  })
+})
+
+describe('StaleSummaryEntrySchema', () => {
+  it('should parse a valid entry', () => {
+    const input = {enqueuedAt: 1_745_539_200_000, path: 'auth/jwt/token.md'}
+    const result = StaleSummaryEntrySchema.parse(input)
+    expect(result).to.deep.equal(input)
+  })
+
+  it('should reject a non-integer enqueuedAt', () => {
+    expect(() => StaleSummaryEntrySchema.parse({enqueuedAt: 1.5, path: 'a.md'})).to.throw()
+  })
+
+  it('should reject a negative enqueuedAt', () => {
+    expect(() => StaleSummaryEntrySchema.parse({enqueuedAt: -1, path: 'a.md'})).to.throw()
+  })
+
+  it('should reject a missing path', () => {
+    expect(() => StaleSummaryEntrySchema.parse({enqueuedAt: 0})).to.throw()
+  })
+})
+
+describe('DreamStateSchema staleSummaryPaths', () => {
+  it('should default staleSummaryPaths to [] when missing', () => {
+    const input = {
+      curationsSinceDream: 0,
+      lastDreamAt: null,
+      lastDreamLogId: null,
+      totalDreams: 0,
+      version: 1,
+    }
+    const result = DreamStateSchema.parse(input)
+    expect(result.staleSummaryPaths).to.deep.equal([])
+  })
+
+  it('should accept a populated staleSummaryPaths array', () => {
+    const input = {
+      curationsSinceDream: 0,
+      lastDreamAt: null,
+      lastDreamLogId: null,
+      staleSummaryPaths: [
+        {enqueuedAt: 1_745_539_200_000, path: 'auth/jwt/token.md'},
+        {enqueuedAt: 1_745_546_400_000, path: 'billing/webhooks/stripe.md'},
+      ],
+      totalDreams: 0,
+      version: 1,
+    }
+    const result = DreamStateSchema.parse(input)
+    expect(result.staleSummaryPaths).to.have.lengthOf(2)
   })
 })
 })

--- a/test/unit/infra/dream/dream-state-service.test.ts
+++ b/test/unit/infra/dream/dream-state-service.test.ts
@@ -13,6 +13,7 @@ function makeState(overrides: Partial<DreamState> = {}): DreamState {
     lastDreamAt: null,
     lastDreamLogId: null,
     pendingMerges: [],
+    staleSummaryPaths: [],
     totalDreams: 0,
     version: 1,
     ...overrides,
@@ -215,6 +216,164 @@ describe('DreamStateService', () => {
       const final = await service.read()
       expect(final.curationsSinceDream).to.equal(5)
       expect(final.totalDreams).to.equal(5)
+    })
+  })
+
+  // ==========================================================================
+  // enqueueStaleSummaryPaths — defer summary cascade
+  // ==========================================================================
+
+  describe('enqueueStaleSummaryPaths', () => {
+    it('appends new paths to an empty queue', async () => {
+      await service.enqueueStaleSummaryPaths(['auth/jwt/token.md', 'billing/webhooks/stripe.md'])
+      const state = await service.read()
+      expect(state.staleSummaryPaths.map((e) => e.path)).to.deep.equal([
+        'auth/jwt/token.md',
+        'billing/webhooks/stripe.md',
+      ])
+    })
+
+    it('stamps each entry with enqueuedAt at the moment of the call', async () => {
+      const before = Date.now()
+      await service.enqueueStaleSummaryPaths(['auth/jwt/token.md'])
+      const after = Date.now()
+
+      const state = await service.read()
+      expect(state.staleSummaryPaths).to.have.lengthOf(1)
+      const [entry] = state.staleSummaryPaths
+      expect(entry.enqueuedAt).to.be.at.least(before)
+      expect(entry.enqueuedAt).to.be.at.most(after)
+    })
+
+    it('dedups entries by path (keeps oldest enqueuedAt)', async () => {
+      await service.enqueueStaleSummaryPaths(['auth/jwt/token.md'])
+      const firstState = await service.read()
+      const firstStamp = firstState.staleSummaryPaths[0].enqueuedAt
+
+      // ensure the second call's Date.now() is strictly later
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 5)
+      })
+
+      await service.enqueueStaleSummaryPaths(['auth/jwt/token.md', 'billing/webhooks/stripe.md'])
+      const secondState = await service.read()
+
+      expect(secondState.staleSummaryPaths).to.have.lengthOf(2)
+      const tokenEntry = secondState.staleSummaryPaths.find((e) => e.path === 'auth/jwt/token.md')
+      expect(tokenEntry?.enqueuedAt, 'oldest enqueuedAt preserved on dedup').to.equal(firstStamp)
+    })
+
+    it('preserves other state fields when enqueuing', async () => {
+      await service.write(makeState({
+        curationsSinceDream: 7,
+        totalDreams: 2,
+      }))
+
+      await service.enqueueStaleSummaryPaths(['auth/jwt/token.md'])
+
+      const state = await service.read()
+      expect(state.curationsSinceDream).to.equal(7)
+      expect(state.totalDreams).to.equal(2)
+      expect(state.staleSummaryPaths).to.have.lengthOf(1)
+    })
+
+    it('is a no-op for an empty input array', async () => {
+      await service.enqueueStaleSummaryPaths([])
+      const state = await service.read()
+      expect(state.staleSummaryPaths).to.deep.equal([])
+    })
+
+    it('does not lose entries when 10 enqueues run concurrently', async () => {
+      const paths = Array.from({length: 10}, (_, i) => `domain/topic-${i}.md`)
+      await Promise.all(paths.map((p) => service.enqueueStaleSummaryPaths([p])))
+      const state = await service.read()
+      const stored = state.staleSummaryPaths.map((e) => e.path).sort()
+      expect(stored).to.deep.equal([...paths].sort())
+    })
+  })
+
+  // ==========================================================================
+  // drainStaleSummaryPaths — snapshot-and-clear pattern
+  // ==========================================================================
+
+  describe('drainStaleSummaryPaths', () => {
+    it('returns the current snapshot of paths AND clears the queue atomically', async () => {
+      await service.enqueueStaleSummaryPaths(['auth/jwt/token.md', 'billing/webhooks/stripe.md'])
+
+      const snapshot = await service.drainStaleSummaryPaths()
+      expect(snapshot.sort()).to.deep.equal([
+        'auth/jwt/token.md',
+        'billing/webhooks/stripe.md',
+      ])
+
+      // queue is empty after drain — the same RMW that read it cleared it
+      const state = await service.read()
+      expect(state.staleSummaryPaths).to.deep.equal([])
+    })
+
+    it('returns an empty snapshot when the queue is empty', async () => {
+      const snapshot = await service.drainStaleSummaryPaths()
+      expect(snapshot).to.deep.equal([])
+    })
+
+    it('different-path enqueue during processing survives', async () => {
+      await service.enqueueStaleSummaryPaths(['auth/jwt/token.md'])
+      const snapshot = await service.drainStaleSummaryPaths()
+      expect(snapshot).to.deep.equal(['auth/jwt/token.md'])
+
+      // simulate a curate enqueue happening WHILE the dream is processing
+      await service.enqueueStaleSummaryPaths(['billing/webhooks/stripe.md'])
+
+      const state = await service.read()
+      expect(state.staleSummaryPaths.map((e) => e.path)).to.deep.equal(['billing/webhooks/stripe.md'])
+    })
+
+    it('drain on an empty queue returns an empty snapshot and leaves enqueues untouched', async () => {
+      const snapshot = await service.drainStaleSummaryPaths()
+      expect(snapshot).to.deep.equal([])
+
+      await service.enqueueStaleSummaryPaths(['auth/jwt/token.md'])
+
+      const state = await service.read()
+      expect(state.staleSummaryPaths.map((e) => e.path)).to.deep.equal(['auth/jwt/token.md'])
+    })
+
+    it('preserves other state fields when draining', async () => {
+      await service.write(makeState({
+        curationsSinceDream: 3,
+        totalDreams: 1,
+      }))
+      await service.enqueueStaleSummaryPaths(['auth/jwt/token.md'])
+      await service.drainStaleSummaryPaths()
+
+      const state = await service.read()
+      expect(state.curationsSinceDream).to.equal(3)
+      expect(state.totalDreams).to.equal(1)
+      expect(state.staleSummaryPaths).to.deep.equal([])
+    })
+
+    it('preserves a same-path enqueue made after the drain (no race loss)', async () => {
+      // Repro of the race the reviewer flagged on PR #551:
+      //   1. Dream drains queue containing X.
+      //   2. Concurrent curate touches X again — enqueue should record it.
+      //   3. Dream finishes propagation.
+      //   4. The post-drain enqueue MUST survive so the next dream picks it up.
+      // Atomic drain (queue cleared upfront) makes the post-drain enqueue see
+      // an empty queue, so it always appends fresh.
+      await service.enqueueStaleSummaryPaths(['auth/jwt/token.md'])
+
+      // (1) Dream drains — entries removed atomically.
+      const snapshot = await service.drainStaleSummaryPaths()
+      expect(snapshot).to.deep.equal(['auth/jwt/token.md'])
+
+      // (2) A curate touches the same path during dream propagation.
+      await service.enqueueStaleSummaryPaths(['auth/jwt/token.md'])
+
+      // (3) Dream finishes — no clear() to call; entries already removed at (1).
+
+      // (4) The path enqueued at (2) survives.
+      const state = await service.read()
+      expect(state.staleSummaryPaths.map((e) => e.path)).to.deep.equal(['auth/jwt/token.md'])
     })
   })
 })

--- a/test/unit/infra/dream/dream-state-service.test.ts
+++ b/test/unit/infra/dream/dream-state-service.test.ts
@@ -283,6 +283,17 @@ describe('DreamStateService', () => {
       expect(state.staleSummaryPaths).to.deep.equal([])
     })
 
+    it('dedups within-batch duplicates so a single call cannot insert the same path twice', async () => {
+      // The contract is "dedup by path". A caller passing a non-unique array
+      // (e.g. multiple changedPaths within a single curate that round-trip
+      // through the same parent dir) must NOT produce duplicate queue entries.
+      await service.enqueueStaleSummaryPaths(['auth/jwt.md', 'auth/jwt.md', 'auth/jwt.md'])
+
+      const state = await service.read()
+      expect(state.staleSummaryPaths).to.have.lengthOf(1)
+      expect(state.staleSummaryPaths[0].path).to.equal('auth/jwt.md')
+    })
+
     it('does not lose entries when 10 enqueues run concurrently', async () => {
       const paths = Array.from({length: 10}, (_, i) => `domain/topic-${i}.md`)
       await Promise.all(paths.map((p) => service.enqueueStaleSummaryPaths([p])))

--- a/test/unit/infra/dream/dream-trigger.test.ts
+++ b/test/unit/infra/dream/dream-trigger.test.ts
@@ -79,6 +79,37 @@ describe('DreamTrigger', () => {
       }
     })
 
+    it('should bypass activity gate when stale-summary queue has work', async () => {
+      // ENG-2485: deferred summary cascade lives in staleSummaryPaths. If a
+      // low-activity project (1-2 curates) accumulates queued paths and the
+      // activity gate kept blocking, _index.md regeneration would never run.
+      const deps = makeDeps({
+        state: makeState({
+          curationsSinceDream: 1,
+          staleSummaryPaths: [{enqueuedAt: Date.now(), path: 'auth/jwt.md'}],
+        }),
+      })
+      const trigger = new DreamTrigger(deps)
+
+      const result = await trigger.tryStartDream('/project')
+      expect(result.eligible).to.be.true
+    })
+
+    it('should still fail activity gate when both curations AND queue are empty', async () => {
+      // Negative case for the bypass: empty queue + low activity means the
+      // activity gate should still block (nothing to drain, no work to do).
+      const deps = makeDeps({
+        state: makeState({curationsSinceDream: 1, staleSummaryPaths: []}),
+      })
+      const trigger = new DreamTrigger(deps)
+
+      const result = await trigger.tryStartDream('/project')
+      expect(result.eligible).to.be.false
+      if (!result.eligible) {
+        expect(result.reason).to.include('activity')
+      }
+    })
+
     it('should fail when queue is not empty', async () => {
       const deps = makeDeps({queueLength: 3})
       const trigger = new DreamTrigger(deps)

--- a/test/unit/infra/dream/dream-trigger.test.ts
+++ b/test/unit/infra/dream/dream-trigger.test.ts
@@ -296,6 +296,22 @@ describe('DreamTrigger', () => {
       }
     })
 
+    it('should bypass activity gate when stale-summary queue has work', async () => {
+      // Symmetry with the tryStartDream bypass test — both methods delegate
+      // to checkGates1to3, so a future refactor of the shared path must keep
+      // this invariant on both call sites.
+      const deps = makeDeps({
+        state: makeState({
+          curationsSinceDream: 1,
+          staleSummaryPaths: [{enqueuedAt: Date.now(), path: 'auth/jwt.md'}],
+        }),
+      })
+      const trigger = new DreamTrigger(deps)
+
+      const result = await trigger.checkEligibility('/project')
+      expect(result.eligible).to.be.true
+    })
+
     it('should fail when queue is not empty', async () => {
       const deps = makeDeps({queueLength: 3})
       const trigger = new DreamTrigger(deps)

--- a/test/unit/infra/dream/dream-trigger.test.ts
+++ b/test/unit/infra/dream/dream-trigger.test.ts
@@ -11,6 +11,7 @@ function makeState(overrides: Partial<DreamState> = {}): DreamState {
     lastDreamAt: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
     lastDreamLogId: null,
     pendingMerges: [],
+    staleSummaryPaths: [],
     totalDreams: 0,
     version: 1,
     ...overrides,

--- a/test/unit/infra/executor/curate-executor.test.ts
+++ b/test/unit/infra/executor/curate-executor.test.ts
@@ -18,6 +18,7 @@ import {FileValidationError} from '../../../../src/server/core/domain/errors/tas
 import {FileContextTreeManifestService} from '../../../../src/server/infra/context-tree/file-context-tree-manifest-service.js'
 import {FileContextTreeSnapshotService} from '../../../../src/server/infra/context-tree/file-context-tree-snapshot-service.js'
 import {FileContextTreeSummaryService} from '../../../../src/server/infra/context-tree/file-context-tree-summary-service.js'
+import {DreamStateService} from '../../../../src/server/infra/dream/dream-state-service.js'
 import {CurateExecutor} from '../../../../src/server/infra/executor/curate-executor.js'
 
 describe('CurateExecutor (regression)', () => {
@@ -250,8 +251,8 @@ describe('CurateExecutor (regression)', () => {
     })
   })
 
-  describe('summary propagation taskId threading (ENG-2100)', () => {
-    it('passes the curate operation taskId to propagateStaleness so summary LLM calls share one billing session', async () => {
+  describe('summary cascade deferral to dream (ENG-2485)', () => {
+    it('enqueues stale-summary paths to the dream queue and does NOT call propagateStaleness inline', async () => {
       const agent = {
         cancel: stub().resolves(false),
         createTaskSession: stub().resolves('session-id'),
@@ -283,6 +284,10 @@ describe('CurateExecutor (regression)', () => {
         'propagateStaleness',
       ).resolves([])
       stub(FileContextTreeManifestService.prototype, 'buildManifest').resolves()
+      const enqueueStub = stub(DreamStateService.prototype, 'enqueueStaleSummaryPaths').resolves()
+      // incrementCurationCount is unrelated dream-state work that runs after the post-curation
+      // step; stub it so the test doesn't hit disk for the dream state file.
+      stub(DreamStateService.prototype, 'incrementCurationCount').resolves()
 
       const taskId = 'curate-op-uuid-1'
       const projectRoot = '/projects/myapp'
@@ -294,10 +299,14 @@ describe('CurateExecutor (regression)', () => {
         taskId,
       })
 
-      expect(propagateStalenessStub.calledOnce).to.be.true
-      // 4th arg must be the curate's taskId so the billing service groups
-      // summary regenerations into the same session as the parent operation.
-      expect(propagateStalenessStub.firstCall.args[3]).to.equal(taskId)
+      // ENG-2485 invariant: the LLM-bound propagateStaleness walk MUST NOT run
+      // on the curate hot path. It is deferred to the next dream cycle.
+      expect(propagateStalenessStub.called).to.equal(false)
+
+      // The deferred work is captured in the dream queue: the changed paths from
+      // diffStates are enqueued for the next dream cycle to drain.
+      expect(enqueueStub.calledOnce).to.equal(true)
+      expect(enqueueStub.firstCall.args[0]).to.deep.equal(['auth/jwt.md'])
     })
   })
 })

--- a/test/unit/infra/executor/dream-executor.test.ts
+++ b/test/unit/infra/executor/dream-executor.test.ts
@@ -48,7 +48,7 @@ function makePartialRunExecutor(args: {
 }
 
 describe('DreamExecutor', () => {
-  let dreamStateService: {read: SinonStub; update: SinonStub; write: SinonStub}
+  let dreamStateService: {drainStaleSummaryPaths: SinonStub; enqueueStaleSummaryPaths: SinonStub; read: SinonStub; update: SinonStub; write: SinonStub}
   let dreamLogStore: {getNextId: SinonStub; save: SinonStub}
   let dreamLockService: {release: SinonStub; rollback: SinonStub}
   let curateLogStore: {getNextId: SinonStub; list: SinonStub; save: SinonStub}
@@ -63,7 +63,12 @@ describe('DreamExecutor', () => {
 
   beforeEach(() => {
     dreamStateService = {
-      read: stub().resolves({...EMPTY_DREAM_STATE, pendingMerges: []}),
+      // Default drain: empty queue. Tests that exercise the queue override.
+      drainStaleSummaryPaths: stub().resolves([]),
+      // Default enqueue: no-op stub. Used by the executor's catch block to
+      // re-enqueue a drained snapshot if propagation fails.
+      enqueueStaleSummaryPaths: stub().resolves(),
+      read: stub().resolves({...EMPTY_DREAM_STATE, pendingMerges: [], staleSummaryPaths: []}),
       // Default update implementation: read → updater → write, mirroring the real
       // service so tests that count write.callCount stay valid without changes.
       update: stub().callsFake(async (updater: (state: import('../../../../src/server/infra/dream/dream-state-schema.js').DreamState) => import('../../../../src/server/infra/dream/dream-state-schema.js').DreamState) => {
@@ -495,6 +500,123 @@ describe('DreamExecutor', () => {
       } finally {
         rmSync(projectRoot, {force: true, recursive: true})
       }
+    })
+
+    // ==========================================================================
+    // Stale-summary queue: drain + re-enqueue on propagation failure
+    // ==========================================================================
+
+    it('propagates over A ∪ B union of drained queue and snapshot diff (happy path)', async () => {
+      // The merge at dream-executor.ts is the central correctness invariant of this
+      // PR — anything in EITHER the queue (A) OR dream's own diff (B) must be
+      // propagated, exactly once per path. This test pins that invariant.
+      dreamStateService.drainStaleSummaryPaths.resolves(['queue/path.md'])
+
+      // Real temp project so snapshotService.getCurrentState succeeds. We override
+      // runOperations to write a new file between pre and post snapshots, so the
+      // snapshot diff produces a non-empty list — that becomes the B half of A ∪ B.
+      const projectRoot = mkdtempSync(join(tmpdir(), 'brv-dream-merge-'))
+      const contextTreeDir = join(projectRoot, '.brv', 'context-tree')
+      mkdirSync(contextTreeDir, {recursive: true})
+      const captured: string[][] = []
+
+      class MergeTestExecutor extends DreamExecutor {
+        protected override async runOperations(): Promise<void> {
+          // Mutate the tree so postState differs from preState by 'diff/added.md'.
+          mkdirSync(join(contextTreeDir, 'diff'), {recursive: true})
+          writeFileSync(join(contextTreeDir, 'diff', 'added.md'), '# new from dream')
+        }
+
+        protected override async runStaleSummaryPropagation(opts: {
+          agent: ICipherAgent
+          paths: string[]
+          projectRoot: string
+        }): Promise<void> {
+          captured.push([...opts.paths].sort())
+        }
+      }
+
+      try {
+        const executor = new MergeTestExecutor(deps)
+        await executor.executeWithAgent(agent, {...defaultOptions, projectRoot})
+      } finally {
+        rmSync(projectRoot, {force: true, recursive: true})
+      }
+
+      expect(captured).to.have.lengthOf(1)
+      expect(captured[0]).to.deep.equal(['diff/added.md', 'queue/path.md'])
+      expect(dreamStateService.enqueueStaleSummaryPaths.callCount).to.equal(0)
+    })
+
+    it('dedups paths that appear in both the queue and the snapshot diff (single regeneration)', async () => {
+      dreamStateService.drainStaleSummaryPaths.resolves(['shared/path.md'])
+
+      const projectRoot = mkdtempSync(join(tmpdir(), 'brv-dream-merge-dedup-'))
+      const contextTreeDir = join(projectRoot, '.brv', 'context-tree')
+      mkdirSync(contextTreeDir, {recursive: true})
+      const captured: string[][] = []
+
+      class MergeTestExecutor extends DreamExecutor {
+        protected override async runOperations(): Promise<void> {
+          // Write the SAME path the queue contains — the merge must dedup.
+          mkdirSync(join(contextTreeDir, 'shared'), {recursive: true})
+          writeFileSync(join(contextTreeDir, 'shared', 'path.md'), '# also touched by dream')
+        }
+
+        protected override async runStaleSummaryPropagation(opts: {
+          agent: ICipherAgent
+          paths: string[]
+          projectRoot: string
+        }): Promise<void> {
+          captured.push([...opts.paths].sort())
+        }
+      }
+
+      try {
+        const executor = new MergeTestExecutor(deps)
+        await executor.executeWithAgent(agent, {...defaultOptions, projectRoot})
+      } finally {
+        rmSync(projectRoot, {force: true, recursive: true})
+      }
+
+      expect(captured).to.have.lengthOf(1)
+      expect(captured[0]).to.deep.equal(['shared/path.md'])
+    })
+
+    it('re-enqueues drained snapshot when post-dream propagation throws', async () => {
+      // Atomic drain removes entries upfront. If propagation fails, the catch
+      // block must re-enqueue so the snapshot is not lost.
+      dreamStateService.drainStaleSummaryPaths.resolves([
+        'auth/jwt/token.md',
+        'billing/webhooks/stripe.md',
+      ])
+
+      // Force the propagation block to throw by making the snapshot service fail.
+      // The dream-executor wraps Step 5 in try/catch so the dream itself completes.
+      const projectRoot = mkdtempSync(join(tmpdir(), 'brv-dream-reenqueue-'))
+      try {
+        const executor = new DreamExecutor(deps)
+        // executeWithAgent uses a real FileContextTreeSnapshotService bound to projectRoot.
+        // The directory exists but has no .brv/context-tree, so getCurrentState throws —
+        // exercising the catch block that should re-enqueue the drained snapshot.
+        await executor.executeWithAgent(agent, {...defaultOptions, projectRoot})
+      } finally {
+        rmSync(projectRoot, {force: true, recursive: true})
+      }
+
+      expect(dreamStateService.enqueueStaleSummaryPaths.calledOnce).to.equal(true)
+      expect(dreamStateService.enqueueStaleSummaryPaths.firstCall.args[0]).to.deep.equal([
+        'auth/jwt/token.md',
+        'billing/webhooks/stripe.md',
+      ])
+    })
+
+    it('does not call enqueue when drain returns an empty snapshot (no work to retry)', async () => {
+      // Default drain stub returns [] — no snapshot to preserve on failure.
+      const executor = new DreamExecutor(deps)
+      await executor.executeWithAgent(agent, defaultOptions)
+
+      expect(dreamStateService.enqueueStaleSummaryPaths.callCount).to.equal(0)
     })
 
     // ==========================================================================


### PR DESCRIPTION
## Summary

- **Problem**: Every `brv curate` runs `propagateStaleness` inline at the end of the hot path, making 1–3 LLM calls per curate to regenerate parent `_index.md` summaries up the directory tree.
- **Why it matters**: Across multi-curate sessions, this is ~5–15% of the per-curate token bill — pure latency/cost on the user-facing path. The work is purely cosmetic for search (parent summaries lag by up to 12h is acceptable; matched leaf content is unaffected).
- **What changed**: Curate now enqueues changed paths to a stale-summary queue persisted in `.brv/dream-state.json`. The next `brv dream` cycle drains the queue, unions with its own snapshot diff (A ∪ B), and runs `propagateStaleness` once per unique path. On propagation failure, the catch re-enqueues the drained snapshot so atomic-drain doesn't lose work.
- **What did NOT change (scope boundary)**: `_index.md` files still exist (frontmatter + body still BM25-indexed); `propagateStaleness` semantics unchanged; manifest rebuild stays inline (pure filesystem, no LLM); dream's 12h cadence unchanged; in-curate writes to leaf topic files unchanged.

## Type of change

- [x] New feature

## Scope (select all touched areas)

- [x] Server / Daemon

## Linked issues

- Closes ENG-2485
- Related ENG-932 (token-cost benchmark methodology), ENG-2100 (parentTaskId threading — preserved through the new `runStaleSummaryPropagation` seam)

## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause: N/A
- Why this was not caught earlier: N/A

## Test plan

- Coverage added:
  - [x] Unit test
  - [x] Integration test
  - [x] Manual verification (real-LLM E2E)
- Test file(s):
  - `test/unit/infra/dream/dream-state-schema.test.ts` (+54)
  - `test/unit/infra/dream/dream-state-service.test.ts` (+159, new tests for `enqueueStaleSummaryPaths`, `drainStaleSummaryPaths`, dedup, concurrency)
  - `test/unit/infra/executor/dream-executor.test.ts` (+126, drain + re-enqueue + A∪B merge)
  - `test/unit/infra/executor/curate-executor.test.ts` (replaced obsolete inline-propagateStaleness ENG-2100 test with ENG-2485 deferral test)
- Key scenarios covered:
  - Dedup: same path enqueued twice → one entry, oldest `enqueuedAt` preserved
  - Concurrency: `Promise.all` over 3 enqueues → 3 unique entries
  - Atomic drain: snapshot-and-clear semantics
  - Re-enqueue on propagation failure (integration test with real `FileContextTreeSnapshotService`)
  - A ∪ B merge in step 5: paths from queue ∪ paths from dream's own diff

## User-visible changes

None directly. Side effect: parent `_index.md` summaries may lag by up to 12h after a curate (until the next dream). BM25 search and leaf-file lookups are unaffected.

## Evidence

- [x] Full unit suite: **6981 passing, 16 pending, 0 failing**
- [x] `node validate.mjs` (BM25 invariants under stale `_index.md`): **15/15 passed** across 4 staleness scenarios
- [x] Real-LLM E2E on ByteRover paid-tier (gemini-3-flash-preview) — 8 curates + 2 dreams covering:
  - Multi-curate accumulation: 6 paths queued across 3 distinct curates
  - Dedup live: same JWT topic re-curated, queue stayed at 3 paths with original `enqueuedAt`
  - Drain: `brv dream --force` cleared 6-path queue, regenerated 5 `_index.md` files at all depths
  - Curate-side fail-open: `chmod 000 dream-state.json` → curate exit 0
  - Dream-side re-enqueue: pre-created `_manifest.json` as a directory → `buildManifest` threw EISDIR → drained snapshot re-enqueued with new `enqueuedAt`
- [x] AC5 timing comparison (BEFORE proj/curation-enhancement vs AFTER feat/ENG-2485):
  - 6 inline `_index.md` LLM regenerations → **0**
  - Per-curate latency: ~10s saved on hot-daemon curates (~30%)