### PR TITLE
feat: [ENG-2501] render task detail from disk via task:get for cold tasks

### DIFF
--- a/src/webui/features/tasks/api/get-task.ts
+++ b/src/webui/features/tasks/api/get-task.ts
@@ -1,0 +1,36 @@
+import {queryOptions, useQuery} from '@tanstack/react-query'
+
+import type {QueryConfig} from '../../../lib/react-query'
+
+import {
+  TaskEvents,
+  type TaskGetRequest,
+  type TaskGetResponse,
+} from '../../../../shared/transport/events/task-events'
+import {useTransportStore} from '../../../stores/transport-store'
+
+export const getTask = (taskId: string): Promise<TaskGetResponse> => {
+  const {apiClient} = useTransportStore.getState()
+  if (!apiClient) return Promise.reject(new Error('Not connected'))
+
+  return apiClient.request<TaskGetResponse, TaskGetRequest>(TaskEvents.GET, {taskId})
+}
+
+export const getTaskQueryOptions = (taskId: string, enabled: boolean) =>
+  queryOptions({
+    enabled,
+    queryFn: () => getTask(taskId),
+    queryKey: ['tasks', 'detail', taskId],
+  })
+
+type UseGetTaskDetailOptions = {
+  enabled: boolean
+  queryConfig?: QueryConfig<typeof getTaskQueryOptions>
+  taskId: string
+}
+
+export const useGetTaskDetail = ({enabled, queryConfig, taskId}: UseGetTaskDetailOptions) =>
+  useQuery({
+    ...getTaskQueryOptions(taskId, enabled),
+    ...queryConfig,
+  })

--- a/src/webui/features/tasks/api/get-task.ts
+++ b/src/webui/features/tasks/api/get-task.ts
@@ -21,6 +21,7 @@ export const getTaskQueryOptions = (taskId: string, enabled: boolean) =>
     enabled,
     queryFn: () => getTask(taskId),
     queryKey: ['tasks', 'detail', taskId],
