### PR TITLE
feat: [ENG-2500] wire WebUI delete + bulk + clear-completed mutations

### DIFF
--- a/src/webui/features/tasks/api/clear-completed.ts
+++ b/src/webui/features/tasks/api/clear-completed.ts
@@ -1,0 +1,34 @@
+import {useMutation} from '@tanstack/react-query'
+
+import type {MutationConfig} from '../../../lib/react-query'
+
+import {
+  type TaskClearCompletedRequest,
+  type TaskClearCompletedResponse,
+  TaskEvents,
+} from '../../../../shared/transport/events/task-events'
+import {useTransportStore} from '../../../stores/transport-store'
+
+export const clearCompleted = async (
+  payload: TaskClearCompletedRequest,
+): Promise<TaskClearCompletedResponse> => {
+  const {apiClient} = useTransportStore.getState()
+  if (!apiClient) throw new Error('Not connected')
+
+  const response = await apiClient.request<TaskClearCompletedResponse, TaskClearCompletedRequest>(
+    TaskEvents.CLEAR_COMPLETED,
+    payload,
+  )
+  if (response.error) throw new Error(response.error)
+  return response
+}
+
+type UseClearCompletedOptions = {
+  mutationConfig?: MutationConfig<typeof clearCompleted>
+}
+
+export const useClearCompleted = ({mutationConfig}: UseClearCompletedOptions = {}) =>
+  useMutation({
+    ...mutationConfig,
+    mutationFn: clearCompleted,
+  })

--- a/src/webui/features/tasks/api/delete-bulk-tasks.ts
+++ b/src/webui/features/tasks/api/delete-bulk-tasks.ts
@@ -1,0 +1,32 @@
+import {useMutation} from '@tanstack/react-query'
+
+import type {MutationConfig} from '../../../lib/react-query'
+
+import {
+  type TaskDeleteBulkRequest,
+  type TaskDeleteBulkResponse,
+  TaskEvents,
+} from '../../../../shared/transport/events/task-events'
+import {useTransportStore} from '../../../stores/transport-store'
+
+export const deleteBulkTasks = async (payload: TaskDeleteBulkRequest): Promise<TaskDeleteBulkResponse> => {
+  const {apiClient} = useTransportStore.getState()
+  if (!apiClient) throw new Error('Not connected')
+
+  const response = await apiClient.request<TaskDeleteBulkResponse, TaskDeleteBulkRequest>(
+    TaskEvents.DELETE_BULK,
+    payload,
+  )
+  if (response.error) throw new Error(response.error)
+  return response
+}
+
+type UseDeleteBulkTasksOptions = {
+  mutationConfig?: MutationConfig<typeof deleteBulkTasks>
+}
+
+export const useDeleteBulkTasks = ({mutationConfig}: UseDeleteBulkTasksOptions = {}) =>
+  useMutation({
+    ...mutationConfig,
+    mutationFn: deleteBulkTasks,
+  })

--- a/src/webui/features/tasks/api/delete-task.ts
+++ b/src/webui/features/tasks/api/delete-task.ts
@@ -1,0 +1,29 @@
+import {useMutation} from '@tanstack/react-query'
+
+import type {MutationConfig} from '../../../lib/react-query'
+
+import {
+  type TaskDeleteRequest,
+  type TaskDeleteResponse,
+  TaskEvents,
+} from '../../../../shared/transport/events/task-events'
+import {useTransportStore} from '../../../stores/transport-store'
+
+export const deleteTask = async (payload: TaskDeleteRequest): Promise<TaskDeleteResponse> => {
+  const {apiClient} = useTransportStore.getState()
+  if (!apiClient) throw new Error('Not connected')
+
+  const response = await apiClient.request<TaskDeleteResponse, TaskDeleteRequest>(TaskEvents.DELETE, payload)
+  if (!response.success) throw new Error(response.error ?? 'Delete failed')
+  return response
+}
+
+type UseDeleteTaskOptions = {
+  mutationConfig?: MutationConfig<typeof deleteTask>
+}
+
+export const useDeleteTask = ({mutationConfig}: UseDeleteTaskOptions = {}) =>
+  useMutation({
+    ...mutationConfig,
+    mutationFn: deleteTask,
+  })

--- a/src/webui/features/tasks/components/task-list-view.tsx
+++ b/src/webui/features/tasks/components/task-list-view.tsx
@@ -2,12 +2,16 @@ import {Button} from '@campfirein/byterover-packages/components/button'
 import {Sheet, SheetContent} from '@campfirein/byterover-packages/components/sheet'
 import {useEffect, useMemo, useState} from 'react'
 import {useSearchParams} from 'react-router-dom'
