### PR TITLE
feat: [ENG-2518] batch abstract generation across queued files

### DIFF
--- a/src/agent/infra/map/abstract-generator.ts
+++ b/src/agent/infra/map/abstract-generator.ts
@@ -51,6 +51,115 @@ ${content}
 const MAX_ABSTRACT_CONTENT_CHARS = 20_000
 
 /**
+ * Per-file truncation when N files share a single batched call. Matches the
+ * non-batched cap (20 KB) so each file gets the same view of its content
+ * regardless of batched vs per-file mode — total batched user content scales
+ * linearly with N. Avoids quality regression on long-file curates that batched
+ * mode would otherwise see.
+ */
+const MAX_BATCHED_CONTENT_CHARS_PER_FILE = MAX_ABSTRACT_CONTENT_CHARS
+
+/** L0 batch output budget: 5 files × ~80 tokens + framing tags ≈ 600 tokens. */
+const BATCH_L0_MAX_OUTPUT_TOKENS = 800
+
+/** L1 batch output budget: 5 files × ~1500 tokens + framing tags ≈ 8000 tokens. */
+const BATCH_L1_MAX_OUTPUT_TOKENS = 8500
+
+/**
+ * Result from a batched abstract generation. One entry per input item, in
+ * input order. Empty string fields signal the model failed to produce content
+ * for that path — the caller's existing fail-open semantics still apply.
+ */
+export interface BatchedAbstractItem {
+  abstractContent: string
+  contextPath: string
+  overviewContent: string
+}
+
+const BATCHED_ABSTRACT_SYSTEM_PROMPT = `You are a technical documentation assistant.
+You produce precise one-line summaries of knowledge documents in a strict XML format.
+Output ONLY the XML — no preamble, no commentary, no markdown fences.`
+
+const BATCHED_OVERVIEW_SYSTEM_PROMPT = `You are a technical documentation assistant.
+You produce structured overviews of knowledge documents in a strict XML format.
+Output ONLY the XML — no preamble, no commentary, no markdown fences.`
+
+function escapeXmlAttr(value: string): string {
+  return value.replaceAll('&', '&amp;').replaceAll('"', '&quot;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+}
+
+function buildBatchedAbstractPrompt(items: ReadonlyArray<{content: string; contextPath: string;}>): string {
+  const filesXml = items.map((it) => `<file path="${escapeXmlAttr(it.contextPath)}">
+<document>
+${it.content}
+</document>
+</file>`).join('\n')
+
+  return `For each of the following knowledge documents, produce a ONE-LINE summary (max 80 tokens) that is a complete sentence capturing the core topic and key insight.
+
+Output format — emit exactly one <file> element per input file, with the same path attribute:
+<file path="<path>"><abstract>One-line summary.</abstract></file>
+
+Output only these XML elements, in any order. No preamble, no markdown fences.
+
+<files>
+${filesXml}
+</files>`
+}
+
+function buildBatchedOverviewPrompt(items: ReadonlyArray<{content: string; contextPath: string;}>): string {
+  const filesXml = items.map((it) => `<file path="${escapeXmlAttr(it.contextPath)}">
+<document>
+${it.content}
+</document>
+</file>`).join('\n')
+
+  return `For each of the following knowledge documents, produce a structured overview (markdown, under 1500 tokens) that includes:
+- Key points (3-7 bullet points)
+- Structure / sections summary
+- Any notable entities, patterns, or decisions mentioned
+
+Output format — emit exactly one <file> element per input file, with the same path attribute:
+<file path="<path>"><overview>
+- bullet 1
+- bullet 2
+...
+</overview></file>
+
+Output only these XML elements, in any order. No preamble, no markdown fences.
+
+<files>
+${filesXml}
+</files>`
+}
+
+/**
+ * Extract <abstract>...</abstract> per <file path="..."> from the model output.
+ * Tolerant: ignores extra whitespace, supports nested newlines inside the inner
+ * tag. Returns a Map keyed by path. Paths that don't appear are absent.
+ */
+function parseBatchedTags(response: string, innerTag: 'abstract' | 'overview'): Map<string, string> {
+  const result = new Map<string, string>()
+  // Match <file path="X">...<innerTag>BODY</innerTag>...</file>; lazy on body so
+  // multiple <file> blocks don't bleed into one. The `.` flag-less regex relies
+  // on the s-flag (dotAll) to span newlines.
+  const fileRe = /<file\s+path="([^"]*)"[^>]*>([\s\S]*?)<\/file>/g
+  const innerRe = new RegExp(`<${innerTag}>([\\s\\S]*?)<\\/${innerTag}>`)
+
+  let m: null | RegExpExecArray
+  while ((m = fileRe.exec(response)) !== null) {
+    const [, rawPath, innerXml] = m
+    const path = rawPath.replaceAll('&amp;', '&').replaceAll('&quot;', '"').replaceAll('&lt;', '<').replaceAll('&gt;', '>')
+    const inner = innerRe.exec(innerXml)
+    if (inner) {
+      result.set(path, inner[1].trim())
+    }
+  }
+
+  return result
+}
+
+/**
  * Generate L0 abstract and L1 overview for a knowledge file.
  *
  * Makes two parallel LLM calls at temperature=0:
@@ -87,4 +196,57 @@ export async function generateFileAbstracts(
     abstractContent: abstractText.trim(),
     overviewContent: overviewText.trim(),
   }
+}
+
+/**
+ * Generate L0 abstracts and L1 overviews for N knowledge files in two batched
+ * LLM calls (one batch for all L0s, one for all L1s) instead of 2N per-file
+ * calls.
+ *
+ * Two parallel calls; each call carries all input files in an XML envelope
+ * and the model is instructed to return one element per file. Output is
+ * parsed by path tag and matched back to the input order. Files the model
+ * fails to produce content for receive empty strings (caller's existing
+ * fail-open semantics still apply).
+ *
+ * Caller is responsible for capping batch size; this function does not split
+ * its input. Recommended cap is 5 files per call to keep the L1 batch's
+ * output budget under ~8K tokens.
+ */
+export async function generateFileAbstractsBatch(
+  items: ReadonlyArray<{contextPath: string; fullContent: string}>,
+  generator: IContentGenerator,
+): Promise<BatchedAbstractItem[]> {
+  if (items.length === 0) return []
+
+  const truncated = items.map((it) => ({
+    content: it.fullContent.slice(0, MAX_BATCHED_CONTENT_CHARS_PER_FILE),
+    contextPath: it.contextPath,
+  }))
+
+  const [abstractText, overviewText] = await Promise.all([
+    streamToText(generator, {
+      config: {maxTokens: BATCH_L0_MAX_OUTPUT_TOKENS, temperature: 0},
+      contents: [{content: buildBatchedAbstractPrompt(truncated), role: 'user'}],
+      model: 'default',
+      systemPrompt: BATCHED_ABSTRACT_SYSTEM_PROMPT,
+      taskId: randomUUID(),
+    }),
+    streamToText(generator, {
+      config: {maxTokens: BATCH_L1_MAX_OUTPUT_TOKENS, temperature: 0},
+      contents: [{content: buildBatchedOverviewPrompt(truncated), role: 'user'}],
+      model: 'default',
+      systemPrompt: BATCHED_OVERVIEW_SYSTEM_PROMPT,
+      taskId: randomUUID(),
+    }),
+  ])
+
+  const abstracts = parseBatchedTags(abstractText, 'abstract')
+  const overviews = parseBatchedTags(overviewText, 'overview')
+
+  return items.map((it) => ({
+    abstractContent: (abstracts.get(it.contextPath) ?? '').trim(),
+    contextPath: it.contextPath,
+    overviewContent: (overviews.get(it.contextPath) ?? '').trim(),
+  }))
 }