+    staleTime: Number.POSITIVE_INFINITY,
   })
 
 type UseGetTaskDetailOptions = {
@@ -33,4 +34,5 @@ export const useGetTaskDetail = ({enabled, queryConfig, taskId}: UseGetTaskDetai
   useQuery({
     ...getTaskQueryOptions(taskId, enabled),
     ...queryConfig,
+    enabled,
   })

--- a/src/webui/features/tasks/components/task-detail-view.tsx
+++ b/src/webui/features/tasks/components/task-detail-view.tsx
@@ -1,10 +1,14 @@
 import type {ComponentRef} from 'react'
 
+import type {StoredTask} from '../types/stored-task'
+
 import {TourTaskBanner, TourTaskContinueCta} from '../../onboarding/components/tour-task-banner'
 import {useOnboardingStore} from '../../onboarding/stores/onboarding-store'
+import {useGetTaskDetail} from '../api/get-task'
 import {useStickToBottom} from '../hooks/use-stick-to-bottom'
 import {useTickingNow} from '../hooks/use-ticking-now'
 import {useTaskById} from '../stores/task-store'
+import {taskHistoryEntryToStoredTask} from '../utils/task-history-entry-to-stored-task'
 import {isActiveStatus} from '../utils/task-status'
 import {EventLogSection} from './task-detail-event-log'
 import {DetailHeader} from './task-detail-header'
@@ -14,9 +18,25 @@ interface TaskDetailViewProps {
   taskId: string
 }
 
+function hasRichDetail(task: StoredTask | undefined): boolean {
+  if (!task) return false
+  if (task.responseContent && task.responseContent.length > 0) return true
+  if (task.toolCalls && task.toolCalls.length > 0) return true
+  return false
+}
+
 // eslint-disable-next-line complexity
 export function TaskDetailView({taskId}: TaskDetailViewProps) {
-  const task = useTaskById(taskId)
+  const storeTask = useTaskById(taskId)
+  const needsFetch = !hasRichDetail(storeTask)
+
+  // Cold restored task: store has only a list-row snapshot (or nothing).
+  // Fetch the full persisted entry; live tasks (have responseContent/toolCalls)
+  // skip the network call entirely via `enabled: false`.
+  const {data, isLoading} = useGetTaskDetail({enabled: needsFetch, taskId})
+
+  const fetched: StoredTask | undefined = data?.task ? taskHistoryEntryToStoredTask(data.task) : undefined
+  const task: StoredTask | undefined = needsFetch ? fetched ?? storeTask : storeTask
   const isActive = task ? isActiveStatus(task.status) : false
   const now = useTickingNow(isActive)
 
@@ -43,6 +63,14 @@ export function TaskDetailView({taskId}: TaskDetailViewProps) {
     isActive || isTourTask,
   )
 
+  if (needsFetch && isLoading) {
+    return <DetailLoading />
+  }
+
+  if (needsFetch && data && data.task === null) {
+    return <NotFound taskId={taskId} />
+  }
+
   if (!task) {
     return <NotFound taskId={taskId} />
   }
@@ -65,6 +93,14 @@ export function TaskDetailView({taskId}: TaskDetailViewProps) {
         {error && <ErrorSection task={task} />}
         <TourTaskContinueCta task={task} />
       </div>
+    </div>
+  )
+}
+
+function DetailLoading() {
+  return (
+    <div className="text-muted-foreground flex h-full items-center justify-center text-sm" role="status">
+      Loading task…
     </div>
   )
 }

--- a/src/webui/features/tasks/components/task-detail-view.tsx
+++ b/src/webui/features/tasks/components/task-detail-view.tsx
@@ -28,11 +28,9 @@ function hasRichDetail(task: StoredTask | undefined): boolean {
 // eslint-disable-next-line complexity
 export function TaskDetailView({taskId}: TaskDetailViewProps) {
   const storeTask = useTaskById(taskId)
-  const needsFetch = !hasRichDetail(storeTask)
+  const isLiveInStore = storeTask !== undefined && isActiveStatus(storeTask.status)
+  const needsFetch = !hasRichDetail(storeTask) && !isLiveInStore
 
-  // Cold restored task: store has only a list-row snapshot (or nothing).
-  // Fetch the full persisted entry; live tasks (have responseContent/toolCalls)
-  // skip the network call entirely via `enabled: false`.
   const {data, isLoading} = useGetTaskDetail({enabled: needsFetch, taskId})
 
   const fetched: StoredTask | undefined = data?.task ? taskHistoryEntryToStoredTask(data.task) : undefined

--- a/src/webui/features/tasks/utils/task-history-entry-to-stored-task.ts
+++ b/src/webui/features/tasks/utils/task-history-entry-to-stored-task.ts
@@ -1,0 +1,57 @@
+import type {TaskHistoryEntry} from '../../../../shared/transport/events/task-events'
+import type {StoredTask} from '../types/stored-task'
+
+export function taskHistoryEntryToStoredTask(entry: TaskHistoryEntry): StoredTask {
+  const base: StoredTask = {
+    content: entry.content,
+    createdAt: entry.createdAt,
+    status: entry.status,
+    taskId: entry.taskId,
+    type: entry.type,
+    ...(entry.files ? {files: entry.files} : {}),
+    ...(entry.folderPath ? {folderPath: entry.folderPath} : {}),
+    ...(entry.model ? {model: entry.model} : {}),
+    ...(entry.projectPath ? {projectPath: entry.projectPath} : {}),
+    ...(entry.provider ? {provider: entry.provider} : {}),
+    ...(entry.reasoningContents ? {reasoningContents: entry.reasoningContents} : {}),
+    ...(entry.responseContent ? {responseContent: entry.responseContent} : {}),
+    ...(entry.sessionId ? {sessionId: entry.sessionId} : {}),
+    ...(entry.toolCalls ? {toolCalls: entry.toolCalls} : {}),
+  }
+
+  switch (entry.status) {
+    case 'cancelled': {
+      return {
+        ...base,
+        completedAt: entry.completedAt,
+        ...(entry.startedAt ? {startedAt: entry.startedAt} : {}),
+      }
+    }
+
+    case 'completed': {
+      return {
+        ...base,
+        completedAt: entry.completedAt,
+        ...(entry.result ? {result: entry.result} : {}),
+        ...(entry.startedAt ? {startedAt: entry.startedAt} : {}),
+      }
+    }
+
+    case 'created': {
+      return base
+    }
+
+    case 'error': {
+      return {
+        ...base,
+        completedAt: entry.completedAt,
+        error: entry.error,
+        ...(entry.startedAt ? {startedAt: entry.startedAt} : {}),
+      }
+    }
+
+    case 'started': {
+      return {...base, startedAt: entry.startedAt}
+    }
+  }
+}

--- a/test/unit/webui/features/tasks/api/get-task.test.ts
+++ b/test/unit/webui/features/tasks/api/get-task.test.ts
@@ -1,0 +1,56 @@
+import {expect} from 'chai'
+import {createSandbox, type SinonSandbox, type SinonStub} from 'sinon'
+
+import type {BrvApiClient} from '../../../../../../src/webui/lib/api-client.js'
+
+import {TaskEvents} from '../../../../../../src/shared/transport/events/task-events.js'
+import {getTask} from '../../../../../../src/webui/features/tasks/api/get-task.js'
+import {useTransportStore} from '../../../../../../src/webui/stores/transport-store.js'
+
+describe('getTask', () => {
+  let sandbox: SinonSandbox
+  let request: SinonStub
+
+  beforeEach(() => {
+    sandbox = createSandbox()
+    request = sandbox.stub()
+    useTransportStore.setState({
+      apiClient: {on: sandbox.stub(), request} as unknown as BrvApiClient,
+    })
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+    useTransportStore.setState({apiClient: null})
+  })
+
+  it('emits task:get with the taskId payload', async () => {
+    request.resolves({task: null})
+    await getTask('tsk-1')
+    expect(request.firstCall.args[0]).to.equal(TaskEvents.GET)
+    expect(request.firstCall.args[1]).to.deep.equal({taskId: 'tsk-1'})
+  })
+
+  it('resolves with the daemon response when the task exists', async () => {
+    const fakeEntry = {status: 'completed', taskId: 'tsk-1'}
+    request.resolves({task: fakeEntry})
+    const result = await getTask('tsk-1')
+    expect(result.task).to.equal(fakeEntry)
+  })
+
+  it('resolves with {task: null} when the task does not exist', async () => {
+    request.resolves({task: null})
+    const result = await getTask('tsk-missing')
+    expect(result.task).to.equal(null)
+  })
+
+  it('throws when not connected to the daemon', async () => {
+    useTransportStore.setState({apiClient: null})
+    try {
+      await getTask('tsk-1')
+      expect.fail('expected to throw')
+    } catch (error) {
+      expect((error as Error).message).to.equal('Not connected')
+    }
+  })
+})

--- a/test/unit/webui/features/tasks/utils/task-history-entry-to-stored-task.test.ts
+++ b/test/unit/webui/features/tasks/utils/task-history-entry-to-stored-task.test.ts
@@ -37,6 +37,14 @@ describe('taskHistoryEntryToStoredTask', () => {
     expect(result.status).to.equal('started')
   })
 
+  it('leaves rich detail fields undefined for a started entry without content', () => {
+    const entry: TaskHistoryEntry = {...baseEntry, startedAt: 1_700_000_001_000, status: 'started'}
+    const result = taskHistoryEntryToStoredTask(entry)
+    expect(result.responseContent).to.equal(undefined)
+    expect(result.toolCalls).to.equal(undefined)
+    expect(result.reasoningContents).to.equal(undefined)
+  })
+
   it('maps a completed entry with result + timestamps', () => {
     const entry: TaskHistoryEntry = {
       ...baseEntry,

--- a/test/unit/webui/features/tasks/utils/task-history-entry-to-stored-task.test.ts
+++ b/test/unit/webui/features/tasks/utils/task-history-entry-to-stored-task.test.ts
@@ -1,0 +1,117 @@
+import {expect} from 'chai'
+
+import {
+  TASK_HISTORY_SCHEMA_VERSION,
+  type TaskHistoryEntry,
+} from '../../../../../../src/shared/transport/events/task-events.js'
+import {taskHistoryEntryToStoredTask} from '../../../../../../src/webui/features/tasks/utils/task-history-entry-to-stored-task.js'
+
+const baseEntry = {
+  content: 'test content',
+  createdAt: 1_700_000_000_000,
+  id: 'storage-id-1',
+  projectPath: '/foo/bar',
+  schemaVersion: TASK_HISTORY_SCHEMA_VERSION,
+  taskId: 'tsk-1',
+  type: 'curate',
+} as const
+
+describe('taskHistoryEntryToStoredTask', () => {
+  it('maps a created entry', () => {
+    const entry: TaskHistoryEntry = {...baseEntry, status: 'created'}
+    const result = taskHistoryEntryToStoredTask(entry)
+    expect(result).to.include({
+      content: 'test content',
+      createdAt: 1_700_000_000_000,
+      projectPath: '/foo/bar',
+      status: 'created',
+      taskId: 'tsk-1',
+      type: 'curate',
+    })
+  })
+
+  it('maps a started entry with startedAt', () => {
+    const entry: TaskHistoryEntry = {...baseEntry, startedAt: 1_700_000_001_000, status: 'started'}
+    const result = taskHistoryEntryToStoredTask(entry)
+    expect(result.startedAt).to.equal(1_700_000_001_000)
+    expect(result.status).to.equal('started')
+  })
+
+  it('maps a completed entry with result + timestamps', () => {
+    const entry: TaskHistoryEntry = {
+      ...baseEntry,
+      completedAt: 1_700_000_002_000,
+      result: 'final answer',
+      startedAt: 1_700_000_001_000,
+      status: 'completed',
+    }
+    const result = taskHistoryEntryToStoredTask(entry)
+    expect(result.result).to.equal('final answer')
+    expect(result.completedAt).to.equal(1_700_000_002_000)
+    expect(result.startedAt).to.equal(1_700_000_001_000)
+    expect(result.status).to.equal('completed')
+  })
+
+  it('maps an error entry with error payload', () => {
+    const entry: TaskHistoryEntry = {
+      ...baseEntry,
+      completedAt: 1_700_000_002_000,
+      error: {code: 'TOOL_FAIL', message: 'tool exploded', name: 'TaskError'},
+      status: 'error',
+    }
+    const result = taskHistoryEntryToStoredTask(entry)
+    expect(result.error).to.deep.equal({code: 'TOOL_FAIL', message: 'tool exploded', name: 'TaskError'})
+    expect(result.status).to.equal('error')
+  })
+
+  it('maps a cancelled entry', () => {
+    const entry: TaskHistoryEntry = {...baseEntry, completedAt: 1_700_000_002_000, status: 'cancelled'}
+    const result = taskHistoryEntryToStoredTask(entry)
+    expect(result.status).to.equal('cancelled')
+    expect(result.completedAt).to.equal(1_700_000_002_000)
+  })
+
+  it('preserves provider, model, sessionId, and rich detail arrays', () => {
+    const entry: TaskHistoryEntry = {
+      ...baseEntry,
+      completedAt: 1_700_000_002_000,
+      model: 'gpt-5-pro',
+      provider: 'openai',
+      reasoningContents: [{content: 'thinking…', timestamp: 1_700_000_001_500}],
+      responseContent: 'hello',
+      result: 'done',
+      sessionId: 'sess-1',
+      status: 'completed',
+      toolCalls: [
+        {
+          args: {path: '/x'},
+          callId: 'call-1',
+          sessionId: 'sess-1',
+          status: 'completed',
+          timestamp: 1_700_000_001_700,
+          toolName: 'read_file',
+        },
+      ],
+    }
+    const result = taskHistoryEntryToStoredTask(entry)
+    expect(result.provider).to.equal('openai')
+    expect(result.model).to.equal('gpt-5-pro')
+    expect(result.sessionId).to.equal('sess-1')
+    expect(result.responseContent).to.equal('hello')
+    expect(result.toolCalls).to.have.lengthOf(1)
+    expect(result.toolCalls?.[0]?.toolName).to.equal('read_file')
+    expect(result.reasoningContents).to.have.lengthOf(1)
+  })
+
+  it('preserves files and folderPath attachments', () => {
+    const entry: TaskHistoryEntry = {
+      ...baseEntry,
+      files: ['a.md', 'b.md'],
+      folderPath: '/some/folder',
+      status: 'created',
+    }
+    const result = taskHistoryEntryToStoredTask(entry)
+    expect(result.files).to.deep.equal(['a.md', 'b.md'])
+    expect(result.folderPath).to.equal('/some/folder')
+  })
+})


### PR DESCRIPTION
## Summary

- New api hook `useGetTaskDetail({enabled, taskId})` fires `task:get` only when the in-store task lacks rich detail (no `responseContent` and no `toolCalls`). Live/recent tasks render from the store with no network call.
- New pure adapter `taskHistoryEntryToStoredTask` maps the discriminated `TaskHistoryEntry` shape (server) to `StoredTask` (UI) so existing detail components don't need to change.
- `task-detail-view.tsx` falls back to fetched + adapted data when the store is cold; loading state during fetch; `data.task === null` → existing NotFound.

## Test plan

- [ ] Run a task to completion; click the row — full detail (input, response, tool calls, reasoning) renders. No `task:get` frame in WS messages.
- [ ] DevTools → Application → Session storage → delete `brv-tasks`, reload page, click a row — exactly **one** `task:get` frame fires; detail panel renders identically.
- [ ] Restart daemon mid-task, then open WebUI in a fresh tab → list shows interrupted row → click it → detail renders the partial trace from disk.
- [ ] Navigate to `?task=<unknown-uuid>` → "Task not found" panel appears after one `task:get` returning `{task: null}`.
- [ ] `npm run typecheck && npm run lint` clean.
- [ ] `npx mocha --forbid-only \"test/unit/webui/features/tasks/api/get-task.test.ts\" \"test/unit/webui/features/tasks/utils/task-history-entry-to-stored-task.test.ts\"` — 11 passing.