### PR TITLE
feat: [ENG-2547] M2.17 WebUI numbered pagination + Filter dropdown + active filter tags

### DIFF
--- a/src/webui/features/tasks/api/get-tasks.ts
+++ b/src/webui/features/tasks/api/get-tasks.ts
@@ -1,4 +1,4 @@
-import {useInfiniteQuery} from '@tanstack/react-query'
+import {useQuery} from '@tanstack/react-query'
 
 import {
   TaskEvents,
@@ -7,8 +7,6 @@ import {
 } from '../../../../shared/transport/events/task-events'
 import {useTransportStore} from '../../../stores/transport-store'
 
-export const DEFAULT_PAGE_LIMIT = 50
-
 export const getTasks = (data?: TaskListRequest): Promise<TaskListResponse> => {
   const {apiClient} = useTransportStore.getState()
   if (!apiClient) return Promise.reject(new Error('Not connected'))
@@ -16,32 +14,10 @@ export const getTasks = (data?: TaskListRequest): Promise<TaskListResponse> => {
   return apiClient.request<TaskListResponse, TaskListRequest>(TaskEvents.LIST, data)
 }
 
-export const initialPageParam = (projectPath?: string): TaskListRequest => ({
-  limit: DEFAULT_PAGE_LIMIT,
-  ...(projectPath ? {projectPath} : {}),
-})
+export type UseGetTasksOptions = TaskListRequest
 
-export const getNextPageParam = (
-  lastPage: TaskListResponse,
-  lastParam: TaskListRequest,
-): TaskListRequest | undefined => {
-  if (lastPage.nextCursor === undefined) return undefined
-  return {
-    ...lastParam,
-    before: lastPage.nextCursor,
-    ...(lastPage.nextCursorTaskId ? {beforeTaskId: lastPage.nextCursorTaskId} : {}),
-  }
-}
-
-type UseGetTasksOptions = {
-  projectPath?: string
-}
-
-export const useGetTasks = ({projectPath}: UseGetTasksOptions = {}) =>
-  useInfiniteQuery({
-    getNextPageParam: (lastPage: TaskListResponse, _allPages, lastParam: TaskListRequest) =>
-      getNextPageParam(lastPage, lastParam),
-    initialPageParam: initialPageParam(projectPath),
-    queryFn: ({pageParam}) => getTasks(pageParam),
-    queryKey: ['tasks', 'list', projectPath ?? ''],
+export const useGetTasks = (options: UseGetTasksOptions = {}) =>
+  useQuery({
+    queryFn: () => getTasks(options),
+    queryKey: ['tasks', 'list', options],
   })

--- a/src/webui/features/tasks/api/get-tasks.ts
+++ b/src/webui/features/tasks/api/get-tasks.ts
@@ -1,6 +1,4 @@
-import {queryOptions, useQuery} from '@tanstack/react-query'
-
-import type {QueryConfig} from '../../../lib/react-query'
+import {useInfiniteQuery} from '@tanstack/react-query'
 
 import {
   TaskEvents,
@@ -9,6 +7,8 @@ import {
 } from '../../../../shared/transport/events/task-events'
 import {useTransportStore} from '../../../stores/transport-store'
 
+export const DEFAULT_PAGE_LIMIT = 50
+
 export const getTasks = (data?: TaskListRequest): Promise<TaskListResponse> => {
   const {apiClient} = useTransportStore.getState()
   if (!apiClient) return Promise.reject(new Error('Not connected'))
@@ -16,19 +16,32 @@ export const getTasks = (data?: TaskListRequest): Promise<TaskListResponse> => {
   return apiClient.request<TaskListResponse, TaskListRequest>(TaskEvents.LIST, data)
 }
 
-export const getTasksQueryOptions = (projectPath?: string) =>
-  queryOptions({
-    queryFn: () => getTasks(projectPath ? {projectPath} : undefined),
-    queryKey: ['tasks', 'list', projectPath ?? ''],
-  })
+export const initialPageParam = (projectPath?: string): TaskListRequest => ({
+  limit: DEFAULT_PAGE_LIMIT,
+  ...(projectPath ? {projectPath} : {}),
+})
+
+export const getNextPageParam = (
+  lastPage: TaskListResponse,
+  lastParam: TaskListRequest,
+): TaskListRequest | undefined => {
+  if (lastPage.nextCursor === undefined) return undefined
+  return {
+    ...lastParam,
+    before: lastPage.nextCursor,
+    ...(lastPage.nextCursorTaskId ? {beforeTaskId: lastPage.nextCursorTaskId} : {}),
+  }
+}
 
 type UseGetTasksOptions = {
   projectPath?: string
-  queryConfig?: QueryConfig<typeof getTasksQueryOptions>
 }
 
-export const useGetTasks = ({projectPath, queryConfig}: UseGetTasksOptions = {}) =>
-  useQuery({
-    ...getTasksQueryOptions(projectPath),
-    ...queryConfig,
+export const useGetTasks = ({projectPath}: UseGetTasksOptions = {}) =>
+  useInfiniteQuery({
+    getNextPageParam: (lastPage: TaskListResponse, _allPages, lastParam: TaskListRequest) =>
+      getNextPageParam(lastPage, lastParam),
+    initialPageParam: initialPageParam(projectPath),
+    queryFn: ({pageParam}) => getTasks(pageParam),
+    queryKey: ['tasks', 'list', projectPath ?? ''],
   })

--- a/src/webui/features/tasks/components/task-date-filter-panel.tsx
+++ b/src/webui/features/tasks/components/task-date-filter-panel.tsx
@@ -1,0 +1,95 @@
+import {Calendar} from '@campfirein/byterover-packages/components/calendar'
+import {endOfDay, startOfDay} from 'date-fns'
+import {useEffect, useState} from 'react'
+
+import {formatTimeRangeLabel} from '../utils/time-presets'
+
+type DateRange = {from: Date | undefined; to?: Date}
+
+export interface TaskDateFilterPanelProps {
+  createdAfter?: number
+  createdBefore?: number
+  onChange: (range: {createdAfter?: number; createdBefore?: number}) => void
+}
+
+export function TaskDateFilterPanel({createdAfter, createdBefore, onChange}: TaskDateFilterPanelProps) {
+  const applied = toDateRange(createdAfter, createdBefore)
+  const [selected, setSelected] = useState<DateRange | undefined>(applied)
+
+  useEffect(() => {
+    setSelected(toDateRange(createdAfter, createdBefore))
+  }, [createdAfter, createdBefore])
+
+  const hasSelection = selected?.from !== undefined && selected?.from !== null
+  const hasApplied = createdAfter !== undefined || createdBefore !== undefined
+  const isChanged =
+    hasSelection &&
+    (toMs(selected.from) !== createdAfter || toMs(selected.to ?? selected.from) !== createdBefore)
+
+  const handleApply = () => {
+    if (!selected?.from) return
+    const from = startOfDay(selected.from).getTime()
+    const to = endOfDay(selected.to ?? selected.from).getTime()
+    onChange({createdAfter: from, createdBefore: to})
+  }
+
+  const handleClear = () => {
+    setSelected(undefined)
+    onChange({})
+  }
+
+  return (
+    <div onKeyDown={(event) => event.stopPropagation()}>
+      <Calendar
+        className="min-w-md bg-transparent p-2"
+        mode="range"
+        numberOfMonths={2}
+        onSelect={setSelected}
+        selected={selected}
+      />
+      <div className="border-border flex items-center justify-between border-t px-3 py-2">
+        {hasApplied ? (
+          <span className="text-foreground text-xs">{formatTimeRangeLabel({createdAfter, createdBefore})}</span>
+        ) : hasSelection ? (
+          <span className="text-muted-foreground text-xs">
+            {formatTimeRangeLabel({
+              createdAfter: toMs(selected.from),
+              createdBefore: toMs(selected.to ?? selected.from),
+            })}
+          </span>
+        ) : (
+          <span />
+        )}
+        <div className="flex items-center gap-2">
+          {hasApplied && (
+            <button
+              className="text-muted-foreground hover:text-foreground text-xs transition"
+              onClick={handleClear}
+              type="button"
+            >
+              Clear
+            </button>
+          )}
+          {hasSelection && isChanged && (
+            <button
+              className="bg-primary text-foreground rounded px-2.5 py-1 text-xs font-medium"
+              onClick={handleApply}
+              type="button"
+            >
+              Apply
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function toDateRange(from?: number, to?: number): DateRange | undefined {
+  if (from === undefined) return undefined
+  return {from: new Date(from), ...(to === undefined ? {} : {to: new Date(to)})}
+}
+
+function toMs(date?: Date): number | undefined {
+  return date ? date.getTime() : undefined
+}

--- a/src/webui/features/tasks/components/task-filter-menu.tsx
+++ b/src/webui/features/tasks/components/task-filter-menu.tsx
@@ -1,0 +1,219 @@
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from '@campfirein/byterover-packages/components/dropdown-menu'
+import {SlidersHorizontal} from 'lucide-react'
+import {useMemo} from 'react'
+
+import type {TaskListAvailableModel} from '../../../../shared/transport/events/task-events'
+
+import {useGetProviders} from '../../provider/api/get-providers'
+import {DURATION_PRESETS, type DurationPreset} from '../utils/duration-presets'
+import {TaskDateFilterPanel} from './task-date-filter-panel'
+
+const TYPE_OPTIONS = [
+  {label: 'Curate', value: 'curate'},
+  {label: 'Query', value: 'query'},
+] as const
+
+const DURATION_VALUES = new Set<string>(DURATION_PRESETS.map((p) => p.value))
+
+function isDurationPreset(value: string): value is DurationPreset {
+  return DURATION_VALUES.has(value)
+}
+
+export interface TaskFilterMenuProps {
+  availableModels: TaskListAvailableModel[]
+  availableProviders: string[]
+  createdAfter?: number
+  createdBefore?: number
+  durationPreset: DurationPreset
+  modelFilter: string[]
+  onDurationChange: (preset: DurationPreset) => void
+  onModelChange: (next: string[]) => void
+  onProviderChange: (next: string[]) => void
+  onTimeRangeChange: (range: {createdAfter?: number; createdBefore?: number}) => void
+  onTypeChange: (next: string[]) => void
+  providerFilter: string[]
+  typeFilter: string[]
+}
+
+export function TaskFilterMenu({
+  availableModels,
+  availableProviders,
+  createdAfter,
+  createdBefore,
+  durationPreset,
+  modelFilter,
+  onDurationChange,
+  onModelChange,
+  onProviderChange,
+  onTimeRangeChange,
+  onTypeChange,
+  providerFilter,
+  typeFilter,
+}: TaskFilterMenuProps) {
+  const {data: providersResponse} = useGetProviders()
+  const providerNames = useMemo(
+    () => new Map((providersResponse?.providers ?? []).map((p) => [p.id, p.name])),
+    [providersResponse],
+  )
+  const modelOptions = useMemo(
+    () => filterModelOptions(availableModels, providerFilter),
+    [availableModels, providerFilter],
+  )
+  const timeActive = createdAfter !== undefined || createdBefore !== undefined
+  const hasActive =
+    typeFilter.length > 0 ||
+    providerFilter.length > 0 ||
+    modelFilter.length > 0 ||
+    timeActive ||
+    durationPreset !== 'all'
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger className="text-muted-foreground hover:text-foreground hover:bg-muted/60 border-border bg-background relative inline-flex h-8 cursor-pointer items-center gap-1.5 rounded-md border px-3 text-sm transition-colors">
+        <SlidersHorizontal className="pointer-events-none size-3.5" />
+        <span className="pointer-events-none">Filter</span>
+        {hasActive && (
+          <span className="bg-primary pointer-events-none absolute -top-1 -right-1 size-2 rounded-full" />
+        )}
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent align="start" className="w-48">
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger className="cursor-pointer">
+            <span>
+              Type
+              {typeFilter.length > 0 && <span className="ml-1">({typeFilter.length})</span>}
+            </span>
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="w-48" sideOffset={8}>
+            {TYPE_OPTIONS.map((option) => (
+              <DropdownMenuCheckboxItem
+                checked={typeFilter.includes(option.value)}
+                className="cursor-pointer"
+                key={option.value}
+                onCheckedChange={() => toggleIn(typeFilter, option.value, onTypeChange)}
+              >
+                {option.label}
+              </DropdownMenuCheckboxItem>
+            ))}
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger className="cursor-pointer">
+            <span>
+              Provider
+              {providerFilter.length > 0 && <span className="ml-1">({providerFilter.length})</span>}
+            </span>
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="w-56" sideOffset={8}>
+            {availableProviders.length === 0 ? (
+              <div className="text-muted-foreground px-2 py-1.5 text-xs">No providers yet</div>
+            ) : (
+              availableProviders.map((provider) => (
+                <DropdownMenuCheckboxItem
+                  checked={providerFilter.includes(provider)}
+                  className="cursor-pointer"
+                  key={provider}
+                  onCheckedChange={() => toggleIn(providerFilter, provider, onProviderChange)}
+                >
+                  {providerNames.get(provider) ?? provider}
+                </DropdownMenuCheckboxItem>
+              ))
+            )}
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger className="cursor-pointer">
+            <span>
+              Model
+              {modelFilter.length > 0 && <span className="ml-1">({modelFilter.length})</span>}
+            </span>
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="w-56" sideOffset={8}>
+            {modelOptions.length === 0 ? (
+              <div className="text-muted-foreground px-2 py-1.5 text-xs">No models yet</div>
+            ) : (
+              modelOptions.map((modelId) => (
+                <DropdownMenuCheckboxItem
+                  checked={modelFilter.includes(modelId)}
+                  className="cursor-pointer"
+                  key={modelId}
+                  onCheckedChange={() => toggleIn(modelFilter, modelId, onModelChange)}
+                >
+                  {modelId}
+                </DropdownMenuCheckboxItem>
+              ))
+            )}
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger className="cursor-pointer">
+            <span>
+              Time
+              {timeActive && <span className="text-primary ml-1">·</span>}
+            </span>
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="w-fit" sideOffset={8}>
+            <TaskDateFilterPanel
+              createdAfter={createdAfter}
+              createdBefore={createdBefore}
+              onChange={onTimeRangeChange}
+            />
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger className="cursor-pointer">
+            <span>
+              Duration
+              {durationPreset !== 'all' && <span className="text-primary ml-1">·</span>}
+            </span>
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="w-48" sideOffset={8}>
+            <DropdownMenuRadioGroup
+              onValueChange={(value) => isDurationPreset(value) && onDurationChange(value)}
+              value={durationPreset}
+            >
+              {DURATION_PRESETS.map((preset) => (
+                <DropdownMenuRadioItem className="cursor-pointer" key={preset.value} value={preset.value}>
+                  {preset.label}
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+function toggleIn(current: string[], value: string, onChange: (next: string[]) => void) {
+  onChange(current.includes(value) ? current.filter((v) => v !== value) : [...current, value])
+}
+
+function filterModelOptions(available: TaskListAvailableModel[], selectedProviders: string[]): string[] {
+  const filtered =
+    selectedProviders.length === 0 ? available : available.filter((entry) => selectedProviders.includes(entry.providerId))
+  const seen = new Set<string>()
+  const options: string[] = []
+  for (const entry of filtered) {
+    if (seen.has(entry.modelId)) continue
+    seen.add(entry.modelId)
+    options.push(entry.modelId)
+  }
+
+  return options
+}

--- a/src/webui/features/tasks/components/task-filter-menu.tsx
+++ b/src/webui/features/tasks/components/task-filter-menu.tsx
@@ -13,21 +13,15 @@ import {SlidersHorizontal} from 'lucide-react'
 import {useMemo} from 'react'
 
 import type {TaskListAvailableModel} from '../../../../shared/transport/events/task-events'
+import type {ProviderDTO} from '../../../../shared/transport/types/dto'
 
-import {useGetProviders} from '../../provider/api/get-providers'
-import {DURATION_PRESETS, type DurationPreset} from '../utils/duration-presets'
+import {DURATION_PRESETS, type DurationPreset, isDurationPreset} from '../utils/duration-presets'
 import {TaskDateFilterPanel} from './task-date-filter-panel'
 
 const TYPE_OPTIONS = [
   {label: 'Curate', value: 'curate'},
   {label: 'Query', value: 'query'},
 ] as const
-
-const DURATION_VALUES = new Set<string>(DURATION_PRESETS.map((p) => p.value))
-
-function isDurationPreset(value: string): value is DurationPreset {
-  return DURATION_VALUES.has(value)
-}
 
 export interface TaskFilterMenuProps {
   availableModels: TaskListAvailableModel[]
@@ -42,6 +36,7 @@ export interface TaskFilterMenuProps {
   onTimeRangeChange: (range: {createdAfter?: number; createdBefore?: number}) => void
   onTypeChange: (next: string[]) => void
   providerFilter: string[]
+  providers: ProviderDTO[]
   typeFilter: string[]
 }
 
@@ -58,13 +53,10 @@ export function TaskFilterMenu({
   onTimeRangeChange,
   onTypeChange,
   providerFilter,
+  providers,
   typeFilter,
 }: TaskFilterMenuProps) {
-  const {data: providersResponse} = useGetProviders()
-  const providerNames = useMemo(
-    () => new Map((providersResponse?.providers ?? []).map((p) => [p.id, p.name])),
-    [providersResponse],
-  )
+  const providerNames = useMemo(() => new Map(providers.map((p) => [p.id, p.name])), [providers])
   const modelOptions = useMemo(
     () => filterModelOptions(availableModels, providerFilter),
     [availableModels, providerFilter],

--- a/src/webui/features/tasks/components/task-filter-tags.tsx
+++ b/src/webui/features/tasks/components/task-filter-tags.tsx
@@ -55,64 +55,85 @@ export function TaskFilterTags({
   typeFilter,
 }: TaskFilterTagsProps) {
   const providerNames = useMemo(() => new Map(providers.map((p) => [p.id, p.name])), [providers])
-  const providerName = (id: string) => providerNames.get(id) ?? id
-  const tags: Array<{key: string; label: string; onRemove: () => void}> = []
 
-  if (statusFilter !== 'all') {
-    tags.push({
-      key: `status:${statusFilter}`,
-      label: `Status: ${STATUS_LABEL[statusFilter]}`,
-      onRemove: () => onStatusChange('all'),
-    })
-  }
+  const tags = useMemo(() => {
+    const result: Array<{key: string; label: string; onRemove: () => void}> = []
 
-  for (const value of typeFilter) {
-    tags.push({
-      key: `type:${value}`,
-      label: `Type: ${TYPE_LABEL[value] ?? value}`,
-      onRemove: () => onTypeChange(typeFilter.filter((v) => v !== value)),
-    })
-  }
+    if (statusFilter !== 'all') {
+      result.push({
+        key: `status:${statusFilter}`,
+        label: `Status: ${STATUS_LABEL[statusFilter]}`,
+        onRemove: () => onStatusChange('all'),
+      })
+    }
 
-  for (const value of providerFilter) {
-    tags.push({
-      key: `provider:${value}`,
-      label: `Provider: ${providerName(value)}`,
-      onRemove: () => onProviderChange(providerFilter.filter((v) => v !== value)),
-    })
-  }
+    for (const value of typeFilter) {
+      result.push({
+        key: `type:${value}`,
+        label: `Type: ${TYPE_LABEL[value] ?? value}`,
+        onRemove: () => onTypeChange(typeFilter.filter((v) => v !== value)),
+      })
+    }
 
-  for (const value of modelFilter) {
-    tags.push({
-      key: `model:${value}`,
-      label: `Model: ${value}`,
-      onRemove: () => onModelChange(modelFilter.filter((v) => v !== value)),
-    })
-  }
+    for (const value of providerFilter) {
+      result.push({
+        key: `provider:${value}`,
+        label: `Provider: ${providerNames.get(value) ?? value}`,
+        onRemove: () => onProviderChange(providerFilter.filter((v) => v !== value)),
+      })
+    }
 
-  if (createdAfter !== undefined || createdBefore !== undefined) {
-    tags.push({
-      key: 'time',
-      label: `Time: ${formatTimeRangeLabel({createdAfter, createdBefore})}`,
-      onRemove: () => onTimeRangeChange({}),
-    })
-  }
+    for (const value of modelFilter) {
+      result.push({
+        key: `model:${value}`,
+        label: `Model: ${value}`,
+        onRemove: () => onModelChange(modelFilter.filter((v) => v !== value)),
+      })
+    }
 
-  if (durationPreset !== 'all') {
-    tags.push({
-      key: `duration:${durationPreset}`,
-      label: `Duration: ${durationPresetLabel(durationPreset)}`,
-      onRemove: () => onDurationChange('all'),
-    })
-  }
+    if (createdAfter !== undefined || createdBefore !== undefined) {
+      result.push({
+        key: 'time',
+        label: `Time: ${formatTimeRangeLabel({createdAfter, createdBefore})}`,
+        onRemove: () => onTimeRangeChange({}),
+      })
+    }
 
-  if (searchQuery.trim()) {
-    tags.push({
-      key: 'search',
-      label: `“${searchQuery.trim()}”`,
-      onRemove: () => onSearchChange(''),
-    })
-  }
+    if (durationPreset !== 'all') {
+      result.push({
+        key: `duration:${durationPreset}`,
+        label: `Duration: ${durationPresetLabel(durationPreset)}`,
+        onRemove: () => onDurationChange('all'),
+      })
+    }
+
+    if (searchQuery.trim()) {
+      result.push({
+        key: 'search',
+        label: `“${searchQuery.trim()}”`,
+        onRemove: () => onSearchChange(''),
+      })
+    }
+
+    return result
+  }, [
+    statusFilter,
+    typeFilter,
+    providerFilter,
+    modelFilter,
+    createdAfter,
+    createdBefore,
+    durationPreset,
+    searchQuery,
+    providerNames,
+    onStatusChange,
+    onTypeChange,
+    onProviderChange,
+    onModelChange,
+    onTimeRangeChange,
+    onDurationChange,
+    onSearchChange,
+  ])
 
   if (tags.length === 0) return null
 

--- a/src/webui/features/tasks/components/task-filter-tags.tsx
+++ b/src/webui/features/tasks/components/task-filter-tags.tsx
@@ -1,0 +1,136 @@
+import {Tag} from '@campfirein/byterover-packages/components/tag/tag'
+import {X} from 'lucide-react'
+import {useMemo} from 'react'
+
+import type {ProviderDTO} from '../../../../shared/transport/types/dto'
+import type {StatusFilter} from '../stores/task-store'
+import type {DurationPreset} from '../utils/duration-presets'
+
+import {durationPresetLabel} from '../utils/duration-presets'
+import {formatTimeRangeLabel} from '../utils/time-presets'
+import {STATUS_LABEL} from './task-list-filter-bar'
+
+const TYPE_LABEL: Record<string, string> = {
+  curate: 'Curate',
+  query: 'Query',
+}
+
+export interface TaskFilterTagsProps {
+  createdAfter?: number
+  createdBefore?: number
+  durationPreset: DurationPreset
+  modelFilter: string[]
+  onClearAll: () => void
+  onDurationChange: (preset: DurationPreset) => void
+  onModelChange: (next: string[]) => void
+  onProviderChange: (next: string[]) => void
+  onSearchChange: (query: string) => void
+  onStatusChange: (filter: StatusFilter) => void
+  onTimeRangeChange: (range: {createdAfter?: number; createdBefore?: number}) => void
+  onTypeChange: (next: string[]) => void
+  providerFilter: string[]
+  providers: ProviderDTO[]
+  searchQuery: string
+  statusFilter: StatusFilter
+  typeFilter: string[]
+}
+
+export function TaskFilterTags({
+  createdAfter,
+  createdBefore,
+  durationPreset,
+  modelFilter,
+  onClearAll,
+  onDurationChange,
+  onModelChange,
+  onProviderChange,
+  onSearchChange,
+  onStatusChange,
+  onTimeRangeChange,
+  onTypeChange,
+  providerFilter,
+  providers,
+  searchQuery,
+  statusFilter,
+  typeFilter,
+}: TaskFilterTagsProps) {
+  const providerNames = useMemo(() => new Map(providers.map((p) => [p.id, p.name])), [providers])
+  const providerName = (id: string) => providerNames.get(id) ?? id
+  const tags: Array<{key: string; label: string; onRemove: () => void}> = []
+
+  if (statusFilter !== 'all') {
+    tags.push({
+      key: `status:${statusFilter}`,
+      label: `Status: ${STATUS_LABEL[statusFilter]}`,
+      onRemove: () => onStatusChange('all'),
+    })
+  }
+
+  for (const value of typeFilter) {
+    tags.push({
+      key: `type:${value}`,
+      label: `Type: ${TYPE_LABEL[value] ?? value}`,
+      onRemove: () => onTypeChange(typeFilter.filter((v) => v !== value)),
+    })
+  }
+
+  for (const value of providerFilter) {
+    tags.push({
+      key: `provider:${value}`,
+      label: `Provider: ${providerName(value)}`,
+      onRemove: () => onProviderChange(providerFilter.filter((v) => v !== value)),
+    })
+  }
+
+  for (const value of modelFilter) {
+    tags.push({
+      key: `model:${value}`,
+      label: `Model: ${value}`,
+      onRemove: () => onModelChange(modelFilter.filter((v) => v !== value)),
+    })
+  }
+
+  if (createdAfter !== undefined || createdBefore !== undefined) {
+    tags.push({
+      key: 'time',
+      label: `Time: ${formatTimeRangeLabel({createdAfter, createdBefore})}`,
+      onRemove: () => onTimeRangeChange({}),
+    })
+  }
+
+  if (durationPreset !== 'all') {
+    tags.push({
+      key: `duration:${durationPreset}`,
+      label: `Duration: ${durationPresetLabel(durationPreset)}`,
+      onRemove: () => onDurationChange('all'),
+    })
+  }
+
+  if (searchQuery.trim()) {
+    tags.push({
+      key: 'search',
+      label: `“${searchQuery.trim()}”`,
+      onRemove: () => onSearchChange(''),
+    })
+  }
+
+  if (tags.length === 0) return null
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5 px-1">
+      {tags.map((tag) => (
+        <Tag closable key={tag.key} onClose={tag.onRemove} variant="secondary">
+          {tag.label}
+        </Tag>
+      ))}
+      <button
+        className="text-muted-foreground hover:text-foreground inline-flex cursor-pointer items-center gap-1 px-1.5 py-0.5 text-xs transition"
+        onClick={onClearAll}
+        type="button"
+      >
+        <X className="size-3" />
+        Clear filters
+      </button>
+    </div>
+  )
+}

--- a/src/webui/features/tasks/components/task-list-empty.tsx
+++ b/src/webui/features/tasks/components/task-list-empty.tsx
@@ -28,7 +28,36 @@ export function LoadingState() {
   return <div className="text-muted-foreground flex h-32 items-center justify-center text-sm">Loading tasks…</div>
 }
 
-export function EmptyState({onNewTask, tourCue}: {onNewTask: () => void; tourCue?: string}) {
+export function EmptyState({
+  hasActiveFilters,
+  onClearFilters,
+  onNewTask,
+  tourCue,
+}: {
+  hasActiveFilters?: boolean
+  onClearFilters?: () => void
+  onNewTask: () => void
+  tourCue?: string
+}) {
+  if (hasActiveFilters) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-4 p-8 text-center">
+        <ListTodo className="text-muted-foreground/70 size-8" />
+        <div>
+          <h2 className="text-foreground text-base font-medium">No matching tasks</h2>
+          <p className="text-muted-foreground mx-auto mt-1 max-w-sm text-sm leading-relaxed">
+            No tasks match the current filters. Try adjusting or clearing them.
+          </p>
+        </div>
+        {onClearFilters && (
+          <Button className="cursor-pointer" onClick={onClearFilters} size="sm" variant="outline">
+            Clear filters
+          </Button>
+        )}
+      </div>
+    )
+  }
+
   return (
     <div className="flex h-full flex-col items-center justify-center gap-4 p-8 text-center">
       <ListTodo className="text-muted-foreground/70 size-8" />

--- a/src/webui/features/tasks/components/task-list-filter-bar.tsx
+++ b/src/webui/features/tasks/components/task-list-filter-bar.tsx
@@ -3,8 +3,12 @@ import {Input} from '@campfirein/byterover-packages/components/input'
 import {cn} from '@campfirein/byterover-packages/lib/utils'
 import {Plus, Search} from 'lucide-react'
 
+import type {TaskListAvailableModel, TaskListCounts} from '../../../../shared/transport/events/task-events'
+
 import {TourPointer} from '../../onboarding/components/tour-pointer'
-import {STATUS_FILTERS, type StatusFilter, type useStatusBreakdown} from '../stores/task-store'
+import {STATUS_FILTERS, type StatusFilter} from '../stores/task-store'
+import {type DurationPreset} from '../utils/duration-presets'
+import {TaskFilterMenu} from './task-filter-menu'
 
 export const STATUS_LABEL: Record<StatusFilter, string> = {
   all: 'All',
@@ -21,23 +25,51 @@ export const STATUS_DOT_COLOR: Record<Exclude<StatusFilter, 'all'>, string> = {
   running: 'bg-blue-400',
 }
 
-export function FilterBar({
-  breakdown,
-  onNewTask,
-  onSearchChange,
-  onStatusChange,
-  searchQuery,
-  statusFilter,
-  tourCue,
-}: {
-  breakdown: ReturnType<typeof useStatusBreakdown>
+export interface FilterBarProps {
+  availableModels: TaskListAvailableModel[]
+  availableProviders: string[]
+  breakdown: TaskListCounts
+  createdAfter?: number
+  createdBefore?: number
+  durationPreset: DurationPreset
+  modelFilter: string[]
+  onDurationChange: (preset: DurationPreset) => void
+  onModelChange: (next: string[]) => void
   onNewTask: () => void
+  onProviderChange: (next: string[]) => void
   onSearchChange: (query: string) => void
   onStatusChange: (filter: StatusFilter) => void
+  onTimeRangeChange: (range: {createdAfter?: number; createdBefore?: number}) => void
+  onTypeChange: (next: string[]) => void
+  providerFilter: string[]
   searchQuery: string
   statusFilter: StatusFilter
   tourCue?: string
-}) {
+  typeFilter: string[]
+}
+
+export function FilterBar({
+  availableModels,
+  availableProviders,
+  breakdown,
+  createdAfter,
+  createdBefore,
+  durationPreset,
+  modelFilter,
+  onDurationChange,
+  onModelChange,
+  onNewTask,
+  onProviderChange,
+  onSearchChange,
+  onStatusChange,
+  onTimeRangeChange,
+  onTypeChange,
+  providerFilter,
+  searchQuery,
+  statusFilter,
+  tourCue,
+  typeFilter,
+}: FilterBarProps) {
   return (
     <div className="flex min-h-9 flex-wrap items-center gap-2">
       {STATUS_FILTERS.map((filter) => {
@@ -65,10 +97,26 @@ export function FilterBar({
       })}
 
       <div className="ml-auto flex items-center gap-2">
+        <TaskFilterMenu
+          availableModels={availableModels}
+          availableProviders={availableProviders}
+          createdAfter={createdAfter}
+          createdBefore={createdBefore}
+          durationPreset={durationPreset}
+          modelFilter={modelFilter}
+          onDurationChange={onDurationChange}
+          onModelChange={onModelChange}
+          onProviderChange={onProviderChange}
+          onTimeRangeChange={onTimeRangeChange}
+          onTypeChange={onTypeChange}
+          providerFilter={providerFilter}
+          typeFilter={typeFilter}
+        />
+
         <div className="relative">
           <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2" />
           <Input
-            className="h-8 min-w-56 pl-8 text-xs"
+            className="dark:bg-background h-8 min-w-56 pl-8 text-xs border border-border"
             onChange={(event) => onSearchChange(event.target.value)}
             placeholder="Search input or id…"
             type="text"
@@ -77,7 +125,7 @@ export function FilterBar({
         </div>
 
         <TourPointer active={Boolean(tourCue)} align="end" label={tourCue ?? ''}>
-          <Button onClick={onNewTask} size="sm" variant="default">
+          <Button className="h-8" onClick={onNewTask} size="sm" variant="default">
             <Plus className="size-4" />
             New task
           </Button>

--- a/src/webui/features/tasks/components/task-list-filter-bar.tsx
+++ b/src/webui/features/tasks/components/task-list-filter-bar.tsx
@@ -4,6 +4,7 @@ import {cn} from '@campfirein/byterover-packages/lib/utils'
 import {Plus, Search} from 'lucide-react'
 
 import type {TaskListAvailableModel, TaskListCounts} from '../../../../shared/transport/events/task-events'
+import type {ProviderDTO} from '../../../../shared/transport/types/dto'
 
 import {TourPointer} from '../../onboarding/components/tour-pointer'
 import {STATUS_FILTERS, type StatusFilter} from '../stores/task-store'
@@ -42,6 +43,7 @@ export interface FilterBarProps {
   onTimeRangeChange: (range: {createdAfter?: number; createdBefore?: number}) => void
   onTypeChange: (next: string[]) => void
   providerFilter: string[]
+  providers: ProviderDTO[]
   searchQuery: string
   statusFilter: StatusFilter
   tourCue?: string
@@ -65,6 +67,7 @@ export function FilterBar({
   onTimeRangeChange,
   onTypeChange,
   providerFilter,
+  providers,
   searchQuery,
   statusFilter,
   tourCue,
@@ -110,6 +113,7 @@ export function FilterBar({
           onTimeRangeChange={onTimeRangeChange}
           onTypeChange={onTypeChange}
           providerFilter={providerFilter}
+          providers={providers}
           typeFilter={typeFilter}
         />
 

--- a/src/webui/features/tasks/components/task-list-pagination.tsx
+++ b/src/webui/features/tasks/components/task-list-pagination.tsx
@@ -1,0 +1,113 @@
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from '@campfirein/byterover-packages/components/pagination'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@campfirein/byterover-packages/components/select'
+import {cn} from '@campfirein/byterover-packages/lib/utils'
+
+const PAGE_SIZE_OPTIONS = [50, 100, 250] as const
+
+export interface TaskListPaginationProps {
+  onPageChange: (page: number) => void
+  onPageSizeChange: (pageSize: number) => void
+  page: number
+  pageCount: number
+  pageSize: number
+  total: number
+}
+
+export function TaskListPagination({
+  onPageChange,
+  onPageSizeChange,
+  page,
+  pageCount,
+  pageSize,
+  total,
+}: TaskListPaginationProps) {
+  if (pageCount <= 1 && total <= PAGE_SIZE_OPTIONS[0]) return null
+
+  const pages = pageNumbersToShow(page, pageCount)
+  const isFirst = page <= 1
+  const isLast = page >= pageCount
+
+  return (
+    <div className="flex items-center justify-between gap-3 px-1">
+      <span className="text-muted-foreground text-xs">
+        {total > 0 ? `${total} task${total === 1 ? '' : 's'}` : 'No tasks'}
+      </span>
+      {pageCount > 1 && (
+        <Pagination className="mx-0 w-auto">
+          <PaginationContent>
+            <PaginationItem>
+              <PaginationPrevious
+                aria-disabled={isFirst}
+                className={cn({'pointer-events-none opacity-50': isFirst})}
+                onClick={() => !isFirst && onPageChange(page - 1)}
+              />
+            </PaginationItem>
+            {pages.map((entry, idx) =>
+              entry === 'ellipsis' ? (
+                <PaginationItem key={`ellipsis-${idx}`}>
+                  <PaginationEllipsis />
+                </PaginationItem>
+              ) : (
+                <PaginationItem key={entry}>
+                  <PaginationLink isActive={entry === page} onClick={() => onPageChange(entry)}>
+                    {entry}
+                  </PaginationLink>
+                </PaginationItem>
+              ),
+            )}
+            <PaginationItem>
+              <PaginationNext
+                aria-disabled={isLast}
+                className={cn({'pointer-events-none opacity-50': isLast})}
+                onClick={() => !isLast && onPageChange(page + 1)}
+              />
+            </PaginationItem>
+          </PaginationContent>
+        </Pagination>
+      )}
+      <Select onValueChange={(value) => onPageSizeChange(Number(value))} value={String(pageSize)}>
+        <SelectTrigger className="h-8 text-xs" size="sm">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {PAGE_SIZE_OPTIONS.map((option) => (
+            <SelectItem key={option} value={String(option)}>
+              {option} / page
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}
+
+function pageNumbersToShow(current: number, total: number): Array<'ellipsis' | number> {
+  if (total <= 7) {
+    return Array.from({length: total}, (_, i) => i + 1)
+  }
+
+  const result: Array<'ellipsis' | number> = [1]
+  const left = Math.max(2, current - 1)
+  const right = Math.min(total - 1, current + 1)
+
+  if (left > 2) result.push('ellipsis')
+  for (let i = left; i <= right; i++) result.push(i)
+  if (right < total - 1) result.push('ellipsis')
+
+  result.push(total)
+  return result
+}

--- a/src/webui/features/tasks/components/task-list-table.tsx
+++ b/src/webui/features/tasks/components/task-list-table.tsx
@@ -1,3 +1,5 @@
+import type {KeyboardEvent} from 'react'
+
 import {Badge} from '@campfirein/byterover-packages/components/badge'
 import {Button} from '@campfirein/byterover-packages/components/button'
 import {
@@ -118,6 +120,14 @@ export function TaskTable({
 }
 
 function LoadMoreRow({isFetching, onClick}: {isFetching: boolean; onClick: () => void}) {
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (isFetching) return
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      onClick()
+    }
+  }
+
   return (
     <TableRow
       aria-disabled={isFetching}
@@ -126,6 +136,9 @@ function LoadMoreRow({isFetching, onClick}: {isFetching: boolean; onClick: () =>
         isFetching ? 'cursor-wait opacity-60' : 'cursor-pointer',
       )}
       onClick={isFetching ? undefined : onClick}
+      onKeyDown={handleKeyDown}
+      role="button"
+      tabIndex={isFetching ? -1 : 0}
     >
       <TableCell className="mono py-3 text-center text-[11px] uppercase tracking-wider" colSpan={8}>
         {isFetching ? 'Loading…' : 'Load more'}

--- a/src/webui/features/tasks/components/task-list-table.tsx
+++ b/src/webui/features/tasks/components/task-list-table.tsx
@@ -43,9 +43,12 @@ function durationOf(task: StoredTask, now: number): string {
 interface TaskTableProps {
   allSelected: boolean
   filtered: StoredTask[]
+  hasNextPage: boolean
+  isFetchingNextPage: boolean
   now: number
   onClearSearch: () => void
   onDelete: (taskId: string) => void
+  onLoadMore: () => void
   onRowClick: (taskId: string) => void
   onToggleSelect: (taskId: string) => void
   onToggleSelectAll: () => void
@@ -57,9 +60,12 @@ interface TaskTableProps {
 export function TaskTable({
   allSelected,
   filtered,
+  hasNextPage,
+  isFetchingNextPage,
   now,
   onClearSearch,
   onDelete,
+  onLoadMore,
   onRowClick,
   onToggleSelect,
   onToggleSelectAll,
@@ -91,20 +97,40 @@ export function TaskTable({
             </TableCell>
           </TableRow>
         ) : (
-          filtered.map((task) => (
-            <TaskRow
-              isSelected={selectedIds.has(task.taskId)}
-              key={task.taskId}
-              now={now}
-              onDelete={onDelete}
-              onRowClick={onRowClick}
-              onToggleSelect={onToggleSelect}
-              task={task}
-            />
-          ))
+          <>
+            {filtered.map((task) => (
+              <TaskRow
+                isSelected={selectedIds.has(task.taskId)}
+                key={task.taskId}
+                now={now}
+                onDelete={onDelete}
+                onRowClick={onRowClick}
+                onToggleSelect={onToggleSelect}
+                task={task}
+              />
+            ))}
+            {hasNextPage && <LoadMoreRow isFetching={isFetchingNextPage} onClick={onLoadMore} />}
+          </>
         )}
       </TableBody>
     </Table>
+  )
+}
+
+function LoadMoreRow({isFetching, onClick}: {isFetching: boolean; onClick: () => void}) {
+  return (
+    <TableRow
+      aria-disabled={isFetching}
+      className={cn(
+        'text-muted-foreground hover:text-foreground hover:bg-muted/50',
+        isFetching ? 'cursor-wait opacity-60' : 'cursor-pointer',
+      )}
+      onClick={isFetching ? undefined : onClick}
+    >
+      <TableCell className="mono py-3 text-center text-[11px] uppercase tracking-wider" colSpan={8}>
+        {isFetching ? 'Loading…' : 'Load more'}
+      </TableCell>
+    </TableRow>
   )
 }
 

--- a/src/webui/features/tasks/components/task-list-table.tsx
+++ b/src/webui/features/tasks/components/task-list-table.tsx
@@ -1,5 +1,3 @@
-import type {KeyboardEvent} from 'react'
-
 import {Badge} from '@campfirein/byterover-packages/components/badge'
 import {Button} from '@campfirein/byterover-packages/components/button'
 import {
@@ -45,12 +43,9 @@ function durationOf(task: StoredTask, now: number): string {
 interface TaskTableProps {
   allSelected: boolean
   filtered: StoredTask[]
-  hasNextPage: boolean
-  isFetchingNextPage: boolean
   now: number
   onClearSearch: () => void
   onDelete: (taskId: string) => void
-  onLoadMore: () => void
   onRowClick: (taskId: string) => void
   onToggleSelect: (taskId: string) => void
   onToggleSelectAll: () => void
@@ -62,12 +57,9 @@ interface TaskTableProps {
 export function TaskTable({
   allSelected,
   filtered,
-  hasNextPage,
-  isFetchingNextPage,
   now,
   onClearSearch,
   onDelete,
-  onLoadMore,
   onRowClick,
   onToggleSelect,
   onToggleSelectAll,
@@ -99,51 +91,20 @@ export function TaskTable({
             </TableCell>
           </TableRow>
         ) : (
-          <>
-            {filtered.map((task) => (
-              <TaskRow
-                isSelected={selectedIds.has(task.taskId)}
-                key={task.taskId}
-                now={now}
-                onDelete={onDelete}
-                onRowClick={onRowClick}
-                onToggleSelect={onToggleSelect}
-                task={task}
-              />
-            ))}
-            {hasNextPage && <LoadMoreRow isFetching={isFetchingNextPage} onClick={onLoadMore} />}
-          </>
+          filtered.map((task) => (
+            <TaskRow
+              isSelected={selectedIds.has(task.taskId)}
+              key={task.taskId}
+              now={now}
+              onDelete={onDelete}
+              onRowClick={onRowClick}
+              onToggleSelect={onToggleSelect}
+              task={task}
+            />
+          ))
         )}
       </TableBody>
     </Table>
-  )
-}
-
-function LoadMoreRow({isFetching, onClick}: {isFetching: boolean; onClick: () => void}) {
-  const handleKeyDown = (event: KeyboardEvent) => {
-    if (isFetching) return
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault()
-      onClick()
-    }
-  }
-
-  return (
-    <TableRow
-      aria-disabled={isFetching}
-      className={cn(
-        'text-muted-foreground hover:text-foreground hover:bg-muted/50',
-        isFetching ? 'cursor-wait opacity-60' : 'cursor-pointer',
-      )}
-      onClick={isFetching ? undefined : onClick}
-      onKeyDown={handleKeyDown}
-      role="button"
-      tabIndex={isFetching ? -1 : 0}
-    >
-      <TableCell className="mono py-3 text-center text-[11px] uppercase tracking-wider" colSpan={8}>
-        {isFetching ? 'Loading…' : 'Load more'}
-      </TableCell>
-    </TableRow>
   )
 }
 
@@ -184,7 +145,9 @@ function TaskRow({
         <TypeBadge type={task.type} />
       </TableCell>
       <TableCell className="text-foreground max-w-0">
-        <div className="truncate">{task.content || <span className="text-muted-foreground italic">(empty)</span>}</div>
+        <div className="truncate" title={task.content || undefined}>
+          {task.content || <span className="text-muted-foreground italic">(empty)</span>}
+        </div>
         {activity && (
           <div className="text-muted-foreground mono mt-1 flex items-center gap-1.5 text-[11px]">
             <span className="text-blue-400">▸</span>
@@ -224,7 +187,7 @@ function TaskRow({
 
 function TypeBadge({type}: {type: string}) {
   return (
-    <Badge className="text-muted-foreground mono text-[10px] uppercase tracking-wider" variant="outline">
+    <Badge className="text-muted-foreground mono text-[10px] leading-none uppercase tracking-wider" variant="outline">
       {displayTaskType(type)}
     </Badge>
   )

--- a/src/webui/features/tasks/components/task-list-view.tsx
+++ b/src/webui/features/tasks/components/task-list-view.tsx
@@ -8,18 +8,26 @@ import type {ComposerType} from './task-composer-types'
 import {useTransportStore} from '../../../stores/transport-store'
 import {CURATE_EXAMPLE, QUERY_EXAMPLE, TOUR_STEP_LABEL} from '../../onboarding/lib/tour-examples'
 import {useOnboardingStore} from '../../onboarding/stores/onboarding-store'
+import {useGetProviders} from '../../provider/api/get-providers'
 import {useGetTasks} from '../api/get-tasks'
+import {useDebouncedValue} from '../hooks/use-debounced-value'
+import {useTaskFilterParams} from '../hooks/use-task-filter-params'
 import {useTickingNow} from '../hooks/use-ticking-now'
 import {useComposerRetryStore} from '../stores/composer-retry-store'
-import {statusMatchesFilter, taskMatchesQuery, useStatusBreakdown, useTaskStore} from '../stores/task-store'
+import {useTaskStore} from '../stores/task-store'
+import {durationPresetToRange} from '../utils/duration-presets'
+import {statusFilterToServer} from '../utils/status-filter-to-server'
 import {isTerminalStatus} from '../utils/task-status'
 import {TaskComposerSheet} from './task-composer'
 import {TaskDetailView} from './task-detail-view'
+import {TaskFilterTags} from './task-filter-tags'
 import {BulkActionsBar} from './task-list-bulk-actions'
 import {EmptyState, LoadingState, PlaceholderCard} from './task-list-empty'
 import {FilterBar} from './task-list-filter-bar'
+import {TaskListPagination} from './task-list-pagination'
 import {TaskTable} from './task-list-table'
 
+// eslint-disable-next-line complexity
 export function TaskListView() {
   const [searchParams, setSearchParams] = useSearchParams()
   const selectedTaskId = searchParams.get('task') ?? undefined
@@ -41,19 +49,78 @@ export function TaskListView() {
 
   const projectPath = useTransportStore((s) => s.selectedProject)
 
-  const tasks = useTaskStore((s) => s.tasks)
-  const statusFilter = useTaskStore((s) => s.statusFilter)
-  const setStatusFilter = useTaskStore((s) => s.setStatusFilter)
-  const searchQuery = useTaskStore((s) => s.searchQuery)
-  const setSearchQuery = useTaskStore((s) => s.setSearchQuery)
   const clearCompleted = useTaskStore((s) => s.clearCompleted)
   const removeTask = useTaskStore((s) => s.removeTask)
 
-  const breakdown = useStatusBreakdown()
-  const {fetchNextPage, hasNextPage, isFetchingNextPage, isLoading} = useGetTasks({
-    projectPath: projectPath || undefined,
+  const {
+    clearAllFilters,
+    filters,
+    setDurationPreset,
+    setModelFilter,
+    setPage,
+    setPageSize,
+    setProviderFilter,
+    setSearchQuery,
+    setStatusFilter,
+    setTimeRange,
+    setTypeFilter,
+  } = useTaskFilterParams()
+  const {data: providersResponse} = useGetProviders()
+  const providers = providersResponse?.providers ?? []
+  const {
+    createdAfter,
+    createdBefore,
+    durationPreset,
+    modelFilter,
+    page,
+    pageSize,
+    providerFilter,
+    searchQuery,
+    statusFilter,
+    typeFilter,
+  } = filters
+
+  const durationRange = useMemo(() => durationPresetToRange(durationPreset), [durationPreset])
+  const debouncedSearch = useDebouncedValue(searchQuery, 300)
+
+  const nonStatusFilters = useMemo(
+    () => ({
+      projectPath: projectPath || undefined,
+      ...(typeFilter.length > 0 ? {type: typeFilter} : {}),
+      ...(providerFilter.length > 0 ? {provider: providerFilter} : {}),
+      ...(modelFilter.length > 0 ? {model: modelFilter} : {}),
+      ...(createdAfter === undefined ? {} : {createdAfter}),
+      ...(createdBefore === undefined ? {} : {createdBefore}),
+      ...durationRange,
+      ...(debouncedSearch.trim() ? {searchText: debouncedSearch.trim()} : {}),
+    }),
+    [projectPath, typeFilter, providerFilter, modelFilter, createdAfter, createdBefore, durationRange, debouncedSearch],
+  )
+
+  const serverStatus = statusFilterToServer(statusFilter)
+  const {data, isLoading} = useGetTasks({
+    page,
+    pageSize,
+    ...nonStatusFilters,
+    ...(serverStatus ? {status: serverStatus} : {}),
   })
+
+  const {data: countsData} = useGetTasks({page: 1, pageSize: 1, ...nonStatusFilters})
+
+  const tasks = data?.tasks ?? []
+  const breakdown = countsData?.counts ?? {all: 0, cancelled: 0, completed: 0, failed: 0, running: 0}
+  const availableProviders = data?.availableProviders ?? []
+  const availableModels = data?.availableModels ?? []
   const now = useTickingNow(breakdown.running > 0)
+  const hasActiveFilters =
+    statusFilter !== 'all' ||
+    typeFilter.length > 0 ||
+    providerFilter.length > 0 ||
+    modelFilter.length > 0 ||
+    createdAfter !== undefined ||
+    createdBefore !== undefined ||
+    durationPreset !== 'all' ||
+    searchQuery.trim().length > 0
 
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const [composer, setComposer] = useState<{
@@ -87,8 +154,6 @@ export function TaskListView() {
 
   const closeComposer = () => setComposer({open: false})
 
-  // Pick up retry seeds from the task-detail "Try again" CTA. Both normal and
-  // tour mode use this composer now, so the seed flow is shared.
   const retrySeed = useComposerRetryStore((s) => s.seed)
   const consumeRetry = useComposerRetryStore((s) => s.consume)
 
@@ -104,23 +169,19 @@ export function TaskListView() {
     if (openDetail) openTask(taskId)
   }
 
-  // O(1) taskId → task lookup. Replaces repeated tasks.find() in bulk action paths.
   const taskMap = useMemo(() => new Map(tasks.map((task) => [task.taskId, task])), [tasks])
 
   const filtered = useMemo(
     () =>
-      tasks
-        .filter((task) => statusMatchesFilter(task.status, statusFilter))
-        .filter((task) => taskMatchesQuery(task, searchQuery))
-        .sort((a, b) => {
-          const aActive = isTerminalStatus(a.status) ? 1 : 0
-          const bActive = isTerminalStatus(b.status) ? 1 : 0
-          if (aActive !== bActive) return aActive - bActive
-          const aRef = a.completedAt ?? a.startedAt ?? a.createdAt
-          const bRef = b.completedAt ?? b.startedAt ?? b.createdAt
-          return bRef - aRef
-        }),
-    [tasks, statusFilter, searchQuery],
+      [...tasks].sort((a, b) => {
+        const aActive = isTerminalStatus(a.status) ? 1 : 0
+        const bActive = isTerminalStatus(b.status) ? 1 : 0
+        if (aActive !== bActive) return aActive - bActive
+        const aRef = a.completedAt ?? a.startedAt ?? a.createdAt
+        const bRef = b.completedAt ?? b.startedAt ?? b.createdAt
+        return bRef - aRef
+      }),
+    [tasks],
   )
 
   const allFilteredSelected = filtered.length > 0 && filtered.every((task) => selectedIds.has(task.taskId))
@@ -176,20 +237,66 @@ export function TaskListView() {
         />
       ) : (
         <FilterBar
+          availableModels={availableModels}
+          availableProviders={availableProviders}
           breakdown={breakdown}
+          createdAfter={createdAfter}
+          createdBefore={createdBefore}
+          durationPreset={durationPreset}
+          modelFilter={modelFilter}
+          onDurationChange={(next) => {
+            setDurationPreset(next)
+            clearSelection()
+          }}
+          onModelChange={(next) => {
+            setModelFilter(next)
+            clearSelection()
+          }}
           onNewTask={openComposer}
+          onProviderChange={(next) => {
+            setProviderFilter(next)
+            clearSelection()
+          }}
           onSearchChange={setSearchQuery}
           onStatusChange={(filter) => {
             setStatusFilter(filter)
             clearSelection()
           }}
+          onTimeRangeChange={(next) => {
+            setTimeRange(next)
+            clearSelection()
+          }}
+          onTypeChange={(next) => {
+            setTypeFilter(next)
+            clearSelection()
+          }}
+          providerFilter={providerFilter}
           searchQuery={searchQuery}
           statusFilter={statusFilter}
-          // Coachmark moves between the empty-state CTA and the header CTA so
-          // we never highlight both simultaneously.
           tourCue={tourCueLabel && tasks.length > 0 ? tourCueLabel : undefined}
+          typeFilter={typeFilter}
         />
       )}
+
+      <TaskFilterTags
+        createdAfter={createdAfter}
+        createdBefore={createdBefore}
+        durationPreset={durationPreset}
+        modelFilter={modelFilter}
+        onClearAll={clearAllFilters}
+        onDurationChange={setDurationPreset}
+        onModelChange={setModelFilter}
+        onProviderChange={setProviderFilter}
+        onSearchChange={setSearchQuery}
+        onStatusChange={setStatusFilter}
+        onTimeRangeChange={setTimeRange}
+        onTypeChange={setTypeFilter}
+        providerFilter={providerFilter}
+        providers={providers}
+        searchQuery={searchQuery}
+        statusFilter={statusFilter}
+        typeFilter={typeFilter}
+      />
 
       {isLoading ? (
         <PlaceholderCard>
@@ -197,24 +304,37 @@ export function TaskListView() {
         </PlaceholderCard>
       ) : tasks.length === 0 ? (
         <PlaceholderCard withDots>
-          <EmptyState onNewTask={openComposer} tourCue={tourCueLabel} />
+          <EmptyState
+            hasActiveFilters={hasActiveFilters}
+            onClearFilters={clearAllFilters}
+            onNewTask={openComposer}
+            tourCue={tourCueLabel}
+          />
         </PlaceholderCard>
       ) : (
         <TaskTable
           allSelected={allFilteredSelected}
           filtered={filtered}
-          hasNextPage={hasNextPage}
-          isFetchingNextPage={isFetchingNextPage}
           now={now}
           onClearSearch={() => setSearchQuery('')}
           onDelete={removeTask}
-          onLoadMore={() => fetchNextPage()}
           onRowClick={openTask}
           onToggleSelect={toggleSelect}
           onToggleSelectAll={toggleSelectAll}
           searchQuery={searchQuery}
           selectedIds={selectedIds}
           statusFilter={statusFilter}
+        />
+      )}
+
+      {data && (
+        <TaskListPagination
+          onPageChange={setPage}
+          onPageSizeChange={setPageSize}
+          page={data.page}
+          pageCount={data.pageCount}
+          pageSize={data.pageSize}
+          total={data.total}
         />
       )}
 

--- a/src/webui/features/tasks/components/task-list-view.tsx
+++ b/src/webui/features/tasks/components/task-list-view.tsx
@@ -50,7 +50,9 @@ export function TaskListView() {
   const removeTask = useTaskStore((s) => s.removeTask)
 
   const breakdown = useStatusBreakdown()
-  const {isLoading} = useGetTasks({projectPath: projectPath || undefined})
+  const {fetchNextPage, hasNextPage, isFetchingNextPage, isLoading} = useGetTasks({
+    projectPath: projectPath || undefined,
+  })
   const now = useTickingNow(breakdown.running > 0)
 
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
@@ -201,9 +203,12 @@ export function TaskListView() {
         <TaskTable
           allSelected={allFilteredSelected}
           filtered={filtered}
+          hasNextPage={hasNextPage}
+          isFetchingNextPage={isFetchingNextPage}
           now={now}
           onClearSearch={() => setSearchQuery('')}
           onDelete={removeTask}
+          onLoadMore={() => fetchNextPage()}
           onRowClick={openTask}
           onToggleSelect={toggleSelect}
           onToggleSelectAll={toggleSelectAll}

--- a/src/webui/features/tasks/components/task-list-view.tsx
+++ b/src/webui/features/tasks/components/task-list-view.tsx
@@ -1,6 +1,6 @@
 import {Button} from '@campfirein/byterover-packages/components/button'
 import {Sheet, SheetContent} from '@campfirein/byterover-packages/components/sheet'
-import {useEffect, useMemo, useState} from 'react'
+import {useCallback, useEffect, useMemo, useState} from 'react'
 import {useSearchParams} from 'react-router-dom'
 
 import type {ComposerType} from './task-composer-types'
@@ -39,13 +39,13 @@ export function TaskListView() {
     })
   }
 
-  const closeTask = () => {
+  const closeTask = useCallback(() => {
     setSearchParams((prev) => {
       const next = new URLSearchParams(prev)
       next.delete('task')
       return next
     })
-  }
+  }, [setSearchParams])
 
   const projectPath = useTransportStore((s) => s.selectedProject)
 
@@ -97,7 +97,7 @@ export function TaskListView() {
     [projectPath, typeFilter, providerFilter, modelFilter, createdAfter, createdBefore, durationRange, debouncedSearch],
   )
 
-  const serverStatus = statusFilterToServer(statusFilter)
+  const serverStatus = useMemo(() => statusFilterToServer(statusFilter), [statusFilter])
   const {data, isLoading} = useGetTasks({
     page,
     pageSize,
@@ -271,6 +271,7 @@ export function TaskListView() {
             clearSelection()
           }}
           providerFilter={providerFilter}
+          providers={providers}
           searchQuery={searchQuery}
           statusFilter={statusFilter}
           tourCue={tourCueLabel && tasks.length > 0 ? tourCueLabel : undefined}

--- a/src/webui/features/tasks/components/task-subscription-initializer.tsx
+++ b/src/webui/features/tasks/components/task-subscription-initializer.tsx
@@ -36,7 +36,8 @@ export function TaskSubscriptionInitializer() {
 
   useEffect(() => {
     if (!data) return
-    mergeTasks(data.tasks)
+    const merged = data.pages.flatMap((page) => page.tasks)
+    mergeTasks(merged)
   }, [data, mergeTasks])
 
   return null

--- a/src/webui/features/tasks/components/task-subscription-initializer.tsx
+++ b/src/webui/features/tasks/components/task-subscription-initializer.tsx
@@ -1,27 +1,26 @@
+import {useQueryClient} from '@tanstack/react-query'
 import {useEffect, useRef} from 'react'
 
+import {TaskEvents} from '../../../../shared/transport/events/task-events'
 import {useTransportStore} from '../../../stores/transport-store'
-import {useGetTasks} from '../api/get-tasks'
 import {useTaskSubscriptions} from '../hooks/use-task-subscriptions'
 import {useTaskStore} from '../stores/task-store'
 
-/**
- * Mounts task lifecycle subscriptions and reconciles the daemon snapshot with
- * the locally-cached tasks. Mounted at the route root so the Tasks tab badge
- * stays accurate regardless of which tab is active.
- *
- * Snapshot policy: merge, don't replace. The daemon discards completed tasks
- * after a 5s grace window, so its `task:list` would otherwise clobber finished
- * tasks the user can still see. Persisted task-store is the source of truth
- * for finished history; the daemon snapshot reconciles in-flight tasks.
- *
- * Project change: clear the cache so a different project starts fresh.
- */
+const TASK_LIFECYCLE_EVENTS = [
+  TaskEvents.CREATED,
+  TaskEvents.STARTED,
+  TaskEvents.COMPLETED,
+  TaskEvents.ERROR,
+  TaskEvents.CANCELLED,
+  TaskEvents.DELETED,
+] as const
+
 export function TaskSubscriptionInitializer() {
   const projectPath = useTransportStore((s) => s.selectedProject)
+  const apiClient = useTransportStore((s) => s.apiClient)
   const reset = useTaskStore((s) => s.reset)
-  const mergeTasks = useTaskStore((s) => s.mergeTasks)
   const previousProject = useRef(projectPath)
+  const queryClient = useQueryClient()
 
   useTaskSubscriptions()
 
@@ -32,13 +31,17 @@ export function TaskSubscriptionInitializer() {
     }
   }, [projectPath, reset])
 
-  const {data} = useGetTasks({projectPath: projectPath || undefined})
-
   useEffect(() => {
-    if (!data) return
-    const merged = data.pages.flatMap((page) => page.tasks)
-    mergeTasks(merged)
-  }, [data, mergeTasks])
+    if (!apiClient) return
+    const unsubscribers = TASK_LIFECYCLE_EVENTS.map((event) =>
+      apiClient.on(event, () => {
+        queryClient.invalidateQueries({queryKey: ['tasks', 'list']})
+      }),
+    )
+    return () => {
+      for (const unsub of unsubscribers) unsub()
+    }
+  }, [apiClient, queryClient])
 
   return null
 }

--- a/src/webui/features/tasks/hooks/use-debounced-value.ts
+++ b/src/webui/features/tasks/hooks/use-debounced-value.ts
@@ -1,0 +1,12 @@
+import {useEffect, useState} from 'react'
+
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value)
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delayMs)
+    return () => clearTimeout(id)
+  }, [value, delayMs])
+
+  return debounced
+}

--- a/src/webui/features/tasks/hooks/use-task-filter-params.ts
+++ b/src/webui/features/tasks/hooks/use-task-filter-params.ts
@@ -1,0 +1,141 @@
+import {useCallback, useMemo} from 'react'
+import {useSearchParams} from 'react-router-dom'
+
+import {type StatusFilter} from '../stores/task-store'
+import {type DurationPreset} from '../utils/duration-presets'
+
+export interface TaskFilters {
+  createdAfter?: number
+  createdBefore?: number
+  durationPreset: DurationPreset
+  modelFilter: string[]
+  page: number
+  pageSize: number
+  providerFilter: string[]
+  searchQuery: string
+  statusFilter: StatusFilter
+  typeFilter: string[]
+}
+
+const STATUS_VALUES = new Set<string>(['all', 'cancelled', 'completed', 'failed', 'running'])
+const DURATION_VALUES = new Set<string>(['all', 'long', 'medium', 'short', 'very-long'])
+const DEFAULT_PAGE_SIZE = 50
+
+const FILTER_PARAM_KEYS = ['status', 'types', 'providers', 'models', 'from', 'to', 'duration', 'q', 'page', 'pageSize'] as const
+
+function isStatusFilter(value: null | string): value is StatusFilter {
+  return value !== null && STATUS_VALUES.has(value)
+}
+
+function isDurationPreset(value: null | string): value is DurationPreset {
+  return value !== null && DURATION_VALUES.has(value)
+}
+
+export function useTaskFilterParams(): {
+  clearAllFilters: () => void
+  filters: TaskFilters
+  setDurationPreset: (preset: DurationPreset) => void
+  setModelFilter: (next: string[]) => void
+  setPage: (page: number) => void
+  setPageSize: (pageSize: number) => void
+  setProviderFilter: (next: string[]) => void
+  setSearchQuery: (query: string) => void
+  setStatusFilter: (filter: StatusFilter) => void
+  setTimeRange: (range: {createdAfter?: number; createdBefore?: number}) => void
+  setTypeFilter: (next: string[]) => void
+} {
+  const [params, setParams] = useSearchParams()
+  const filters = useMemo(() => parseFilters(params), [params])
+
+  const update = useCallback(
+    (updates: Record<string, null | string | string[]>, resetPage = true) => {
+      setParams((prev) => {
+        const next = new URLSearchParams(prev)
+        for (const [key, value] of Object.entries(updates)) {
+          if (value === null || value === '' || (Array.isArray(value) && value.length === 0)) {
+            next.delete(key)
+          } else if (Array.isArray(value)) {
+            next.set(key, value.join(','))
+          } else {
+            next.set(key, value)
+          }
+        }
+
+        if (resetPage) next.delete('page')
+        return next
+      })
+    },
+    [setParams],
+  )
+
+  const setters = useMemo(
+    () => ({
+      clearAllFilters() {
+        setParams((prev) => {
+          const next = new URLSearchParams(prev)
+          for (const key of FILTER_PARAM_KEYS) next.delete(key)
+          return next
+        })
+      },
+      setDurationPreset(preset: DurationPreset) {
+        update({duration: preset === 'all' ? null : preset})
+      },
+      setModelFilter(next: string[]) {
+        update({models: next})
+      },
+      setPage(page: number) {
+        update({page: page === 1 ? null : String(page)}, false)
+      },
+      setPageSize(pageSize: number) {
+        update({pageSize: pageSize === DEFAULT_PAGE_SIZE ? null : String(pageSize)})
+      },
+      setProviderFilter(next: string[]) {
+        update({providers: next})
+      },
+      setSearchQuery(query: string) {
+        update({q: query})
+      },
+      setStatusFilter(filter: StatusFilter) {
+        update({status: filter === 'all' ? null : filter})
+      },
+      setTimeRange(range: {createdAfter?: number; createdBefore?: number}) {
+        update({
+          from: range.createdAfter === undefined ? null : String(range.createdAfter),
+          to: range.createdBefore === undefined ? null : String(range.createdBefore),
+        })
+      },
+      setTypeFilter(next: string[]) {
+        update({types: next})
+      },
+    }),
+    [update, setParams],
+  )
+
+  return {filters, ...setters}
+}
+
+function parseFilters(params: URLSearchParams): TaskFilters {
+  const status = params.get('status')
+  const duration = params.get('duration')
+  const pageRaw = params.get('page')
+  const pageSizeRaw = params.get('pageSize')
+  const fromRaw = params.get('from')
+  const toRaw = params.get('to')
+  return {
+    durationPreset: isDurationPreset(duration) ? duration : 'all',
+    modelFilter: parseList(params.get('models')),
+    page: pageRaw ? Math.max(1, Number.parseInt(pageRaw, 10) || 1) : 1,
+    pageSize: pageSizeRaw ? Math.max(1, Number.parseInt(pageSizeRaw, 10) || DEFAULT_PAGE_SIZE) : DEFAULT_PAGE_SIZE,
+    providerFilter: parseList(params.get('providers')),
+    searchQuery: params.get('q') ?? '',
+    statusFilter: isStatusFilter(status) ? status : 'all',
+    typeFilter: parseList(params.get('types')),
+    ...(fromRaw && Number.isFinite(Number(fromRaw)) ? {createdAfter: Number(fromRaw)} : {}),
+    ...(toRaw && Number.isFinite(Number(toRaw)) ? {createdBefore: Number(toRaw)} : {}),
+  }
+}
+
+function parseList(raw: null | string): string[] {
+  if (!raw) return []
+  return raw.split(',').filter(Boolean)
+}

--- a/src/webui/features/tasks/hooks/use-task-filter-params.ts
+++ b/src/webui/features/tasks/hooks/use-task-filter-params.ts
@@ -2,7 +2,7 @@ import {useCallback, useMemo} from 'react'
 import {useSearchParams} from 'react-router-dom'
 
 import {type StatusFilter} from '../stores/task-store'
-import {type DurationPreset} from '../utils/duration-presets'
+import {type DurationPreset, isDurationPreset} from '../utils/duration-presets'
 
 export interface TaskFilters {
   createdAfter?: number
@@ -18,17 +18,12 @@ export interface TaskFilters {
 }
 
 const STATUS_VALUES = new Set<string>(['all', 'cancelled', 'completed', 'failed', 'running'])
-const DURATION_VALUES = new Set<string>(['all', 'long', 'medium', 'short', 'very-long'])
 const DEFAULT_PAGE_SIZE = 50
 
 const FILTER_PARAM_KEYS = ['status', 'types', 'providers', 'models', 'from', 'to', 'duration', 'q', 'page', 'pageSize'] as const
 
 function isStatusFilter(value: null | string): value is StatusFilter {
   return value !== null && STATUS_VALUES.has(value)
-}
-
-function isDurationPreset(value: null | string): value is DurationPreset {
-  return value !== null && DURATION_VALUES.has(value)
 }
 
 export function useTaskFilterParams(): {
@@ -122,7 +117,7 @@ function parseFilters(params: URLSearchParams): TaskFilters {
   const fromRaw = params.get('from')
   const toRaw = params.get('to')
   return {
-    durationPreset: isDurationPreset(duration) ? duration : 'all',
+    durationPreset: duration !== null && isDurationPreset(duration) ? duration : 'all',
     modelFilter: parseList(params.get('models')),
     page: pageRaw ? Math.max(1, Number.parseInt(pageRaw, 10) || 1) : 1,
     pageSize: pageSizeRaw ? Math.max(1, Number.parseInt(pageSizeRaw, 10) || DEFAULT_PAGE_SIZE) : DEFAULT_PAGE_SIZE,

--- a/src/webui/features/tasks/utils/duration-presets.ts
+++ b/src/webui/features/tasks/utils/duration-presets.ts
@@ -8,6 +8,12 @@ export const DURATION_PRESETS: ReadonlyArray<{label: string; value: DurationPres
   {label: '> 2m', value: 'very-long'},
 ]
 
+const DURATION_VALUES = new Set<string>(DURATION_PRESETS.map((p) => p.value))
+
+export function isDurationPreset(value: string): value is DurationPreset {
+  return DURATION_VALUES.has(value)
+}
+
 const DURATION_LABEL: Record<DurationPreset, string> = {
   all: 'Any duration',
   long: '30s – 2m',

--- a/src/webui/features/tasks/utils/duration-presets.ts
+++ b/src/webui/features/tasks/utils/duration-presets.ts
@@ -1,0 +1,33 @@
+export type DurationPreset = 'all' | 'long' | 'medium' | 'short' | 'very-long'
+
+export const DURATION_PRESETS: ReadonlyArray<{label: string; value: DurationPreset}> = [
+  {label: 'Any duration', value: 'all'},
+  {label: '< 5s', value: 'short'},
+  {label: '5s – 30s', value: 'medium'},
+  {label: '30s – 2m', value: 'long'},
+  {label: '> 2m', value: 'very-long'},
+]
+
+const DURATION_LABEL: Record<DurationPreset, string> = {
+  all: 'Any duration',
+  long: '30s – 2m',
+  medium: '5s – 30s',
+  short: '< 5s',
+  'very-long': '> 2m',
+}
+
+const DURATION_RANGE: Record<DurationPreset, {maxDurationMs?: number; minDurationMs?: number}> = {
+  all: {},
+  long: {maxDurationMs: 120_000, minDurationMs: 30_000},
+  medium: {maxDurationMs: 30_000, minDurationMs: 5000},
+  short: {maxDurationMs: 5000},
+  'very-long': {minDurationMs: 120_000},
+}
+
+export function durationPresetToRange(preset: DurationPreset): {maxDurationMs?: number; minDurationMs?: number} {
+  return DURATION_RANGE[preset]
+}
+
+export function durationPresetLabel(preset: DurationPreset): string {
+  return DURATION_LABEL[preset]
+}

--- a/src/webui/features/tasks/utils/status-filter-to-server.ts
+++ b/src/webui/features/tasks/utils/status-filter-to-server.ts
@@ -1,0 +1,14 @@
+import type {TaskListItemStatus} from '../../../../shared/transport/events/task-events'
+import type {StatusFilter} from '../stores/task-store'
+
+const STATUS_FILTER_TO_SERVER: Record<StatusFilter, TaskListItemStatus[] | undefined> = {
+  all: undefined,
+  cancelled: ['cancelled'],
+  completed: ['completed'],
+  failed: ['error'],
+  running: ['created', 'started'],
+}
+
+export function statusFilterToServer(filter: StatusFilter): TaskListItemStatus[] | undefined {
+  return STATUS_FILTER_TO_SERVER[filter]
+}

--- a/src/webui/features/tasks/utils/time-presets.ts
+++ b/src/webui/features/tasks/utils/time-presets.ts
@@ -1,0 +1,56 @@
+import {format, startOfDay, startOfMonth, startOfWeek} from 'date-fns'
+
+export type TimePreset = 'all' | 'month' | 'today' | 'week'
+
+export const TIME_PRESETS: ReadonlyArray<{label: string; value: TimePreset}> = [
+  {label: 'Any time', value: 'all'},
+  {label: 'Today', value: 'today'},
+  {label: 'This week', value: 'week'},
+  {label: 'This month', value: 'month'},
+]
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+export function timePresetToRange(preset: TimePreset, now: number): {createdAfter?: number; createdBefore?: number} {
+  if (preset === 'all') return {}
+  if (preset === 'today') return {createdAfter: startOfDay(now).getTime()}
+  if (preset === 'week') return {createdAfter: startOfWeek(now, {weekStartsOn: 1}).getTime()}
+  if (preset === 'month') return {createdAfter: startOfMonth(now).getTime()}
+  return {}
+}
+
+export function timePresetLabel(preset: TimePreset): string {
+  return TIME_PRESETS.find((p) => p.value === preset)?.label ?? 'Any time'
+}
+
+export function detectActiveTimePreset(
+  range: {createdAfter?: number; createdBefore?: number},
+  now: number,
+): 'custom' | TimePreset {
+  if (range.createdAfter === undefined && range.createdBefore === undefined) return 'all'
+  for (const preset of TIME_PRESETS) {
+    if (preset.value === 'all') continue
+    const expected = timePresetToRange(preset.value, now)
+    if (expected.createdAfter === range.createdAfter && expected.createdBefore === range.createdBefore) {
+      return preset.value
+    }
+  }
+
+  return 'custom'
+}
+
+function formatRangeBoundary(ms: number): string {
+  return format(ms, 'd MMM yyyy')
+}
+
+export function formatTimeRangeLabel(range: {createdAfter?: number; createdBefore?: number}): string {
+  if (range.createdAfter !== undefined && range.createdBefore !== undefined) {
+    return `${formatRangeBoundary(range.createdAfter)} – ${formatRangeBoundary(range.createdBefore)}`
+  }
+
+  if (range.createdAfter !== undefined) return `Since ${formatRangeBoundary(range.createdAfter)}`
+  if (range.createdBefore !== undefined) return `Until ${formatRangeBoundary(range.createdBefore)}`
+  return 'Any time'
+}
+
+export {DAY_MS}

--- a/test/unit/webui/features/tasks/api/get-tasks.test.ts
+++ b/test/unit/webui/features/tasks/api/get-tasks.test.ts
@@ -13,87 +13,87 @@ import {
 import {useTransportStore} from '../../../../../../src/webui/stores/transport-store.js'
 
 describe('get-tasks api', () => {
-describe('getTasks', () => {
-  let sandbox: SinonSandbox
-  let request: SinonStub
+  describe('getTasks', () => {
+    let sandbox: SinonSandbox
+    let request: SinonStub
 
-  beforeEach(() => {
-    sandbox = createSandbox()
-    request = sandbox.stub()
-    useTransportStore.setState({
-      apiClient: {on: sandbox.stub(), request} as unknown as BrvApiClient,
+    beforeEach(() => {
+      sandbox = createSandbox()
+      request = sandbox.stub()
+      useTransportStore.setState({
+        apiClient: {on: sandbox.stub(), request} as unknown as BrvApiClient,
+      })
+    })
+
+    afterEach(() => {
+      sandbox.restore()
+      useTransportStore.setState({apiClient: null})
+    })
+
+    it('emits task:list with the request payload', async () => {
+      request.resolves({tasks: []})
+      await getTasks({limit: 50, projectPath: '/foo'})
+      expect(request.firstCall.args[0]).to.equal(TaskEvents.LIST)
+      expect(request.firstCall.args[1]).to.deep.equal({limit: 50, projectPath: '/foo'})
+    })
+
+    it('forwards before + beforeTaskId for paginated requests', async () => {
+      request.resolves({tasks: []})
+      await getTasks({before: 1234, beforeTaskId: 'tsk-x', limit: 50, projectPath: '/foo'})
+      expect(request.firstCall.args[1]).to.deep.equal({
+        before: 1234,
+        beforeTaskId: 'tsk-x',
+        limit: 50,
+        projectPath: '/foo',
+      })
+    })
+
+    it('throws when not connected to the daemon', async () => {
+      useTransportStore.setState({apiClient: null})
+      try {
+        await getTasks({limit: 50})
+        expect.fail('expected to throw')
+      } catch (error) {
+        expect((error as Error).message).to.equal('Not connected')
+      }
     })
   })
 
-  afterEach(() => {
-    sandbox.restore()
-    useTransportStore.setState({apiClient: null})
-  })
+  describe('initialPageParam', () => {
+    it('returns default limit and projectPath when projectPath is provided', () => {
+      expect(initialPageParam('/foo')).to.deep.equal({limit: DEFAULT_PAGE_LIMIT, projectPath: '/foo'})
+    })
 
-  it('emits task:list with the request payload', async () => {
-    request.resolves({tasks: []})
-    await getTasks({limit: 50, projectPath: '/foo'})
-    expect(request.firstCall.args[0]).to.equal(TaskEvents.LIST)
-    expect(request.firstCall.args[1]).to.deep.equal({limit: 50, projectPath: '/foo'})
-  })
-
-  it('forwards before + beforeTaskId for paginated requests', async () => {
-    request.resolves({tasks: []})
-    await getTasks({before: 1234, beforeTaskId: 'tsk-x', limit: 50, projectPath: '/foo'})
-    expect(request.firstCall.args[1]).to.deep.equal({
-      before: 1234,
-      beforeTaskId: 'tsk-x',
-      limit: 50,
-      projectPath: '/foo',
+    it('omits projectPath when not provided', () => {
+      expect(initialPageParam()).to.deep.equal({limit: DEFAULT_PAGE_LIMIT})
     })
   })
 
-  it('throws when not connected to the daemon', async () => {
-    useTransportStore.setState({apiClient: null})
-    try {
-      await getTasks({limit: 50})
-      expect.fail('expected to throw')
-    } catch (error) {
-      expect((error as Error).message).to.equal('Not connected')
-    }
-  })
-})
+  describe('getNextPageParam', () => {
+    const lastParam = {limit: 50, projectPath: '/foo'}
 
-describe('initialPageParam', () => {
-  it('returns default limit and projectPath when projectPath is provided', () => {
-    expect(initialPageParam('/foo')).to.deep.equal({limit: DEFAULT_PAGE_LIMIT, projectPath: '/foo'})
-  })
+    it('returns undefined when lastPage has no nextCursor (last page reached)', () => {
+      const lastPage: TaskListResponse = {tasks: []}
+      expect(getNextPageParam(lastPage, lastParam)).to.equal(undefined)
+    })
 
-  it('omits projectPath when not provided', () => {
-    expect(initialPageParam()).to.deep.equal({limit: DEFAULT_PAGE_LIMIT})
-  })
-})
+    it('returns next-page params when nextCursor is set', () => {
+      const lastPage: TaskListResponse = {nextCursor: 1234, tasks: []}
+      expect(getNextPageParam(lastPage, lastParam)).to.deep.equal({
+        before: 1234,
+        limit: 50,
+        projectPath: '/foo',
+      })
+    })
 
-describe('getNextPageParam', () => {
-  const lastParam = {limit: 50, projectPath: '/foo'}
-
-  it('returns undefined when lastPage has no nextCursor (last page reached)', () => {
-    const lastPage: TaskListResponse = {tasks: []}
-    expect(getNextPageParam(lastPage, lastParam)).to.equal(undefined)
-  })
-
-  it('returns next-page params when nextCursor is set', () => {
-    const lastPage: TaskListResponse = {nextCursor: 1234, tasks: []}
-    expect(getNextPageParam(lastPage, lastParam)).to.deep.equal({
-      before: 1234,
-      limit: 50,
-      projectPath: '/foo',
+    it('forwards nextCursorTaskId as beforeTaskId tiebreaker', () => {
+      const lastPage: TaskListResponse = {nextCursor: 1234, nextCursorTaskId: 'tsk-x', tasks: []}
+      expect(getNextPageParam(lastPage, lastParam)).to.deep.equal({
+        before: 1234,
+        beforeTaskId: 'tsk-x',
+        limit: 50,
+        projectPath: '/foo',
+      })
     })
   })
-
-  it('forwards nextCursorTaskId as beforeTaskId tiebreaker', () => {
-    const lastPage: TaskListResponse = {nextCursor: 1234, nextCursorTaskId: 'tsk-x', tasks: []}
-    expect(getNextPageParam(lastPage, lastParam)).to.deep.equal({
-      before: 1234,
-      beforeTaskId: 'tsk-x',
-      limit: 50,
-      projectPath: '/foo',
-    })
-  })
-})
 })

--- a/test/unit/webui/features/tasks/api/get-tasks.test.ts
+++ b/test/unit/webui/features/tasks/api/get-tasks.test.ts
@@ -3,97 +3,94 @@ import {createSandbox, type SinonSandbox, type SinonStub} from 'sinon'
 
 import type {BrvApiClient} from '../../../../../../src/webui/lib/api-client.js'
 
-import {TaskEvents, type TaskListResponse} from '../../../../../../src/shared/transport/events/task-events.js'
-import {
-  DEFAULT_PAGE_LIMIT,
-  getNextPageParam,
-  getTasks,
-  initialPageParam,
-} from '../../../../../../src/webui/features/tasks/api/get-tasks.js'
+import {TaskEvents} from '../../../../../../src/shared/transport/events/task-events.js'
+import {getTasks} from '../../../../../../src/webui/features/tasks/api/get-tasks.js'
 import {useTransportStore} from '../../../../../../src/webui/stores/transport-store.js'
 
-describe('get-tasks api', () => {
-  describe('getTasks', () => {
-    let sandbox: SinonSandbox
-    let request: SinonStub
+describe('getTasks', () => {
+  let sandbox: SinonSandbox
+  let request: SinonStub
 
-    beforeEach(() => {
-      sandbox = createSandbox()
-      request = sandbox.stub()
-      useTransportStore.setState({
-        apiClient: {on: sandbox.stub(), request} as unknown as BrvApiClient,
-      })
-    })
-
-    afterEach(() => {
-      sandbox.restore()
-      useTransportStore.setState({apiClient: null})
-    })
-
-    it('emits task:list with the request payload', async () => {
-      request.resolves({tasks: []})
-      await getTasks({limit: 50, projectPath: '/foo'})
-      expect(request.firstCall.args[0]).to.equal(TaskEvents.LIST)
-      expect(request.firstCall.args[1]).to.deep.equal({limit: 50, projectPath: '/foo'})
-    })
-
-    it('forwards before + beforeTaskId for paginated requests', async () => {
-      request.resolves({tasks: []})
-      await getTasks({before: 1234, beforeTaskId: 'tsk-x', limit: 50, projectPath: '/foo'})
-      expect(request.firstCall.args[1]).to.deep.equal({
-        before: 1234,
-        beforeTaskId: 'tsk-x',
-        limit: 50,
-        projectPath: '/foo',
-      })
-    })
-
-    it('throws when not connected to the daemon', async () => {
-      useTransportStore.setState({apiClient: null})
-      try {
-        await getTasks({limit: 50})
-        expect.fail('expected to throw')
-      } catch (error) {
-        expect((error as Error).message).to.equal('Not connected')
-      }
+  beforeEach(() => {
+    sandbox = createSandbox()
+    request = sandbox.stub()
+    useTransportStore.setState({
+      apiClient: {on: sandbox.stub(), request} as unknown as BrvApiClient,
     })
   })
 
-  describe('initialPageParam', () => {
-    it('returns default limit and projectPath when projectPath is provided', () => {
-      expect(initialPageParam('/foo')).to.deep.equal({limit: DEFAULT_PAGE_LIMIT, projectPath: '/foo'})
-    })
-
-    it('omits projectPath when not provided', () => {
-      expect(initialPageParam()).to.deep.equal({limit: DEFAULT_PAGE_LIMIT})
-    })
+  afterEach(() => {
+    sandbox.restore()
+    useTransportStore.setState({apiClient: null})
   })
 
-  describe('getNextPageParam', () => {
-    const lastParam = {limit: 50, projectPath: '/foo'}
-
-    it('returns undefined when lastPage has no nextCursor (last page reached)', () => {
-      const lastPage: TaskListResponse = {tasks: []}
-      expect(getNextPageParam(lastPage, lastParam)).to.equal(undefined)
+  it('emits task:list with the projectPath payload', async () => {
+    request.resolves({
+      availableModels: [],
+      availableProviders: [],
+      counts: {all: 0, cancelled: 0, completed: 0, failed: 0, running: 0},
+      page: 1,
+      pageCount: 1,
+      pageSize: 50,
+      tasks: [],
+      total: 0,
     })
+    await getTasks({projectPath: '/foo'})
+    expect(request.firstCall.args[0]).to.equal(TaskEvents.LIST)
+    expect(request.firstCall.args[1]).to.deep.equal({projectPath: '/foo'})
+  })
 
-    it('returns next-page params when nextCursor is set', () => {
-      const lastPage: TaskListResponse = {nextCursor: 1234, tasks: []}
-      expect(getNextPageParam(lastPage, lastParam)).to.deep.equal({
-        before: 1234,
-        limit: 50,
-        projectPath: '/foo',
-      })
+  it('forwards page + pageSize to the daemon', async () => {
+    request.resolves({
+      availableModels: [],
+      availableProviders: [],
+      counts: {all: 0, cancelled: 0, completed: 0, failed: 0, running: 0},
+      page: 3,
+      pageCount: 5,
+      pageSize: 50,
+      tasks: [],
+      total: 250,
     })
+    await getTasks({page: 3, pageSize: 50, projectPath: '/foo'})
+    expect(request.firstCall.args[1]).to.deep.equal({page: 3, pageSize: 50, projectPath: '/foo'})
+  })
 
-    it('forwards nextCursorTaskId as beforeTaskId tiebreaker', () => {
-      const lastPage: TaskListResponse = {nextCursor: 1234, nextCursorTaskId: 'tsk-x', tasks: []}
-      expect(getNextPageParam(lastPage, lastParam)).to.deep.equal({
-        before: 1234,
-        beforeTaskId: 'tsk-x',
-        limit: 50,
-        projectPath: '/foo',
-      })
+  it('forwards all filter dims (status, type, provider, model, time, duration, search)', async () => {
+    request.resolves({
+      availableModels: [],
+      availableProviders: [],
+      counts: {all: 0, cancelled: 0, completed: 0, failed: 0, running: 0},
+      page: 1,
+      pageCount: 1,
+      pageSize: 50,
+      tasks: [],
+      total: 0,
     })
+    const payload = {
+      createdAfter: 1_700_000_000_000,
+      createdBefore: 1_700_000_999_999,
+      maxDurationMs: 60_000,
+      minDurationMs: 1000,
+      model: ['gpt-5-pro'],
+      page: 1,
+      pageSize: 50,
+      projectPath: '/foo',
+      provider: ['openai'],
+      searchText: 'auth',
+      status: ['error' as const],
+      type: ['curate'],
+    }
+    await getTasks(payload)
+    expect(request.firstCall.args[1]).to.deep.equal(payload)
+  })
+
+  it('throws when not connected to the daemon', async () => {
+    useTransportStore.setState({apiClient: null})
+    try {
+      await getTasks({projectPath: '/foo'})
+      expect.fail('expected to throw')
+    } catch (error) {
+      expect((error as Error).message).to.equal('Not connected')
+    }
   })
 })

--- a/test/unit/webui/features/tasks/api/get-tasks.test.ts
+++ b/test/unit/webui/features/tasks/api/get-tasks.test.ts
@@ -1,0 +1,99 @@
+import {expect} from 'chai'
+import {createSandbox, type SinonSandbox, type SinonStub} from 'sinon'
+
+import type {BrvApiClient} from '../../../../../../src/webui/lib/api-client.js'
+
+import {TaskEvents, type TaskListResponse} from '../../../../../../src/shared/transport/events/task-events.js'
+import {
+  DEFAULT_PAGE_LIMIT,
+  getNextPageParam,
+  getTasks,
+  initialPageParam,
+} from '../../../../../../src/webui/features/tasks/api/get-tasks.js'
+import {useTransportStore} from '../../../../../../src/webui/stores/transport-store.js'
+
+describe('get-tasks api', () => {
+describe('getTasks', () => {
+  let sandbox: SinonSandbox
+  let request: SinonStub
+
+  beforeEach(() => {
+    sandbox = createSandbox()
+    request = sandbox.stub()
+    useTransportStore.setState({
+      apiClient: {on: sandbox.stub(), request} as unknown as BrvApiClient,
+    })
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+    useTransportStore.setState({apiClient: null})
+  })
+
+  it('emits task:list with the request payload', async () => {
+    request.resolves({tasks: []})
+    await getTasks({limit: 50, projectPath: '/foo'})
+    expect(request.firstCall.args[0]).to.equal(TaskEvents.LIST)
+    expect(request.firstCall.args[1]).to.deep.equal({limit: 50, projectPath: '/foo'})
+  })
+
+  it('forwards before + beforeTaskId for paginated requests', async () => {
+    request.resolves({tasks: []})
+    await getTasks({before: 1234, beforeTaskId: 'tsk-x', limit: 50, projectPath: '/foo'})
+    expect(request.firstCall.args[1]).to.deep.equal({
+      before: 1234,
+      beforeTaskId: 'tsk-x',
+      limit: 50,
+      projectPath: '/foo',
+    })
+  })
+
+  it('throws when not connected to the daemon', async () => {
+    useTransportStore.setState({apiClient: null})
+    try {
+      await getTasks({limit: 50})
+      expect.fail('expected to throw')
+    } catch (error) {
+      expect((error as Error).message).to.equal('Not connected')
+    }
+  })
+})
+
+describe('initialPageParam', () => {
+  it('returns default limit and projectPath when projectPath is provided', () => {
+    expect(initialPageParam('/foo')).to.deep.equal({limit: DEFAULT_PAGE_LIMIT, projectPath: '/foo'})
+  })
+
+  it('omits projectPath when not provided', () => {
+    expect(initialPageParam()).to.deep.equal({limit: DEFAULT_PAGE_LIMIT})
+  })
+})
+
+describe('getNextPageParam', () => {
+  const lastParam = {limit: 50, projectPath: '/foo'}
+
+  it('returns undefined when lastPage has no nextCursor (last page reached)', () => {
+    const lastPage: TaskListResponse = {tasks: []}
+    expect(getNextPageParam(lastPage, lastParam)).to.equal(undefined)
+  })
+
+  it('returns next-page params when nextCursor is set', () => {
+    const lastPage: TaskListResponse = {nextCursor: 1234, tasks: []}
+    expect(getNextPageParam(lastPage, lastParam)).to.deep.equal({
+      before: 1234,
+      limit: 50,
+      projectPath: '/foo',
+    })
+  })
+
+  it('forwards nextCursorTaskId as beforeTaskId tiebreaker', () => {
+    const lastPage: TaskListResponse = {nextCursor: 1234, nextCursorTaskId: 'tsk-x', tasks: []}
+    expect(getNextPageParam(lastPage, lastParam)).to.deep.equal({
+      before: 1234,
+      beforeTaskId: 'tsk-x',
+      limit: 50,
+      projectPath: '/foo',
+    })
+  })
+})
+})

--- a/test/unit/webui/features/tasks/utils/duration-presets.test.ts
+++ b/test/unit/webui/features/tasks/utils/duration-presets.test.ts
@@ -1,0 +1,25 @@
+import {expect} from 'chai'
+
+import {durationPresetToRange} from '../../../../../../src/webui/features/tasks/utils/duration-presets.js'
+
+describe('durationPresetToRange', () => {
+  it('returns empty object for all (no constraint)', () => {
+    expect(durationPresetToRange('all')).to.deep.equal({})
+  })
+
+  it('short maps to maxDurationMs only (open-ended low)', () => {
+    expect(durationPresetToRange('short')).to.deep.equal({maxDurationMs: 5000})
+  })
+
+  it('medium maps to a 5-30s range', () => {
+    expect(durationPresetToRange('medium')).to.deep.equal({maxDurationMs: 30_000, minDurationMs: 5000})
+  })
+
+  it('long maps to a 30s-2m range', () => {
+    expect(durationPresetToRange('long')).to.deep.equal({maxDurationMs: 120_000, minDurationMs: 30_000})
+  })
+
+  it('very-long maps to minDurationMs only (open-ended high)', () => {
+    expect(durationPresetToRange('very-long')).to.deep.equal({minDurationMs: 120_000})
+  })
+})

--- a/test/unit/webui/features/tasks/utils/status-filter-to-server.test.ts
+++ b/test/unit/webui/features/tasks/utils/status-filter-to-server.test.ts
@@ -1,0 +1,19 @@
+import {expect} from 'chai'
+
+import {statusFilterToServer} from '../../../../../../src/webui/features/tasks/utils/status-filter-to-server.js'
+
+describe('statusFilterToServer', () => {
+  it('returns undefined for all (no server filter)', () => {
+    expect(statusFilterToServer('all')).to.equal(undefined)
+  })
+
+  it('maps cancelled, completed, failed to single-value arrays', () => {
+    expect(statusFilterToServer('cancelled')).to.deep.equal(['cancelled'])
+    expect(statusFilterToServer('completed')).to.deep.equal(['completed'])
+    expect(statusFilterToServer('failed')).to.deep.equal(['error'])
+  })
+
+  it('expands running to created + started', () => {
+    expect(statusFilterToServer('running')).to.deep.equal(['created', 'started'])
+  })
+})

--- a/test/unit/webui/features/tasks/utils/time-presets.test.ts
+++ b/test/unit/webui/features/tasks/utils/time-presets.test.ts
@@ -1,0 +1,27 @@
+import {expect} from 'chai'
+
+import {timePresetToRange} from '../../../../../../src/webui/features/tasks/utils/time-presets.js'
+
+const NOW = new Date(2026, 4, 2, 14, 30, 0).getTime()
+
+describe('timePresetToRange', () => {
+  it('returns empty object for all (no constraint)', () => {
+    expect(timePresetToRange('all', NOW)).to.deep.equal({})
+  })
+
+  it('today snapshots createdAfter to start-of-day local time', () => {
+    const startOfDay = new Date(2026, 4, 2).getTime()
+    expect(timePresetToRange('today', NOW)).to.deep.equal({createdAfter: startOfDay})
+  })
+
+  it('week snapshots createdAfter to start-of-week (Monday)', () => {
+    // 2026-05-02 is Saturday → Monday is 2026-04-27
+    const monday = new Date(2026, 3, 27).getTime()
+    expect(timePresetToRange('week', NOW)).to.deep.equal({createdAfter: monday})
+  })
+
+  it('month snapshots createdAfter to first-of-month', () => {
+    const startOfMonth = new Date(2026, 4, 1).getTime()
+    expect(timePresetToRange('month', NOW)).to.deep.equal({createdAfter: startOfMonth})
+  })
+})


### PR DESCRIPTION
## Summary

- Replace cursor `useInfiniteQuery` with single `useQuery` numbered pagination (`page` / `pageSize`); shared `Pagination` primitives + page-size `Select`.
- New unified **Filter** dropdown (`task-filter-menu.tsx`) with submenus: Type, Provider, Model, Time (Calendar via `task-date-filter-panel.tsx`), Duration. Active dot indicator on the trigger.
- New `task-filter-tags.tsx` row renders each active filter as a removable shared `Tag` plus a "Clear filters" CTA.
- URL is the source of truth via `use-task-filter-params.ts` (status/types/providers/models/from/to/duration/q/page/pageSize) — shareable URLs, browser back/forward work, and filter changes auto-reset to page 1.
- Status pills use a second `useGetTasks` call (no status filter) so per-status counts stay stable when the active filter has zero matches.
- `task-subscription-initializer.tsx` invalidates `['tasks', 'list']` on the six task lifecycle events (CREATED / STARTED / COMPLETED / ERROR / CANCELLED / DELETED).
- Type-guarded URL parsing (no `as` casts), `Record<…>`-based status/duration lookups, `useMemo` for derived filter args / provider Maps / model options, and `cn({…: cond})` for conditional pagination classes.
- Native `title` tooltip on the truncated Input cell + `leading-none` fix for the `TYPE` badge optical centering.

## Test plan

- [ ] Open WebUI with >50 tasks — list shows the first page; numbered pagination + page-size selector visible.
- [ ] Click page 2/3/last — URL updates with `?page=N`; correct slice loads.
- [ ] Open the Filter dropdown:
  - [ ] Type submenu — toggle Curate / Query; rows filter; active dot appears on trigger.
  - [ ] Provider submenu — only providers from the index appear; toggling filters the list and narrows the Model submenu.
  - [ ] Model submenu — choose a model; rows filter.
  - [ ] Time submenu — pick a date range on the Calendar; click Apply; rows filter; Clear resets.
  - [ ] Duration submenu — radio select a bucket; rows filter.
- [ ] Apply 3 filters — three Tags appear; click each X to remove individually; "Clear filters" wipes everything.
- [ ] Search box (debounced 300ms) — types narrow results; URL gets `?q=...`.
- [ ] Apply a filter that returns zero rows for one status pill — other pill counts stay accurate (not zeroed out).
- [ ] Refresh page with all filters in URL — same filtered view restored.
- [ ] Switch projects — page resets, filters re-apply for the new project.
- [ ] Hover a truncated input cell — full prompt appears in the native tooltip.
- [ ] CURATE / QUERY badges sit vertically centered in the Type column.
- [ ] `npm run typecheck && npm run lint` clean.
- [ ] `npx mocha --forbid-only "test/unit/webui/features/tasks/**/*.test.ts"` — all passing.