+import {toast} from 'sonner'
 
 import type {ComposerType} from './task-composer-types'
 
 import {useTransportStore} from '../../../stores/transport-store'
 import {CURATE_EXAMPLE, QUERY_EXAMPLE, TOUR_STEP_LABEL} from '../../onboarding/lib/tour-examples'
 import {useOnboardingStore} from '../../onboarding/stores/onboarding-store'
+import {useClearCompleted} from '../api/clear-completed'
+import {useDeleteBulkTasks} from '../api/delete-bulk-tasks'
+import {useDeleteTask} from '../api/delete-task'
 import {useGetTasks} from '../api/get-tasks'
 import {useTickingNow} from '../hooks/use-ticking-now'
 import {useComposerRetryStore} from '../stores/composer-retry-store'
@@ -52,6 +56,10 @@ export function TaskListView() {
   const breakdown = useStatusBreakdown()
   const {isLoading} = useGetTasks({projectPath: projectPath || undefined})
   const now = useTickingNow(breakdown.running > 0)
+
+  const deleteMutation = useDeleteTask()
+  const deleteBulkMutation = useDeleteBulkTasks()
+  const clearCompletedMutation = useClearCompleted()
 
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const [composer, setComposer] = useState<{
@@ -154,13 +162,44 @@ export function TaskListView() {
 
   const clearSelection = () => setSelectedIds(new Set())
 
+  const handleDelete = (taskId: string) => {
+    deleteMutation.mutate(
+      {taskId},
+      {
+        onError: (err) => toast.error(err.message),
+        onSuccess: () => removeTask(taskId),
+      },
+    )
+  }
+
   const deleteSelected = () => {
-    for (const taskId of selectedIds) {
-      const task = taskMap.get(taskId)
-      if (task && isTerminalStatus(task.status)) removeTask(taskId)
+    const eligibleIds = [...selectedIds].filter((id) => {
+      const task = taskMap.get(id)
+      return task !== undefined && isTerminalStatus(task.status)
+    })
+    if (eligibleIds.length === 0) {
+      clearSelection()
+      return
     }
 
+    deleteBulkMutation.mutate(
+      {taskIds: eligibleIds},
+      {
+        onError: (err) => toast.error(err.message),
+        onSuccess() {
+          for (const id of eligibleIds) removeTask(id)
+        },
+      },
+    )
     clearSelection()
+  }
+
+  const handleClearCompleted = () => {
+    const path = projectPath || undefined
+    clearCompletedMutation.mutate(path ? {projectPath: path} : {}, {
+      onError: (err) => toast.error(err.message),
+      onSuccess: () => clearCompleted(),
+    })
   }
 
   return (
@@ -203,7 +242,7 @@ export function TaskListView() {
           filtered={filtered}
           now={now}
           onClearSearch={() => setSearchQuery('')}
-          onDelete={removeTask}
+          onDelete={handleDelete}
           onRowClick={openTask}
           onToggleSelect={toggleSelect}
           onToggleSelectAll={toggleSelectAll}
@@ -215,7 +254,7 @@ export function TaskListView() {
 
       {finishedCount > 0 && (
         <div className="flex items-center justify-end px-1">
-          <Button onClick={() => clearCompleted()} size="xs" variant="ghost">
+          <Button onClick={handleClearCompleted} size="xs" variant="ghost">
             Clear finished ({finishedCount})
           </Button>
         </div>

--- a/src/webui/features/tasks/components/task-list-view.tsx
+++ b/src/webui/features/tasks/components/task-list-view.tsx
@@ -188,15 +188,14 @@ export function TaskListView() {
         onError: (err) => toast.error(err.message),
         onSuccess() {
           for (const id of eligibleIds) removeTask(id)
+          clearSelection()
         },
       },
     )
-    clearSelection()
   }
 
   const handleClearCompleted = () => {
-    const path = projectPath || undefined
-    clearCompletedMutation.mutate(path ? {projectPath: path} : {}, {
+    clearCompletedMutation.mutate(projectPath ? {projectPath} : {}, {
       onError: (err) => toast.error(err.message),
       onSuccess: () => clearCompleted(),
     })

--- a/test/unit/webui/features/tasks/api/clear-completed.test.ts
+++ b/test/unit/webui/features/tasks/api/clear-completed.test.ts
@@ -1,0 +1,65 @@
+import {expect} from 'chai'
+import {createSandbox, type SinonSandbox, type SinonStub} from 'sinon'
+
+import type {BrvApiClient} from '../../../../../../src/webui/lib/api-client.js'
+
+import {TaskEvents} from '../../../../../../src/shared/transport/events/task-events.js'
+import {clearCompleted} from '../../../../../../src/webui/features/tasks/api/clear-completed.js'
+import {useTransportStore} from '../../../../../../src/webui/stores/transport-store.js'
+
+describe('clearCompleted', () => {
+  let sandbox: SinonSandbox
+  let request: SinonStub
+
+  beforeEach(() => {
+    sandbox = createSandbox()
+    request = sandbox.stub()
+    useTransportStore.setState({
+      apiClient: {on: sandbox.stub(), request} as unknown as BrvApiClient,
+    })
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+    useTransportStore.setState({apiClient: null})
+  })
+
+  it('emits task:clearCompleted with the projectPath payload', async () => {
+    request.resolves({deletedCount: 5})
+    await clearCompleted({projectPath: '/foo/bar'})
+    expect(request.firstCall.args[0]).to.equal(TaskEvents.CLEAR_COMPLETED)
+    expect(request.firstCall.args[1]).to.deep.equal({projectPath: '/foo/bar'})
+  })
+
+  it('emits task:clearCompleted with empty payload when projectPath is omitted', async () => {
+    request.resolves({deletedCount: 0})
+    await clearCompleted({})
+    expect(request.firstCall.args[1]).to.deep.equal({})
+  })
+
+  it('resolves with the daemon response on success', async () => {
+    request.resolves({deletedCount: 7})
+    const result = await clearCompleted({projectPath: '/p'})
+    expect(result).to.deep.equal({deletedCount: 7})
+  })
+
+  it('throws when the daemon response has error', async () => {
+    request.resolves({deletedCount: 0, error: 'project not found'})
+    try {
+      await clearCompleted({projectPath: '/p'})
+      expect.fail('expected to throw')
+    } catch (error) {
+      expect((error as Error).message).to.equal('project not found')
+    }
+  })
+
+  it('throws when not connected to the daemon', async () => {
+    useTransportStore.setState({apiClient: null})
+    try {
+      await clearCompleted({projectPath: '/p'})
+      expect.fail('expected to throw')
+    } catch (error) {
+      expect((error as Error).message).to.equal('Not connected')
+    }
+  })
+})

--- a/test/unit/webui/features/tasks/api/delete-bulk-tasks.test.ts
+++ b/test/unit/webui/features/tasks/api/delete-bulk-tasks.test.ts
@@ -1,0 +1,59 @@
+import {expect} from 'chai'
+import {createSandbox, type SinonSandbox, type SinonStub} from 'sinon'
+
+import type {BrvApiClient} from '../../../../../../src/webui/lib/api-client.js'
+
+import {TaskEvents} from '../../../../../../src/shared/transport/events/task-events.js'
+import {deleteBulkTasks} from '../../../../../../src/webui/features/tasks/api/delete-bulk-tasks.js'
+import {useTransportStore} from '../../../../../../src/webui/stores/transport-store.js'
+
+describe('deleteBulkTasks', () => {
+  let sandbox: SinonSandbox
+  let request: SinonStub
+
+  beforeEach(() => {
+    sandbox = createSandbox()
+    request = sandbox.stub()
+    useTransportStore.setState({
+      apiClient: {on: sandbox.stub(), request} as unknown as BrvApiClient,
+    })
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+    useTransportStore.setState({apiClient: null})
+  })
+
+  it('emits task:deleteBulk with the taskIds payload', async () => {
+    request.resolves({deletedCount: 2})
+    await deleteBulkTasks({taskIds: ['tsk-1', 'tsk-2']})
+    expect(request.firstCall.args[0]).to.equal(TaskEvents.DELETE_BULK)
+    expect(request.firstCall.args[1]).to.deep.equal({taskIds: ['tsk-1', 'tsk-2']})
+  })
+
+  it('resolves with the daemon response on success', async () => {
+    request.resolves({deletedCount: 3})
+    const result = await deleteBulkTasks({taskIds: ['a', 'b', 'c']})
+    expect(result).to.deep.equal({deletedCount: 3})
+  })
+
+  it('throws when the daemon response has error', async () => {
+    request.resolves({deletedCount: 0, error: 'project not found'})
+    try {
+      await deleteBulkTasks({taskIds: ['tsk-1']})
+      expect.fail('expected to throw')
+    } catch (error) {
+      expect((error as Error).message).to.equal('project not found')
+    }
+  })
+
+  it('throws when not connected to the daemon', async () => {
+    useTransportStore.setState({apiClient: null})
+    try {
+      await deleteBulkTasks({taskIds: ['tsk-1']})
+      expect.fail('expected to throw')
+    } catch (error) {
+      expect((error as Error).message).to.equal('Not connected')
+    }
+  })
+})

--- a/test/unit/webui/features/tasks/api/delete-task.test.ts
+++ b/test/unit/webui/features/tasks/api/delete-task.test.ts
@@ -1,0 +1,59 @@
+import {expect} from 'chai'
+import {createSandbox, type SinonSandbox, type SinonStub} from 'sinon'
+
+import type {BrvApiClient} from '../../../../../../src/webui/lib/api-client.js'
+
+import {TaskEvents} from '../../../../../../src/shared/transport/events/task-events.js'
+import {deleteTask} from '../../../../../../src/webui/features/tasks/api/delete-task.js'
+import {useTransportStore} from '../../../../../../src/webui/stores/transport-store.js'
+
+describe('deleteTask', () => {
+  let sandbox: SinonSandbox
+  let request: SinonStub
+
+  beforeEach(() => {
+    sandbox = createSandbox()
+    request = sandbox.stub()
+    useTransportStore.setState({
+      apiClient: {on: sandbox.stub(), request} as unknown as BrvApiClient,
+    })
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+    useTransportStore.setState({apiClient: null})
+  })
+
+  it('emits task:delete with the taskId payload', async () => {
+    request.resolves({removed: true, success: true})
+    await deleteTask({taskId: 'tsk-1'})
+    expect(request.firstCall.args[0]).to.equal(TaskEvents.DELETE)
+    expect(request.firstCall.args[1]).to.deep.equal({taskId: 'tsk-1'})
+  })
+
+  it('resolves with the daemon response on success', async () => {
+    request.resolves({removed: true, success: true})
+    const result = await deleteTask({taskId: 'tsk-1'})
+    expect(result).to.deep.equal({removed: true, success: true})
+  })
+
+  it('throws when the daemon returns success: false', async () => {
+    request.resolves({error: 'cannot delete running task; cancel it first', success: false})
+    try {
+      await deleteTask({taskId: 'tsk-1'})
+      expect.fail('expected to throw')
+    } catch (error) {
+      expect((error as Error).message).to.equal('cannot delete running task; cancel it first')
+    }
+  })
+
+  it('throws when not connected to the daemon', async () => {
+    useTransportStore.setState({apiClient: null})
+    try {
+      await deleteTask({taskId: 'tsk-1'})
+      expect.fail('expected to throw')
+    } catch (error) {
+      expect((error as Error).message).to.equal('Not connected')
+    }
+  })
+})

--- a/test/unit/webui/features/tasks/api/delete-task.test.ts
+++ b/test/unit/webui/features/tasks/api/delete-task.test.ts
@@ -47,6 +47,16 @@ describe('deleteTask', () => {
     }
   })
 
+  it('falls back to "Delete failed" when success: false has no error string', async () => {
+    request.resolves({success: false})
+    try {
+      await deleteTask({taskId: 'tsk-1'})
+      expect.fail('expected to throw')
+    } catch (error) {
+      expect((error as Error).message).to.equal('Delete failed')
+    }
+  })
+
   it('throws when not connected to the daemon', async () => {
     useTransportStore.setState({apiClient: null})
     try {


### PR DESCRIPTION
## Summary

- New api hooks under `features/tasks/api/`: `delete-task`, `delete-bulk-tasks`, `clear-completed`. Each wraps `apiClient.request` and throws on `success: false` so react-query's `onError` covers all failure paths.
- `task-list-view.tsx` rewires single delete, bulk delete, and "Clear finished" to fire mutations; local store mutation now happens **only** in `onSuccess`. Errors surface via `sonner` toast.
- `task:deleted` broadcast subscription (already in `use-task-subscriptions.ts`) keeps cross-tab/TUI clients in sync after one client deletes.

## Test plan

- [ ] Trigger 3 tasks to completion; click Delete on a row → WS frame shows `task:delete` request, row removed.
- [ ] Refresh page — deleted row stays gone (no longer just hides locally).
- [ ] Open WebUI in two tabs, delete in tab A — tab B's row also disappears via `task:deleted` broadcast.
- [ ] Select 3 terminal rows, click "Delete selected" — single `task:deleteBulk` frame, all three removed.
- [ ] Click "Clear finished" — single `task:clearCompleted` frame, all terminal entries removed.
- [ ] Try deleting a still-running task (force the error path) — toast shows the daemon's error message; row stays.
- [ ] `npm run typecheck && npm run lint` clean.
- [ ] `npx mocha --forbid-only \"test/unit/webui/features/tasks/api/*.test.ts\"` — 13 passing.