--- a/src/agent/infra/map/abstract-generator.ts
+++ b/src/agent/infra/map/abstract-generator.ts
@@ -88,11 +88,20 @@ function escapeXmlAttr(value: string): string {
   return value.replaceAll('&', '&amp;').replaceAll('"', '&quot;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
 }
 
+/**
+ * Wrap raw file content in a CDATA section so XML/HTML/JSX/markdown that
+ * mentions `</document>` or `</file>` (perfectly normal for docs that describe
+ * those formats) cannot terminate the envelope and conflate files. The inner
+ * `]]>` escape is the standard CDATA-in-CDATA trick: split the sequence so it
+ * never appears verbatim inside the active section.
+ */
+function wrapCdata(content: string): string {
+  return `<![CDATA[${content.replaceAll(']]>', ']]]]><![CDATA[>')}]]>`
+}
+
 function buildBatchedAbstractPrompt(items: ReadonlyArray<{content: string; contextPath: string;}>): string {
   const filesXml = items.map((it) => `<file path="${escapeXmlAttr(it.contextPath)}">
-<document>
-${it.content}
-</document>
+<document>${wrapCdata(it.content)}</document>
 </file>`).join('\n')
 
   return `For each of the following knowledge documents, produce a ONE-LINE summary (max 80 tokens) that is a complete sentence capturing the core topic and key insight.
@@ -109,9 +118,7 @@ ${filesXml}
 
 function buildBatchedOverviewPrompt(items: ReadonlyArray<{content: string; contextPath: string;}>): string {
   const filesXml = items.map((it) => `<file path="${escapeXmlAttr(it.contextPath)}">
-<document>
-${it.content}
-</document>
+<document>${wrapCdata(it.content)}</document>
 </file>`).join('\n')
 
   return `For each of the following knowledge documents, produce a structured overview (markdown, under 1500 tokens) that includes:
@@ -219,10 +226,22 @@ export async function generateFileAbstractsBatch(
 ): Promise<BatchedAbstractItem[]> {
   if (items.length === 0) return []
 
-  const truncated = items.map((it) => ({
-    content: it.fullContent.slice(0, MAX_BATCHED_CONTENT_CHARS_PER_FILE),
-    contextPath: it.contextPath,
-  }))
+  // Dedup by contextPath, keeping the LAST occurrence's content. The queue is
+  // FIFO so later items carry the most recent fullContent — and the disk file
+  // already reflects that write, so the abstract must summarize the latest
+  // state rather than an intermediate one. Without this dedup, duplicate paths
+  // emit two `<file path>` blocks the model may answer in either order; the
+  // tag parser keys on path and Map-collapses, leaving non-deterministic
+  // results for the duplicates.
+  const byPath = new Map<string, {content: string; contextPath: string}>()
+  for (const it of items) {
+    byPath.set(it.contextPath, {
+      content: it.fullContent.slice(0, MAX_BATCHED_CONTENT_CHARS_PER_FILE),
+      contextPath: it.contextPath,
+    })
+  }
+
+  const truncated = [...byPath.values()]
 
   const [abstractText, overviewText] = await Promise.all([
     streamToText(generator, {

--- a/src/agent/infra/map/abstract-generator.ts
+++ b/src/agent/infra/map/abstract-generator.ts
@@ -144,21 +144,35 @@ ${filesXml}
  * Extract <abstract>...</abstract> per <file path="..."> from the model output.
  * Tolerant: ignores extra whitespace, supports nested newlines inside the inner
  * tag. Returns a Map keyed by path. Paths that don't appear are absent.
+ *
+ * Anchored on `<file path="...">` openers (not `</file>` closers) so a model
+ * overview that mentions `</file>` literally in prose — perfectly normal for
+ * docs about XML, JSX, or build systems — cannot prematurely terminate the
+ * outer match and orphan the inner tag. Each opener owns the response slice
+ * up to the next opener (or end-of-string), and the inner regex extracts
+ * the payload from that slice.
  */
 function parseBatchedTags(response: string, innerTag: 'abstract' | 'overview'): Map<string, string> {
   const result = new Map<string, string>()
-  // Match <file path="X">...<innerTag>BODY</innerTag>...</file>; lazy on body so
-  // multiple <file> blocks don't bleed into one. The `.` flag-less regex relies
-  // on the s-flag (dotAll) to span newlines.
-  const fileRe = /<file\s+path="([^"]*)"[^>]*>([\s\S]*?)<\/file>/g
+  const fileOpenerRe = /<file\s+path="([^"]*)"[^>]*>/g
   const innerRe = new RegExp(`<${innerTag}>([\\s\\S]*?)<\\/${innerTag}>`)
 
+  const openers: Array<{bodyStart: number; rawPath: string}> = []
   let m: null | RegExpExecArray
-  while ((m = fileRe.exec(response)) !== null) {
-    const [, rawPath, innerXml] = m
-    const path = rawPath.replaceAll('&amp;', '&').replaceAll('&quot;', '"').replaceAll('&lt;', '<').replaceAll('&gt;', '>')
-    const inner = innerRe.exec(innerXml)
+  while ((m = fileOpenerRe.exec(response)) !== null) {
+    openers.push({bodyStart: fileOpenerRe.lastIndex, rawPath: m[1]})
+  }
+
+  for (const [i, opener] of openers.entries()) {
+    // Each opener's slice runs from its end to the start of the next opener
+    // (or end-of-string). Within that slice, the inner regex picks up the
+    // payload. A literal `</file>` in prose has no special meaning here.
+    const sliceEnd = i + 1 < openers.length ? openers[i + 1].bodyStart : response.length
+    const slice = response.slice(opener.bodyStart, sliceEnd)
+    const inner = innerRe.exec(slice)
     if (inner) {
+      const path = opener.rawPath
+        .replaceAll('&amp;', '&').replaceAll('&quot;', '"').replaceAll('&lt;', '<').replaceAll('&gt;', '>')
       result.set(path, inner[1].trim())
     }
   }

--- a/src/agent/infra/map/abstract-queue.ts
+++ b/src/agent/infra/map/abstract-queue.ts
@@ -4,7 +4,17 @@ import {join} from 'node:path'
 
 import type {IContentGenerator} from '../../core/interfaces/i-content-generator.js'
 
-import {generateFileAbstracts} from './abstract-generator.js'
+import {generateFileAbstractsBatch} from './abstract-generator.js'
+
+/**
+ * Maximum files combined into a single batched L0/L1 LLM call.
+ *
+ * Two parallel calls fire per cycle: one L0 batch (~80 tok output × N files +
+ * tags), one L1 batch (~1500 tok output × N files + tags). At N=5 the L1
+ * output budget caps at ~8K tokens; raising N further risks output truncation
+ * on smaller-context models. Lowering N reduces savings without quality gain.
+ */
+const BATCH_SIZE_CAP = 5
 
 const QUEUE_TRACE_ENABLED = process.env.BRV_QUEUE_TRACE === '1'
 const LOG_PATH = process.env.BRV_SESSION_LOG
@@ -47,6 +57,13 @@ export interface AbstractQueueStatus {
  * - drain() waits for all pending/processing items to complete (for graceful shutdown)
  */
 export class AbstractGenerationQueue {
+  /**
+   * When true, scheduleNext fires the next batch even if pending is below
+   * BATCH_SIZE_CAP. Set by drain(); reset once the queue is fully idle.
+   * Without this, items below the cap would be buffered indefinitely with
+   * no flush trigger when a curate writes fewer files than the cap.
+   */
+  private drainRequested = false
   private drainResolvers: Array<() => void> = []
   private failed = 0
   private generator: IContentGenerator | undefined
@@ -71,7 +88,13 @@ export class AbstractGenerationQueue {
    */
   async drain(): Promise<void> {
     queueLog(`drain:start idle=${this.isIdle()} pending=${this.pending.length} retrying=${this.retrying} processing=${this.processing}`)
+    // Force any buffered (below-cap) pending items to fire as a final batch.
+    // scheduleNext respects drainRequested even when pending < BATCH_SIZE_CAP.
+    this.drainRequested = true
+    this.scheduleNext()
+
     if (this.isIdle()) {
+      this.drainRequested = false
       await this.statusWritePromise.catch(() => {})
       queueLog('drain:resolved-immediate')
       return
@@ -105,7 +128,13 @@ export class AbstractGenerationQueue {
     this.pending.push({attempts: 0, contextPath: item.contextPath, fullContent: item.fullContent})
     queueLog(`enqueue path=${item.contextPath} pending=${this.pending.length} retrying=${this.retrying} processing=${this.processing}`)
     this.queueStatusWrite()
-    this.scheduleNext()
+    // Buffer until cap is reached; drain() will trigger the final flush
+    // for partial batches at curate-end. Without this gating, the first
+    // enqueue starts a 1-item batch before the curate finishes writing
+    // the rest of its files.
+    if (this.pending.length >= BATCH_SIZE_CAP || this.drainRequested) {
+      this.scheduleNext()
+    }
   }
 
   /**
@@ -151,8 +180,10 @@ export class AbstractGenerationQueue {
     this.processing = true
     this.queueStatusWrite()
 
-    const item = this.pending.shift()!
-    queueLog(`process:start path=${item.contextPath} remaining=${this.pending.length} retrying=${this.retrying}`)
+    // Drain up to BATCH_SIZE_CAP items into a single batch. Items beyond the
+    // cap stay pending for the next cycle.
+    const batch = this.pending.splice(0, BATCH_SIZE_CAP)
+    queueLog(`process:start batchSize=${batch.length} remaining=${this.pending.length} retrying=${this.retrying}`)
 
     try {
       // Refresh credentials before each generation (OAuth tokens may expire)
@@ -163,28 +194,45 @@ export class AbstractGenerationQueue {
         console.debug(`[AbstractQueue] token refresh failed, proceeding with existing generator: ${msg}`)
       }
 
-      const {abstractContent, overviewContent} = await generateFileAbstracts(
-        item.fullContent,
+      const results = await generateFileAbstractsBatch(
+        batch.map((it) => ({contextPath: it.contextPath, fullContent: it.fullContent})),
         this.generator,
       )
 
-      // Derive sibling paths: replace .md with .abstract.md and .overview.md
-      const abstractPath = item.contextPath.replace(/\.md$/, '.abstract.md')
-      const overviewPath = item.contextPath.replace(/\.md$/, '.overview.md')
+      // Write all batched outputs in parallel. Empty strings are valid (model
+      // produced no content for that path) — preserves existing fail-open.
+      await Promise.all(results.flatMap((r) => {
+        const abstractPath = r.contextPath.replace(/\.md$/, '.abstract.md')
+        const overviewPath = r.contextPath.replace(/\.md$/, '.overview.md')
+        return [
+          writeFile(abstractPath, r.abstractContent, 'utf8'),
+          writeFile(overviewPath, r.overviewContent, 'utf8'),
+        ]
+      }))
 
-      await Promise.all([
-        writeFile(abstractPath, abstractContent, 'utf8'),
-        writeFile(overviewPath, overviewContent, 'utf8'),
-      ])
-
-      this.processed++
-      queueLog(`process:success path=${item.contextPath} processed=${this.processed}`)
+      this.processed += batch.length
+      queueLog(`process:success batchSize=${batch.length} processed=${this.processed}`)
     } catch (error) {
+      // Batch-level failure → re-enqueue each item individually with its own
+      // attempts counter, mirroring per-item retry semantics. Items past
+      // maxAttempts count as failed.
       const msg = error instanceof Error ? error.message : String(error)
-      console.debug(`[AbstractQueue] ${item.contextPath} attempt ${item.attempts + 1}/${this.maxAttempts}: ${msg}`)
-      item.attempts++
-      if (item.attempts < this.maxAttempts) {
-        // Exponential backoff: 500ms, 1000ms, 2000ms, ...
+      const failedThisCycle: QueueItem[] = []
+      const retryThisCycle: QueueItem[] = []
+      for (const item of batch) {
+        item.attempts++
+        if (item.attempts < this.maxAttempts) {
+          retryThisCycle.push(item)
+        } else {
+          this.failed++
+          failedThisCycle.push(item)
+          queueLog(`process:failed path=${item.contextPath} failed=${this.failed}`)
+        }
+      }
+
+      console.debug(`[AbstractQueue] batch attempt failed (${msg}); retrying=${retryThisCycle.length}, exhausted=${failedThisCycle.length}`)
+
+      for (const item of retryThisCycle) {
         const delay = 500 * 2 ** (item.attempts - 1)
         this.retrying++
         this.queueStatusWrite()
@@ -195,13 +243,10 @@ export class AbstractGenerationQueue {
           this.queueStatusWrite()
           this.scheduleNext()
         }, delay)
-      } else {
-        this.failed++
-        queueLog(`process:failed path=${item.contextPath} failed=${this.failed}`)
       }
     } finally {
       this.processing = false
-      queueLog(`process:finally path=${item.contextPath} pending=${this.pending.length} retrying=${this.retrying} processed=${this.processed} failed=${this.failed}`)
+      queueLog(`process:finally batchSize=${batch.length} pending=${this.pending.length} retrying=${this.retrying} processed=${this.processed} failed=${this.failed}`)
       this.queueStatusWrite()
     }
 
@@ -220,6 +265,10 @@ export class AbstractGenerationQueue {
       return
     }
 
+    // Reset drain state once the queue settles — next curate's enqueue burst
+    // should buffer normally up to BATCH_SIZE_CAP again.
+    this.drainRequested = false
+
     queueLog(`drain:idle pending=${this.pending.length} retrying=${this.retrying} processed=${this.processed} failed=${this.failed}`)
     const resolvers = this.drainResolvers.splice(0)
     const settledStatusWrite = this.statusWritePromise.catch(() => {})
@@ -229,8 +278,19 @@ export class AbstractGenerationQueue {
   }
 
   private scheduleNext(): void {
-    if (!this.generator || this.processing || this.pending.length === 0) {
+    if (!this.generator || this.processing) {
+      return
+    }
+
+    if (this.pending.length === 0) {
       this.resolveDrainersIfIdle()
+      return
+    }
+
+    // Buffer items below the cap unless drain has been requested (curate-end
+    // signal). This keeps the queue from firing partial 1-item batches in the
+    // middle of a multi-file curate.
+    if (this.pending.length < BATCH_SIZE_CAP && !this.drainRequested) {
       return
     }
 

--- a/src/agent/infra/map/abstract-queue.ts
+++ b/src/agent/infra/map/abstract-queue.ts
@@ -172,7 +172,11 @@ export class AbstractGenerationQueue {
   }
 
   private async processNext(): Promise<void> {
-    if (!this.generator || this.processing || this.pending.length === 0) {
+    // Capture the generator in a local const so type narrowing survives the
+    // `await` boundary below — TS won't keep `this.generator` narrow across
+    // suspensions because another async path could reassign the property.
+    const {generator} = this
+    if (!generator || this.processing || this.pending.length === 0) {
       this.resolveDrainersIfIdle()
       return
     }
@@ -181,7 +185,12 @@ export class AbstractGenerationQueue {
     this.queueStatusWrite()
 
     // Drain up to BATCH_SIZE_CAP items into a single batch. Items beyond the
-    // cap stay pending for the next cycle.
+    // cap stay pending for the next cycle. Note: `maxAttempts` counts BATCH
+    // attempts for this item, not individual-call attempts — a transient
+    // failure on attempt 1 consumes one retry token for every item in the
+    // batch, including ones whose content was unrelated to the failure.
+    // Acceptable: batches are small (cap=5) and the per-item re-enqueue on
+    // batch failure preserves attempts independently across cycles.
     const batch = this.pending.splice(0, BATCH_SIZE_CAP)
     queueLog(`process:start batchSize=${batch.length} remaining=${this.pending.length} retrying=${this.retrying}`)
 
@@ -196,7 +205,7 @@ export class AbstractGenerationQueue {
 
       const results = await generateFileAbstractsBatch(
         batch.map((it) => ({contextPath: it.contextPath, fullContent: it.fullContent})),
-        this.generator,
+        generator,
       )
 
       // Write all batched outputs in parallel. Empty strings are valid (model

--- a/test/unit/agent/map/abstract-generator-batch.test.ts
+++ b/test/unit/agent/map/abstract-generator-batch.test.ts
@@ -160,7 +160,11 @@ describe('generateFileAbstractsBatch', () => {
   })
 
   it('CDATA-wraps file content so XML/HTML markers in the body cannot break the envelope', async () => {
-    let capturedPrompt = ''
+    // Capture BOTH the L0 and L1 prompts so we assert the wrap is applied to
+    // each independent builder. Without separate captures, we'd only validate
+    // the last call's prompt — a future refactor that forgot wrapCdata in one
+    // builder would slip past.
+    const capturedPrompts: {abstract?: string; overview?: string} = {}
     const generator: IContentGenerator = {
       estimateTokensSync: () => 10,
       generateContent: sandbox.stub().rejects(new Error('n/a')),
@@ -168,8 +172,9 @@ describe('generateFileAbstractsBatch', () => {
         contents?: Array<{content?: string}>
         systemPrompt?: string
       }) {
-        capturedPrompt = req.contents?.[0]?.content ?? ''
         const isAbstract = (req.systemPrompt ?? '').includes('one-line')
+        if (isAbstract) capturedPrompts.abstract = req.contents?.[0]?.content ?? ''
+        else capturedPrompts.overview = req.contents?.[0]?.content ?? ''
         const innerTag = isAbstract ? 'abstract' : 'overview'
         yield {content: `<file path="docs/xml.md"><${innerTag}>OK</${innerTag}></file>`, isComplete: false}
         yield {isComplete: true}
@@ -185,18 +190,46 @@ describe('generateFileAbstractsBatch', () => {
       generator,
     )
 
-    // The raw treacherous text must appear inside a CDATA section, not as
-    // bare nested elements, so the model parses one document and one file.
-    expect(capturedPrompt).to.include('<![CDATA[')
-    expect(capturedPrompt).to.include(']]>')
-    // The prompt has exactly one <document> opener and exactly one closing
-    // </document> at the structural level (the body's </document> is now
-    // inert inside CDATA).
-    const docOpen = (capturedPrompt.match(/<document>/g) ?? []).length
-    expect(docOpen).to.equal(1, 'exactly one <document> envelope per file')
+    // Both prompts (L0 and L1) must independently wrap content in CDATA.
+    for (const [label, prompt] of [['abstract', capturedPrompts.abstract], ['overview', capturedPrompts.overview]] as const) {
+      expect(prompt, `${label} prompt was captured`).to.be.a('string')
+      const promptText = prompt ?? ''
+      expect(promptText, `${label} prompt opens CDATA`).to.include('<![CDATA[')
+      expect(promptText, `${label} prompt closes CDATA`).to.include(']]>')
+      // Exactly one structural <document> opener per file (the body's literal
+      // </document> is now inert inside CDATA).
+      const docOpen = (promptText.match(/<document>/g) ?? []).length
+      expect(docOpen, `${label} prompt has exactly one <document> envelope`).to.equal(1)
+    }
 
     // Result still parses cleanly.
     expect(result[0].abstractContent).to.equal('OK')
+  })
+
+  it('parser is robust to a literal </file> appearing inside the model overview prose', async () => {
+    // The model output is plain text (NOT CDATA-wrapped). A document about
+    // build systems / XML / JSX may legitimately produce overview prose like
+    // "the </file> closing tag in Ant build files…" — a closer-anchored
+    // parser would stop at the premature </file> and orphan the inner tag.
+    const l0Response = '<file path="ant.md"><abstract>Ant build files use a closing </file> tag.</abstract></file>'
+    const l1Response = `<file path="ant.md"><overview>
+- Mentions the </file> closing tag in build prose
+- Still must round-trip cleanly
+</overview></file>`
+
+    const generator = makeScriptedGenerator(sandbox, [l0Response, l1Response])
+    const result = await generateFileAbstractsBatch(
+      [{contextPath: 'ant.md', fullContent: 'Ant build files'}],
+      generator,
+    )
+
+    // Both fields are populated despite the literal </file> in the body —
+    // the parser anchors on `<file path>` openers, not `</file>` closers.
+    expect(result).to.have.lengthOf(1)
+    expect(result[0].abstractContent).to.include('Ant build files')
+    expect(result[0].abstractContent).to.include('</file>')
+    expect(result[0].overviewContent).to.include('Mentions the </file>')
+    expect(result[0].overviewContent).to.include('Still must round-trip cleanly')
   })
 
   it('escapes nested CDATA terminators in content so the wrap stays valid', async () => {

--- a/test/unit/agent/map/abstract-generator-batch.test.ts
+++ b/test/unit/agent/map/abstract-generator-batch.test.ts
@@ -1,0 +1,132 @@
+import {expect} from 'chai'
+import {createSandbox, type SinonSandbox} from 'sinon'
+
+import type {IContentGenerator} from '../../../../src/agent/core/interfaces/i-content-generator.js'
+
+import {generateFileAbstractsBatch} from '../../../../src/agent/infra/map/abstract-generator.js'
+
+/**
+ * Build a generator whose generateContentStream yields a fixed text response
+ * the n-th time it's called. Useful for stubbing the parallel L0/L1 batch
+ * calls with two distinct texts.
+ */
+function makeScriptedGenerator(sandbox: SinonSandbox, responsesByCall: string[]): IContentGenerator {
+  let callIndex = 0
+  return {
+    estimateTokensSync: () => 10,
+    generateContent: sandbox.stub().rejects(new Error('n/a')),
+    generateContentStream: sandbox.stub().callsFake(async function *() {
+      const text = responsesByCall[callIndex++] ?? ''
+      yield {content: text, isComplete: false}
+      yield {isComplete: true}
+    }),
+  } as unknown as IContentGenerator
+}
+
+describe('generateFileAbstractsBatch', () => {
+  const sandbox = createSandbox()
+
+  afterEach(() => sandbox.restore())
+
+  it('returns one result per input file when the model responds with all paths', async () => {
+    const l0Response = [
+      '<file path="a.md"><abstract>One-line summary of A.</abstract></file>',
+      '<file path="b.md"><abstract>One-line summary of B.</abstract></file>',
+    ].join('\n')
+    const l1Response = [
+      '<file path="a.md"><overview>- bullet 1\n- bullet 2\n- bullet 3</overview></file>',
+      '<file path="b.md"><overview>- bullet 1\n- bullet 2</overview></file>',
+    ].join('\n')
+
+    const generator = makeScriptedGenerator(sandbox, [l0Response, l1Response])
+    const result = await generateFileAbstractsBatch(
+      [
+        {contextPath: 'a.md', fullContent: 'content of A'},
+        {contextPath: 'b.md', fullContent: 'content of B'},
+      ],
+      generator,
+    )
+
+    expect(result).to.have.lengthOf(2)
+    expect(result[0].contextPath).to.equal('a.md')
+    expect(result[0].abstractContent).to.equal('One-line summary of A.')
+    expect(result[0].overviewContent).to.contain('bullet 1')
+    expect(result[1].contextPath).to.equal('b.md')
+    expect(result[1].abstractContent).to.equal('One-line summary of B.')
+  })
+
+  it('keeps input order when the model returns paths out of order', async () => {
+    const l0Response = [
+      '<file path="b.md"><abstract>B summary.</abstract></file>',
+      '<file path="a.md"><abstract>A summary.</abstract></file>',
+    ].join('\n')
+    const l1Response = [
+      '<file path="b.md"><overview>B over.</overview></file>',
+      '<file path="a.md"><overview>A over.</overview></file>',
+    ].join('\n')
+
+    const generator = makeScriptedGenerator(sandbox, [l0Response, l1Response])
+    const result = await generateFileAbstractsBatch(
+      [
+        {contextPath: 'a.md', fullContent: 'A'},
+        {contextPath: 'b.md', fullContent: 'B'},
+      ],
+      generator,
+    )
+
+    expect(result.map((r: {contextPath: string}) => r.contextPath)).to.deep.equal(['a.md', 'b.md'])
+    expect(result[0].abstractContent).to.equal('A summary.')
+    expect(result[1].abstractContent).to.equal('B summary.')
+  })
+
+  it('returns empty strings for files the model omits', async () => {
+    const l0Response = '<file path="a.md"><abstract>Only A.</abstract></file>'
+    const l1Response = '<file path="a.md"><overview>Only A over.</overview></file>'
+
+    const generator = makeScriptedGenerator(sandbox, [l0Response, l1Response])
+    const result = await generateFileAbstractsBatch(
+      [
+        {contextPath: 'a.md', fullContent: 'A'},
+        {contextPath: 'b.md', fullContent: 'B'},
+      ],
+      generator,
+    )
+
+    expect(result).to.have.lengthOf(2)
+    expect(result[0].abstractContent).to.equal('Only A.')
+    expect(result[1].abstractContent).to.equal('')
+    expect(result[1].overviewContent).to.equal('')
+  })
+
+  it('returns empty strings when the model output is malformed (no matching tags)', async () => {
+    const generator = makeScriptedGenerator(sandbox, ['random unparseable text', 'also unparseable'])
+    const result = await generateFileAbstractsBatch(
+      [
+        {contextPath: 'a.md', fullContent: 'A'},
+      ],
+      generator,
+    )
+
+    expect(result).to.have.lengthOf(1)
+    expect(result[0].abstractContent).to.equal('')
+    expect(result[0].overviewContent).to.equal('')
+  })
+
+  it('issues exactly two LLM calls regardless of batch size (one L0 batch, one L1 batch)', async () => {
+    const l0Response = Array.from({length: 5}, (_, i) =>
+      `<file path="${i}.md"><abstract>S${i}.</abstract></file>`,
+    ).join('\n')
+    const l1Response = Array.from({length: 5}, (_, i) =>
+      `<file path="${i}.md"><overview>O${i}.</overview></file>`,
+    ).join('\n')
+
+    const generator = makeScriptedGenerator(sandbox, [l0Response, l1Response])
+    await generateFileAbstractsBatch(
+      Array.from({length: 5}, (_, i) => ({contextPath: `${i}.md`, fullContent: `c${i}`})),
+      generator,
+    )
+
+    const stubbed = generator.generateContentStream as ReturnType<typeof sandbox.stub>
+    expect(stubbed.callCount).to.equal(2)
+  })
+})

--- a/test/unit/agent/map/abstract-generator-batch.test.ts
+++ b/test/unit/agent/map/abstract-generator-batch.test.ts
@@ -112,6 +112,119 @@ describe('generateFileAbstractsBatch', () => {
     expect(result[0].overviewContent).to.equal('')
   })
 
+  it('dedups duplicate contextPath inputs, keeping the last item content (most recent state)', async () => {
+    // Capture the prompt the model receives so we can assert it carries the
+    // LATEST content (v2), not the older content (v1) for a duplicated path.
+    let capturedAbstractPrompt = ''
+    const generator: IContentGenerator = {
+      estimateTokensSync: () => 10,
+      generateContent: sandbox.stub().rejects(new Error('n/a')),
+      generateContentStream: sandbox.stub().callsFake(async function *(req: {
+        contents?: Array<{content?: string}>
+        systemPrompt?: string
+      }) {
+        const userContent = req.contents?.[0]?.content ?? ''
+        const isAbstract = (req.systemPrompt ?? '').includes('one-line')
+        if (isAbstract) capturedAbstractPrompt = userContent
+        const innerTag = isAbstract ? 'abstract' : 'overview'
+        yield {content: `<file path="auth/jwt.md"><${innerTag}>S</${innerTag}></file>`, isComplete: false}
+        yield {isComplete: true}
+      }),
+    } as unknown as IContentGenerator
+
+    const result = await generateFileAbstractsBatch(
+      [
+        {contextPath: 'auth/jwt.md', fullContent: 'v1: original draft'},
+        {contextPath: 'auth/jwt.md', fullContent: 'v2: updated content'},
+      ],
+      generator,
+    )
+
+    // Only one `<file path="auth/jwt.md">` block should appear in the prompt
+    // (deduped at the generator boundary). Without the dedup, the model would
+    // see two blocks and may answer them in either order.
+    const pathOccurrences = (capturedAbstractPrompt.match(/<file\s+path="auth\/jwt\.md"/g) ?? []).length
+    expect(pathOccurrences).to.equal(1, 'duplicate paths must collapse to a single prompt block')
+
+    // The deduped content must be the LATEST one (v2) — disk file reflects v2.
+    expect(capturedAbstractPrompt).to.include('v2: updated content')
+    expect(capturedAbstractPrompt).to.not.include('v1: original draft')
+
+    // Result returns ONE entry per ORIGINAL input (callers expect array
+    // alignment with the queue items they passed in).
+    expect(result).to.have.lengthOf(2)
+    expect(result[0].contextPath).to.equal('auth/jwt.md')
+    expect(result[1].contextPath).to.equal('auth/jwt.md')
+    expect(result[0].abstractContent).to.equal('S')
+    expect(result[1].abstractContent).to.equal('S')
+  })
+
+  it('CDATA-wraps file content so XML/HTML markers in the body cannot break the envelope', async () => {
+    let capturedPrompt = ''
+    const generator: IContentGenerator = {
+      estimateTokensSync: () => 10,
+      generateContent: sandbox.stub().rejects(new Error('n/a')),
+      generateContentStream: sandbox.stub().callsFake(async function *(req: {
+        contents?: Array<{content?: string}>
+        systemPrompt?: string
+      }) {
+        capturedPrompt = req.contents?.[0]?.content ?? ''
+        const isAbstract = (req.systemPrompt ?? '').includes('one-line')
+        const innerTag = isAbstract ? 'abstract' : 'overview'
+        yield {content: `<file path="docs/xml.md"><${innerTag}>OK</${innerTag}></file>`, isComplete: false}
+        yield {isComplete: true}
+      }),
+    } as unknown as IContentGenerator
+
+    // Content that would break the prompt envelope without CDATA: literal
+    // </document> and </file> markers, plus an XML-flavored payload.
+    const treacherousContent = 'A doc explaining the </document> tag and </file>: <foo>bar</foo>'
+
+    const result = await generateFileAbstractsBatch(
+      [{contextPath: 'docs/xml.md', fullContent: treacherousContent}],
+      generator,
+    )
+
+    // The raw treacherous text must appear inside a CDATA section, not as
+    // bare nested elements, so the model parses one document and one file.
+    expect(capturedPrompt).to.include('<![CDATA[')
+    expect(capturedPrompt).to.include(']]>')
+    // The prompt has exactly one <document> opener and exactly one closing
+    // </document> at the structural level (the body's </document> is now
+    // inert inside CDATA).
+    const docOpen = (capturedPrompt.match(/<document>/g) ?? []).length
+    expect(docOpen).to.equal(1, 'exactly one <document> envelope per file')
+
+    // Result still parses cleanly.
+    expect(result[0].abstractContent).to.equal('OK')
+  })
+
+  it('escapes nested CDATA terminators in content so the wrap stays valid', async () => {
+    let capturedPrompt = ''
+    const generator: IContentGenerator = {
+      estimateTokensSync: () => 10,
+      generateContent: sandbox.stub().rejects(new Error('n/a')),
+      generateContentStream: sandbox.stub().callsFake(async function *(req: {
+        contents?: Array<{content?: string}>
+      }) {
+        capturedPrompt = req.contents?.[0]?.content ?? ''
+        yield {content: '<file path="x.md"><abstract>OK</abstract></file>', isComplete: false}
+        yield {isComplete: true}
+      }),
+    } as unknown as IContentGenerator
+
+    // Content that contains a literal `]]>` sequence — would terminate CDATA
+    // prematurely without the in-CDATA escape trick.
+    await generateFileAbstractsBatch(
+      [{contextPath: 'x.md', fullContent: 'before ]]> after'}],
+      generator,
+    )
+
+    // The bare `]]>` must NOT appear inside the still-active CDATA section —
+    // it should be split via `]]]]><![CDATA[>`.
+    expect(capturedPrompt).to.include(']]]]><![CDATA[>')
+  })
+
   it('issues exactly two LLM calls regardless of batch size (one L0 batch, one L1 batch)', async () => {
     const l0Response = Array.from({length: 5}, (_, i) =>
       `<file path="${i}.md"><abstract>S${i}.</abstract></file>`,

--- a/test/unit/agent/map/abstract-queue.test.ts
+++ b/test/unit/agent/map/abstract-queue.test.ts
@@ -20,12 +20,24 @@ function makeFailingGenerator(sandbox: SinonSandbox): IContentGenerator {
   } as unknown as IContentGenerator
 }
 
+/**
+ * Stream stub that responds in the XML format expected by H3's batched generator.
+ * Sniffs the request's user content for `<file path="..."` tokens and emits one
+ * `<file path="X"><abstract|overview>generated text</...></file>` per detected
+ * path. The L0 vs L1 branch is detected from the system prompt.
+ */
 function makeSuccessfulGenerator(sandbox: SinonSandbox): IContentGenerator {
   return {
     estimateTokensSync: () => 10,
     generateContent: sandbox.stub().rejects(new Error('n/a')),
-    generateContentStream: sandbox.stub().callsFake(async function *() {
-      yield {content: 'generated text', isComplete: false}
+    generateContentStream: sandbox.stub().callsFake(async function *(request: {contents?: Array<{content?: string}>; systemPrompt?: string}) {
+      const userContent = request.contents?.[0]?.content ?? ''
+      const isAbstract = (request.systemPrompt ?? '').includes('one-line')
+      const innerTag = isAbstract ? 'abstract' : 'overview'
+      const pathMatches = [...userContent.matchAll(/<file\s+path="([^"]+)"/g)]
+      const paths = pathMatches.length > 0 ? pathMatches.map((m) => m[1]) : ['unknown']
+      const xml = paths.map((p) => `<file path="${p}"><${innerTag}>generated text</${innerTag}></file>`).join('\n')
+      yield {content: xml, isComplete: false}
       yield {isComplete: true}
     }),
   } as unknown as IContentGenerator
@@ -99,24 +111,28 @@ describe('AbstractGenerationQueue', () => {
       const q = new AbstractGenerationQueue(tmpDir, 2) // maxAttempts=2 → one retry
 
       q.setGenerator(generator)
-      q.enqueue({contextPath: join(tmpDir, 'file.md'), fullContent: 'content'})
+      // Enqueue BATCH_SIZE_CAP=5 items so the batch fires immediately.
+      for (let i = 0; i < 5; i++) {
+        q.enqueue({contextPath: join(tmpDir, `file-${i}.md`), fullContent: 'content'})
+      }
 
-      // scheduleNext fires via setImmediate; processNext is now awaiting generateFileAbstracts
+      // scheduleNext fires via setImmediate; processNext is now awaiting generateFileAbstractsBatch
       await new Promise<void>((r) => { setImmediate(r) })
       expect(q.getStatus().processing).to.equal(true)
 
-      // Trigger failure — processNext catch fires: retrying++, setTimeout(500ms backoff)
+      // Trigger failure — Promise.all over the two parallel streams rejects,
+      // processNext catch fires: each item retrying++, setTimeout(500ms backoff)
       rejectNextCall(new Error('deliberate failure'))
-      // Two setImmediate ticks: one for the catch block, one for the finally block
+      // Ticks for catch + finally + microtask queue
+      await new Promise<void>((r) => { setImmediate(r) })
       await new Promise<void>((r) => { setImmediate(r) })
       await new Promise<void>((r) => { setImmediate(r) })
 
-      // Item is now in retry backoff: retrying=1, pending=[]
-      // Before fix: getStatus().pending was 0 (retrying items invisible)
-      // After fix:  getStatus().pending is 1 (retrying items folded into pending)
+      // All 5 items now in retry backoff: retrying=5, pending=[]
+      // getStatus().pending folds retrying into pending so callers don't see false-idle.
       const status = q.getStatus()
       expect(status.processing).to.equal(false)
-      expect(status.pending).to.equal(1)
+      expect(status.pending).to.equal(5)
       expect(status.failed).to.equal(0)
     })
   })
@@ -213,6 +229,79 @@ describe('AbstractGenerationQueue', () => {
       const raw = await fs.readFile(join(tmpDir, '.brv', '_queue_status.json'), 'utf8')
       const written = JSON.parse(raw) as {pending: number}
       expect(written.pending).to.equal(1)
+    })
+
+    it('buffers items below BATCH_SIZE_CAP without firing LLM calls', async () => {
+      const successfulGenerator = makeSuccessfulGenerator(sandbox)
+      const q = new AbstractGenerationQueue(tmpDir)
+      q.setGenerator(successfulGenerator)
+
+      // Enqueue 3 items — below BATCH_SIZE_CAP=5, so no batch should fire.
+      for (let i = 0; i < 3; i++) {
+        q.enqueue({contextPath: join(tmpDir, `f${i}.md`), fullContent: `content ${i}`})
+      }
+
+      // Give scheduleNext time to (incorrectly) fire if the buffer guard is broken.
+      await new Promise<void>((r) => { setImmediate(r) })
+      await new Promise<void>((r) => { setImmediate(r) })
+
+      const stub = successfulGenerator.generateContentStream as ReturnType<typeof sandbox.stub>
+      expect(stub.callCount).to.equal(0, 'Expected 0 LLM calls while pending is below BATCH_SIZE_CAP')
+      expect(q.getStatus()).to.deep.equal({failed: 0, pending: 3, processed: 0, processing: false})
+
+      // drain() forces the partial batch to flush → exactly 2 stream calls.
+      await q.drain()
+      expect(stub.callCount).to.equal(2, 'Expected drain() to flush the partial batch as 1×L0 + 1×L1')
+      expect(q.getStatus().processed).to.equal(3)
+    })
+
+    it('processes up to BATCH_SIZE_CAP items in a single LLM cycle', async () => {
+      const successfulGenerator = makeSuccessfulGenerator(sandbox)
+      const q = new AbstractGenerationQueue(tmpDir)
+      q.setGenerator(successfulGenerator)
+
+      const N = 5
+      for (let i = 0; i < N; i++) {
+        q.enqueue({contextPath: join(tmpDir, `f${i}.md`), fullContent: `content ${i}`})
+      }
+
+      await q.drain()
+
+      // 1 batch * 2 LLM calls (L0 + L1) = exactly 2 stream calls for N=5
+      const stub = successfulGenerator.generateContentStream as ReturnType<typeof sandbox.stub>
+      expect(stub.callCount).to.equal(2, 'Expected exactly 2 LLM stream calls for a 5-item batch (1×L0 + 1×L1)')
+      expect(q.getStatus()).to.deep.equal({failed: 0, pending: 0, processed: N, processing: false})
+
+      // Every file gets its abstract.md and overview.md written
+      const fileChecks = Array.from({length: N}, async (_, i) => {
+        const abstractPath = join(tmpDir, `f${i}.abstract.md`)
+        const overviewPath = join(tmpDir, `f${i}.overview.md`)
+        const [abstractText, overviewText] = await Promise.all([
+          fs.readFile(abstractPath, 'utf8'),
+          fs.readFile(overviewPath, 'utf8'),
+        ])
+        expect(abstractText).to.equal('generated text')
+        expect(overviewText).to.equal('generated text')
+      })
+      await Promise.all(fileChecks)
+    })
+
+    it('splits oversized backlogs into multiple batches', async () => {
+      const successfulGenerator = makeSuccessfulGenerator(sandbox)
+      const q = new AbstractGenerationQueue(tmpDir)
+      q.setGenerator(successfulGenerator)
+
+      const N = 7  // > BATCH_SIZE_CAP=5 → expect 2 batches (5 + 2)
+      for (let i = 0; i < N; i++) {
+        q.enqueue({contextPath: join(tmpDir, `f${i}.md`), fullContent: `content ${i}`})
+      }
+
+      await q.drain()
+
+      const stub = successfulGenerator.generateContentStream as ReturnType<typeof sandbox.stub>
+      // 2 batches × 2 LLM calls each = 4 stream calls
+      expect(stub.callCount).to.equal(4, 'Expected 4 stream calls for 7 items split into batches of 5+2')
+      expect(q.getStatus().processed).to.equal(N)
     })
 
     it('status file reflects retrying items in pending count', async () => {

--- a/test/unit/agent/map/abstract-queue.test.ts
+++ b/test/unit/agent/map/abstract-queue.test.ts
@@ -231,6 +231,32 @@ describe('AbstractGenerationQueue', () => {
       expect(written.pending).to.equal(1)
     })
 
+    it('status file reflects retrying items in pending count', async () => {
+      const {generator, rejectNextCall} = makeControlledGenerator(sandbox)
+      const q = new AbstractGenerationQueue(tmpDir, 2)
+
+      q.setGenerator(generator)
+      q.enqueue({contextPath: join(tmpDir, 'file.md'), fullContent: 'content'})
+
+      await new Promise<void>((r) => { setImmediate(r) })
+      rejectNextCall(new Error('fail'))
+      await new Promise<void>((r) => { setImmediate(r) })
+      await new Promise<void>((r) => { setImmediate(r) })
+
+      // Status file is written during retrying++ branch — wait for disk I/O to flush
+      await new Promise<void>((r) => { setTimeout(r, 50) })
+
+      const statusPath = join(tmpDir, '.brv', '_queue_status.json')
+      const raw = await fs.readFile(statusPath, 'utf8')
+      const written = JSON.parse(raw) as {pending: number; processing: boolean}
+      expect(written.pending).to.equal(1) // retrying item must appear in status file
+      expect(written.processing).to.equal(false)
+    })
+  })
+
+  // ── batching behaviour ─────────────────────────────────────────────────────
+
+  describe('batching behaviour', () => {
     it('buffers items below BATCH_SIZE_CAP without firing LLM calls', async () => {
       const successfulGenerator = makeSuccessfulGenerator(sandbox)
       const q = new AbstractGenerationQueue(tmpDir)
@@ -302,28 +328,6 @@ describe('AbstractGenerationQueue', () => {
       // 2 batches × 2 LLM calls each = 4 stream calls
       expect(stub.callCount).to.equal(4, 'Expected 4 stream calls for 7 items split into batches of 5+2')
       expect(q.getStatus().processed).to.equal(N)
-    })
-
-    it('status file reflects retrying items in pending count', async () => {
-      const {generator, rejectNextCall} = makeControlledGenerator(sandbox)
-      const q = new AbstractGenerationQueue(tmpDir, 2)
-
-      q.setGenerator(generator)
-      q.enqueue({contextPath: join(tmpDir, 'file.md'), fullContent: 'content'})
-
-      await new Promise<void>((r) => { setImmediate(r) })
-      rejectNextCall(new Error('fail'))
-      await new Promise<void>((r) => { setImmediate(r) })
-      await new Promise<void>((r) => { setImmediate(r) })
-
-      // Status file is written during retrying++ branch — wait for disk I/O to flush
-      await new Promise<void>((r) => { setTimeout(r, 50) })
-
-      const statusPath = join(tmpDir, '.brv', '_queue_status.json')
-      const raw = await fs.readFile(statusPath, 'utf8')
-      const written = JSON.parse(raw) as {pending: number; processing: boolean}
-      expect(written.pending).to.equal(1) // retrying item must appear in status file
-      expect(written.processing).to.equal(false)
     })
   })
 })


### PR DESCRIPTION
## Summary

- **Problem**: The abstract queue makes 2N LLM calls per curate (one L0 `.abstract.md` + one L1 `.overview.md` per file). On a 30-file pack, that's 60 independent calls each paying its own per-call fixed-overhead tax (system prompt + framing).
- **Why it matters**: Token-usage hypothesis H3 (over-engineered, high-confidence). Validated A/B savings on the 3-fixture corpus:
  - OpenAI 5-pack: 10 → 2 calls (−80%), 8,240 → 6,976 tokens (−15%)
  - ByteRover 5-pack: 10 → 2 calls (−80%), 10,770 → 7,755 tokens (−28%)
  - ByteRover 10-pack: 10 → 2 calls (−80%), 11,027 → 8,508 tokens (−23%)
  - Free-tier ByteRover users: 30-file folder pack drops from ~60 quota requests to ~12 (under the 50/day cap).
- **What changed**: New `generateFileAbstractsBatch(items, generator)` in `abstract-generator.ts` fires two parallel `streamToText` calls (1 batched L0 + 1 batched L1) with XML-tagged input/output. `AbstractGenerationQueue.processNext` drains up to `BATCH_SIZE_CAP=5` items per cycle. `enqueue` only triggers `scheduleNext` when `pending >= cap || drainRequested`; `drain()` (called from `curate-executor` via `drainBackgroundWork` at curate-end) sets the flag for partial-batch flush.
- **What did NOT change (scope boundary)**: Existing fail-open semantics (empty content → empty file, no crash); `onAfterWrite` enqueue trigger; per-file 20K char content cap (matches non-batched path so per-file view is identical regardless of mode).

## Type of change

- [x] New feature

## Scope (select all touched areas)

- [x] Agent / Tools

## Linked issues

- Closes ENG-2518
- Related: H3 hypothesis in `research/token-optimization/token-usage-reduction/research/06-hypotheses.md`; A/B validated by `notes/token-usage-reduction/h3-batch-abstracts/RESULTS.md`

## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause: N/A
- Why this was not caught earlier: N/A

## Test plan

- Coverage added:
  - [x] Unit test
  - [x] Manual verification (real-LLM E2E)
- Test file(s):
  - `test/unit/agent/map/abstract-generator-batch.test.ts` (new, 5 tests covering correct response parsing, input order preservation, missing paths → empty strings, malformed-response tolerance, exactly 2 LLM calls per batch)
  - `test/unit/agent/map/abstract-queue.test.ts` (added "buffers below cap", "processes up to BATCH_SIZE_CAP in single cycle", "splits oversized backlogs", and adapted retry-backoff test for batched semantics)
- Key scenarios covered:
  - Buffer-until-cap-or-drain: enqueue 3 items → 0 LLM calls until drain
  - Cap fires single batch: enqueue 5 → exactly 2 stream calls (1×L0 + 1×L1)
  - Oversized split: enqueue 7 → batches of 5+2, exactly 4 stream calls
  - Per-batch failure → per-item retry with existing 3× exponential backoff
  - Tolerant XML parser: missing paths → empty strings, malformed → all empty (no crash)

## User-visible changes

None directly. Side effect: faster abstract generation on multi-file curates; ByteRover free-tier users no longer hit 50/day quota on 30-file packs.

## Evidence

- [x] Full unit suite: **6967 passing, 16 pending, 0 failing**
- [x] Real-LLM E2E on ByteRover paid-tier (gemini-3-flash-preview) — 4 fixtures covering all behavior:
  - **5-pack**: 5 enqueues → `process:start batchSize=5` → 2 LLM calls (vs 10 non-batched, **−80%**)
  - **6-distinct** (engineered to defeat curate-agent consolidation): 6 enqueues → batches of 5+1 → 4 LLM calls (vs 12, **−67%**) — exercises the multi-batch split path
  - **10-pack**: real LLM error on first batch → all 5 items entered retry pool → retry batch succeeded — exercises per-batch failure + retry path
  - **7-pack**: 4 buffered items below cap → drain at curate-end fired the partial batch — exercises drain-flush path
- [x] Quality spot-check: every L0 ≤ 80 tokens (one-line summary), every L1 has 3-7 markdown bullets + structure section, no XML tag leakage, no file conflation
- [x] Branch on remote: https://github.com/campfirein/byterover-cli/tree/feat/ENG-2518
- [x] Validated by: `notes/token-usage-reduction/h3-batch-abstracts/RESULTS.md` (3-fixture A/B on OpenAI + ByteRover)