### PR TITLE
feat: [ENG-2519] enable prefix caching for providers

### DIFF
--- a/src/agent/infra/agent/service-initializer.ts
+++ b/src/agent/infra/agent/service-initializer.ts
@@ -193,12 +193,18 @@ export async function createCipherAgentServices(
     basePath: promptsBasePath,
     validateConfig: true,
   })
-  // Register default contributors
+  // Register default contributors.
+  //
+  // Note: dateTime is intentionally NOT in the system prompt. Anthropic
+  // prompt caching does token-level prefix matching, so a per-iteration
+  // refreshed timestamp here would invalidate the cache for everything
+  // past it. dateTime is instead injected into the first user message
+  // by AgentLLMService, where it lives after the cache breakpoints and
+  // does not poison the cached prefix.
   systemPromptManager.registerContributors([
     {enabled: true, filepath: 'system-prompt.yml', id: 'base', priority: 0, type: 'file'},
     {enabled: true, id: 'env', priority: 10, type: 'environment'},
     {enabled: true, id: 'memories', priority: 20, type: 'memory'},
-    {enabled: true, id: 'datetime', priority: 30, type: 'dateTime'},
   ])
 
   // Register context tree structure contributor for query/curate commands

--- a/src/agent/infra/llm/agent-llm-service.ts
+++ b/src/agent/infra/llm/agent-llm-service.ts
@@ -902,8 +902,11 @@ export class AgentLLMService implements ILLMService {
       this.cachedBasePrompt = basePrompt
       this.memoryDirtyFlag = false
     } else {
-      // Cache hit: reuse base prompt, only refresh the DateTime section
-      basePrompt = this.refreshDateTime(this.cachedBasePrompt!)
+      // Cache hit: reuse base prompt verbatim. The cached prompt has no
+      // dateTime section to refresh — dateTime is injected into the
+      // first user message instead so the system prefix stays byte-stable
+      // across iterations and prompt caching can engage cleanly.
+      basePrompt = this.cachedBasePrompt!
     }
 
     let systemPrompt = basePrompt
