### PR TITLE
feat: [ENG-2522] detach post-curate Phase 4 to remove user-visible  wait

### DIFF
--- a/src/server/infra/context-tree/propagate-summaries.ts
+++ b/src/server/infra/context-tree/propagate-summaries.ts
@@ -1,0 +1,69 @@
+import path from 'node:path'
+
+import type {ICipherAgent} from '../../../agent/core/interfaces/i-cipher-agent.js'
+import type {FileState} from '../../core/domain/entities/context-tree-snapshot.js'
+import type {FileContextTreeSnapshotService} from './file-context-tree-snapshot-service.js'
+
+import {BRV_DIR} from '../../constants.js'
+import {DreamLockService} from '../dream/dream-lock-service.js'
+import {FileContextTreeManifestService} from './file-context-tree-manifest-service.js'
+import {FileContextTreeSummaryService} from './file-context-tree-summary-service.js'
+import {diffStates} from './snapshot-diff.js'
+
+export type PropagateSummariesUnderLockOptions = {
+  agent: ICipherAgent
+  baseDir: string
+  preState: Map<string, FileState> | undefined
+  snapshotService: FileContextTreeSnapshotService
+  taskId: string
+}
+
+/**
+ * Phase 4 write block shared by curate and folder-pack post-work: snapshot
+ * diff → `propagateStaleness` → opportunistic manifest rebuild. Holds the
+ * dream lock around the writes so a concurrent dream cannot interleave on
+ * `_index.md` / `_manifest.json`; if the lock is held, this skips because
+ * dream's own propagation covers the same diff. Fail-open.
+ */
+export async function propagateSummariesUnderLock(
+  options: PropagateSummariesUnderLockOptions,
+): Promise<void> {
+  const {agent, baseDir, preState, snapshotService, taskId} = options
+  if (!preState) return
+
+  const dreamLockService = new DreamLockService({baseDir: path.join(baseDir, BRV_DIR)})
+  let acquireResult: Awaited<ReturnType<DreamLockService['tryAcquire']>>
+  try {
+    acquireResult = await dreamLockService.tryAcquire()
+  } catch {
+    return
+  }
+
+  if (!acquireResult.acquired) return
+
+  let succeeded = false
+  try {
+    const postState = await snapshotService.getCurrentState(baseDir)
+    const changedPaths = diffStates(preState, postState)
+    if (changedPaths.length === 0) {
+      succeeded = true
+      return
+    }
+
+    const summaryService = new FileContextTreeSummaryService()
+    const results = await summaryService.propagateStaleness(changedPaths, agent, baseDir, taskId)
+    if (results.some((result) => result.actionTaken)) {
+      const manifestService = new FileContextTreeManifestService({baseDirectory: baseDir})
+      await manifestService.buildManifest(baseDir)
+    }
+
+    succeeded = true
+  } catch {
+    // Fail-open: summary/manifest errors never block the caller.
+  } finally {
+    await (succeeded
+      ? dreamLockService.release()
+      : dreamLockService.rollback(acquireResult.priorMtime)
+    ).catch(() => {})
+  }
+}

--- a/src/server/infra/daemon/agent-process.ts
+++ b/src/server/infra/daemon/agent-process.ts
@@ -64,6 +64,7 @@ import {FileCurateLogStore} from '../storage/file-curate-log-store.js'
 import {FileReviewBackupStore} from '../storage/file-review-backup-store.js'
 import {AgentInstanceDiscovery} from '../transport/agent-instance-discovery.js'
 import {createAgentLogger} from './agent-logger.js'
+import {PostWorkRegistry} from './post-work-registry.js'
 import {resolveSessionId} from './session-resolver.js'
 import {validateProviderForTask} from './task-validation.js'
 
@@ -96,6 +97,17 @@ const port = portEnv
 const projectPath = projectPathEnv
 
 const agentLog = createAgentLogger(process.env.BRV_SESSION_LOG, `[agent-process:${projectPath}]`)
