### PR TITLE
feat: [ENG-2610] M2.18 pagination polish + default page size 20 + friendly provider names

### DIFF
--- a/src/webui/features/tasks/components/task-list-pagination.tsx
+++ b/src/webui/features/tasks/components/task-list-pagination.tsx
@@ -1,9 +1,9 @@
 import {
   Pagination,
   PaginationContent,
-  PaginationEllipsis,
+  PaginationFirst,
   PaginationItem,
-  PaginationLink,
+  PaginationLast,
   PaginationNext,
   PaginationPrevious,
 } from '@campfirein/byterover-packages/components/pagination'
@@ -16,7 +16,7 @@ import {
 } from '@campfirein/byterover-packages/components/select'
 import {cn} from '@campfirein/byterover-packages/lib/utils'
 
-const PAGE_SIZE_OPTIONS = [50, 100, 250] as const
+const PAGE_SIZE_OPTIONS = [20, 50, 100] as const
 
 export interface TaskListPaginationProps {
   onPageChange: (page: number) => void
@@ -37,77 +37,63 @@ export function TaskListPagination({
 }: TaskListPaginationProps) {
   if (pageCount <= 1 && total <= PAGE_SIZE_OPTIONS[0]) return null
 
-  const pages = pageNumbersToShow(page, pageCount)
-  const isFirst = page <= 1
-  const isLast = page >= pageCount
+  const canPrev = page > 1
+  const canNext = page < pageCount
 
   return (
-    <div className="flex items-center justify-between gap-3 px-1">
-      <span className="text-muted-foreground text-xs">
-        {total > 0 ? `${total} task${total === 1 ? '' : 's'}` : 'No tasks'}
-      </span>
-      {pageCount > 1 && (
-        <Pagination className="mx-0 w-auto">
-          <PaginationContent>
-            <PaginationItem>
-              <PaginationPrevious
-                aria-disabled={isFirst}
-                className={cn({'pointer-events-none opacity-50': isFirst})}
-                onClick={() => !isFirst && onPageChange(page - 1)}
-              />
-            </PaginationItem>
-            {pages.map((entry, idx) =>
-              entry === 'ellipsis' ? (
-                <PaginationItem key={`ellipsis-${idx}`}>
-                  <PaginationEllipsis />
-                </PaginationItem>
-              ) : (
-                <PaginationItem key={entry}>
-                  <PaginationLink isActive={entry === page} onClick={() => onPageChange(entry)}>
-                    {entry}
-                  </PaginationLink>
-                </PaginationItem>
-              ),
-            )}
-            <PaginationItem>
-              <PaginationNext
-                aria-disabled={isLast}
-                className={cn({'pointer-events-none opacity-50': isLast})}
-                onClick={() => !isLast && onPageChange(page + 1)}
-              />
-            </PaginationItem>
-          </PaginationContent>
-        </Pagination>
-      )}
-      <Select onValueChange={(value) => onPageSizeChange(Number(value))} value={String(pageSize)}>
-        <SelectTrigger className="h-8 text-xs" size="sm">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          {PAGE_SIZE_OPTIONS.map((option) => (
-            <SelectItem key={option} value={String(option)}>
-              {option} / page
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </div>
+    <Pagination className="mx-0 w-auto">
+      <PaginationContent>
+        <PaginationItem>
+          <div className="flex items-center gap-2">
+            <span className="text-muted-foreground text-sm">Rows per page</span>
+            <Select onValueChange={(value) => onPageSizeChange(Number(value))} value={String(pageSize)}>
+              <SelectTrigger className="h-8 text-xs" size="sm">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {PAGE_SIZE_OPTIONS.map((option) => (
+                  <SelectItem key={option} value={String(option)}>
+                    {option}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </PaginationItem>
+        <PaginationItem>
+          <span className="text-muted-foreground px-2 text-sm">
+            Page {page} of {Math.max(pageCount, 1)}
+          </span>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationFirst
+            aria-disabled={!canPrev}
+            className={cn({'pointer-events-none opacity-50': !canPrev})}
+            onClick={() => canPrev && onPageChange(1)}
+          />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationPrevious
+            aria-disabled={!canPrev}
+            className={cn({'pointer-events-none opacity-50': !canPrev})}
+            onClick={() => canPrev && onPageChange(page - 1)}
+          />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationNext
+            aria-disabled={!canNext}
+            className={cn({'pointer-events-none opacity-50': !canNext})}
+            onClick={() => canNext && onPageChange(page + 1)}
+          />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLast
+            aria-disabled={!canNext}
+            className={cn({'pointer-events-none opacity-50': !canNext})}
+            onClick={() => canNext && onPageChange(pageCount)}
+          />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
   )
-}
-
-function pageNumbersToShow(current: number, total: number): Array<'ellipsis' | number> {
-  if (total <= 7) {
-    return Array.from({length: total}, (_, i) => i + 1)
-  }
-
-  const result: Array<'ellipsis' | number> = [1]
-  const left = Math.max(2, current - 1)
-  const right = Math.min(total - 1, current + 1)
-
-  if (left > 2) result.push('ellipsis')
-  for (let i = left; i <= right; i++) result.push(i)
-  if (right < total - 1) result.push('ellipsis')
-
-  result.push(total)
-  return result
 }

--- a/src/webui/features/tasks/components/task-list-table.tsx
+++ b/src/webui/features/tasks/components/task-list-table.tsx
@@ -53,6 +53,7 @@ interface TaskTableProps {
   onRowClick: (taskId: string) => void
   onToggleSelect: (taskId: string) => void
   onToggleSelectAll: () => void
+  providerNames: Map<string, string>
   searchQuery: string
   selectedIds: Set<string>
   statusFilter: StatusFilter
@@ -67,6 +68,7 @@ export function TaskTable({
   onRowClick,
   onToggleSelect,
   onToggleSelectAll,
+  providerNames,
   searchQuery,
   selectedIds,
   statusFilter,
@@ -104,6 +106,7 @@ export function TaskTable({
               onDelete={onDelete}
               onRowClick={onRowClick}
               onToggleSelect={onToggleSelect}
+              providerNames={providerNames}
               task={task}
             />
           ))
@@ -119,6 +122,7 @@ function TaskRow({
   onDelete,
   onRowClick,
   onToggleSelect,
+  providerNames,
   task,
 }: {
   isSelected: boolean
@@ -126,6 +130,7 @@ function TaskRow({
   onDelete: (taskId: string) => void
   onRowClick: (taskId: string) => void
   onToggleSelect: (taskId: string) => void
+  providerNames: Map<string, string>
   task: StoredTask
 }) {
   const terminal = isTerminalStatus(task.status)
@@ -152,7 +157,11 @@ function TaskRow({
         <TypeBadge type={task.type} />
       </TableCell>
       <TableCell>
-        <ProviderChip model={task.model} provider={task.provider} />
+        <ProviderChip
+          model={task.model}
+          provider={task.provider}
+          providerName={task.provider ? providerNames.get(task.provider) : undefined}
+        />
       </TableCell>
       <TableCell className="text-foreground max-w-0">
         <div className="truncate" title={task.content || undefined}>
@@ -212,8 +221,8 @@ function TypeBadge({type}: {type: string}) {
   )
 }
 
-function ProviderChip({model, provider}: {model?: string; provider?: string}) {
-  const label = formatProviderModel(provider, model)
+function ProviderChip({model, provider, providerName}: {model?: string; provider?: string; providerName?: string}) {
+  const label = formatProviderModel(provider, model, providerName)
   if (!label) return null
   return (
     <Badge className="text-muted-foreground mono max-w-full truncate text-[10px] tracking-wider" title={label} variant="outline">

--- a/src/webui/features/tasks/components/task-list-view.tsx
+++ b/src/webui/features/tasks/components/task-list-view.tsx
@@ -71,6 +71,7 @@ export function TaskListView() {
   } = useTaskFilterParams()
   const {data: providersResponse} = useGetProviders()
   const providers = providersResponse?.providers ?? []
+  const providerNames = useMemo(() => new Map(providers.map((p) => [p.id, p.name])), [providers])
   const {
     createdAfter,
     createdBefore,
@@ -360,28 +361,32 @@ export function TaskListView() {
           onRowClick={openTask}
           onToggleSelect={toggleSelect}
           onToggleSelectAll={toggleSelectAll}
+          providerNames={providerNames}
           searchQuery={searchQuery}
           selectedIds={selectedIds}
           statusFilter={statusFilter}
         />
       )}
 
-      {data && (
-        <TaskListPagination
-          onPageChange={setPage}
-          onPageSizeChange={setPageSize}
-          page={data.page}
-          pageCount={data.pageCount}
-          pageSize={data.pageSize}
-          total={data.total}
-        />
-      )}
-
-      {finishedCount > 0 && (
-        <div className="flex items-center justify-end px-1">
-          <Button onClick={handleClearCompleted} size="xs" variant="ghost">
-            Clear finished ({finishedCount})
-          </Button>
+      {(data || finishedCount > 0) && (
+        <div className="flex items-center justify-between gap-3 px-1">
+          {data ? (
+            <TaskListPagination
+              onPageChange={setPage}
+              onPageSizeChange={setPageSize}
+              page={data.page}
+              pageCount={data.pageCount}
+              pageSize={data.pageSize}
+              total={data.total}
+            />
+          ) : (
+            <span />
+          )}
+          {finishedCount > 0 && (
+            <Button onClick={handleClearCompleted} size="xs" variant="ghost">
+              Clear finished ({finishedCount})
+            </Button>
+          )}
         </div>
       )}
 

--- a/src/webui/features/tasks/components/task-list-view.tsx
+++ b/src/webui/features/tasks/components/task-list-view.tsx
@@ -71,7 +71,10 @@ export function TaskListView() {
   } = useTaskFilterParams()
   const {data: providersResponse} = useGetProviders()
   const providers = providersResponse?.providers ?? []
-  const providerNames = useMemo(() => new Map(providers.map((p) => [p.id, p.name])), [providers])
+  const providerNames = useMemo(
+    () => new Map((providersResponse?.providers ?? []).map((p) => [p.id, p.name])),
+    [providersResponse],
+  )
   const {
     createdAfter,
     createdBefore,

--- a/src/webui/features/tasks/hooks/use-task-filter-params.ts
+++ b/src/webui/features/tasks/hooks/use-task-filter-params.ts
@@ -18,7 +18,7 @@ export interface TaskFilters {
 }
 
 const STATUS_VALUES = new Set<string>(['all', 'cancelled', 'completed', 'failed', 'running'])
-const DEFAULT_PAGE_SIZE = 50
+const DEFAULT_PAGE_SIZE = 20
 
 const FILTER_PARAM_KEYS = ['status', 'types', 'providers', 'models', 'from', 'to', 'duration', 'q', 'page', 'pageSize'] as const
 

--- a/src/webui/features/tasks/utils/format-provider-model.ts
+++ b/src/webui/features/tasks/utils/format-provider-model.ts
@@ -1,5 +1,6 @@
-export function formatProviderModel(provider?: string, model?: string): string | undefined {
+export function formatProviderModel(provider?: string, model?: string, providerName?: string): string | undefined {
   if (!provider) return undefined
-  if (!model) return provider
-  return `${provider}:${model}`
+  const display = providerName || provider
+  if (!model) return display
+  return `${display}:${model}`
 }

--- a/test/unit/webui/features/tasks/utils/format-provider-model.test.ts
+++ b/test/unit/webui/features/tasks/utils/format-provider-model.test.ts
@@ -25,4 +25,18 @@ describe('formatProviderModel', () => {
     expect(formatProviderModel('', 'gpt-5-pro')).to.equal(undefined)
     expect(formatProviderModel('openai', '')).to.equal('openai')
   })
+
+  it('uses providerName when provided for byterover-internal', () => {
+    expect(formatProviderModel('byterover', undefined, 'ByteRover')).to.equal('ByteRover')
+  })
+
+  it('uses providerName when provided for external <provider>:<model>', () => {
+    expect(formatProviderModel('openai', 'gpt-5-pro', 'OpenAI')).to.equal('OpenAI:gpt-5-pro')
+  })
+
+  it('falls back to provider id when providerName is empty or missing', () => {
+    expect(formatProviderModel('openai', 'gpt-5-pro')).to.equal('openai:gpt-5-pro')
+    expect(formatProviderModel('openai', 'gpt-5-pro', '')).to.equal('openai:gpt-5-pro')
+    expect(formatProviderModel('byterover', undefined, '')).to.equal('byterover')
+  })
 })


### PR DESCRIPTION
## Summary

- **Pagination UI rework** — replaces the numbered-page row with the byterover web pattern: rows-per-page Select + "Page X of Y" + First/Previous/Next/Last icon buttons via shared `PaginationFirst`/`PaginationLast` from `@campfirein/byterover-packages`. Sits on the same row as "Clear finished" via `justify-between`.
- **Default page size 20** — `DEFAULT_PAGE_SIZE` in `use-task-filter-params.ts`: `50` → `20`. `PAGE_SIZE_OPTIONS` in pagination: `[50, 100, 250]` → `[20, 50, 100]`.
- **Friendly provider name** — `formatProviderModel(provider, model, providerName?)` accepts an optional 3rd arg. `TaskListView` builds a `Map<id, name>` from the cached `useGetProviders()` result (no extra network call) and threads it through `TaskTable` → `TaskRow` → `ProviderChip`. Falls back to the raw id when no provider record matches.

## Test plan

- [ ] Seed >20 tasks. Pagination renders; default page size is 20.
- [ ] "Rows per page" selector shows `20 / 50 / 100`. Switching resets to page 1.
- [ ] Pagination layout matches byterover branch-list page: First (`«`) / Previous (`‹`) / Next (`›`) / Last (`»`) icons + "Page X of Y" text. Buttons disabled with `opacity-50` at the boundaries.
- [ ] Pagination row sits on the same horizontal line as the "Clear finished" button (left + right via `justify-between`).
- [ ] Provider chip on a `byterover` task reads `ByteRover` (friendly name from `useGetProviders` cache).
- [ ] Provider chip on an `openai`/`anthropic`/etc. task reads `OpenAI:gpt-5-pro` etc.
- [ ] Tasks with no provider record (or unknown id) fall back to the raw id in the chip.
- [ ] `npm run typecheck && npm run lint` clean.
- [ ] `npx mocha --forbid-only "test/unit/webui/features/tasks/**/*.test.ts"` — 98 passing (3 new for friendly-name branch in `formatProviderModel`).