### PR TITLE
feat: [ENG-2502] paginate task list with useInfiniteQuery + Load more table row

### DIFF
--- a/src/webui/features/tasks/api/get-tasks.ts
+++ b/src/webui/features/tasks/api/get-tasks.ts
@@ -1,6 +1,4 @@
-import {queryOptions, useQuery} from '@tanstack/react-query'
-
-import type {QueryConfig} from '../../../lib/react-query'
+import {useInfiniteQuery} from '@tanstack/react-query'
 
 import {
   TaskEvents,
@@ -9,6 +7,8 @@ import {
 } from '../../../../shared/transport/events/task-events'
 import {useTransportStore} from '../../../stores/transport-store'
 
+export const DEFAULT_PAGE_LIMIT = 50
+
 export const getTasks = (data?: TaskListRequest): Promise<TaskListResponse> => {
   const {apiClient} = useTransportStore.getState()
   if (!apiClient) return Promise.reject(new Error('Not connected'))
@@ -16,19 +16,32 @@ export const getTasks = (data?: TaskListRequest): Promise<TaskListResponse> => {
   return apiClient.request<TaskListResponse, TaskListRequest>(TaskEvents.LIST, data)
 }
 
-export const getTasksQueryOptions = (projectPath?: string) =>
-  queryOptions({
-    queryFn: () => getTasks(projectPath ? {projectPath} : undefined),
-    queryKey: ['tasks', 'list', projectPath ?? ''],
-  })
+export const initialPageParam = (projectPath?: string): TaskListRequest => ({
+  limit: DEFAULT_PAGE_LIMIT,
+  ...(projectPath ? {projectPath} : {}),
+})
+
+export const getNextPageParam = (
+  lastPage: TaskListResponse,
+  lastParam: TaskListRequest,
+): TaskListRequest | undefined => {
+  if (lastPage.nextCursor === undefined) return undefined
+  return {
+    ...lastParam,
+    before: lastPage.nextCursor,
+    ...(lastPage.nextCursorTaskId ? {beforeTaskId: lastPage.nextCursorTaskId} : {}),
+  }
+}
 
 type UseGetTasksOptions = {
   projectPath?: string
-  queryConfig?: QueryConfig<typeof getTasksQueryOptions>
 }
 
-export const useGetTasks = ({projectPath, queryConfig}: UseGetTasksOptions = {}) =>
-  useQuery({
-    ...getTasksQueryOptions(projectPath),
-    ...queryConfig,
+export const useGetTasks = ({projectPath}: UseGetTasksOptions = {}) =>
+  useInfiniteQuery({
+    getNextPageParam: (lastPage: TaskListResponse, _allPages, lastParam: TaskListRequest) =>
+      getNextPageParam(lastPage, lastParam),
+    initialPageParam: initialPageParam(projectPath),
+    queryFn: ({pageParam}) => getTasks(pageParam),
+    queryKey: ['tasks', 'list', projectPath ?? ''],
   })

--- a/src/webui/features/tasks/components/task-list-table.tsx
+++ b/src/webui/features/tasks/components/task-list-table.tsx
@@ -1,3 +1,5 @@
+import type {KeyboardEvent} from 'react'
+
 import {Badge} from '@campfirein/byterover-packages/components/badge'
 import {Button} from '@campfirein/byterover-packages/components/button'
 import {
@@ -118,6 +120,14 @@ export function TaskTable({
 }
 
 function LoadMoreRow({isFetching, onClick}: {isFetching: boolean; onClick: () => void}) {
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (isFetching) return
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      onClick()
+    }
+  }
+
   return (
     <TableRow
       aria-disabled={isFetching}
@@ -126,6 +136,9 @@ function LoadMoreRow({isFetching, onClick}: {isFetching: boolean; onClick: () =>
         isFetching ? 'cursor-wait opacity-60' : 'cursor-pointer',
       )}
       onClick={isFetching ? undefined : onClick}
+      onKeyDown={handleKeyDown}
+      role="button"
+      tabIndex={isFetching ? -1 : 0}
     >
       <TableCell className="mono py-3 text-center text-[11px] uppercase tracking-wider" colSpan={8}>
         {isFetching ? 'Loading…' : 'Load more'}

--- a/src/webui/features/tasks/components/task-list-table.tsx
+++ b/src/webui/features/tasks/components/task-list-table.tsx
@@ -43,9 +43,12 @@ function durationOf(task: StoredTask, now: number): string {
 interface TaskTableProps {
   allSelected: boolean
   filtered: StoredTask[]
+  hasNextPage: boolean
+  isFetchingNextPage: boolean
   now: number
   onClearSearch: () => void
   onDelete: (taskId: string) => void
+  onLoadMore: () => void
   onRowClick: (taskId: string) => void
   onToggleSelect: (taskId: string) => void
   onToggleSelectAll: () => void
@@ -57,9 +60,12 @@ interface TaskTableProps {
 export function TaskTable({
   allSelected,
   filtered,
+  hasNextPage,
+  isFetchingNextPage,
   now,
   onClearSearch,
   onDelete,
+  onLoadMore,
   onRowClick,
   onToggleSelect,
   onToggleSelectAll,
@@ -91,20 +97,40 @@ export function TaskTable({
             </TableCell>
           </TableRow>
         ) : (
-          filtered.map((task) => (
-            <TaskRow
-              isSelected={selectedIds.has(task.taskId)}
-              key={task.taskId}
-              now={now}
-              onDelete={onDelete}
-              onRowClick={onRowClick}
-              onToggleSelect={onToggleSelect}
-              task={task}
-            />
-          ))
+          <>
+            {filtered.map((task) => (
+              <TaskRow
+                isSelected={selectedIds.has(task.taskId)}
+                key={task.taskId}
+                now={now}
+                onDelete={onDelete}
+                onRowClick={onRowClick}
+                onToggleSelect={onToggleSelect}
+                task={task}
+              />
+            ))}
+            {hasNextPage && <LoadMoreRow isFetching={isFetchingNextPage} onClick={onLoadMore} />}
+          </>
         )}
       </TableBody>
     </Table>
+  )
+}
+
+function LoadMoreRow({isFetching, onClick}: {isFetching: boolean; onClick: () => void}) {
+  return (
+    <TableRow
+      aria-disabled={isFetching}
+      className={cn(
+        'text-muted-foreground hover:text-foreground hover:bg-muted/50',
+        isFetching ? 'cursor-wait opacity-60' : 'cursor-pointer',
+      )}
+      onClick={isFetching ? undefined : onClick}
+    >
+      <TableCell className="mono py-3 text-center text-[11px] uppercase tracking-wider" colSpan={8}>
+        {isFetching ? 'Loading…' : 'Load more'}
+      </TableCell>
+    </TableRow>
   )
 }
 

--- a/src/webui/features/tasks/components/task-list-view.tsx
+++ b/src/webui/features/tasks/components/task-list-view.tsx
@@ -50,7 +50,9 @@ export function TaskListView() {
   const removeTask = useTaskStore((s) => s.removeTask)
 
   const breakdown = useStatusBreakdown()
-  const {isLoading} = useGetTasks({projectPath: projectPath || undefined})
+  const {fetchNextPage, hasNextPage, isFetchingNextPage, isLoading} = useGetTasks({
+    projectPath: projectPath || undefined,
+  })
   const now = useTickingNow(breakdown.running > 0)
 
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
@@ -201,9 +203,12 @@ export function TaskListView() {
         <TaskTable
           allSelected={allFilteredSelected}
           filtered={filtered}
+          hasNextPage={hasNextPage}
+          isFetchingNextPage={isFetchingNextPage}
           now={now}
           onClearSearch={() => setSearchQuery('')}
           onDelete={removeTask}
+          onLoadMore={() => fetchNextPage()}
           onRowClick={openTask}
           onToggleSelect={toggleSelect}
           onToggleSelectAll={toggleSelectAll}

--- a/src/webui/features/tasks/components/task-subscription-initializer.tsx
+++ b/src/webui/features/tasks/components/task-subscription-initializer.tsx
@@ -36,7 +36,8 @@ export function TaskSubscriptionInitializer() {
 
   useEffect(() => {
     if (!data) return
-    mergeTasks(data.tasks)
+    const merged = data.pages.flatMap((page) => page.tasks)
+    mergeTasks(merged)
   }, [data, mergeTasks])
 
   return null

--- a/test/unit/webui/features/tasks/api/get-tasks.test.ts
+++ b/test/unit/webui/features/tasks/api/get-tasks.test.ts
@@ -13,87 +13,87 @@ import {
 import {useTransportStore} from '../../../../../../src/webui/stores/transport-store.js'
 
 describe('get-tasks api', () => {
-describe('getTasks', () => {
-  let sandbox: SinonSandbox
-  let request: SinonStub
+  describe('getTasks', () => {
+    let sandbox: SinonSandbox
+    let request: SinonStub
 
-  beforeEach(() => {
-    sandbox = createSandbox()
-    request = sandbox.stub()
-    useTransportStore.setState({
-      apiClient: {on: sandbox.stub(), request} as unknown as BrvApiClient,
+    beforeEach(() => {
+      sandbox = createSandbox()
+      request = sandbox.stub()
+      useTransportStore.setState({
+        apiClient: {on: sandbox.stub(), request} as unknown as BrvApiClient,
+      })
+    })
+
+    afterEach(() => {
+      sandbox.restore()
+      useTransportStore.setState({apiClient: null})
+    })
+
+    it('emits task:list with the request payload', async () => {
+      request.resolves({tasks: []})
+      await getTasks({limit: 50, projectPath: '/foo'})
+      expect(request.firstCall.args[0]).to.equal(TaskEvents.LIST)
+      expect(request.firstCall.args[1]).to.deep.equal({limit: 50, projectPath: '/foo'})
+    })
+
+    it('forwards before + beforeTaskId for paginated requests', async () => {
+      request.resolves({tasks: []})
+      await getTasks({before: 1234, beforeTaskId: 'tsk-x', limit: 50, projectPath: '/foo'})
+      expect(request.firstCall.args[1]).to.deep.equal({
+        before: 1234,
+        beforeTaskId: 'tsk-x',
+        limit: 50,
+        projectPath: '/foo',
+      })
+    })
+
+    it('throws when not connected to the daemon', async () => {
+      useTransportStore.setState({apiClient: null})
+      try {
+        await getTasks({limit: 50})
+        expect.fail('expected to throw')
+      } catch (error) {
+        expect((error as Error).message).to.equal('Not connected')
+      }
     })
   })
 
-  afterEach(() => {
-    sandbox.restore()
-    useTransportStore.setState({apiClient: null})
-  })
+  describe('initialPageParam', () => {
+    it('returns default limit and projectPath when projectPath is provided', () => {
+      expect(initialPageParam('/foo')).to.deep.equal({limit: DEFAULT_PAGE_LIMIT, projectPath: '/foo'})
+    })
 
-  it('emits task:list with the request payload', async () => {
-    request.resolves({tasks: []})
-    await getTasks({limit: 50, projectPath: '/foo'})
-    expect(request.firstCall.args[0]).to.equal(TaskEvents.LIST)
-    expect(request.firstCall.args[1]).to.deep.equal({limit: 50, projectPath: '/foo'})
-  })
-
-  it('forwards before + beforeTaskId for paginated requests', async () => {
-    request.resolves({tasks: []})
-    await getTasks({before: 1234, beforeTaskId: 'tsk-x', limit: 50, projectPath: '/foo'})
-    expect(request.firstCall.args[1]).to.deep.equal({
-      before: 1234,
-      beforeTaskId: 'tsk-x',
-      limit: 50,
-      projectPath: '/foo',
+    it('omits projectPath when not provided', () => {
+      expect(initialPageParam()).to.deep.equal({limit: DEFAULT_PAGE_LIMIT})
     })
   })
 
-  it('throws when not connected to the daemon', async () => {
-    useTransportStore.setState({apiClient: null})
-    try {
-      await getTasks({limit: 50})
-      expect.fail('expected to throw')
-    } catch (error) {
-      expect((error as Error).message).to.equal('Not connected')
-    }
-  })
-})
+  describe('getNextPageParam', () => {
+    const lastParam = {limit: 50, projectPath: '/foo'}
 
-describe('initialPageParam', () => {
-  it('returns default limit and projectPath when projectPath is provided', () => {
-    expect(initialPageParam('/foo')).to.deep.equal({limit: DEFAULT_PAGE_LIMIT, projectPath: '/foo'})
-  })
+    it('returns undefined when lastPage has no nextCursor (last page reached)', () => {
+      const lastPage: TaskListResponse = {tasks: []}
+      expect(getNextPageParam(lastPage, lastParam)).to.equal(undefined)
+    })
 
-  it('omits projectPath when not provided', () => {
-    expect(initialPageParam()).to.deep.equal({limit: DEFAULT_PAGE_LIMIT})
-  })
-})
+    it('returns next-page params when nextCursor is set', () => {
+      const lastPage: TaskListResponse = {nextCursor: 1234, tasks: []}
+      expect(getNextPageParam(lastPage, lastParam)).to.deep.equal({
+        before: 1234,
+        limit: 50,
+        projectPath: '/foo',
+      })
+    })
 
-describe('getNextPageParam', () => {
-  const lastParam = {limit: 50, projectPath: '/foo'}
-
-  it('returns undefined when lastPage has no nextCursor (last page reached)', () => {
-    const lastPage: TaskListResponse = {tasks: []}
-    expect(getNextPageParam(lastPage, lastParam)).to.equal(undefined)
-  })
-
-  it('returns next-page params when nextCursor is set', () => {
-    const lastPage: TaskListResponse = {nextCursor: 1234, tasks: []}
-    expect(getNextPageParam(lastPage, lastParam)).to.deep.equal({
-      before: 1234,
-      limit: 50,
-      projectPath: '/foo',
+    it('forwards nextCursorTaskId as beforeTaskId tiebreaker', () => {
+      const lastPage: TaskListResponse = {nextCursor: 1234, nextCursorTaskId: 'tsk-x', tasks: []}
+      expect(getNextPageParam(lastPage, lastParam)).to.deep.equal({
+        before: 1234,
+        beforeTaskId: 'tsk-x',
+        limit: 50,
+        projectPath: '/foo',
+      })
     })
   })
-
-  it('forwards nextCursorTaskId as beforeTaskId tiebreaker', () => {
-    const lastPage: TaskListResponse = {nextCursor: 1234, nextCursorTaskId: 'tsk-x', tasks: []}
-    expect(getNextPageParam(lastPage, lastParam)).to.deep.equal({
-      before: 1234,
-      beforeTaskId: 'tsk-x',
-      limit: 50,
-      projectPath: '/foo',
-    })
-  })
-})
 })

--- a/test/unit/webui/features/tasks/api/get-tasks.test.ts
+++ b/test/unit/webui/features/tasks/api/get-tasks.test.ts
@@ -1,0 +1,99 @@
+import {expect} from 'chai'
+import {createSandbox, type SinonSandbox, type SinonStub} from 'sinon'
+
+import type {BrvApiClient} from '../../../../../../src/webui/lib/api-client.js'
+
+import {TaskEvents, type TaskListResponse} from '../../../../../../src/shared/transport/events/task-events.js'
+import {
+  DEFAULT_PAGE_LIMIT,
+  getNextPageParam,
+  getTasks,
+  initialPageParam,
+} from '../../../../../../src/webui/features/tasks/api/get-tasks.js'
+import {useTransportStore} from '../../../../../../src/webui/stores/transport-store.js'
+
+describe('get-tasks api', () => {
+describe('getTasks', () => {
+  let sandbox: SinonSandbox
+  let request: SinonStub
+
+  beforeEach(() => {
+    sandbox = createSandbox()
+    request = sandbox.stub()
+    useTransportStore.setState({
+      apiClient: {on: sandbox.stub(), request} as unknown as BrvApiClient,
+    })
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+    useTransportStore.setState({apiClient: null})
+  })
+
+  it('emits task:list with the request payload', async () => {
+    request.resolves({tasks: []})
+    await getTasks({limit: 50, projectPath: '/foo'})
+    expect(request.firstCall.args[0]).to.equal(TaskEvents.LIST)
+    expect(request.firstCall.args[1]).to.deep.equal({limit: 50, projectPath: '/foo'})
+  })
+
+  it('forwards before + beforeTaskId for paginated requests', async () => {
+    request.resolves({tasks: []})
+    await getTasks({before: 1234, beforeTaskId: 'tsk-x', limit: 50, projectPath: '/foo'})
+    expect(request.firstCall.args[1]).to.deep.equal({
+      before: 1234,
+      beforeTaskId: 'tsk-x',
+      limit: 50,
+      projectPath: '/foo',
+    })
+  })
+
+  it('throws when not connected to the daemon', async () => {
+    useTransportStore.setState({apiClient: null})
+    try {
+      await getTasks({limit: 50})
+      expect.fail('expected to throw')
+    } catch (error) {
+      expect((error as Error).message).to.equal('Not connected')
+    }
+  })
+})
+
+describe('initialPageParam', () => {
+  it('returns default limit and projectPath when projectPath is provided', () => {
+    expect(initialPageParam('/foo')).to.deep.equal({limit: DEFAULT_PAGE_LIMIT, projectPath: '/foo'})
+  })
+
+  it('omits projectPath when not provided', () => {
+    expect(initialPageParam()).to.deep.equal({limit: DEFAULT_PAGE_LIMIT})
+  })
+})
+
+describe('getNextPageParam', () => {
+  const lastParam = {limit: 50, projectPath: '/foo'}
+
+  it('returns undefined when lastPage has no nextCursor (last page reached)', () => {
+    const lastPage: TaskListResponse = {tasks: []}
+    expect(getNextPageParam(lastPage, lastParam)).to.equal(undefined)
+  })
+
+  it('returns next-page params when nextCursor is set', () => {
+    const lastPage: TaskListResponse = {nextCursor: 1234, tasks: []}
+    expect(getNextPageParam(lastPage, lastParam)).to.deep.equal({
+      before: 1234,
+      limit: 50,
+      projectPath: '/foo',
+    })
+  })
+
+  it('forwards nextCursorTaskId as beforeTaskId tiebreaker', () => {
+    const lastPage: TaskListResponse = {nextCursor: 1234, nextCursorTaskId: 'tsk-x', tasks: []}
+    expect(getNextPageParam(lastPage, lastParam)).to.deep.equal({
+      before: 1234,
+      beforeTaskId: 'tsk-x',
+      limit: 50,
+      projectPath: '/foo',
+    })
+  })
+})
+})


### PR DESCRIPTION
## Summary

- `useGetTasks` migrated from `useQuery` (single-shot) to `useInfiniteQuery`. Server-driven cursor (`nextCursor` + `nextCursorTaskId` tiebreaker); 50 entries per page.
- Both `useGetTasks` consumers (`task-list-view.tsx`, `task-subscription-initializer.tsx`) updated together — `data.pages.flatMap(...)` feeds `useTaskStore.mergeTasks`.
- "Load more" rendered as a full-width clickable table row at the bottom of the list, keeping the table grid uniform. Hides automatically when `hasNextPage` is false.

## Test plan

- [ ] Project with >50 tasks: list shows 50 rows; "Load more" row visible at bottom of table.
- [ ] Click anywhere on the Load more row — next 50 fetched; second `task:list` WS frame includes `before: <oldest createdAt>` (and `beforeTaskId` when supplied).
- [ ] Continue clicking until the last page — Load more row hides.
- [ ] Project with ≤50 tasks: no Load more row.
- [ ] Switch projects — list resets and refetches first page (`useInfiniteQuery` keys on projectPath).
- [ ] `npm run typecheck && npm run lint` clean.
- [ ] `npx mocha --forbid-only \"test/unit/webui/features/tasks/api/get-tasks.test.ts\"` — 8 passing.