+
+/**
+ * Tracks detached post-curate work (Phase 4) so the user-perceived
+ * `task:completed` fires immediately after the agent body finishes
+ * (ENG-2522). Drained on shutdown to avoid truncating partial writes.
+ */
+const postWorkRegistry = new PostWorkRegistry({
+  onError(_projectPath, error) {
+    agentLog(`post-work error: ${error instanceof Error ? error.message : String(error)}`)
+  },
+})
 
 /**
  * Persist a brand-new session's metadata and set it as active.
@@ -527,9 +539,14 @@ async function executeTask(
     try {
       let result: string
       let logId: string | undefined
+      // Detached post-curate work (Phase 4). Captured during the curate /
+      // curate-folder cases and submitted to the PostWorkRegistry AFTER
+      // task:completed fires, so the user does not wait on summary regen
+      // and manifest rebuild (ENG-2522).
+      let postWork: (() => Promise<void>) | undefined
       switch (type) {
         case 'curate': {
-          result = await curateExecutor.executeWithAgent(agent, {
+          const curateResult = await curateExecutor.runAgentBody(agent, {
             clientCwd,
             content,
             files,
@@ -537,12 +554,14 @@ async function executeTask(
             taskId,
             worktreeRoot,
           })
+          result = curateResult.response
+          postWork = curateResult.finalize
 
           break
         }
 
         case 'curate-folder': {
-          result = await folderPackExecutor.executeWithAgent(agent, {
+          const folderResult = await folderPackExecutor.runAgentBody(agent, {
             clientCwd,
             content,
             folderPath: folderPath!,
@@ -550,6 +569,8 @@ async function executeTask(
             taskId,
             worktreeRoot,
           })
+          result = folderResult.response
+          postWork = folderResult.finalize
 
           break
         }
@@ -628,7 +649,8 @@ async function executeTask(
         }
       }
 
-      // Emit task:completed
+      // Emit task:completed BEFORE running detached Phase 4 — user sees the
+      // response as soon as the agent body finishes (ENG-2522).
       agentLog(`task:completed taskId=${taskId}`)
       try {
         transport.request(TransportTaskEventNames.COMPLETED, {clientId, ...(logId ? {logId} : {}), projectPath, result, taskId})
@@ -636,6 +658,13 @@ async function executeTask(
         agentLog(
           `task:completed send failed taskId=${taskId}: ${error instanceof Error ? error.message : String(error)}`,
         )
+      }
+
+      // Submit detached post-curate work to the registry. Mutex'd per project
+      // and drained on shutdown so SIGTERM mid-work cannot truncate `_index.md`.
+      if (postWork) {
+        agentLog(`post-work queued taskId=${taskId}`)
+        postWorkRegistry.submit(projectPath, postWork)
       }
     } catch (error) {
       // Emit task:error
@@ -818,6 +847,20 @@ async function hotSwapProvider(
 
 async function shutdown(): Promise<void> {
   agentLog('Shutting down...')
+
+  // Drain any in-flight detached post-curate work BEFORE stopping the agent
+  // and disconnecting transport. propagateStaleness mid-write would otherwise
+  // leave `_index.md` truncated on SIGTERM. 30s + 5s grace mirrors the
+  // hardening committed to in the ENG-2522 plan.
+  try {
+    const drainStart = Date.now()
+    const drainResult = await postWorkRegistry.drain(30_000)
+    agentLog(
+      `post-work drain (${Date.now() - drainStart}ms): drained=${drainResult.drained} abandoned=${drainResult.abandoned}`,
+    )
+  } catch (error) {
+    agentLog(`post-work drain failed: ${error instanceof Error ? error.message : String(error)}`)
+  }
 
   try {
     if (agent) {

--- a/src/server/infra/daemon/agent-process.ts
+++ b/src/server/infra/daemon/agent-process.ts
@@ -535,9 +535,11 @@ async function executeTask(
       // Socket dropped — continue executing so we can still emit task:completed/error when socket reconnects
     }
 
-    // Block new context-tree work until any detached Phase 4 from a prior
-    // task on this project drains — `task:completed` no longer implies the
-    // tree is free.
+    // Block new tree-writers until any detached Phase 4 from a prior task
+    // on this project drains. `query` / `search` are intentionally NOT
+    // gated — they read the manifest and tolerate a stale snapshot via
+    // `readManifestIfFresh` + rebuild fallback, so blocking them would
+    // be a needless latency hit.
     if (type === 'curate' || type === 'curate-folder' || type === 'dream') {
       await postWorkRegistry.awaitProject(projectPath)
     }
@@ -694,13 +696,18 @@ async function executeTask(
     // Deferred hot-swap when provider changed mid-task. Wait on detached
     // Phase 4 first — rebuilding SessionManager during an in-flight
     // `propagateStaleness` LLM call would silently corrupt Phase 4.
+    // Reserve the swap slot synchronously by clearing the dirty flag now;
+    // a task arriving during the awaitAll wait then sees a clean flag and
+    // skips its inline swap, so only the deferred chain runs hotSwap.
     if (activeTaskCount === 0 && providerConfigDirty && agent && transport) {
+      providerConfigDirty = false
       const swapAgent = agent
       const swapTransport = transport
       postWorkRegistry
         .awaitAll()
         .then(() => hotSwapProvider(swapAgent, swapTransport))
         .catch((error: unknown) => {
+          providerConfigDirty = true
           agentLog(`deferred hotSwapProvider failed: ${error instanceof Error ? error.message : String(error)}`)
         })
     }

--- a/src/server/infra/daemon/agent-process.ts
+++ b/src/server/infra/daemon/agent-process.ts
@@ -536,6 +536,16 @@ async function executeTask(
       // Socket dropped — continue executing so we can still emit task:completed/error when socket reconnects
     }
 
+    // Detached Phase 4 from a prior task on this project may still be writing
+    // `_index.md` / `_manifest.json`. Block new context-tree work until that
+    // drains — `task:completed` no longer implies "tree is free" since
+    // ENG-2522 detached Phase 4. Bounded by the prior task's Phase 4 (~18s
+    // worst case from the ticket); the user is already in the queue, so the
+    // task:started they observe is unaffected.
+    if (type === 'curate' || type === 'curate-folder' || type === 'dream') {
+      await postWorkRegistry.awaitProject(projectPath)
+    }
+
     try {
       let result: string
       let logId: string | undefined
@@ -688,11 +698,20 @@ async function executeTask(
     activeTaskCount--
 
     // Deferred hot-swap: if provider changed while tasks were in-flight,
-    // trigger swap now that all tasks are done
+    // trigger swap now that all tasks are done. Detached Phase 4 means
+    // post-curate work can still be running `propagateStaleness` against
+    // `agent` after activeTaskCount reaches 0; rebuilding the SessionManager
+    // mid-LLM-call would cause Phase 4 to fail silently. Wait on the registry
+    // first so any in-flight Phase 4 finishes before the swap (ENG-2522).
     if (activeTaskCount === 0 && providerConfigDirty && agent && transport) {
-      hotSwapProvider(agent, transport).catch((error) => {
-        agentLog(`deferred hotSwapProvider failed: ${error instanceof Error ? error.message : String(error)}`)
-      })
+      const swapAgent = agent
+      const swapTransport = transport
+      postWorkRegistry
+        .awaitAll()
+        .then(() => hotSwapProvider(swapAgent, swapTransport))
+        .catch((error: unknown) => {
+          agentLog(`deferred hotSwapProvider failed: ${error instanceof Error ? error.message : String(error)}`)
+        })
     }
   }
 }

--- a/src/server/infra/daemon/agent-process.ts
+++ b/src/server/infra/daemon/agent-process.ts
@@ -99,9 +99,8 @@ const projectPath = projectPathEnv
 const agentLog = createAgentLogger(process.env.BRV_SESSION_LOG, `[agent-process:${projectPath}]`)
 
 /**
- * Tracks detached post-curate work (Phase 4) so the user-perceived
- * `task:completed` fires immediately after the agent body finishes
- * (ENG-2522). Drained on shutdown to avoid truncating partial writes.
+ * Holds detached post-curate work so `task:completed` can fire as soon as
+ * the agent body finishes. Drained on shutdown to avoid truncated writes.
  */
 const postWorkRegistry = new PostWorkRegistry({
   onError(_projectPath, error) {
@@ -536,12 +535,9 @@ async function executeTask(
       // Socket dropped — continue executing so we can still emit task:completed/error when socket reconnects
     }
 
-    // Detached Phase 4 from a prior task on this project may still be writing
-    // `_index.md` / `_manifest.json`. Block new context-tree work until that
-    // drains — `task:completed` no longer implies "tree is free" since
-    // ENG-2522 detached Phase 4. Bounded by the prior task's Phase 4 (~18s
-    // worst case from the ticket); the user is already in the queue, so the
-    // task:started they observe is unaffected.
+    // Block new context-tree work until any detached Phase 4 from a prior
+    // task on this project drains — `task:completed` no longer implies the
+    // tree is free.
     if (type === 'curate' || type === 'curate-folder' || type === 'dream') {
       await postWorkRegistry.awaitProject(projectPath)
     }
@@ -549,10 +545,8 @@ async function executeTask(
     try {
       let result: string
       let logId: string | undefined
-      // Detached post-curate work (Phase 4). Captured during the curate /
-      // curate-folder cases and submitted to the PostWorkRegistry AFTER
-      // task:completed fires, so the user does not wait on summary regen
-      // and manifest rebuild (ENG-2522).
+      // Captured during curate / curate-folder; submitted to the registry
+      // after `task:completed` so the user does not wait on Phase 4.
       let postWork: (() => Promise<void>) | undefined
       switch (type) {
         case 'curate': {
@@ -659,8 +653,8 @@ async function executeTask(
         }
       }
 
-      // Emit task:completed BEFORE running detached Phase 4 — user sees the
-      // response as soon as the agent body finishes (ENG-2522).
+      // Emit task:completed BEFORE the detached Phase 4 so the user sees
+      // the response as soon as the agent body finishes.
       agentLog(`task:completed taskId=${taskId}`)
       try {
         transport.request(TransportTaskEventNames.COMPLETED, {clientId, ...(logId ? {logId} : {}), projectPath, result, taskId})
@@ -697,12 +691,9 @@ async function executeTask(
   } finally {
     activeTaskCount--
 
-    // Deferred hot-swap: if provider changed while tasks were in-flight,
-    // trigger swap now that all tasks are done. Detached Phase 4 means
-    // post-curate work can still be running `propagateStaleness` against
-    // `agent` after activeTaskCount reaches 0; rebuilding the SessionManager
-    // mid-LLM-call would cause Phase 4 to fail silently. Wait on the registry
-    // first so any in-flight Phase 4 finishes before the swap (ENG-2522).
+    // Deferred hot-swap when provider changed mid-task. Wait on detached
+    // Phase 4 first — rebuilding SessionManager during an in-flight
+    // `propagateStaleness` LLM call would silently corrupt Phase 4.
     if (activeTaskCount === 0 && providerConfigDirty && agent && transport) {
       const swapAgent = agent
       const swapTransport = transport
@@ -867,10 +858,8 @@ async function hotSwapProvider(
 async function shutdown(): Promise<void> {
   agentLog('Shutting down...')
 
-  // Drain any in-flight detached post-curate work BEFORE stopping the agent
-  // and disconnecting transport. propagateStaleness mid-write would otherwise
-  // leave `_index.md` truncated on SIGTERM. 30s + 5s grace mirrors the
-  // hardening committed to in the ENG-2522 plan.
+  // Drain detached Phase 4 BEFORE stopping the agent — `propagateStaleness`
+  // mid-write would otherwise leave `_index.md` truncated on SIGTERM.
   try {
     const drainStart = Date.now()
     const drainResult = await postWorkRegistry.drain(30_000)

--- a/src/server/infra/daemon/post-work-registry.ts
+++ b/src/server/infra/daemon/post-work-registry.ts
@@ -1,28 +1,13 @@
 /**
- * PostWorkRegistry
- *
- * Tracks fire-and-forget work that runs after `task:completed` is emitted to
- * the user — primarily the post-curate Phase 4 (summary regeneration, manifest
- * rebuild, dream-state increment, background drain).
- *
- * Three guarantees:
- *   - Work submitted for the same project runs serially (per-project mutex).
- *     Two concurrent curates' Phase 4 cannot race on snapshot pre-state or
- *     `_index.md` writes.
- *   - Work for different projects runs concurrently. No global lock.
- *   - The daemon can `drain()` on shutdown — wait for in-flight thunks to
- *     finish, abandoning any that exceed the timeout. Without this, SIGTERM
- *     during a propagateStaleness call could truncate a partially-written
- *     `_index.md`.
- *
- * Errors inside a thunk are swallowed (logged via the optional `onError`).
- * The registry is fail-open — one bad thunk must not block subsequent work.
+ * Per-project serialized fire-and-forget queue with bounded shutdown drain.
+ * Different projects run concurrently; same project runs serially so two
+ * writers cannot race on `_index.md`. Thunk errors are swallowed (via
+ * `onError`) so one bad thunk cannot block the chain.
  */
 
 export type PostWorkThunk = () => Promise<void>
 
 export type PostWorkRegistryOptions = {
-  /** Optional logger called on thunk errors. Stays light to keep the registry test-friendly. */
   onError?: (projectPath: string, error: unknown) => void
 }
 
@@ -41,22 +26,18 @@ export class PostWorkRegistry {
   }
 
   /**
-   * Wait until all currently-queued work across all projects completes. New
-   * submissions arriving during the await are NOT awaited — only the tails
-   * captured at call time. Used by the deferred hot-swap path so the agent
-   * is not rebuilt while a Phase 4 thunk is mid-LLM-call (ENG-2522).
+   * Wait on the snapshot of tails captured at call time across all projects.
+   * Submissions arriving during the await are not awaited.
    */
   public async awaitAll(): Promise<void> {
     const tails = [...this.tails.values()]
     if (tails.length === 0) return
-    // Tails are guaranteed not to reject — submit() swallows errors via onError.
     await Promise.all(tails)
   }
 
   /**
-   * Wait until all currently-queued work for `projectPath` completes. New
-   * submissions arriving during the await are NOT awaited — only the tail
-   * captured at call time. This makes `--wait-finalize` deterministic.
+   * Wait on the project's tail captured at call time. Submissions arriving
+   * during the await are not awaited — keeps `--wait-finalize` deterministic.
    */
   public async awaitProject(projectPath: string): Promise<void> {
     const tail = this.tails.get(projectPath)
@@ -66,13 +47,9 @@ export class PostWorkRegistry {
   }
 
   /**
-   * Drain all in-flight work across all projects. Returns counts of
-   * thunks that completed (`drained`) and that exceeded the timeout
-   * (`abandoned`). Errored thunks count as `drained` because the work
-   * has resolved (the error has surfaced to onError).
-   *
-   * Used by the daemon's shutdown handler to give post-curate work a
-   * bounded grace window before exit.
+   * Wait up to `timeoutMs` for in-flight work across all projects.
+   * Errored thunks count as `drained` (work resolved, surfaced to onError);
+   * thunks still running at the deadline count as `abandoned`.
    */
   public async drain(timeoutMs: number): Promise<{abandoned: number; drained: number}> {
     const tails = [...this.tails.values()]
@@ -109,11 +86,9 @@ export class PostWorkRegistry {
       .then(thunk)
       .catch((error: unknown) => {
         this.onError?.(projectPath, error)
-        // Swallow so subsequent submissions still run.
       })
       .finally(() => {
-        // Clean up the map entry if our tail is the latest (no follow-up
-        // submission appended). Keeps the registry from leaking entries.
+        // Drop the map entry only if no follow-up submission appended.
         if (this.tails.get(projectPath) === newTail) {
           this.tails.delete(projectPath)
         }

--- a/src/server/infra/daemon/post-work-registry.ts
+++ b/src/server/infra/daemon/post-work-registry.ts
@@ -21,26 +21,36 @@
 
 export type PostWorkThunk = () => Promise<void>
 
-export interface PostWorkRegistryOptions {
+export type PostWorkRegistryOptions = {
   /** Optional logger called on thunk errors. Stays light to keep the registry test-friendly. */
   onError?: (projectPath: string, error: unknown) => void
 }
 
 export class PostWorkRegistry {
-  /**
-   * In-flight tails across all projects — used by drain() to wait on
-   * everything. We re-derive this from `tails` on demand.
-   */
+  /** Optional logger called when a thunk throws. */
   private readonly onError?: (projectPath: string, error: unknown) => void
-/**
- * Per-project tail promise. Each `submit(project, thunk)` chains the new
- * thunk after the previous tail. The tail is replaced atomically so the
- * next submission picks up the latest one without races.
- */
+  /**
+   * Per-project tail promise. Each `submit(project, thunk)` chains the new
+   * thunk after the previous tail. The tail is replaced atomically so the
+   * next submission picks up the latest one without races.
+   */
   private readonly tails = new Map<string, Promise<void>>()
 
   public constructor(options: PostWorkRegistryOptions = {}) {
     this.onError = options.onError
+  }
+
+  /**
+   * Wait until all currently-queued work across all projects completes. New
+   * submissions arriving during the await are NOT awaited — only the tails
+   * captured at call time. Used by the deferred hot-swap path so the agent
+   * is not rebuilt while a Phase 4 thunk is mid-LLM-call (ENG-2522).
+   */
+  public async awaitAll(): Promise<void> {
+    const tails = [...this.tails.values()]
+    if (tails.length === 0) return
+    // Tails are guaranteed not to reject — submit() swallows errors via onError.
+    await Promise.all(tails)
   }
 
   /**

--- a/src/server/infra/daemon/post-work-registry.ts
+++ b/src/server/infra/daemon/post-work-registry.ts
@@ -1,0 +1,113 @@
+/**
+ * PostWorkRegistry
+ *
+ * Tracks fire-and-forget work that runs after `task:completed` is emitted to
+ * the user — primarily the post-curate Phase 4 (summary regeneration, manifest
+ * rebuild, dream-state increment, background drain).
+ *
+ * Three guarantees:
+ *   - Work submitted for the same project runs serially (per-project mutex).
+ *     Two concurrent curates' Phase 4 cannot race on snapshot pre-state or
+ *     `_index.md` writes.
+ *   - Work for different projects runs concurrently. No global lock.
+ *   - The daemon can `drain()` on shutdown — wait for in-flight thunks to
+ *     finish, abandoning any that exceed the timeout. Without this, SIGTERM
+ *     during a propagateStaleness call could truncate a partially-written
+ *     `_index.md`.
+ *
+ * Errors inside a thunk are swallowed (logged via the optional `onError`).
+ * The registry is fail-open — one bad thunk must not block subsequent work.
+ */
+
+export type PostWorkThunk = () => Promise<void>
+
+export interface PostWorkRegistryOptions {
+  /** Optional logger called on thunk errors. Stays light to keep the registry test-friendly. */
+  onError?: (projectPath: string, error: unknown) => void
+}
+
+export class PostWorkRegistry {
+  /**
+   * In-flight tails across all projects — used by drain() to wait on
+   * everything. We re-derive this from `tails` on demand.
+   */
+  private readonly onError?: (projectPath: string, error: unknown) => void
+/**
+ * Per-project tail promise. Each `submit(project, thunk)` chains the new
+ * thunk after the previous tail. The tail is replaced atomically so the
+ * next submission picks up the latest one without races.
+ */
+  private readonly tails = new Map<string, Promise<void>>()
+
+  public constructor(options: PostWorkRegistryOptions = {}) {
+    this.onError = options.onError
+  }
+
+  /**
+   * Wait until all currently-queued work for `projectPath` completes. New
+   * submissions arriving during the await are NOT awaited — only the tail
+   * captured at call time. This makes `--wait-finalize` deterministic.
+   */
+  public async awaitProject(projectPath: string): Promise<void> {
+    const tail = this.tails.get(projectPath)
+    if (tail) {
+      await tail
+    }
+  }
+
+  /**
+   * Drain all in-flight work across all projects. Returns counts of
+   * thunks that completed (`drained`) and that exceeded the timeout
+   * (`abandoned`). Errored thunks count as `drained` because the work
+   * has resolved (the error has surfaced to onError).
+   *
+   * Used by the daemon's shutdown handler to give post-curate work a
+   * bounded grace window before exit.
+   */
+  public async drain(timeoutMs: number): Promise<{abandoned: number; drained: number}> {
+    const tails = [...this.tails.values()]
+    if (tails.length === 0) {
+      return {abandoned: 0, drained: 0}
+    }
+
+    let timeoutHandle: NodeJS.Timeout | undefined
+    const timeoutPromise = new Promise<'timeout'>((resolve) => {
+      timeoutHandle = setTimeout(() => resolve('timeout'), timeoutMs)
+    })
+
+    const results = await Promise.all(
+      tails.map(async (tail) => {
+        const outcome = await Promise.race([tail.then(() => 'done' as const), timeoutPromise])
+        return outcome
+      }),
+    )
+
+    if (timeoutHandle !== undefined) clearTimeout(timeoutHandle)
+
+    const drained = results.filter((r) => r === 'done').length
+    const abandoned = results.filter((r) => r === 'timeout').length
+    return {abandoned, drained}
+  }
+
+  /**
+   * Submit a thunk to run after any prior work for `projectPath` finishes.
+   * Returns synchronously; the thunk runs on the microtask queue.
+   */
+  public submit(projectPath: string, thunk: PostWorkThunk): void {
+    const previousTail = this.tails.get(projectPath) ?? Promise.resolve()
+    const newTail = previousTail
+      .then(thunk)
+      .catch((error: unknown) => {
+        this.onError?.(projectPath, error)
+        // Swallow so subsequent submissions still run.
+      })
+      .finally(() => {
+        // Clean up the map entry if our tail is the latest (no follow-up
+        // submission appended). Keeps the registry from leaking entries.
+        if (this.tails.get(projectPath) === newTail) {
+          this.tails.delete(projectPath)
+        }
+      })
+    this.tails.set(projectPath, newTail)
+  }
+}

--- a/src/server/infra/dream/dream-lock-service.ts
+++ b/src/server/infra/dream/dream-lock-service.ts
@@ -10,16 +10,9 @@ type DreamLockServiceOptions = {
 }
 
 /**
- * PID-based lock for context-tree writers.
- *
- * Originally dream-only; since ENG-2522 also held by curate's detached Phase 4
- * around `propagateStaleness` + `buildManifest` so dream and curate cannot
- * interleave on `_index.md` / `_manifest.json`. Naming preserved (`dream.lock`
- * filename + `DreamLockService` class) to avoid churning every call site —
- * dream is still the dominant caller and the semantics are identical.
- *
- * Lock file contains the owning process PID. Staleness is determined by mtime.
- * Uses write-then-verify to handle race conditions between concurrent acquirers.
+ * PID-based file lock for context-tree writers (dream and curate's detached
+ * post-work). Lock file holds the owner PID; staleness is mtime-based. Uses
+ * write-then-verify to settle races between concurrent acquirers.
  */
 export class DreamLockService {
   private readonly lockFilePath: string

--- a/src/server/infra/dream/dream-lock-service.ts
+++ b/src/server/infra/dream/dream-lock-service.ts
@@ -10,7 +10,13 @@ type DreamLockServiceOptions = {
 }
 
 /**
- * PID-based lock for dream execution.
+ * PID-based lock for context-tree writers.
+ *
+ * Originally dream-only; since ENG-2522 also held by curate's detached Phase 4
+ * around `propagateStaleness` + `buildManifest` so dream and curate cannot
+ * interleave on `_index.md` / `_manifest.json`. Naming preserved (`dream.lock`
+ * filename + `DreamLockService` class) to avoid churning every call site —
+ * dream is still the dominant caller and the semantics are identical.
  *
  * Lock file contains the owning process PID. Staleness is determined by mtime.
  * Uses write-then-verify to handle race conditions between concurrent acquirers.

--- a/src/server/infra/executor/curate-executor.ts
+++ b/src/server/infra/executor/curate-executor.ts
@@ -16,6 +16,7 @@ import {FileContextTreeManifestService} from '../context-tree/file-context-tree-
 import {FileContextTreeSnapshotService} from '../context-tree/file-context-tree-snapshot-service.js'
 import {FileContextTreeSummaryService} from '../context-tree/file-context-tree-summary-service.js'
 import {diffStates} from '../context-tree/snapshot-diff.js'
+import {DreamLockService} from '../dream/dream-lock-service.js'
 import {DreamStateService} from '../dream/dream-state-service.js'
 import {PreCompactionService} from './pre-compaction/pre-compaction-service.js'
 
@@ -366,15 +367,39 @@ export class CurateExecutor implements ICurateExecutor {
 
   /**
    * Phase 4a–c: snapshot diff → propagateStaleness → opportunistic manifest rebuild.
-   * Fail-open: any error inside is swallowed so it cannot block curate completion.
+   *
+   * Acquires the DreamLockService PID-lock around the write block so a
+   * concurrent dream (which writes the same `_index.md` / `_manifest.json`)
+   * cannot interleave. Detached Phase 4 made this race reachable: with Phase
+   * 4 inline, the daemon was busy and idle-trigger dream couldn't fire. With
+   * Phase 4 detached, dream and curate's post-work can overlap. If the lock
+   * is held (dream is running), this method skips propagation — dream's own
+   * propagateStaleness covers the same changes, and the next curate catches
+   * any residual diff. Fail-open: any error inside is swallowed so it cannot
+   * block curate completion.
    */
   private async propagateSummariesIfChanged(ctx: PropagateSummariesContext): Promise<void> {
     const {agent, baseDir, preState, snapshotService, taskId} = ctx
     if (!preState) return
+
+    const dreamLockService = new DreamLockService({baseDir: path.join(baseDir, BRV_DIR)})
+    let acquireResult: Awaited<ReturnType<DreamLockService['tryAcquire']>>
+    try {
+      acquireResult = await dreamLockService.tryAcquire()
+    } catch {
+      return
+    }
+
+    if (!acquireResult.acquired) return
+
+    let succeeded = false
     try {
       const postState = await snapshotService.getCurrentState(baseDir)
       const changedPaths = diffStates(preState, postState)
-      if (changedPaths.length === 0) return
+      if (changedPaths.length === 0) {
+        succeeded = true
+        return
+      }
 
       const summaryService = new FileContextTreeSummaryService()
       const results = await summaryService.propagateStaleness(changedPaths, agent, baseDir, taskId)
@@ -382,8 +407,15 @@ export class CurateExecutor implements ICurateExecutor {
         const manifestService = new FileContextTreeManifestService({baseDirectory: baseDir})
         await manifestService.buildManifest(baseDir)
       }
+
+      succeeded = true
     } catch {
       // Fail-open: summary/manifest errors never block curation
+    } finally {
+      await (succeeded
+        ? dreamLockService.release()
+        : dreamLockService.rollback(acquireResult.priorMtime)
+      ).catch(() => {})
     }
   }
 }

--- a/src/server/infra/executor/curate-executor.ts
+++ b/src/server/infra/executor/curate-executor.ts
@@ -12,11 +12,8 @@ import {
   type FileReadResult,
 } from '../../utils/file-content-reader.js'
 import {validateFileForCurate} from '../../utils/file-validator.js'
-import {FileContextTreeManifestService} from '../context-tree/file-context-tree-manifest-service.js'
 import {FileContextTreeSnapshotService} from '../context-tree/file-context-tree-snapshot-service.js'
-import {FileContextTreeSummaryService} from '../context-tree/file-context-tree-summary-service.js'
-import {diffStates} from '../context-tree/snapshot-diff.js'
-import {DreamLockService} from '../dream/dream-lock-service.js'
+import {propagateSummariesUnderLock} from '../context-tree/propagate-summaries.js'
 import {DreamStateService} from '../dream/dream-state-service.js'
 import {PreCompactionService} from './pre-compaction/pre-compaction-service.js'
 
@@ -159,7 +156,7 @@ export class CurateExecutor implements ICurateExecutor {
 
     const finalize = async (): Promise<void> => {
       try {
-        await this.propagateSummariesIfChanged({agent, baseDir, preState, snapshotService, taskId})
+        await propagateSummariesUnderLock({agent, baseDir, preState, snapshotService, taskId})
         await this.incrementDreamCounter(baseDir)
         await (agent as BackgroundDrainAgent).drainBackgroundWork?.()
       } finally {
@@ -347,60 +344,4 @@ export class CurateExecutor implements ICurateExecutor {
     // Format with actual content
     return this.formatFileContentsForPrompt(readResults, skippedFiles, projectRoot)
   }
-
-  /**
-   * Phase 4a–c: snapshot diff → propagateStaleness → opportunistic manifest
-   * rebuild. Holds the dream lock around the write block so a concurrent
-   * dream cannot interleave on `_index.md` / `_manifest.json`. Skips when
-   * the lock is held — dream's own propagation covers the same diff, and
-   * the next curate catches any residual. Fail-open.
-   */
-  private async propagateSummariesIfChanged(ctx: PropagateSummariesContext): Promise<void> {
-    const {agent, baseDir, preState, snapshotService, taskId} = ctx
-    if (!preState) return
-
-    const dreamLockService = new DreamLockService({baseDir: path.join(baseDir, BRV_DIR)})
-    let acquireResult: Awaited<ReturnType<DreamLockService['tryAcquire']>>
-    try {
-      acquireResult = await dreamLockService.tryAcquire()
-    } catch {
-      return
-    }
-
-    if (!acquireResult.acquired) return
-
-    let succeeded = false
-    try {
-      const postState = await snapshotService.getCurrentState(baseDir)
-      const changedPaths = diffStates(preState, postState)
-      if (changedPaths.length === 0) {
-        succeeded = true
-        return
-      }
-
-      const summaryService = new FileContextTreeSummaryService()
-      const results = await summaryService.propagateStaleness(changedPaths, agent, baseDir, taskId)
-      if (results.some((r) => r.actionTaken)) {
-        const manifestService = new FileContextTreeManifestService({baseDirectory: baseDir})
-        await manifestService.buildManifest(baseDir)
-      }
-
-      succeeded = true
-    } catch {
-      // Fail-open: summary/manifest errors never block curation
-    } finally {
-      await (succeeded
-        ? dreamLockService.release()
-        : dreamLockService.rollback(acquireResult.priorMtime)
-      ).catch(() => {})
-    }
-  }
-}
-
-type PropagateSummariesContext = {
-  agent: ICipherAgent
-  baseDir: string
-  preState: Map<string, import('../../core/domain/entities/context-tree-snapshot.js').FileState> | undefined
-  snapshotService: FileContextTreeSnapshotService
-  taskId: string
 }

--- a/src/server/infra/executor/curate-executor.ts
+++ b/src/server/infra/executor/curate-executor.ts
@@ -51,7 +51,37 @@ export class CurateExecutor implements ICurateExecutor {
     this.fileContentReader = fileContentReader ?? createFileContentReader()
   }
 
+  /**
+   * Synchronous wrapper kept for backwards compatibility — runs the agent body
+   * AND awaits Phase 4 before returning. Equivalent to the pre-detach behaviour.
+   *
+   * agent-process uses runAgentBody directly so it can fire `task:completed`
+   * after the agent body and queue Phase 4 to the PostWorkRegistry for
+   * asynchronous execution.
+   */
   public async executeWithAgent(agent: ICipherAgent, options: CurateExecuteOptions): Promise<string> {
+    const {finalize, response} = await this.runAgentBody(agent, options)
+    await finalize()
+    return response
+  }
+
+  /**
+   * Run the agent body (Phases 1–3) and return the response immediately along
+   * with a `finalize` thunk that runs Phase 4 (snapshot diff, summary
+   * regeneration, manifest rebuild, dream counter, background drain, task
+   * session cleanup).
+   *
+   * The caller is responsible for invoking `finalize()` exactly once. The
+   * thunk is fail-open by design: errors inside Phase 4 do not propagate.
+   *
+   * If the agent body itself throws, the task session is cleaned up before
+   * the error propagates and no `finalize` is returned (the caller has
+   * nothing to invoke).
+   */
+  public async runAgentBody(
+    agent: ICipherAgent,
+    options: CurateExecuteOptions,
+  ): Promise<{finalize: () => Promise<void>; response: string}> {
     const {clientCwd, content, files, projectRoot, taskId} = options
 
     // --- Phase 1: Preprocessing (no sessions created yet — safe to throw) ---
@@ -76,6 +106,8 @@ export class CurateExecutor implements ICurateExecutor {
     }
 
     const taskSessionId = await agent.createTaskSession(taskId, 'curate', {mapRootEligible: true, userFacing: true})
+
+    let response: string
     try {
       // Task-scoped variable names for RLM pattern.
       // Replace hyphens with underscores: UUIDs have hyphens which are invalid in JS identifiers,
@@ -124,49 +156,35 @@ export class CurateExecutor implements ICurateExecutor {
 
       // Execute on the task session (isolated sandbox + history)
       // Task lifecycle is managed by Transport (task:started, task:completed, task:error)
-      const response = await agent.executeOnSession(taskSessionId, prompt, {
+      response = await agent.executeOnSession(taskSessionId, prompt, {
         executionContext: {clearHistory: true, commandType: 'curate', maxIterations: 50},
         taskId,
       })
 
       // Parse curation status from agent response for status tracking
       this.lastStatus = this.parseCurationStatus(taskId, response)
-
-      // --- Phase 4: Post-curation summary propagation (fail-open) ---
-      if (preState) {
-        try {
-          const postState = await snapshotService.getCurrentState(baseDir)
-          const changedPaths = diffStates(preState, postState)
-          if (changedPaths.length > 0) {
-            const summaryService = new FileContextTreeSummaryService()
-            const results = await summaryService.propagateStaleness(changedPaths, agent, baseDir, taskId)
-
-            // Opportunistic manifest rebuild (pre-warm for next query)
-            if (results.some((r) => r.actionTaken)) {
-              const manifestService = new FileContextTreeManifestService({baseDirectory: baseDir})
-              await manifestService.buildManifest(baseDir)
-            }
-          }
-        } catch {
-          // Fail-open: summary/manifest errors never block curation
-        }
-      }
-
-      // Increment dream curation counter (fail-open: non-critical for curation)
-      try {
-        const dreamStateService = new DreamStateService({baseDir: path.join(baseDir, BRV_DIR)})
-        await dreamStateService.incrementCurationCount()
-      } catch {
-        // Dream state tracking is non-critical — don't block curation
-      }
-
-      await (agent as BackgroundDrainAgent).drainBackgroundWork?.()
-
-      return response
-    } finally {
-      // Clean up entire task session (sandbox + history) in one call
+    } catch (error) {
+      // Agent body failed — clean up the session before rethrowing so we don't leak it.
+      // No finalize is returned in this path (the caller has nothing to await).
       await agent.deleteTaskSession(taskSessionId)
+      throw error
     }
+
+    // Build the Phase 4 thunk. It captures the closure state (preState, baseDir,
+    // agent, taskId, taskSessionId) and runs the post-curate work asynchronously.
+    const finalize = async (): Promise<void> => {
+      try {
+        await this.propagateSummariesIfChanged({agent, baseDir, preState, snapshotService, taskId})
+        await this.incrementDreamCounter(baseDir)
+        await (agent as BackgroundDrainAgent).drainBackgroundWork?.()
+      } finally {
+        // Clean up entire task session (sandbox + history) in one call.
+        // Lives in finally so it runs even if Phase 4 above throws.
+        await agent.deleteTaskSession(taskSessionId)
+      }
+    }
+
+    return {finalize, response}
   }
 
   /**
@@ -240,6 +258,19 @@ export class CurateExecutor implements ICurateExecutor {
       default: {
         return fileType
       }
+    }
+  }
+
+  /**
+   * Phase 4d: bump the dream-state curation counter. Fail-open — dream state
+   * tracking is non-critical and must never block curate completion.
+   */
+  private async incrementDreamCounter(baseDir: string): Promise<void> {
+    try {
+      const dreamStateService = new DreamStateService({baseDir: path.join(baseDir, BRV_DIR)})
+      await dreamStateService.incrementCurationCount()
+    } catch {
+      // Dream state tracking is non-critical
     }
   }
 
@@ -332,4 +363,35 @@ export class CurateExecutor implements ICurateExecutor {
     // Format with actual content
     return this.formatFileContentsForPrompt(readResults, skippedFiles, projectRoot)
   }
+
+  /**
+   * Phase 4a–c: snapshot diff → propagateStaleness → opportunistic manifest rebuild.
+   * Fail-open: any error inside is swallowed so it cannot block curate completion.
+   */
+  private async propagateSummariesIfChanged(ctx: PropagateSummariesContext): Promise<void> {
+    const {agent, baseDir, preState, snapshotService, taskId} = ctx
+    if (!preState) return
+    try {
+      const postState = await snapshotService.getCurrentState(baseDir)
+      const changedPaths = diffStates(preState, postState)
+      if (changedPaths.length === 0) return
+
+      const summaryService = new FileContextTreeSummaryService()
+      const results = await summaryService.propagateStaleness(changedPaths, agent, baseDir, taskId)
+      if (results.some((r) => r.actionTaken)) {
+        const manifestService = new FileContextTreeManifestService({baseDirectory: baseDir})
+        await manifestService.buildManifest(baseDir)
+      }
+    } catch {
+      // Fail-open: summary/manifest errors never block curation
+    }
+  }
+}
+
+type PropagateSummariesContext = {
+  agent: ICipherAgent
+  baseDir: string
+  preState: Map<string, import('../../core/domain/entities/context-tree-snapshot.js').FileState> | undefined
+  snapshotService: FileContextTreeSnapshotService
+  taskId: string
 }

--- a/src/server/infra/executor/curate-executor.ts
+++ b/src/server/infra/executor/curate-executor.ts
@@ -52,14 +52,7 @@ export class CurateExecutor implements ICurateExecutor {
     this.fileContentReader = fileContentReader ?? createFileContentReader()
   }
 
-  /**
-   * Synchronous wrapper kept for backwards compatibility — runs the agent body
-   * AND awaits Phase 4 before returning. Equivalent to the pre-detach behaviour.
-   *
-   * agent-process uses runAgentBody directly so it can fire `task:completed`
-   * after the agent body and queue Phase 4 to the PostWorkRegistry for
-   * asynchronous execution.
-   */
+  /** Synchronous wrapper — runs Phases 1-3 and awaits Phase 4 inline. */
   public async executeWithAgent(agent: ICipherAgent, options: CurateExecuteOptions): Promise<string> {
     const {finalize, response} = await this.runAgentBody(agent, options)
     await finalize()
@@ -67,17 +60,11 @@ export class CurateExecutor implements ICurateExecutor {
   }
 
   /**
-   * Run the agent body (Phases 1–3) and return the response immediately along
-   * with a `finalize` thunk that runs Phase 4 (snapshot diff, summary
-   * regeneration, manifest rebuild, dream counter, background drain, task
-   * session cleanup).
-   *
-   * The caller is responsible for invoking `finalize()` exactly once. The
-   * thunk is fail-open by design: errors inside Phase 4 do not propagate.
-   *
-   * If the agent body itself throws, the task session is cleaned up before
-   * the error propagates and no `finalize` is returned (the caller has
-   * nothing to invoke).
+   * Returns the response after Phases 1-3 plus a `finalize` thunk for Phase 4
+   * (snapshot diff, summary regen, manifest rebuild, dream counter, drain,
+   * task-session cleanup). Caller invokes `finalize` exactly once. The thunk
+   * is fail-open. If the agent body itself throws, the task session is cleaned
+   * up before propagating and no `finalize` is returned.
    */
   public async runAgentBody(
     agent: ICipherAgent,
@@ -165,22 +152,18 @@ export class CurateExecutor implements ICurateExecutor {
       // Parse curation status from agent response for status tracking
       this.lastStatus = this.parseCurationStatus(taskId, response)
     } catch (error) {
-      // Agent body failed — clean up the session before rethrowing so we don't leak it.
-      // No finalize is returned in this path (the caller has nothing to await).
+      // Clean up before propagating — error path returns no finalize.
       await agent.deleteTaskSession(taskSessionId)
       throw error
     }
 
-    // Build the Phase 4 thunk. It captures the closure state (preState, baseDir,
-    // agent, taskId, taskSessionId) and runs the post-curate work asynchronously.
     const finalize = async (): Promise<void> => {
       try {
         await this.propagateSummariesIfChanged({agent, baseDir, preState, snapshotService, taskId})
         await this.incrementDreamCounter(baseDir)
         await (agent as BackgroundDrainAgent).drainBackgroundWork?.()
       } finally {
-        // Clean up entire task session (sandbox + history) in one call.
-        // Lives in finally so it runs even if Phase 4 above throws.
+        // In `finally` so the session is deleted even if Phase 4 throws.
         await agent.deleteTaskSession(taskSessionId)
       }
     }
@@ -366,17 +349,11 @@ export class CurateExecutor implements ICurateExecutor {
   }
 
   /**
-   * Phase 4a–c: snapshot diff → propagateStaleness → opportunistic manifest rebuild.
-   *
-   * Acquires the DreamLockService PID-lock around the write block so a
-   * concurrent dream (which writes the same `_index.md` / `_manifest.json`)
-   * cannot interleave. Detached Phase 4 made this race reachable: with Phase
-   * 4 inline, the daemon was busy and idle-trigger dream couldn't fire. With
-   * Phase 4 detached, dream and curate's post-work can overlap. If the lock
-   * is held (dream is running), this method skips propagation — dream's own
-   * propagateStaleness covers the same changes, and the next curate catches
-   * any residual diff. Fail-open: any error inside is swallowed so it cannot
-   * block curate completion.
+   * Phase 4a–c: snapshot diff → propagateStaleness → opportunistic manifest
+   * rebuild. Holds the dream lock around the write block so a concurrent
+   * dream cannot interleave on `_index.md` / `_manifest.json`. Skips when
+   * the lock is held — dream's own propagation covers the same diff, and
+   * the next curate catches any residual. Fail-open.
    */
   private async propagateSummariesIfChanged(ctx: PropagateSummariesContext): Promise<void> {
     const {agent, baseDir, preState, snapshotService, taskId} = ctx

--- a/src/server/infra/executor/folder-pack-executor.ts
+++ b/src/server/infra/executor/folder-pack-executor.ts
@@ -47,7 +47,27 @@ function folderPackLog(message: string): void {
 export class FolderPackExecutor implements IFolderPackExecutor {
   constructor(private readonly folderPackService: IFolderPackService) {}
 
+  /**
+   * Synchronous wrapper kept for backwards compatibility — runs the agent body
+   * AND awaits Phase 4 before returning. agent-process uses runAgentBody
+   * directly to fire `task:completed` early and queue Phase 4 to the
+   * PostWorkRegistry.
+   */
   public async executeWithAgent(agent: ICipherAgent, options: FolderPackExecuteOptions): Promise<string> {
+    const {finalize, response} = await this.runAgentBody(agent, options)
+    await finalize()
+    return response
+  }
+
+  /**
+   * Run the folder-pack agent body and return the response immediately along
+   * with a finalize thunk that runs the post-curate Phase 4. See
+   * CurateExecutor.runAgentBody for the rationale (ENG-2522).
+   */
+  public async runAgentBody(
+    agent: ICipherAgent,
+    options: FolderPackExecuteOptions,
+  ): Promise<{finalize: () => Promise<void>; response: string}> {
     const {clientCwd, content, folderPath, projectRoot, taskId, worktreeRoot} = options
 
     // Resolve folder path:
@@ -83,31 +103,15 @@ export class FolderPackExecutor implements IFolderPackExecutor {
     })
 
     // Use iterative extraction strategy (inspired by rlm)
-    // Stores packed folder in sandbox environment and lets agent iteratively query/extract
-    // This avoids token limits entirely - works for folders of any size
     const response = await this.executeIterative(agent, packResult, content, absoluteFolderPath, taskId, tempFileDir)
 
-    if (preState) {
-      try {
-        const postState = await snapshotService.getCurrentState(tempFileDir)
-        const changedPaths = diffStates(preState, postState)
-        if (changedPaths.length > 0) {
-          const summaryService = new FileContextTreeSummaryService()
-          const results = await summaryService.propagateStaleness(changedPaths, agent, tempFileDir, taskId)
-
-          if (results.some((result) => result.actionTaken)) {
-            const manifestService = new FileContextTreeManifestService({baseDirectory: tempFileDir})
-            await manifestService.buildManifest(tempFileDir)
-          }
-        }
-      } catch {
-        // Fail-open: summary/manifest errors never block curation
-      }
+    // Build the Phase 4 thunk — captures snapshot/agent state for the detached path.
+    const finalize = async (): Promise<void> => {
+      await this.runFolderPackPostWork({agent, preState, snapshotService, taskId, tempFileDir})
+      await (agent as BackgroundDrainAgent).drainBackgroundWork?.()
     }
 
-    await (agent as BackgroundDrainAgent).drainBackgroundWork?.()
-
-    return response
+    return {finalize, response}
   }
 
   /**
@@ -947,4 +951,31 @@ await tools.curate([{
 
     return response
   }
+
+  private async runFolderPackPostWork(ctx: FolderPackPostWorkContext): Promise<void> {
+    const {agent, preState, snapshotService, taskId, tempFileDir} = ctx
+    if (!preState) return
+    try {
+      const postState = await snapshotService.getCurrentState(tempFileDir)
+      const changedPaths = diffStates(preState, postState)
+      if (changedPaths.length === 0) return
+
+      const summaryService = new FileContextTreeSummaryService()
+      const results = await summaryService.propagateStaleness(changedPaths, agent, tempFileDir, taskId)
+      if (results.some((result) => result.actionTaken)) {
+        const manifestService = new FileContextTreeManifestService({baseDirectory: tempFileDir})
+        await manifestService.buildManifest(tempFileDir)
+      }
+    } catch {
+      // Fail-open: summary/manifest errors never block curation
+    }
+  }
+}
+
+type FolderPackPostWorkContext = {
+  agent: ICipherAgent
+  preState: Map<string, import('../../core/domain/entities/context-tree-snapshot.js').FileState> | undefined
+  snapshotService: FileContextTreeSnapshotService
+  taskId: string
+  tempFileDir: string
 }

--- a/src/server/infra/executor/folder-pack-executor.ts
+++ b/src/server/infra/executor/folder-pack-executor.ts
@@ -10,12 +10,8 @@ import type {
   IFolderPackExecutor,
 } from '../../core/interfaces/executor/i-folder-pack-executor.js'
 
-import {BRV_DIR} from '../../constants.js'
-import {FileContextTreeManifestService} from '../context-tree/file-context-tree-manifest-service.js'
 import {FileContextTreeSnapshotService} from '../context-tree/file-context-tree-snapshot-service.js'
-import {FileContextTreeSummaryService} from '../context-tree/file-context-tree-summary-service.js'
-import {diffStates} from '../context-tree/snapshot-diff.js'
-import {DreamLockService} from '../dream/dream-lock-service.js'
+import {propagateSummariesUnderLock} from '../context-tree/propagate-summaries.js'
 
 const LOG_PATH = process.env.BRV_SESSION_LOG
 type BackgroundDrainAgent = ICipherAgent & {drainBackgroundWork?: () => Promise<void>}
@@ -102,9 +98,13 @@ export class FolderPackExecutor implements IFolderPackExecutor {
     // Use iterative extraction strategy (inspired by rlm)
     const response = await this.executeIterative(agent, packResult, content, absoluteFolderPath, taskId, tempFileDir)
 
-    // Build the Phase 4 thunk — captures snapshot/agent state for the detached path.
+    // Build the Phase 4 thunk. Note: unlike CurateExecutor, the task session
+    // was already deleted inside `executeIterative`'s `finally`, so Phase 4's
+    // `propagateStaleness` runs against the agent's default session. That
+    // is fine for folder-pack — it has no per-task sandbox state to preserve
+    // through Phase 4.
     const finalize = async (): Promise<void> => {
-      await this.runFolderPackPostWork({agent, preState, snapshotService, taskId, tempFileDir})
+      await propagateSummariesUnderLock({agent, baseDir: tempFileDir, preState, snapshotService, taskId})
       await (agent as BackgroundDrainAgent).drainBackgroundWork?.()
     }
 
@@ -948,58 +948,4 @@ await tools.curate([{
 
     return response
   }
-
-  /**
-   * Folder-pack Phase 4. Holds the dream lock so a concurrent dream cannot
-   * interleave on `_index.md` / `_manifest.json`; skips when the lock is
-   * held. Fail-open.
-   */
-  private async runFolderPackPostWork(ctx: FolderPackPostWorkContext): Promise<void> {
-    const {agent, preState, snapshotService, taskId, tempFileDir} = ctx
-    if (!preState) return
-
-    const dreamLockService = new DreamLockService({baseDir: path.join(tempFileDir, BRV_DIR)})
-    let acquireResult: Awaited<ReturnType<DreamLockService['tryAcquire']>>
-    try {
-      acquireResult = await dreamLockService.tryAcquire()
-    } catch {
-      return
-    }
-
-    if (!acquireResult.acquired) return
-
-    let succeeded = false
-    try {
-      const postState = await snapshotService.getCurrentState(tempFileDir)
-      const changedPaths = diffStates(preState, postState)
-      if (changedPaths.length === 0) {
-        succeeded = true
-        return
-      }
-
-      const summaryService = new FileContextTreeSummaryService()
-      const results = await summaryService.propagateStaleness(changedPaths, agent, tempFileDir, taskId)
-      if (results.some((result) => result.actionTaken)) {
-        const manifestService = new FileContextTreeManifestService({baseDirectory: tempFileDir})
-        await manifestService.buildManifest(tempFileDir)
-      }
-
-      succeeded = true
-    } catch {
-      // Fail-open: summary/manifest errors never block curation
-    } finally {
-      await (succeeded
-        ? dreamLockService.release()
-        : dreamLockService.rollback(acquireResult.priorMtime)
-      ).catch(() => {})
-    }
-  }
-}
-
-type FolderPackPostWorkContext = {
-  agent: ICipherAgent
-  preState: Map<string, import('../../core/domain/entities/context-tree-snapshot.js').FileState> | undefined
-  snapshotService: FileContextTreeSnapshotService
-  taskId: string
-  tempFileDir: string
 }

--- a/src/server/infra/executor/folder-pack-executor.ts
+++ b/src/server/infra/executor/folder-pack-executor.ts
@@ -10,10 +10,12 @@ import type {
   IFolderPackExecutor,
 } from '../../core/interfaces/executor/i-folder-pack-executor.js'
 
+import {BRV_DIR} from '../../constants.js'
 import {FileContextTreeManifestService} from '../context-tree/file-context-tree-manifest-service.js'
 import {FileContextTreeSnapshotService} from '../context-tree/file-context-tree-snapshot-service.js'
 import {FileContextTreeSummaryService} from '../context-tree/file-context-tree-summary-service.js'
 import {diffStates} from '../context-tree/snapshot-diff.js'
+import {DreamLockService} from '../dream/dream-lock-service.js'
 
 const LOG_PATH = process.env.BRV_SESSION_LOG
 type BackgroundDrainAgent = ICipherAgent & {drainBackgroundWork?: () => Promise<void>}
@@ -952,13 +954,35 @@ await tools.curate([{
     return response
   }
 
+  /**
+   * Phase 4 post-work for folder-pack curation. Mirrors CurateExecutor's
+   * propagateSummariesIfChanged: acquires the DreamLockService PID-lock so
+   * a concurrent dream cannot interleave on `_index.md` / `_manifest.json`.
+   * Skips propagation if the lock is held — dream's own propagateStaleness
+   * covers the same diff and the next curate catches anything residual.
+   */
   private async runFolderPackPostWork(ctx: FolderPackPostWorkContext): Promise<void> {
     const {agent, preState, snapshotService, taskId, tempFileDir} = ctx
     if (!preState) return
+
+    const dreamLockService = new DreamLockService({baseDir: path.join(tempFileDir, BRV_DIR)})
+    let acquireResult: Awaited<ReturnType<DreamLockService['tryAcquire']>>
+    try {
+      acquireResult = await dreamLockService.tryAcquire()
+    } catch {
+      return
+    }
+
+    if (!acquireResult.acquired) return
+
+    let succeeded = false
     try {
       const postState = await snapshotService.getCurrentState(tempFileDir)
       const changedPaths = diffStates(preState, postState)
-      if (changedPaths.length === 0) return
+      if (changedPaths.length === 0) {
+        succeeded = true
+        return
+      }
 
       const summaryService = new FileContextTreeSummaryService()
       const results = await summaryService.propagateStaleness(changedPaths, agent, tempFileDir, taskId)
@@ -966,8 +990,15 @@ await tools.curate([{
         const manifestService = new FileContextTreeManifestService({baseDirectory: tempFileDir})
         await manifestService.buildManifest(tempFileDir)
       }
+
+      succeeded = true
     } catch {
       // Fail-open: summary/manifest errors never block curation
+    } finally {
+      await (succeeded
+        ? dreamLockService.release()
+        : dreamLockService.rollback(acquireResult.priorMtime)
+      ).catch(() => {})
     }
   }
 }

--- a/src/server/infra/executor/folder-pack-executor.ts
+++ b/src/server/infra/executor/folder-pack-executor.ts
@@ -49,12 +49,7 @@ function folderPackLog(message: string): void {
 export class FolderPackExecutor implements IFolderPackExecutor {
   constructor(private readonly folderPackService: IFolderPackService) {}
 
-  /**
-   * Synchronous wrapper kept for backwards compatibility — runs the agent body
-   * AND awaits Phase 4 before returning. agent-process uses runAgentBody
-   * directly to fire `task:completed` early and queue Phase 4 to the
-   * PostWorkRegistry.
-   */
+  /** Synchronous wrapper — runs the agent body and awaits Phase 4 inline. */
   public async executeWithAgent(agent: ICipherAgent, options: FolderPackExecuteOptions): Promise<string> {
     const {finalize, response} = await this.runAgentBody(agent, options)
     await finalize()
@@ -62,9 +57,9 @@ export class FolderPackExecutor implements IFolderPackExecutor {
   }
 
   /**
-   * Run the folder-pack agent body and return the response immediately along
-   * with a finalize thunk that runs the post-curate Phase 4. See
-   * CurateExecutor.runAgentBody for the rationale (ENG-2522).
+   * Returns the response after the agent body, plus a `finalize` thunk for
+   * Phase 4 (snapshot diff → propagateStaleness → manifest rebuild → drain).
+   * Caller invokes `finalize` exactly once.
    */
   public async runAgentBody(
     agent: ICipherAgent,
@@ -955,11 +950,9 @@ await tools.curate([{
   }
 
   /**
-   * Phase 4 post-work for folder-pack curation. Mirrors CurateExecutor's
-   * propagateSummariesIfChanged: acquires the DreamLockService PID-lock so
-   * a concurrent dream cannot interleave on `_index.md` / `_manifest.json`.
-   * Skips propagation if the lock is held — dream's own propagateStaleness
-   * covers the same diff and the next curate catches anything residual.
+   * Folder-pack Phase 4. Holds the dream lock so a concurrent dream cannot
+   * interleave on `_index.md` / `_manifest.json`; skips when the lock is
+   * held. Fail-open.
    */
   private async runFolderPackPostWork(ctx: FolderPackPostWorkContext): Promise<void> {
     const {agent, preState, snapshotService, taskId, tempFileDir} = ctx

--- a/test/unit/infra/daemon/post-work-registry.test.ts
+++ b/test/unit/infra/daemon/post-work-registry.test.ts
@@ -189,6 +189,76 @@ describe('PostWorkRegistry', () => {
     })
   })
 
+  describe('awaitAll', () => {
+    it('resolves immediately when there is no work in any project', async () => {
+      const registry = new PostWorkRegistry()
+      const start = Date.now()
+      await registry.awaitAll()
+      expect(Date.now() - start).to.be.lessThan(50)
+    })
+
+    it('resolves only after every queued tail completes (multi-project)', async () => {
+      const registry = new PostWorkRegistry()
+      const a = deferred<void>()
+      const b = deferred<void>()
+      let done = false
+
+      registry.submit('/projA', async () => {
+        await a.promise
+      })
+      registry.submit('/projB', async () => {
+        await b.promise
+      })
+
+      const awaiting = registry.awaitAll().then(() => {
+        done = true
+      })
+
+      // Neither project finished yet — awaitAll must block.
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 20)
+      })
+      expect(done).to.equal(false)
+
+      a.resolve()
+      // Still waiting on B.
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 20)
+      })
+      expect(done).to.equal(false)
+
+      b.resolve()
+      await awaiting
+      expect(done).to.equal(true)
+    })
+
+    it('does not block on submissions arriving after the call', async () => {
+      // Captures the tail at call time (matches awaitProject semantics) — the
+      // hot-swap path needs deterministic completion against the snapshot, not
+      // an indefinite wait.
+      const registry = new PostWorkRegistry()
+      const a = deferred<void>()
+      registry.submit('/proj', async () => {
+        await a.promise
+      })
+
+      const awaiting = registry.awaitAll()
+      // Submit a fresh, slow thunk AFTER awaitAll started.
+      const b = deferred<void>()
+      registry.submit('/proj', async () => {
+        await b.promise
+      })
+
+      a.resolve()
+      // awaitAll resolves once the snapshot's tail finishes — even though the
+      // chained tail (via b) is still pending.
+      await awaiting
+      // Cleanup: release the lingering thunk so the test exits cleanly.
+      b.resolve()
+      await registry.awaitProject('/proj')
+    })
+  })
+
   describe('drain', () => {
     it('returns when all in-flight work across all projects completes', async () => {
       const registry = new PostWorkRegistry()

--- a/test/unit/infra/daemon/post-work-registry.test.ts
+++ b/test/unit/infra/daemon/post-work-registry.test.ts
@@ -1,0 +1,232 @@
+/**
+ * PostWorkRegistry — tracks fire-and-forget post-curate work so the daemon can
+ * (a) serialise work per project, (b) wait for all in-flight work on shutdown,
+ * (c) let `--wait-finalize` block on completion for a specific project.
+ *
+ * These tests describe the contract before the implementation lands.
+ */
+
+import {expect} from 'chai'
+
+import {PostWorkRegistry} from '../../../../src/server/infra/daemon/post-work-registry.js'
+
+const noop = (): void => {
+  // intentionally empty
+}
+
+/**
+ * Manually-resolvable promise: lets a test pause a thunk mid-execution and
+ * step through ordering invariants without sleeps.
+ */
+function deferred<T = void>(): {promise: Promise<T>; reject: (err: Error) => void; resolve: (value: T) => void;} {
+  let resolve: (value: T) => void = noop
+  let reject: (err: Error) => void = noop
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return {promise, reject, resolve}
+}
+
+/**
+ * A never-resolving promise — feeds drain() with a thunk that exceeds the
+ * timeout. Wrapped in a function so we can assign it as a thunk and so the
+ * `(_resolve) => {}` executor body is not interpreted by ESLint as returning.
+ */
+function neverResolves(): Promise<void> {
+  return new Promise<void>((_resolve) => {
+    // never call resolve — drain must abandon this thunk after its timeout
+  })
+}
+
+describe('PostWorkRegistry', () => {
+  describe('submit', () => {
+    it('runs the submitted thunk asynchronously', async () => {
+      const registry = new PostWorkRegistry()
+      const ran: string[] = []
+      const done = deferred<void>()
+
+      registry.submit('/projA', async () => {
+        ran.push('thunk')
+        done.resolve()
+      })
+
+      // submit returns synchronously; the thunk has not necessarily started yet
+      ran.push('after-submit')
+
+      await done.promise
+      expect(ran).to.deep.equal(['after-submit', 'thunk'])
+    })
+
+    it('serialises work for the same project (per-project mutex)', async () => {
+      const registry = new PostWorkRegistry()
+      const order: string[] = []
+      const a = deferred<void>()
+      const b = deferred<void>()
+      const aStarted = deferred<void>()
+      const bStarted = deferred<void>()
+
+      registry.submit('/proj', async () => {
+        order.push('a-start')
+        aStarted.resolve()
+        await a.promise
+        order.push('a-end')
+      })
+      registry.submit('/proj', async () => {
+        order.push('b-start')
+        bStarted.resolve()
+        await b.promise
+        order.push('b-end')
+      })
+
+      // A starts immediately; B is blocked by mutex until A completes.
+      await aStarted.promise
+      // Let several macro/microtasks run — B must NOT start while A is awaiting `a`.
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 20)
+      })
+      expect(order).to.deep.equal(['a-start'])
+
+      // Release A. B should start after A finishes.
+      a.resolve()
+      await bStarted.promise
+      expect(order).to.deep.equal(['a-start', 'a-end', 'b-start'])
+
+      // Release B and wait for the project tail to drain.
+      b.resolve()
+      await registry.awaitProject('/proj')
+      expect(order).to.deep.equal(['a-start', 'a-end', 'b-start', 'b-end'])
+    })
+
+    it('runs work for different projects concurrently', async () => {
+      const registry = new PostWorkRegistry()
+      const order: string[] = []
+      const a = deferred<void>()
+      const b = deferred<void>()
+
+      registry.submit('/projA', async () => {
+        order.push('A-start')
+        await a.promise
+        order.push('A-end')
+      })
+      registry.submit('/projB', async () => {
+        order.push('B-start')
+        await b.promise
+        order.push('B-end')
+      })
+
+      await Promise.resolve()
+      await Promise.resolve()
+      // Both should have started — different projects, no shared mutex.
+      expect(order).to.have.members(['A-start', 'B-start'])
+
+      a.resolve()
+      b.resolve()
+      await registry.awaitProject('/projA')
+      await registry.awaitProject('/projB')
+      expect(order).to.have.members(['A-start', 'B-start', 'A-end', 'B-end'])
+    })
+
+    it('isolates errors — a thrown thunk does not block subsequent submissions', async () => {
+      const registry = new PostWorkRegistry()
+      const order: string[] = []
+
+      registry.submit('/proj', async () => {
+        order.push('a')
+        throw new Error('boom')
+      })
+      registry.submit('/proj', async () => {
+        order.push('b')
+      })
+
+      await registry.awaitProject('/proj')
+      expect(order).to.deep.equal(['a', 'b'])
+    })
+  })
+
+  describe('awaitProject', () => {
+    it('resolves immediately when there is no work for the project', async () => {
+      const registry = new PostWorkRegistry()
+      const start = Date.now()
+      await registry.awaitProject('/never-submitted')
+      expect(Date.now() - start).to.be.lessThan(50)
+    })
+
+    it('resolves only after all queued work for the project completes', async () => {
+      const registry = new PostWorkRegistry()
+      const work = deferred<void>()
+      let done = false
+
+      registry.submit('/proj', async () => {
+        await work.promise
+      })
+
+      const awaitPromise = registry.awaitProject('/proj').then(() => {
+        done = true
+      })
+
+      await Promise.resolve()
+      expect(done).to.equal(false)
+
+      work.resolve()
+      await awaitPromise
+      expect(done).to.equal(true)
+    })
+
+    it('does not wait for work submitted to other projects', async () => {
+      const registry = new PostWorkRegistry()
+      const otherWork = deferred<void>()
+
+      registry.submit('/other', async () => {
+        await otherWork.promise
+      })
+
+      const start = Date.now()
+      await registry.awaitProject('/proj')
+      expect(Date.now() - start).to.be.lessThan(50)
+      otherWork.resolve()
+      await registry.awaitProject('/other')
+    })
+  })
+
+  describe('drain', () => {
+    it('returns when all in-flight work across all projects completes', async () => {
+      const registry = new PostWorkRegistry()
+      const a = deferred<void>()
+      const b = deferred<void>()
+
+      registry.submit('/projA', async () => { await a.promise })
+      registry.submit('/projB', async () => { await b.promise })
+
+      const drainPromise = registry.drain(5000)
+      await Promise.resolve()
+
+      a.resolve()
+      b.resolve()
+
+      const result = await drainPromise
+      expect(result.drained).to.equal(2)
+      expect(result.abandoned).to.equal(0)
+    })
+
+    it('abandons work that does not finish within the timeout', async () => {
+      const registry = new PostWorkRegistry()
+      registry.submit('/proj', neverResolves)
+
+      const result = await registry.drain(50)
+      expect(result.drained).to.equal(0)
+      expect(result.abandoned).to.equal(1)
+    })
+
+    it('counts errored thunks as drained, not abandoned', async () => {
+      const registry = new PostWorkRegistry()
+      registry.submit('/proj', async () => {
+        throw new Error('failure inside drain')
+      })
+
+      const result = await registry.drain(1000)
+      expect(result.drained).to.equal(1)
+      expect(result.abandoned).to.equal(0)
+    })
+  })
+})

--- a/test/unit/infra/daemon/post-work-registry.test.ts
+++ b/test/unit/infra/daemon/post-work-registry.test.ts
@@ -1,11 +1,3 @@
-/**
- * PostWorkRegistry — tracks fire-and-forget post-curate work so the daemon can
- * (a) serialise work per project, (b) wait for all in-flight work on shutdown,
- * (c) let `--wait-finalize` block on completion for a specific project.
- *
- * These tests describe the contract before the implementation lands.
- */
-
 import {expect} from 'chai'
 
 import {PostWorkRegistry} from '../../../../src/server/infra/daemon/post-work-registry.js'
@@ -14,10 +6,7 @@ const noop = (): void => {
   // intentionally empty
 }
 
-/**
- * Manually-resolvable promise: lets a test pause a thunk mid-execution and
- * step through ordering invariants without sleeps.
- */
+/** Manually-resolvable promise — lets a test step through ordering invariants without sleeps. */
 function deferred<T = void>(): {promise: Promise<T>; reject: (err: Error) => void; resolve: (value: T) => void;} {
   let resolve: (value: T) => void = noop
   let reject: (err: Error) => void = noop
@@ -28,14 +17,10 @@ function deferred<T = void>(): {promise: Promise<T>; reject: (err: Error) => voi
   return {promise, reject, resolve}
 }
 
-/**
- * A never-resolving promise — feeds drain() with a thunk that exceeds the
- * timeout. Wrapped in a function so we can assign it as a thunk and so the
- * `(_resolve) => {}` executor body is not interpreted by ESLint as returning.
- */
+/** A never-resolving promise — feeds drain() with a thunk that exceeds the timeout. */
 function neverResolves(): Promise<void> {
   return new Promise<void>((_resolve) => {
-    // never call resolve — drain must abandon this thunk after its timeout
+    // never call resolve
   })
 }
 
@@ -233,9 +218,8 @@ describe('PostWorkRegistry', () => {
     })
 
     it('does not block on submissions arriving after the call', async () => {
-      // Captures the tail at call time (matches awaitProject semantics) — the
-      // hot-swap path needs deterministic completion against the snapshot, not
-      // an indefinite wait.
+      // Tail captured at call time (matches awaitProject semantics) — the
+      // hot-swap caller needs a deterministic completion, not an open wait.
       const registry = new PostWorkRegistry()
       const a = deferred<void>()
       registry.submit('/proj', async () => {
@@ -243,17 +227,13 @@ describe('PostWorkRegistry', () => {
       })
 
       const awaiting = registry.awaitAll()
-      // Submit a fresh, slow thunk AFTER awaitAll started.
       const b = deferred<void>()
       registry.submit('/proj', async () => {
         await b.promise
       })
 
       a.resolve()
-      // awaitAll resolves once the snapshot's tail finishes — even though the
-      // chained tail (via b) is still pending.
       await awaiting
-      // Cleanup: release the lingering thunk so the test exits cleanly.
       b.resolve()
       await registry.awaitProject('/proj')
     })

--- a/test/unit/infra/executor/curate-executor.test.ts
+++ b/test/unit/infra/executor/curate-executor.test.ts
@@ -50,8 +50,7 @@ import {CurateExecutor} from '../../../../src/server/infra/executor/curate-execu
 
 /**
  * Default DreamLockService stubs so Phase 4 tests don't write real
- * `/p/.brv/dream.lock` files to disk. Tests that exercise the lock
- * coordination directly override these via stub.restore() + re-stub.
+ * `dream.lock` files. Tests exercising the lock directly re-stub via restore.
  */
 function stubDreamLockServiceDefaults(): void {
   stub(DreamLockService.prototype, 'tryAcquire').resolves({acquired: true, priorMtime: 0})
@@ -344,10 +343,9 @@ describe('CurateExecutor (regression)', () => {
     })
   })
 
-  describe('runAgentBody / finalize split (ENG-2522)', () => {
-    // The detached-Phase-4 design depends on runAgentBody returning the
-    // response BEFORE Phase 4 runs. agent-process fires task:completed off
-    // the response and submits finalize() to the PostWorkRegistry.
+  describe('runAgentBody / finalize split', () => {
+    // runAgentBody must return the response BEFORE Phase 4 runs so the daemon
+    // can fire `task:completed` early and queue finalize for background work.
 
     it('returns the agent response without running Phase 4 first', async () => {
       const agent = buildSplitTestAgent()
@@ -423,15 +421,13 @@ describe('CurateExecutor (regression)', () => {
     })
   })
 
-  describe('dream-lock coordination in Phase 4 (ENG-2522)', () => {
-    // The detached Phase 4 races with idle-triggered dream on `_index.md` /
-    // `_manifest.json`. Curate's finalize must hold DreamLockService while it
-    // runs propagateStaleness + buildManifest, otherwise dream's Phase 5 (which
-    // writes the same files) can interleave and corrupt the summary tree.
+  describe('dream-lock coordination in Phase 4', () => {
+    // Detached Phase 4 races with idle-triggered dream on `_index.md` /
+    // `_manifest.json`. Curate's finalize must hold the dream lock around
+    // propagateStaleness + buildManifest to prevent interleaving.
 
     it('acquires the dream lock before propagation and releases on success', async () => {
-      // Restore the default stubs from the top-level beforeEach so we can
-      // observe the actual call sequence (acquire → propagate → release).
+      // Restore default stubs so we can observe the real call sequence.
       restore()
       const tryAcquire = stub(DreamLockService.prototype, 'tryAcquire').resolves({acquired: true, priorMtime: 1234})
       const release = stub(DreamLockService.prototype, 'release').resolves()

--- a/test/unit/infra/executor/curate-executor.test.ts
+++ b/test/unit/infra/executor/curate-executor.test.ts
@@ -45,9 +45,25 @@ import {FileValidationError} from '../../../../src/server/core/domain/errors/tas
 import {FileContextTreeManifestService} from '../../../../src/server/infra/context-tree/file-context-tree-manifest-service.js'
 import {FileContextTreeSnapshotService} from '../../../../src/server/infra/context-tree/file-context-tree-snapshot-service.js'
 import {FileContextTreeSummaryService} from '../../../../src/server/infra/context-tree/file-context-tree-summary-service.js'
+import {DreamLockService} from '../../../../src/server/infra/dream/dream-lock-service.js'
 import {CurateExecutor} from '../../../../src/server/infra/executor/curate-executor.js'
 
+/**
+ * Default DreamLockService stubs so Phase 4 tests don't write real
+ * `/p/.brv/dream.lock` files to disk. Tests that exercise the lock
+ * coordination directly override these via stub.restore() + re-stub.
+ */
+function stubDreamLockServiceDefaults(): void {
+  stub(DreamLockService.prototype, 'tryAcquire').resolves({acquired: true, priorMtime: 0})
+  stub(DreamLockService.prototype, 'release').resolves()
+  stub(DreamLockService.prototype, 'rollback').resolves()
+}
+
 describe('CurateExecutor (regression)', () => {
+  beforeEach(() => {
+    stubDreamLockServiceDefaults()
+  })
+
   afterEach(() => {
     restore()
   })
@@ -404,6 +420,107 @@ describe('CurateExecutor (regression)', () => {
       expect(result).to.equal('curated')
       // Wrapper awaits finalize internally — Phase 4 ran by the time we get here.
       expect(propagateStalenessStub.calledOnce).to.be.true
+    })
+  })
+
+  describe('dream-lock coordination in Phase 4 (ENG-2522)', () => {
+    // The detached Phase 4 races with idle-triggered dream on `_index.md` /
+    // `_manifest.json`. Curate's finalize must hold DreamLockService while it
+    // runs propagateStaleness + buildManifest, otherwise dream's Phase 5 (which
+    // writes the same files) can interleave and corrupt the summary tree.
+
+    it('acquires the dream lock before propagation and releases on success', async () => {
+      // Restore the default stubs from the top-level beforeEach so we can
+      // observe the actual call sequence (acquire → propagate → release).
+      restore()
+      const tryAcquire = stub(DreamLockService.prototype, 'tryAcquire').resolves({acquired: true, priorMtime: 1234})
+      const release = stub(DreamLockService.prototype, 'release').resolves()
+      const rollback = stub(DreamLockService.prototype, 'rollback').resolves()
+
+      const agent = buildSplitTestAgent()
+      stub(FileContextTreeSnapshotService.prototype, 'getCurrentState')
+        .onFirstCall()
+        .resolves(new Map())
+        .onSecondCall()
+        .resolves(new Map([['auth/jwt.md', {hash: 'h', size: 1}]]))
+      const propagateStaleness = stub(FileContextTreeSummaryService.prototype, 'propagateStaleness').resolves([])
+
+      const executor = new CurateExecutor()
+      const {finalize} = await executor.runAgentBody(agent, {
+        clientCwd: '/p',
+        content: 'x',
+        projectRoot: '/p',
+        taskId: 't-lock-success',
+      })
+      await finalize()
+
+      expect(tryAcquire.calledOnce).to.be.true
+      expect(propagateStaleness.calledOnce).to.be.true
+      // Lock-then-propagate, then release on success (no rollback).
+      expect(tryAcquire.calledBefore(propagateStaleness)).to.be.true
+      expect(release.calledOnce).to.be.true
+      expect(rollback.called).to.be.false
+    })
+
+    it('skips propagation when the lock is held (dream is running)', async () => {
+      restore()
+      const tryAcquire = stub(DreamLockService.prototype, 'tryAcquire').resolves({acquired: false})
+      const release = stub(DreamLockService.prototype, 'release').resolves()
+      const rollback = stub(DreamLockService.prototype, 'rollback').resolves()
+
+      const agent = buildSplitTestAgent()
+      // Snapshot is reachable so without the lock check, propagation would run.
+      stub(FileContextTreeSnapshotService.prototype, 'getCurrentState')
+        .onFirstCall()
+        .resolves(new Map())
+        .onSecondCall()
+        .resolves(new Map([['auth/jwt.md', {hash: 'h', size: 1}]]))
+      const propagateStaleness = stub(FileContextTreeSummaryService.prototype, 'propagateStaleness').resolves([])
+
+      const executor = new CurateExecutor()
+      const {finalize} = await executor.runAgentBody(agent, {
+        clientCwd: '/p',
+        content: 'x',
+        projectRoot: '/p',
+        taskId: 't-lock-held',
+      })
+      await finalize()
+
+      // Lock was checked; propagation skipped; nothing to release/rollback.
+      expect(tryAcquire.calledOnce).to.be.true
+      expect(propagateStaleness.called).to.be.false
+      expect(release.called).to.be.false
+      expect(rollback.called).to.be.false
+    })
+
+    it('rolls back the lock (preserves prior mtime) when propagation throws', async () => {
+      restore()
+      const priorMtime = 9999
+      stub(DreamLockService.prototype, 'tryAcquire').resolves({acquired: true, priorMtime})
+      const release = stub(DreamLockService.prototype, 'release').resolves()
+      const rollback = stub(DreamLockService.prototype, 'rollback').resolves()
+
+      const agent = buildSplitTestAgent()
+      stub(FileContextTreeSnapshotService.prototype, 'getCurrentState')
+        .onFirstCall()
+        .resolves(new Map())
+        .onSecondCall()
+        .resolves(new Map([['auth/jwt.md', {hash: 'h', size: 1}]]))
+      stub(FileContextTreeSummaryService.prototype, 'propagateStaleness').rejects(new Error('boom'))
+
+      const executor = new CurateExecutor()
+      const {finalize} = await executor.runAgentBody(agent, {
+        clientCwd: '/p',
+        content: 'x',
+        projectRoot: '/p',
+        taskId: 't-lock-fail',
+      })
+
+      // Phase 4 is fail-open: finalize must not throw even though propagation did.
+      await finalize()
+
+      expect(release.called).to.be.false
+      expect(rollback.calledOnceWithExactly(priorMtime)).to.be.true
     })
   })
 })

--- a/test/unit/infra/executor/curate-executor.test.ts
+++ b/test/unit/infra/executor/curate-executor.test.ts
@@ -14,6 +14,33 @@ import {restore, stub} from 'sinon'
 import type {ICipherAgent} from '../../../../src/agent/core/interfaces/i-cipher-agent.js'
 
 import {LocalSandbox} from '../../../../src/agent/infra/sandbox/local-sandbox.js'
+
+/**
+ * Mock cipher agent used by the runAgentBody / finalize split tests.
+ * Hoisted to module scope (consistent-function-scoping lint rule).
+ */
+function buildSplitTestAgent(): ICipherAgent {
+  return {
+    cancel: stub().resolves(false),
+    createTaskSession: stub().resolves('session-id'),
+    deleteSandboxVariable: stub(),
+    deleteSandboxVariableOnSession: stub(),
+    deleteSession: stub().resolves(true),
+    deleteTaskSession: stub().resolves(),
+    execute: stub().resolves(''),
+    executeOnSession: stub().resolves('curated'),
+    generate: stub().resolves({content: '', toolCalls: [], usage: {inputTokens: 0, outputTokens: 0}}),
+    getSessionMetadata: stub().resolves(),
+    getState: stub().returns({currentIteration: 0, executionHistory: [], executionState: 'idle', toolCallsExecuted: 0}),
+    listPersistedSessions: stub().resolves([]),
+    reset: stub(),
+    setSandboxVariable: stub(),
+    setSandboxVariableOnSession: stub(),
+    start: stub().resolves(),
+    stream: stub().resolves({[Symbol.asyncIterator]: () => ({next: () => Promise.resolve({done: true, value: undefined})})}),
+  } as unknown as ICipherAgent
+}
+
 import {FileValidationError} from '../../../../src/server/core/domain/errors/task-error.js'
 import {FileContextTreeManifestService} from '../../../../src/server/infra/context-tree/file-context-tree-manifest-service.js'
 import {FileContextTreeSnapshotService} from '../../../../src/server/infra/context-tree/file-context-tree-snapshot-service.js'
@@ -298,6 +325,85 @@ describe('CurateExecutor (regression)', () => {
       // 4th arg must be the curate's taskId so the billing service groups
       // summary regenerations into the same session as the parent operation.
       expect(propagateStalenessStub.firstCall.args[3]).to.equal(taskId)
+    })
+  })
+
+  describe('runAgentBody / finalize split (ENG-2522)', () => {
+    // The detached-Phase-4 design depends on runAgentBody returning the
+    // response BEFORE Phase 4 runs. agent-process fires task:completed off
+    // the response and submits finalize() to the PostWorkRegistry.
+
+    it('returns the agent response without running Phase 4 first', async () => {
+      const agent = buildSplitTestAgent()
+      stub(FileContextTreeSnapshotService.prototype, 'getCurrentState')
+        .onFirstCall()
+        .resolves(new Map())
+        .onSecondCall()
+        .resolves(new Map([['auth/jwt.md', {hash: 'h', size: 1}]]))
+      const propagateStalenessStub = stub(
+        FileContextTreeSummaryService.prototype,
+        'propagateStaleness',
+      ).resolves([])
+      stub(FileContextTreeManifestService.prototype, 'buildManifest').resolves()
+
+      const executor = new CurateExecutor()
+      const {finalize, response} = await executor.runAgentBody(agent, {
+        clientCwd: '/p',
+        content: 'capture',
+        projectRoot: '/p',
+        taskId: 't1',
+      })
+
+      // Phase 4 must NOT have run yet — response was returned immediately.
+      expect(response).to.equal('curated')
+      expect(propagateStalenessStub.called).to.be.false
+      expect((agent.deleteTaskSession as ReturnType<typeof stub>).called).to.be.false
+
+      // finalize() actually runs Phase 4
+      await finalize()
+      expect(propagateStalenessStub.calledOnce).to.be.true
+      expect((agent.deleteTaskSession as ReturnType<typeof stub>).calledOnce).to.be.true
+    })
+
+    it('cleans up the task session if the agent body throws (no finalize returned)', async () => {
+      const agent = buildSplitTestAgent()
+      ;(agent.executeOnSession as ReturnType<typeof stub>).rejects(new Error('agent failed'))
+
+      const executor = new CurateExecutor()
+      try {
+        await executor.runAgentBody(agent, {clientCwd: '/p', content: 'x', taskId: 't2'})
+        expect.fail('should have thrown')
+      } catch (error) {
+        expect((error as Error).message).to.equal('agent failed')
+      }
+
+      // Even on agent body failure, the session must be cleaned up — no leak.
+      expect((agent.deleteTaskSession as ReturnType<typeof stub>).calledOnceWithExactly('session-id')).to.be.true
+    })
+
+    it('executeWithAgent (backwards-compat wrapper) still runs Phase 4 inline before returning', async () => {
+      const agent = buildSplitTestAgent()
+      stub(FileContextTreeSnapshotService.prototype, 'getCurrentState')
+        .onFirstCall()
+        .resolves(new Map())
+        .onSecondCall()
+        .resolves(new Map([['auth/jwt.md', {hash: 'h', size: 1}]]))
+      const propagateStalenessStub = stub(
+        FileContextTreeSummaryService.prototype,
+        'propagateStaleness',
+      ).resolves([])
+
+      const executor = new CurateExecutor()
+      const result = await executor.executeWithAgent(agent, {
+        clientCwd: '/p',
+        content: 'x',
+        projectRoot: '/p',
+        taskId: 't3',
+      })
+
+      expect(result).to.equal('curated')
+      // Wrapper awaits finalize internally — Phase 4 ran by the time we get here.
+      expect(propagateStalenessStub.calledOnce).to.be.true
     })
   })
 })

--- a/test/unit/infra/executor/folder-pack-executor.test.ts
+++ b/test/unit/infra/executor/folder-pack-executor.test.ts
@@ -109,6 +109,7 @@ describe('FolderPackExecutor', () => {
       expect(instructionsVar).to.equal(llmGeneratedVarName)
     })
   })
+  })
 
   describe('summary propagation', () => {
   beforeEach(() => {
@@ -324,7 +325,6 @@ describe('FolderPackExecutor', () => {
     expect(drainBackgroundWork.calledOnce).to.be.true
   })
   })
-})
 
   describe('workspace path resolution (PR3)', () => {
     let testDir: string

--- a/test/unit/infra/executor/folder-pack-executor.test.ts
+++ b/test/unit/infra/executor/folder-pack-executor.test.ts
@@ -422,4 +422,91 @@ describe('FolderPackExecutor', () => {
       })
     })
   })
+
+describe('runAgentBody / finalize split (ENG-2522)', () => {
+  // Mirrors the curate-executor split coverage. agent-process needs response
+  // BEFORE Phase 4 so it can fire `task:completed` and submit finalize() to
+  // the PostWorkRegistry. Folder-pack has no task-session lifecycle to test.
+
+  beforeEach(() => {
+    stubDreamLockServiceDefaults()
+  })
+
+  afterEach(() => {
+    restore()
+  })
+
+  it('returns the response without running Phase 4 first', async () => {
+    const folderPackService = {
+      generateXml: stub().returns('<packed_folder />'),
+      initialize: stub().resolves(),
+      pack: stub().resolves({fileCount: 0, files: [], totalLines: 0}),
+    } as unknown as IFolderPackService
+
+    const executor = new FolderPackExecutor(folderPackService)
+    stub(
+      executor as unknown as {executeIterative: (...args: unknown[]) => Promise<string>},
+      'executeIterative',
+    ).resolves('curated')
+    stub(FileContextTreeSnapshotService.prototype, 'getCurrentState')
+      .onFirstCall()
+      .resolves(new Map())
+      .onSecondCall()
+      .resolves(new Map([['auth/jwt.md', {hash: 'h', size: 1}]]))
+    const propagateStaleness = stub(FileContextTreeSummaryService.prototype, 'propagateStaleness').resolves([])
+    stub(FileContextTreeManifestService.prototype, 'buildManifest').resolves()
+
+    const drainBackgroundWork = stub().resolves()
+    const agent = {drainBackgroundWork} as unknown as ICipherAgent
+    const {finalize, response} = await executor.runAgentBody(agent, {
+      clientCwd: '/workspace',
+      content: 'curate',
+      folderPath: 'src',
+      taskId: 'fp-split-1',
+    })
+
+    // Phase 4 must NOT have run yet — response was returned immediately.
+    expect(response).to.equal('curated')
+    expect(propagateStaleness.called).to.be.false
+    expect(drainBackgroundWork.called).to.be.false
+
+    await finalize()
+    expect(propagateStaleness.calledOnce).to.be.true
+    expect(drainBackgroundWork.calledOnce).to.be.true
+  })
+
+  it('executeWithAgent (backwards-compat wrapper) still runs Phase 4 inline before returning', async () => {
+    const folderPackService = {
+      generateXml: stub().returns('<packed_folder />'),
+      initialize: stub().resolves(),
+      pack: stub().resolves({fileCount: 0, files: [], totalLines: 0}),
+    } as unknown as IFolderPackService
+
+    const executor = new FolderPackExecutor(folderPackService)
+    stub(
+      executor as unknown as {executeIterative: (...args: unknown[]) => Promise<string>},
+      'executeIterative',
+    ).resolves('curated')
+    stub(FileContextTreeSnapshotService.prototype, 'getCurrentState')
+      .onFirstCall()
+      .resolves(new Map())
+      .onSecondCall()
+      .resolves(new Map([['auth/jwt.md', {hash: 'h', size: 1}]]))
+    const propagateStaleness = stub(FileContextTreeSummaryService.prototype, 'propagateStaleness').resolves([])
+
+    const drainBackgroundWork = stub().resolves()
+    const agent = {drainBackgroundWork} as unknown as ICipherAgent
+    const result = await executor.executeWithAgent(agent, {
+      clientCwd: '/workspace',
+      content: 'curate',
+      folderPath: 'src',
+      taskId: 'fp-split-2',
+    })
+
+    expect(result).to.equal('curated')
+    // Wrapper awaits finalize internally — Phase 4 ran by the time we get here.
+    expect(propagateStaleness.calledOnce).to.be.true
+    expect(drainBackgroundWork.calledOnce).to.be.true
+  })
+})
 })

--- a/test/unit/infra/executor/folder-pack-executor.test.ts
+++ b/test/unit/infra/executor/folder-pack-executor.test.ts
@@ -21,7 +21,19 @@ import {LocalSandbox} from '../../../../src/agent/infra/sandbox/local-sandbox.js
 import {FileContextTreeManifestService} from '../../../../src/server/infra/context-tree/file-context-tree-manifest-service.js'
 import {FileContextTreeSnapshotService} from '../../../../src/server/infra/context-tree/file-context-tree-snapshot-service.js'
 import {FileContextTreeSummaryService} from '../../../../src/server/infra/context-tree/file-context-tree-summary-service.js'
+import {DreamLockService} from '../../../../src/server/infra/dream/dream-lock-service.js'
 import {FolderPackExecutor} from '../../../../src/server/infra/executor/folder-pack-executor.js'
+
+/**
+ * Stub DreamLockService so Phase 4 tests don't hit a real filesystem
+ * `<projectRoot>/.brv/dream.lock`. ENG-2522 added lock coordination around
+ * propagateStaleness/buildManifest in folder-pack post-work.
+ */
+function stubDreamLockServiceDefaults(): void {
+  stub(DreamLockService.prototype, 'tryAcquire').resolves({acquired: true, priorMtime: 0})
+  stub(DreamLockService.prototype, 'release').resolves()
+  stub(DreamLockService.prototype, 'rollback').resolves()
+}
 
 function createMockAgent(): ICipherAgent {
   return {
@@ -99,6 +111,10 @@ describe('FolderPackExecutor', () => {
   })
 
   describe('summary propagation', () => {
+  beforeEach(() => {
+    stubDreamLockServiceDefaults()
+  })
+
   afterEach(() => {
     restore()
   })

--- a/test/unit/infra/executor/folder-pack-executor.test.ts
+++ b/test/unit/infra/executor/folder-pack-executor.test.ts
@@ -25,9 +25,9 @@ import {DreamLockService} from '../../../../src/server/infra/dream/dream-lock-se
 import {FolderPackExecutor} from '../../../../src/server/infra/executor/folder-pack-executor.js'
 
 /**
- * Stub DreamLockService so Phase 4 tests don't hit a real filesystem
- * `<projectRoot>/.brv/dream.lock`. ENG-2522 added lock coordination around
- * propagateStaleness/buildManifest in folder-pack post-work.
+ * Default DreamLockService stubs so Phase 4 tests don't write real
+ * `dream.lock` files. Folder-pack's post-work holds the lock around
+ * propagateStaleness + buildManifest.
  */
 function stubDreamLockServiceDefaults(): void {
   stub(DreamLockService.prototype, 'tryAcquire').resolves({acquired: true, priorMtime: 0})
@@ -423,10 +423,9 @@ describe('FolderPackExecutor', () => {
     })
   })
 
-describe('runAgentBody / finalize split (ENG-2522)', () => {
-  // Mirrors the curate-executor split coverage. agent-process needs response
-  // BEFORE Phase 4 so it can fire `task:completed` and submit finalize() to
-  // the PostWorkRegistry. Folder-pack has no task-session lifecycle to test.
+describe('runAgentBody / finalize split', () => {
+  // Mirrors the curate-executor split: response must return before Phase 4
+  // so the daemon can fire `task:completed` and queue finalize.
 
   beforeEach(() => {
     stubDreamLockServiceDefaults()


### PR DESCRIPTION
## Summary

After `task:completed` fires, the user perceives an 18s wait while curate's Phase 4 (snapshot diff → `propagateStaleness` → `buildManifest`) runs three sequential summary-regen LLM calls against ancestor directories. This PR detaches Phase 4 from the user's path so `task:completed` returns as soon as the agent body finishes. Phase 4 still runs — it just runs in the background.

**Mechanism:**

- **`PostWorkRegistry`** — per-project serialized fire-and-forget queue with bounded shutdown drain. Same project runs serially (no race on `_index.md`); different projects run concurrently; SIGTERM gives in-flight thunks 30s to finish before exit.
- **Executor split** — `CurateExecutor` and `FolderPackExecutor` now expose `runAgentBody(...) → {response, finalize}`. The legacy `executeWithAgent` is preserved as a thin inline-await wrapper. `agent-process` calls `runAgentBody`, fires `task:completed` off the response, and submits `finalize` to the registry.
- **`DreamLockService` coordination** — Phase 4's write block (`propagateStaleness` + `buildManifest`) holds the existing dream lock so a concurrent dream cannot interleave on `_index.md` / `_manifest.json`. If the lock is held, Phase 4 skips — dream's own propagation covers the same diff.
- **`awaitProject` dispatch gate** — curate / curate-folder / dream wait on the project's tail at the top of `runTaskBody`. `task:completed` no longer implies "tree is free", so the next context-tree task must drain the prior Phase 4 first.
- **`awaitAll` hot-swap gate** — deferred `hotSwapProvider` waits on every in-flight tail before rebuilding `SessionManager`. Without this, a hot-swap mid-`propagateStaleness` LLM call would silently corrupt Phase 4.

**Out of scope** (deferred follow-ups noted in the original ticket):

- `task:post-processing` event + CLI rendering (UX polish — Rec #2)
- Defer Phase 4 entirely to dream (Rec #3)
- Sibling parallelism across `propagateStaleness` (Rec #4)

## Test plan

- [x] Unit tests — 6072 passing (added 8 new: 3 `awaitAll`, 3 lock-coordination on curate, 2 folder-pack split)
- [x] Integration tests — 488 passing
- [x] Command-level tests — 429 passing
- [x] Lint clean (0 errors on changed files; only pre-existing warnings remain)
- [x] Typecheck clean
- [x] Live curate against `gemini-3-flash-preview`: prompt returns in **8.5s** wall clock; `task:completed` and `post-work queued` fire at the same instant; `_index.md` written ~24s later in background
- [x] SIGTERM mid-Phase-4 → `post-work drain (11186ms): drained=1 abandoned=0`; `_index.md` not truncated; agent-process honors its 30s drain budget independently of the daemon's 3s SIGKILL fallback (separate PIDs)
- [x] `brv curate` → immediate `brv dream --force` while Phase 4 in-flight: dream blocks ~24s on `awaitProject`, then runs cleanly; `_index.md` final mtime is dream's output (compression 0.526 = dream synthesis signature, distinct from curate Phase 4's 0.7+); `dream.lock` released cleanly