@@ -944,9 +947,13 @@ export class AgentLLMService implements ILLMService {
 
     // Add user message and compress context within mutex lock
     return this.mutex.withLock(async () => {
-      // Add user message to context only on the first iteration
+      // Add user message to context only on the first iteration. The
+      // dateTime block is prefixed here (not in the system prompt) so
+      // the cached system prefix stays byte-stable across iterations
+      // and Anthropic/OpenAI/Google prefix caches can engage cleanly.
       if (iterationCount === 0) {
-        await this.contextManager.addUserMessage(textInput, imageData, fileData)
+        const inputWithDateTime = `<dateTime>Current date and time: ${new Date().toISOString()}</dateTime>\n\n${textInput}`
+        await this.contextManager.addUserMessage(inputWithDateTime, imageData, fileData)
       }
 
       // Rolling checkpoint: periodically save progress and clear history for RLM commands.
@@ -1553,19 +1560,6 @@ export class AgentLLMService implements ILLMService {
     this.sessionEventBus.emit('llmservice:warning', {
       message: `Rolling checkpoint at iteration ${iterationCount}: history cleared, progress saved to ${checkpointVar}`,
     })
-  }
-
-  /**
-   * Replace the DateTime section in a cached system prompt with a fresh timestamp.
-   * DateTimeContributor wraps its output in <dateTime>...</dateTime> XML tags,
-   * enabling reliable regex replacement without rebuilding the entire prompt.
-   *
-   * @param cachedPrompt - Previously cached system prompt
-   * @returns Updated prompt with fresh DateTime
-   */
-  private refreshDateTime(cachedPrompt: string): string {
-    const freshDateTime = `<dateTime>Current date and time: ${new Date().toISOString()}</dateTime>`
-    return cachedPrompt.replace(/<dateTime>[\S\s]*?<\/dateTime>/, freshDateTime)
   }
 
   /**

--- a/src/agent/infra/llm/agent-llm-service.ts
+++ b/src/agent/infra/llm/agent-llm-service.ts
@@ -61,6 +61,18 @@ import {type ProcessedOutput, ToolOutputProcessor, type TruncationConfig} from '
 const TARGET_MESSAGE_TOKEN_UTILIZATION = 0.7
 
 /**
+ * Build a `<dateTime>...</dateTime>\n\n` prefix for a user-message body.
+ *
+ * Per-call timestamps must NOT enter the system prompt (they would poison
+ * the prefix cache). They are injected into the user message instead, at
+ * the boundaries where the model legitimately needs fresh time context:
+ * the iter-0 input, and after a rolling-checkpoint history clear.
+ */
+export function buildDateTimePrefix(now: Date = new Date()): string {
+  return `<dateTime>Current date and time: ${now.toISOString()}</dateTime>\n\n`
+}
+
+/**
  * Result of parallel tool execution (before adding to context).
  * Contains all information needed to add the result to context in order.
  */
@@ -952,7 +964,7 @@ export class AgentLLMService implements ILLMService {
       // the cached system prefix stays byte-stable across iterations
       // and Anthropic/OpenAI/Google prefix caches can engage cleanly.
       if (iterationCount === 0) {
-        const inputWithDateTime = `<dateTime>Current date and time: ${new Date().toISOString()}</dateTime>\n\n${textInput}`
+        const inputWithDateTime = `${buildDateTimePrefix()}${textInput}`
         await this.contextManager.addUserMessage(inputWithDateTime, imageData, fileData)
       }
 
@@ -1547,8 +1559,12 @@ export class AgentLLMService implements ILLMService {
     // Clear conversation history
     await this.contextManager.clearHistory()
 
-    // Re-inject continuation prompt with variable reference
-    const continuationPrompt = [
+    // Re-inject continuation prompt with variable reference.
+    // Prepend the dateTime block: clearHistory wiped the iter-0 user
+    // message that originally carried it, and the iter-0 guard upstream
+    // prevents re-injection. Without this, every iteration after the
+    // first checkpoint loses time context for the rest of the run.
+    const continuationPrompt = buildDateTimePrefix() + [
       `Continue task. Iteration checkpoint at turn ${iterationCount}.`,
       `Previous progress stored in variable: ${checkpointVar}`,
       `Original task: ${textInput.slice(0, 200)}${textInput.length > 200 ? '...' : ''}`,

--- a/src/agent/infra/llm/generators/ai-sdk-content-generator.ts
+++ b/src/agent/infra/llm/generators/ai-sdk-content-generator.ts
@@ -5,7 +5,7 @@
  * Replaces per-provider content generators with one unified implementation.
  */
 
-import type {LanguageModel} from 'ai'
+import type {LanguageModel, ModelMessage} from 'ai'
 
 import {generateText, streamText} from 'ai'
 
@@ -21,6 +21,28 @@ import {StreamChunkType} from '../../../core/interfaces/i-content-generator.js'
 import {toAiSdkTools, toModelMessages} from './ai-sdk-message-converter.js'
 
 const DEFAULT_CHARS_PER_TOKEN = 4
+
+/**
+ * Prepend the system prompt as a system-role message carrying
+ * `providerOptions.anthropic.cacheControl: ephemeral`. AI SDK's top-level
+ * `system: string` parameter does not propagate providerOptions, so the
+ * only way to attach Anthropic cache_control to the system block is to
+ * pass it through the messages array. Non-Anthropic providers ignore the
+ * `anthropic` namespace.
+ */
+export function prependCachedSystemMessage(systemPrompt: string | undefined, messages: ModelMessage[]): ModelMessage[] {
+  if (!systemPrompt) {
+    return messages
+  }
+
+  const systemMessage: ModelMessage = {
+    content: systemPrompt,
+    providerOptions: {anthropic: {cacheControl: {type: 'ephemeral'}}},
+    role: 'system',
+  }
+
+  return [systemMessage, ...messages]
+}
 
 /**
  * Configuration for AiSdkContentGenerator.
@@ -54,7 +76,7 @@ export class AiSdkContentGenerator implements IContentGenerator {
   }
 
   public async generateContent(request: GenerateContentRequest): Promise<GenerateContentResponse> {
-    const messages = toModelMessages(request.contents)
+    const messages = prependCachedSystemMessage(request.systemPrompt, toModelMessages(request.contents))
     const tools = toAiSdkTools(request.tools)
 
     const result = await generateText({
@@ -63,7 +85,6 @@ export class AiSdkContentGenerator implements IContentGenerator {
       messages,
       model: this.model,
       temperature: request.config.temperature,
-      ...(request.systemPrompt && {system: request.systemPrompt}),
       ...(tools && {tools}),
       ...(request.config.topK !== undefined && {topK: request.config.topK}),
       ...(request.config.topP !== undefined && {topP: request.config.topP}),
@@ -100,7 +121,7 @@ export class AiSdkContentGenerator implements IContentGenerator {
   }
 
   public async *generateContentStream(request: GenerateContentRequest): AsyncGenerator<GenerateContentChunk> {
-    const messages = toModelMessages(request.contents)
+    const messages = prependCachedSystemMessage(request.systemPrompt, toModelMessages(request.contents))
     const tools = toAiSdkTools(request.tools)
 
     const result = streamText({
@@ -109,7 +130,6 @@ export class AiSdkContentGenerator implements IContentGenerator {
       messages,
       model: this.model,
       temperature: request.config.temperature,
-      ...(request.systemPrompt && {system: request.systemPrompt}),
       ...(tools && {tools}),
       ...(request.config.topK !== undefined && {topK: request.config.topK}),
       ...(request.config.topP !== undefined && {topP: request.config.topP}),

--- a/src/agent/infra/llm/generators/ai-sdk-message-converter.ts
+++ b/src/agent/infra/llm/generators/ai-sdk-message-converter.ts
@@ -63,18 +63,25 @@ export function toModelMessages(messages: InternalMessage[]): ModelMessage[] {
 /**
  * Convert our ToolSet to AI SDK tool definitions.
  * Tools are declared without `execute` — our agentic loop handles execution.
+ *
+ * The last tool gets `providerOptions.anthropic.cacheControl: ephemeral`,
+ * which makes Anthropic cache the entire tool block (and the system prompt
+ * before it). Non-Anthropic providers ignore the `anthropic` namespace.
  */
 export function toAiSdkTools(tools?: InternalToolSet): Record<string, ReturnType<typeof aiSdkTool>> | undefined {
   if (!tools || Object.keys(tools).length === 0) {
     return undefined
   }
 
+  const entries = Object.entries(tools)
   const result: Record<string, ReturnType<typeof aiSdkTool>> = {}
 
-  for (const [name, def] of Object.entries(tools)) {
+  for (const [index, [name, def]] of entries.entries()) {
+    const isLast = index === entries.length - 1
     result[name] = aiSdkTool({
       description: def.description ?? '',
       inputSchema: jsonSchema(def.parameters as Record<string, unknown>),
+      ...(isLast && {providerOptions: {anthropic: {cacheControl: {type: 'ephemeral'}}}}),
     })
   }
 

--- a/src/agent/infra/system-prompt/contributors/file-contributor.ts
+++ b/src/agent/infra/system-prompt/contributors/file-contributor.ts
@@ -150,12 +150,16 @@ export class FileContributor implements SystemPromptContributor {
   private renderTemplateVariables(template: string, context: ContributorContext): string {
     let result = template
 
-    // Build variables from context
+    // Build variables from context.
+    // Note: a `datetime` template variable is intentionally NOT exposed here.
+    // Per-call timestamps must never enter the system prompt — they would
+    // poison the prefix cache from that byte onward. The current date/time
+    // is injected once into the iter-0 user message instead (see
+    // agent-llm-service.ts).
     /* eslint-disable camelcase */
     const variables: Record<string, string> = {
       available_markers: context.availableMarkers ? Object.keys(context.availableMarkers).join(', ') : '',
       available_tools: context.availableTools?.join(', ') ?? '',
-      datetime: `<dateTime>Current date and time: ${new Date().toISOString()}</dateTime>`,
     }
     /* eslint-enable camelcase */
 

--- a/test/unit/agent/llm/agent-llm-service.test.ts
+++ b/test/unit/agent/llm/agent-llm-service.test.ts
@@ -1,0 +1,32 @@
+import {expect} from 'chai'
+
+import {buildDateTimePrefix} from '../../../../src/agent/infra/llm/agent-llm-service.js'
+
+describe('buildDateTimePrefix', () => {
+  it('renders the supplied date as an ISO-8601 dateTime block followed by a blank line', () => {
+    const fixed = new Date('2026-05-01T10:30:00.000Z')
+    const result = buildDateTimePrefix(fixed)
+
+    expect(result).to.equal('<dateTime>Current date and time: 2026-05-01T10:30:00.000Z</dateTime>\n\n')
+  })
+
+  it('uses the current time when no date is supplied', () => {
+    const before = Date.now()
+    const result = buildDateTimePrefix()
+    const after = Date.now()
+
+    const match = /<dateTime>Current date and time: (\S+)<\/dateTime>\n\n$/.exec(result)
+    expect(match).to.not.equal(null)
+
+    const rendered = match === null ? 0 : Date.parse(match[1])
+    expect(rendered).to.be.at.least(before)
+    expect(rendered).to.be.at.most(after)
+  })
+
+  it('terminates with a double-newline so the prefix can be concatenated directly to a text body', () => {
+    const result = buildDateTimePrefix(new Date('2026-01-01T00:00:00.000Z'))
+    const composed = `${result}body`
+
+    expect(composed).to.equal('<dateTime>Current date and time: 2026-01-01T00:00:00.000Z</dateTime>\n\nbody')
+  })
+})

--- a/test/unit/agent/llm/generators/ai-sdk-content-generator.test.ts
+++ b/test/unit/agent/llm/generators/ai-sdk-content-generator.test.ts
@@ -1,0 +1,41 @@
+import type {ModelMessage} from 'ai'
+
+import {expect} from 'chai'
+
+import {prependCachedSystemMessage} from '../../../../../src/agent/infra/llm/generators/ai-sdk-content-generator.js'
+
+describe('prependCachedSystemMessage', () => {
+  const userMsg: ModelMessage = {content: 'hi', role: 'user'}
+
+  it('returns the input messages unchanged when systemPrompt is undefined', () => {
+    const result = prependCachedSystemMessage(undefined, [userMsg])
+    expect(result).to.deep.equal([userMsg])
+  })
+
+  it('returns the input messages unchanged when systemPrompt is the empty string', () => {
+    const result = prependCachedSystemMessage('', [userMsg])
+    expect(result).to.deep.equal([userMsg])
+  })
+
+  it('prepends a system-role message with cacheControl providerOptions when systemPrompt is non-empty', () => {
+    const result = prependCachedSystemMessage('You are a helpful assistant.', [userMsg])
+
+    expect(result).to.have.length(2)
+
+    const [system, user] = result
+    expect(system.role).to.equal('system')
+    expect(system.content).to.equal('You are a helpful assistant.')
+    expect(system.providerOptions).to.deep.equal({
+      anthropic: {cacheControl: {type: 'ephemeral'}},
+    })
+    expect(user).to.deep.equal(userMsg)
+  })
+
+  it('does not mutate the original messages array', () => {
+    const original: ModelMessage[] = [userMsg]
+    const result = prependCachedSystemMessage('sys', original)
+
+    expect(original).to.have.length(1)
+    expect(result).to.not.equal(original)
+  })
+})

--- a/test/unit/agent/llm/generators/ai-sdk-message-converter.test.ts
+++ b/test/unit/agent/llm/generators/ai-sdk-message-converter.test.ts
@@ -40,9 +40,14 @@ describe('toAiSdkTools — anthropic cache_control on last tool', () => {
     const result = toAiSdkTools(tools)
     expect(result).to.exist
 
-    // Object literal key order is alphabetical here (lint sort-objects), so
-    // entry iteration is firstTool → lastTool → middleTool. The "last"
-    // iterated entry is middleTool, which is what should carry cacheControl.
+    // The cache_control marker is attached to the LAST entry by insertion
+    // order, NOT by name. In production, tool registration is deterministic
+    // (driven by getToolNamesForCommand), so the "last" entry is stable.
+    // In this test, the object literal is alphabetically sorted by the
+    // sort-objects lint rule, so iteration order is
+    // firstTool → lastTool → middleTool — and middleTool ends up last,
+    // which is what should carry cacheControl. This test pins the
+    // insertion-order contract, not an alphabetical or name-based one.
     expect(getProviderOptions(result?.firstTool)).to.equal(undefined)
     expect(getProviderOptions(result?.lastTool)).to.equal(undefined)
     expect(getProviderOptions(result?.middleTool)).to.deep.equal(EPHEMERAL_CACHE_CONTROL)

--- a/test/unit/agent/llm/generators/ai-sdk-message-converter.test.ts
+++ b/test/unit/agent/llm/generators/ai-sdk-message-converter.test.ts
@@ -1,0 +1,50 @@
+import {expect} from 'chai'
+
+import type {ToolSet as InternalToolSet} from '../../../../../src/agent/core/domain/tools/types.js'
+
+import {toAiSdkTools} from '../../../../../src/agent/infra/llm/generators/ai-sdk-message-converter.js'
+
+function makeTool(description: string): InternalToolSet[string] {
+  return {
+    description,
+    parameters: {properties: {}, type: 'object'},
+  }
+}
+
+function getProviderOptions(tool: unknown): Record<string, unknown> | undefined {
+  if (!tool || typeof tool !== 'object') return undefined
+  return (tool as {providerOptions?: Record<string, unknown>}).providerOptions
+}
+
+const EPHEMERAL_CACHE_CONTROL = {anthropic: {cacheControl: {type: 'ephemeral'}}}
+
+describe('toAiSdkTools — anthropic cache_control on last tool', () => {
+  it('returns undefined when tools is undefined or empty', () => {
+    expect(toAiSdkTools()).to.equal(undefined)
+    expect(toAiSdkTools({})).to.equal(undefined)
+  })
+
+  it('attaches cache_control to the single tool when only one is registered', () => {
+    const tools: InternalToolSet = {onlyTool: makeTool('the only one')}
+    const result = toAiSdkTools(tools)
+    expect(result).to.exist
+    expect(getProviderOptions(result?.onlyTool)).to.deep.equal(EPHEMERAL_CACHE_CONTROL)
+  })
+
+  it('attaches cache_control to the LAST tool only when multiple are registered', () => {
+    const tools: InternalToolSet = {
+      firstTool: makeTool('first'),
+      lastTool: makeTool('last'),
+      middleTool: makeTool('middle'),
+    }
+    const result = toAiSdkTools(tools)
+    expect(result).to.exist
+
+    // Object literal key order is alphabetical here (lint sort-objects), so
+    // entry iteration is firstTool → lastTool → middleTool. The "last"
+    // iterated entry is middleTool, which is what should carry cacheControl.
+    expect(getProviderOptions(result?.firstTool)).to.equal(undefined)
+    expect(getProviderOptions(result?.lastTool)).to.equal(undefined)
+    expect(getProviderOptions(result?.middleTool)).to.deep.equal(EPHEMERAL_CACHE_CONTROL)
+  })
+})

--- a/test/unit/infra/llm/internal-llm-service.test.ts
+++ b/test/unit/infra/llm/internal-llm-service.test.ts
@@ -788,8 +788,13 @@ describe('AgentLLMService', () => {
 
       await service.completeTask('Analyze this image', {imageData})
 
-      // Verify imageData was passed to addUserMessage
-      expect(addUserMessageStub.calledWith('Analyze this image', imageData)).to.be.true
+      // Verify imageData was passed to addUserMessage. The first argument now
+      // includes a `<dateTime>` prefix injected at iteration 0 to keep the
+      // system prefix byte-stable for prompt caching, so we match by suffix.
+      expect(addUserMessageStub.calledOnce).to.be.true
+      const [firstArg, secondArg] = addUserMessageStub.firstCall.args as [string, typeof imageData]
+      expect(firstArg).to.match(/<dateTime>.*<\/dateTime>\n\nAnalyze this image$/s)
+      expect(secondArg).to.equal(imageData)
     })
   })
 })


### PR DESCRIPTION
## Summary

- **Problem:** Anthropic emits 0 cache reads on curate workloads — `cache_control` markers were never set on the system / tool prefix. OpenAI and Google auto-caches were also under-engaged because `<dateTime>` in the system prompt rotated every iteration and poisoned the cached prefix from byte ~1,800 onward.
- **Why it matters:** Per the team's exp 03 doc, fixing both problems together delivers ~28% normalized cost reduction on Anthropic, ~12% on Google, ~7% on OpenAI. Re-validated on `proj/curation-enhancement` (see `notes/token-usage-reduction/eng-2519-prefix-caching/REPORT.md`): **−21.5% Anthropic 12-fixture, −29.7% Anthropic 30-curate progression, −8% OpenAI**, ~flat on gemini-3-flash-preview.
- **What changed:** Two coupled behavior changes that must ship together — `cache_control: ephemeral` on system + last tool, and `<dateTime>` relocation from the system prompt to an iter-0 user-message prefix.
- **What did NOT change (scope boundary):** Telemetry/UsageLogger plumbing, response.usage cache-field extraction, Anthropic daemon-stability mitigations, max-iterations review — all deferred to follow-ups.

## Type of change

- [x] New feature

## Scope (select all touched areas)

- [x] Agent / Tools
- [x] LLM Providers

## Linked issues

- Closes ENG-2519

## Root cause (bug fixes only, otherwise write `N/A`)

N/A

## Test plan

- Coverage added:
  - [x] Unit test
- Test file(s):
  - `test/unit/agent/llm/generators/ai-sdk-message-converter.test.ts` (new) — 3 tests covering `toAiSdkTools` cache_control attachment on the last tool only, across tool-set sizes 0, 1, and 3.
  - `test/unit/agent/llm/generators/ai-sdk-content-generator.test.ts` (new) — 4 tests covering `prependCachedSystemMessage`: undefined systemPrompt, empty string, non-empty (correct providerOptions wiring), input-array non-mutation.
  - `test/unit/infra/llm/internal-llm-service.test.ts` — updated `should support image data in completeTask` to match the new iter-0 dateTime prefix on `addUserMessage`'s first argument.
- Key scenario(s) covered:
  - cache_control attaches to last tool only (not all tools)
  - empty/undefined systemPrompt passes the messages array through unchanged
  - dateTime is injected once at iter 0 and lives in conversation history thereafter (not refreshed per iteration)
  - non-Anthropic providers ignore the `anthropic` providerOptions namespace by AI SDK design

## User-visible changes

None at the surface API level. Reduced billed token cost on Anthropic-backed curates.

## Evidence

A/B run report with concrete iter-by-iter cache-engagement traces and per-provider deltas:
`notes/token-usage-reduction/eng-2519-prefix-caching/REPORT.md`

Sample iter-by-iter on Anthropic claude-haiku-4-5 (treatment side):

```
iter 1: in=762   out=237    cacheRead=0       cacheCreate=12,943   ← prime
iter 2: in=1,190 out=447    cacheRead=12,943  cacheCreate=759      ← full hit
iter 3: in=4,075 out=1,539  cacheRead=12,943  cacheCreate=759      ← full hit
```

## Checklist

- [x] Tests added or updated and passing (7004 passing, 16 pending, 0 failing)
- [x] Lint passes on touched files
- [x] Type check passes
- [x] Build succeeds
- [x] Commits follow Conventional Commits format
- [x] No breaking changes

## Risks and mitigations

- **Risk:** dateTime relocation moves a piece of context from `role: 'system'` to `role: 'user'`. The LLM sees identical text, just one role-block over.
  - **Mitigation:** Validated across 120 curates × 3 providers in `notes/token-usage-reduction/eng-2519-prefix-caching/`. No fixture failures, no quality regression at the leaf-count / byte-size level. Curated context trees preserved per-(condition, provider, fixture) for manual quality spot-checking.

- **Risk:** AI SDK version compatibility — the `providerOptions.anthropic.cacheControl` API requires `@ai-sdk/anthropic` 2.x with cache_control support. Older versions silently drop the markers, collapsing savings to ~2.4%.
  - **Mitigation:** Verified iter-2+ Anthropic responses surface `cache_read_input_tokens > 0` in the 60-curate Anthropic A/B run; cache engagement is observable in the live experiment artifacts. Project-branch's `package-lock.json` is unchanged by this PR.

- **Risk:** Non-Anthropic providers receive the system content via a different code path now (top-level `system` arg → first message in array).
  - **Mitigation:** AI SDK 5.x normalizes both forms to the same internal representation. All 30 OpenAI and 30 Google fixtures completed successfully with no warning logs about unsupported providerOptions namespaces.