### PR TITLE
feat: [ENG-2503] dim styling + tooltip for daemon-interrupted task entries

### DIFF
--- a/src/webui/features/tasks/components/task-list-table.tsx
+++ b/src/webui/features/tasks/components/task-list-table.tsx
@@ -8,6 +8,7 @@ import {
   TableHeader,
   TableRow,
 } from '@campfirein/byterover-packages/components/table'
+import {Tooltip, TooltipContent, TooltipTrigger} from '@campfirein/byterover-packages/components/tooltip'
 import {cn} from '@campfirein/byterover-packages/lib/utils'
 import {Trash2} from 'lucide-react'
 
@@ -128,12 +129,12 @@ function TaskRow({
   const isRunning = !terminal
   const interrupted = isInterrupted(task)
   const activity = getCurrentActivity(task)
-  return (
+
+  const row = (
     <TableRow
       className={cn('cursor-pointer [&>td]:align-middle', {'opacity-60': interrupted})}
       data-state={isSelected ? 'selected' : undefined}
       onClick={() => onRowClick(task.taskId)}
-      title={interrupted ? 'Daemon was restarted while this task was running. The task did not complete.' : undefined}
     >
       <TableCell className="relative" onClick={(event) => event.stopPropagation()}>
         {isRunning && (
@@ -183,6 +184,15 @@ function TaskRow({
         {terminal && <RowAction onClick={() => onDelete(task.taskId)} />}
       </TableCell>
     </TableRow>
+  )
+
+  if (!interrupted) return row
+
+  return (
+    <Tooltip>
+      <TooltipTrigger render={row} />
+      <TooltipContent>Daemon was restarted while this task was running. The task did not complete.</TooltipContent>
+    </Tooltip>
   )
 }
 

--- a/src/webui/features/tasks/components/task-list-table.tsx
+++ b/src/webui/features/tasks/components/task-list-table.tsx
@@ -16,6 +16,7 @@ import type {StoredTask} from '../types/stored-task'
 
 import {getCurrentActivity} from '../utils/current-activity'
 import {formatDuration, formatRelative, formatTimeOfDay, shortTaskId} from '../utils/format-time'
+import {isInterrupted} from '../utils/is-interrupted'
 import {displayTaskType, isTerminalStatus} from '../utils/task-status'
 import {StatusPill} from './status-pill'
 import {NoMatchState} from './task-list-empty'
@@ -125,12 +126,14 @@ function TaskRow({
 }) {
   const terminal = isTerminalStatus(task.status)
   const isRunning = !terminal
+  const interrupted = isInterrupted(task)
   const activity = getCurrentActivity(task)
   return (
     <TableRow
-      className="cursor-pointer [&>td]:align-middle"
+      className={cn('cursor-pointer [&>td]:align-middle', {'opacity-60': interrupted})}
       data-state={isSelected ? 'selected' : undefined}
       onClick={() => onRowClick(task.taskId)}
+      title={interrupted ? 'Daemon was restarted while this task was running. The task did not complete.' : undefined}
     >
       <TableCell className="relative" onClick={(event) => event.stopPropagation()}>
         {isRunning && (

--- a/src/webui/features/tasks/utils/is-interrupted.ts
+++ b/src/webui/features/tasks/utils/is-interrupted.ts
@@ -1,3 +1,5 @@
+import type {TaskListItemStatus} from '../../../../shared/transport/events/task-events'
+
 type TaskError = {
   code?: string
   message: string
@@ -6,20 +8,12 @@ type TaskError = {
 
 type Input = {
   error?: TaskError
-  status: string
+  status: TaskListItemStatus
 }
 
 const INTERRUPTED_CODE = 'INTERRUPTED'
 const INTERRUPTED_MESSAGE = 'Interrupted (daemon terminated)'
 
-/**
- * Returns true when an `error`-status task represents a daemon-termination interrupt
- * rather than a genuine failure.
- *
- * Belt-and-suspenders: matches on both the canonical `error.code` and the legacy
- * `error.message` text, so entries written before the code field landed are still
- * recognised. Non-error statuses and entries without an error are never interrupted.
- */
 export function isInterrupted(task: Input): boolean {
   if (task.status !== 'error') return false
   if (!task.error) return false

--- a/src/webui/features/tasks/utils/is-interrupted.ts
+++ b/src/webui/features/tasks/utils/is-interrupted.ts
@@ -1,0 +1,29 @@
+type TaskError = {
+  code?: string
+  message: string
+  name?: string
+}
+
+type Input = {
+  error?: TaskError
+  status: string
+}
+
+const INTERRUPTED_CODE = 'INTERRUPTED'
+const INTERRUPTED_MESSAGE = 'Interrupted (daemon terminated)'
+
+/**
+ * Returns true when an `error`-status task represents a daemon-termination interrupt
+ * rather than a genuine failure.
+ *
+ * Belt-and-suspenders: matches on both the canonical `error.code` and the legacy
+ * `error.message` text, so entries written before the code field landed are still
+ * recognised. Non-error statuses and entries without an error are never interrupted.
+ */
+export function isInterrupted(task: Input): boolean {
+  if (task.status !== 'error') return false
+  if (!task.error) return false
+  if (task.error.code === INTERRUPTED_CODE) return true
+  if (task.error.message === INTERRUPTED_MESSAGE) return true
+  return false
+}

--- a/test/unit/webui/features/tasks/utils/is-interrupted.test.ts
+++ b/test/unit/webui/features/tasks/utils/is-interrupted.test.ts
@@ -40,4 +40,13 @@ describe('isInterrupted', () => {
   it('returns false when error is undefined', () => {
     expect(isInterrupted({status: 'error'})).to.equal(false)
   })
+
+  it('status guard fires before error inspection (completed status with INTERRUPTED code → false)', () => {
+    expect(
+      isInterrupted({
+        error: {code: 'INTERRUPTED', message: 'Interrupted (daemon terminated)', name: 'TaskError'},
+        status: 'completed',
+      }),
+    ).to.equal(false)
+  })
 })

--- a/test/unit/webui/features/tasks/utils/is-interrupted.test.ts
+++ b/test/unit/webui/features/tasks/utils/is-interrupted.test.ts
@@ -1,0 +1,43 @@
+import {expect} from 'chai'
+
+import {isInterrupted} from '../../../../../../src/webui/features/tasks/utils/is-interrupted.js'
+
+describe('isInterrupted', () => {
+  it('returns true when error.code === INTERRUPTED', () => {
+    expect(
+      isInterrupted({
+        error: {code: 'INTERRUPTED', message: 'Interrupted (daemon terminated)', name: 'TaskError'},
+        status: 'error',
+      }),
+    ).to.equal(true)
+  })
+
+  it('returns true when error.message matches the canonical interruption phrase', () => {
+    expect(
+      isInterrupted({
+        error: {message: 'Interrupted (daemon terminated)', name: 'TaskError'},
+        status: 'error',
+      }),
+    ).to.equal(true)
+  })
+
+  it('returns false for a genuine error with unrelated code/message', () => {
+    expect(
+      isInterrupted({
+        error: {code: 'ERR_TOOL_FAILED', message: 'Tool failed', name: 'TaskError'},
+        status: 'error',
+      }),
+    ).to.equal(false)
+  })
+
+  it('returns false for non-error statuses', () => {
+    expect(isInterrupted({status: 'completed'})).to.equal(false)
+    expect(isInterrupted({status: 'cancelled'})).to.equal(false)
+    expect(isInterrupted({status: 'started'})).to.equal(false)
+    expect(isInterrupted({status: 'created'})).to.equal(false)
+  })
+
+  it('returns false when error is undefined', () => {
+    expect(isInterrupted({status: 'error'})).to.equal(false)
+  })
+})


### PR DESCRIPTION
## Summary

- New pure `isInterrupted(task)` util: returns true when `error.code === 'INTERRUPTED'` OR `error.message === 'Interrupted (daemon terminated)'` and the task is in `error` status. Belt-and-suspenders covers both canonical and legacy entries.
- `task-list-table.tsx` rows for interrupted tasks render at 60% opacity with a hover tooltip ("Daemon was restarted while this task was running. The task did not complete.").
- Status pill stays as the existing red ERROR pill — distinction is row-level only, no new UI primitive (per ticket scope).

## Test plan

- [ ] Lower `TASK_HISTORY_STALE_THRESHOLD_MS` to ~5000 in `src/server/constants.ts` (revert before merging the project).
- [ ] `npm run dev` — daemon picks up the new threshold.
- [ ] Trigger a task; once it transitions to `started`, kill the daemon process; wait 6+ seconds; restart daemon.
- [ ] Open WebUI list — the interrupted row appears at 60% opacity.
- [ ] Hover the row — tooltip text appears.
- [ ] Click the dim row — detail panel still opens with the partial trace + INTERRUPTED error section (interaction not gated).
- [ ] Genuine error rows (real tool failures, etc.) render normally — no dim, no tooltip.
- [ ] `npm run typecheck && npm run lint` clean.
- [ ] `npx mocha --forbid-only \"test/unit/webui/features/tasks/utils/is-interrupted.test.ts\"` — 5 passing.