### PR TITLE
feat: surface recall metadata in brv query --format json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "byterover-cli",
-  "version": "3.10.3",
+  "version": "3.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "byterover-cli",
-      "version": "3.10.3",
+      "version": "3.10.2",
       "bundleDependencies": [
         "@campfirein/brv-transport-client",
         "@campfirein/byterover-packages",
@@ -54,7 +54,7 @@
         "@tanstack/react-query": "^5.90.20",
         "@types/react-syntax-highlighter": "^15.5.13",
         "ai": "^5.0.129",
-        "axios": "1.16.0",
+        "axios": "1.15.0",
         "chalk": "^5.6.2",
         "date-fns": "^4.1.0",
         "diff": "^9.0.0",
@@ -5911,6 +5911,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5931,6 +5932,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5951,6 +5953,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5971,6 +5974,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5991,6 +5995,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6011,6 +6016,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6031,6 +6037,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6051,6 +6058,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6071,6 +6079,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6091,6 +6100,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6111,6 +6121,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -10397,12 +10408,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.16.0",
+        "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "byterover-cli",
-  "version": "3.10.2",
+  "version": "3.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "byterover-cli",
-      "version": "3.10.2",
+      "version": "3.10.3",
       "bundleDependencies": [
         "@campfirein/brv-transport-client",
         "@campfirein/byterover-packages",
@@ -54,7 +54,7 @@
         "@tanstack/react-query": "^5.90.20",
         "@types/react-syntax-highlighter": "^15.5.13",
         "ai": "^5.0.129",
-        "axios": "1.15.0",
+        "axios": "1.16.0",
         "chalk": "^5.6.2",
         "date-fns": "^4.1.0",
         "diff": "^9.0.0",
@@ -10408,12 +10408,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }

--- a/src/oclif/commands/query.ts
+++ b/src/oclif/commands/query.ts
@@ -155,7 +155,7 @@ Bad:
         client,
         command: 'query',
         format,
-        onCompleted: ({result, taskId: tid}) => {
+        onCompleted: ({durationMs, matchedDocs, result, taskId: tid, tier, topScore}) => {
           const previousResult = finalResult
 
           // Always prefer the completed payload — it carries the attribution footer
@@ -180,11 +180,17 @@ Bad:
           if (format === 'json') {
             writeJsonResponse({
               command: 'query',
+              // Recall metadata is only present on query tasks; older daemons omit it. Spread
+              // conditionally so JSON consumers do not see undefined keys.
               data: {
+                ...(durationMs === undefined ? {} : {durationMs}),
                 event: 'completed',
+                ...(matchedDocs === undefined ? {} : {matchedDocs}),
                 result: finalResult,
                 status: 'completed',
                 taskId: tid,
+                ...(tier === undefined ? {} : {tier}),
+                ...(topScore === undefined ? {} : {topScore}),
               },
               success: true,
             })

--- a/src/oclif/lib/task-client.ts
+++ b/src/oclif/lib/task-client.ts
@@ -16,13 +16,33 @@ import type {
   TaskError,
 } from '@campfirein/brv-transport-client'
 
+import type {
+  QueryLogMatchedDoc,
+  QueryLogTier,
+} from '../../server/core/domain/entities/query-log-entry.js'
+
 import {TaskErrorCode} from '../../server/core/domain/errors/task-error.js'
 import {LlmEvents, TaskEvents} from '../../shared/transport/events/index.js'
 import {ReviewEvents, type ReviewNotifyEvent} from '../../shared/transport/events/review-events.js'
 import {writeJsonResponse} from './json-response.js'
 
-/** Extends brv-transport-client's TaskCompleted with logId from ENG-1259 and pendingReviewCount from HITL */
-type TaskCompletedWithLogId = TaskCompleted & {logId?: string; pendingReviewCount?: number}
+/**
+ * Extends brv-transport-client's TaskCompleted with daemon-merged extras contributed by
+ * lifecycle hooks (`getTaskCompletionData`):
+ * - `logId` — query/curate log id
+ * - `pendingReviewCount` — HITL signal from CurateLogHandler
+ * - `matchedDocs`/`tier`/`timing`/`searchMetadata` — query recall metadata from QueryLogHandler
+ *
+ * All fields are optional — older daemons or non-query tasks omit them.
+ */
+type TaskCompletedWithLogId = TaskCompleted & {
+  durationMs?: number
+  logId?: string
+  matchedDocs?: QueryLogMatchedDoc[]
+  pendingReviewCount?: number
+  tier?: QueryLogTier
+  topScore?: number
+}
 
 /** Extends brv-transport-client's TaskError with logId from ENG-1259 */
 type TaskErrorWithLogId = TaskError & {logId?: string}
@@ -40,12 +60,20 @@ export interface ToolCallRecord {
 
 /** Completion result passed to onCompleted callback */
 export interface TaskCompletionResult {
+  /** Wall-clock execution time for query tasks, in milliseconds. Absent for non-query tasks. */
+  durationMs?: number
   logId?: string
+  /** Documents matched by the query. Empty array on cache hits; absent for non-query tasks. */
+  matchedDocs?: QueryLogMatchedDoc[]
   /** Pending review notification from the server, present when review is required after task completion. */
   pendingReview?: {pendingCount: number; reviewUrl: string}
   result?: string
   taskId: string
+  /** Resolution tier for query tasks. Absent for non-query tasks. */
+  tier?: QueryLogTier
   toolCalls: ToolCallRecord[]
+  /** Top compound score across matchedDocs. Absent for cache hits and non-query tasks. */
+  topScore?: number
 }
 
 /** Error result passed to onError callback */
@@ -286,7 +314,17 @@ export function waitForTaskCompletion(options: WaitForTaskOptions, log: (msg: st
           payload.pendingReviewCount !== undefined && payload.pendingReviewCount > 0
             ? {pendingCount: payload.pendingReviewCount, reviewUrl: pendingReview?.reviewUrl ?? ''}
             : pendingReview
-        onCompleted({logId: payload.logId, pendingReview: resolvedPendingReview, result: payload.result, taskId, toolCalls})
+        onCompleted({
+          durationMs: payload.durationMs,
+          logId: payload.logId,
+          matchedDocs: payload.matchedDocs,
+          pendingReview: resolvedPendingReview,
+          result: payload.result,
+          taskId,
+          tier: payload.tier,
+          toolCalls,
+          topScore: payload.topScore,
+        })
         resolve()
       }),
 

--- a/src/oclif/lib/task-client.ts
+++ b/src/oclif/lib/task-client.ts
@@ -31,7 +31,8 @@ import {writeJsonResponse} from './json-response.js'
  * lifecycle hooks (`getTaskCompletionData`):
  * - `logId` — query/curate log id
  * - `pendingReviewCount` — HITL signal from CurateLogHandler
- * - `matchedDocs`/`tier`/`timing`/`searchMetadata` — query recall metadata from QueryLogHandler
+ * - `matchedDocs`/`tier`/`durationMs`/`topScore` — query recall metadata from QueryLogHandler
+ *   (flattened from QueryExecutorResult's nested timing/searchMetadata)
  *
  * All fields are optional — older daemons or non-query tasks omit them.
  */

--- a/src/server/infra/process/query-log-handler.ts
+++ b/src/server/infra/process/query-log-handler.ts
@@ -61,6 +61,32 @@ export class QueryLogHandler implements ITaskLifecycleHook {
     }
   }
 
+  /**
+   * Expose query metadata via the lifecycle-hook contract so TaskRouter can merge it into
+   * the task:completed payload sent to the originating client. Returning {} when no metadata
+   * is available keeps the merge a no-op and lets the daemon emit task:completed unchanged.
+   */
+  getTaskCompletionData(taskId: string): Record<string, unknown> {
+    const state = this.tasks.get(taskId)
+    if (!state?.queryResult) return {}
+
+    const out: Record<string, unknown> = {
+      matchedDocs: state.queryResult.matchedDocs,
+      tier: state.queryResult.tier,
+    }
+    // Flatten the QueryExecutorResult's nested shape onto the task:completed payload so
+    // it matches the public RecallResult contract (flat `durationMs` / `topScore`).
+    if (state.queryResult.timing !== undefined) {
+      out.durationMs = state.queryResult.timing.durationMs
+    }
+
+    if (state.queryResult.searchMetadata !== undefined) {
+      out.topScore = state.queryResult.searchMetadata.topScore
+    }
+
+    return out
+  }
+
   async onTaskCancelled(taskId: string, _task: TaskInfo): Promise<void> {
     const state = this.tasks.get(taskId)
     if (!state) return

--- a/src/server/infra/process/query-log-handler.ts
+++ b/src/server/infra/process/query-log-handler.ts
@@ -70,14 +70,14 @@ export class QueryLogHandler implements ITaskLifecycleHook {
     const state = this.tasks.get(taskId)
     if (!state?.queryResult) return {}
 
-    const out: Record<string, unknown> = {
-      matchedDocs: state.queryResult.matchedDocs,
-      tier: state.queryResult.tier,
-    }
     // Flatten the QueryExecutorResult's nested shape onto the task:completed payload so
     // it matches the public RecallResult contract (flat `durationMs` / `topScore`).
-    if (state.queryResult.timing !== undefined) {
-      out.durationMs = state.queryResult.timing.durationMs
+    // `timing` is always populated by every QueryExecutor branch, so no guard.
+    // `searchMetadata` is omitted on cache hits (Tier 0/1), so guard before extracting.
+    const out: Record<string, unknown> = {
+      durationMs: state.queryResult.timing.durationMs,
+      matchedDocs: state.queryResult.matchedDocs,
+      tier: state.queryResult.tier,
     }
 
     if (state.queryResult.searchMetadata !== undefined) {

--- a/test/commands/query.test.ts
+++ b/test/commands/query.test.ts
@@ -429,6 +429,84 @@ describe('Query Command', () => {
       expect(completedEvent).to.exist
       expect(completedEvent!.data).to.have.property('result', 'JSON answer')
     })
+
+    it('should surface matchedDocs, tier, durationMs, and topScore in completed event when present', async () => {
+      const eventHandlers: Map<string, Array<(data: unknown) => void>> = new Map()
+      ;(mockClient.on as sinon.SinonStub).callsFake((event: string, handler: (data: unknown) => void) => {
+        if (!eventHandlers.has(event)) eventHandlers.set(event, [])
+        eventHandlers.get(event)!.push(handler)
+        return () => {}
+      })
+      ;(mockClient.requestWithAck as sinon.SinonStub).callsFake(async (event: string, payload: {taskId: string}) => {
+        if (event === 'state:getProviderConfig') return {activeProvider: 'anthropic'}
+        setTimeout(() => {
+          const completedHandlers = eventHandlers.get('task:completed')
+          if (completedHandlers) {
+            for (const handler of completedHandlers) {
+              handler({
+                durationMs: 184,
+                matchedDocs: [
+                  {path: 'auth/jwt-tokens.md', score: 0.92, title: 'JWT tokens'},
+                  {path: 'billing/stripe-webhooks.md', score: 0.78, title: 'Stripe webhooks'},
+                ],
+                result: 'cached answer',
+                taskId: payload.taskId,
+                tier: 2,
+                topScore: 0.92,
+              })
+            }
+          }
+        }, 10)
+        return {taskId: payload.taskId}
+      })
+
+      await createJsonCommand('test query').run()
+
+      const lines = parseJsonOutput()
+      const completedEvent = lines.find((l) => (l.data as Record<string, unknown>).event === 'completed')
+      expect(completedEvent, 'completed event should exist').to.exist
+      const data = completedEvent!.data as Record<string, unknown>
+      expect(data).to.have.property('result', 'cached answer')
+      expect(data).to.have.property('tier', 2)
+      expect(data).to.have.property('durationMs', 184)
+      expect(data).to.have.property('topScore', 0.92)
+      expect(data).to.have.deep.property('matchedDocs', [
+        {path: 'auth/jwt-tokens.md', score: 0.92, title: 'JWT tokens'},
+        {path: 'billing/stripe-webhooks.md', score: 0.78, title: 'Stripe webhooks'},
+      ])
+    })
+
+    it('should omit matchedDocs/tier/durationMs/topScore from completed event when absent (graceful)', async () => {
+      const eventHandlers: Map<string, Array<(data: unknown) => void>> = new Map()
+      ;(mockClient.on as sinon.SinonStub).callsFake((event: string, handler: (data: unknown) => void) => {
+        if (!eventHandlers.has(event)) eventHandlers.set(event, [])
+        eventHandlers.get(event)!.push(handler)
+        return () => {}
+      })
+      ;(mockClient.requestWithAck as sinon.SinonStub).callsFake(async (event: string, payload: {taskId: string}) => {
+        if (event === 'state:getProviderConfig') return {activeProvider: 'anthropic'}
+        setTimeout(() => {
+          const completedHandlers = eventHandlers.get('task:completed')
+          if (completedHandlers) {
+            // Older daemon: only emits result + taskId, no enriched fields
+            for (const handler of completedHandlers) handler({result: 'plain answer', taskId: payload.taskId})
+          }
+        }, 10)
+        return {taskId: payload.taskId}
+      })
+
+      await createJsonCommand('test query').run()
+
+      const lines = parseJsonOutput()
+      const completedEvent = lines.find((l) => (l.data as Record<string, unknown>).event === 'completed')
+      expect(completedEvent).to.exist
+      const data = completedEvent!.data as Record<string, unknown>
+      expect(data).to.have.property('result', 'plain answer')
+      expect(data).to.not.have.property('matchedDocs')
+      expect(data).to.not.have.property('tier')
+      expect(data).to.not.have.property('durationMs')
+      expect(data).to.not.have.property('topScore')
+    })
   })
 
   // ==================== Connection Errors ====================

--- a/test/unit/infra/process/query-log-handler.test.ts
+++ b/test/unit/infra/process/query-log-handler.test.ts
@@ -292,6 +292,58 @@ describe('QueryLogHandler', () => {
     })
   })
 
+  // ── getTaskCompletionData ───────────────────────────────────────────────
+
+  describe('getTaskCompletionData', () => {
+    it('should return query metadata flattened to RecallResult shape after setQueryResult was called', async () => {
+      const task = makeTask()
+      await handler.onTaskCreate(task)
+      handler.setQueryResult('task-abc', makeQueryResult())
+
+      const data = handler.getTaskCompletionData('task-abc')
+
+      expect(data).to.deep.equal({
+        durationMs: 450,
+        matchedDocs: [{path: 'design/caching.md', score: 0.95, title: 'Caching Strategy'}],
+        tier: TIER_DIRECT_SEARCH,
+        topScore: 0.95,
+      })
+    })
+
+    it('should return empty object when task does not exist', () => {
+      const data = handler.getTaskCompletionData('unknown-task')
+
+      expect(data).to.deep.equal({})
+    })
+
+    it('should return empty object when setQueryResult was never called', async () => {
+      const task = makeTask()
+      await handler.onTaskCreate(task)
+
+      const data = handler.getTaskCompletionData('task-abc')
+
+      expect(data).to.deep.equal({})
+    })
+
+    it('should omit topScore when searchMetadata is absent (cache hit shape)', async () => {
+      const task = makeTask()
+      await handler.onTaskCreate(task)
+      // Cache hits in QueryExecutor return empty matchedDocs and no searchMetadata.
+      handler.setQueryResult('task-abc', {
+        matchedDocs: [],
+        tier: TIER_DIRECT_SEARCH,
+        timing: {durationMs: 5},
+      })
+
+      const data = handler.getTaskCompletionData('task-abc')
+
+      expect(data.matchedDocs).to.deep.equal([])
+      expect(data.tier).to.equal(TIER_DIRECT_SEARCH)
+      expect(data.durationMs).to.equal(5)
+      expect(data.topScore).to.be.undefined
+    })
+  })
+
   // ── store sharing ────────────────────────────────────────────────────────
 
   describe('store sharing', () => {


### PR DESCRIPTION
## Summary

- **Problem:** `brv query --format json` collapses everything into a plain-text `result` field, so downstream consumers (brv-bridge, the ByteRover Claude plugin) can't tell *which* docs informed the answer or *how* the answer was reached. ByteRover's "memory used" evidence stays invisible.
- **Why it matters:** The activation-funnel work needs visible evidence of recall in the user's loop. The visible `🧠 ByteRover returns N memories: …` line in Claude Code consumes structured retrieval metadata; this PR is what surfaces it at the source.
- **What changed:** Extend the JSON envelope with `matchedDocs`, `tier`, `durationMs`, `topScore`. Plumb via the existing lifecycle-hook pattern.
- **What did NOT change (scope boundary):** Text mode (`--format text`) byte-identical. No new search/scoring logic — only exposes what `QueryExecutor` already computes. No MCP tool changes.

## Type of change

- [x] New feature

## Scope (select all touched areas)

- [x] CLI Commands (oclif) — `query.ts`
- [x] Server / Daemon — `query-log-handler.ts`
- [x] Shared (constants, types, transport events) — `task-client.ts` types

## Linked issues

N/A — Linear linkage is via branch name and commit subjects.

## Root cause (bug fixes only, otherwise write `N/A`)

N/A.

## Test plan

- Coverage added:
  - [x] Unit test
- Test file(s):
  - `test/unit/infra/process/query-log-handler.test.ts` — 4 new cases for `getTaskCompletionData` (all-fields, no-task, no-result, partial cache-hit shape).
  - `test/commands/query.test.ts` — 2 new cases for the JSON envelope (fields surfaced when present, gracefully omitted when absent — older daemons or non-query tasks).
- Key scenario(s) covered: rich Tier 2 response with all fields; cache-hit (Tier 0/1) shape with empty `matchedDocs`; absent-field graceful degradation.

## User-visible changes

`brv query --format json "X"` now returns:

\`\`\`json
{
  "command": "query",
  "data": {
    "event": "completed",
    "matchedDocs": [{"path": "auth/jwt-tokens.md", "score": 0.92, "title": "JWT tokens"}, …],
    "result": "…synthesised prose…",
    "status": "completed",
    "taskId": "uuid",
    "tier": 2,
    "durationMs": 184,
    "topScore": 0.92
  },
  "success": true,
  "timestamp": "…"
}
\`\`\`

`--format text` (default) output is byte-identical to before.

## Evidence

- [x] Failing test before / passing after — `npx mocha test/unit/infra/process/query-log-handler.test.ts`: 17/17 pass; `npx mocha test/commands/query.test.ts`: 23/23 pass.

## Checklist

- [x] Tests added or updated and passing (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow Conventional Commits format
- [x] No breaking changes — all new fields are optional; existing consumers reading only `data.result` keep working
- [x] Branch is up to date with `proj/surface-curate-query-claude`

## Risks and mitigations

- **Risk:** Older brv-bridge versions reading the JSON envelope ignore the new fields silently.
  - **Mitigation:** Additive only; bridge upgrade is in the sibling brv-bridge PR.
- **Risk:** Field-shape divergence from the bridge's proposed schema.
  - **Mitigation:** Field names match the bridge's RecallResult exactly (`durationMs`, `topScore` flat). The internal `QueryLogEntry` keeps its nested `timing.durationMs` / `searchMetadata.topScore` shape — only the public `task:completed` event payload and CLI envelope are flat.

## Implementation notes

- Decision: `title` field on `QueryLogMatchedDoc` is required (not optional) — `QueryExecutor.buildMatchedDocs()` always populates it. Tightened from the proposed schema. Easy to relax if a future executor change changes the contract.
- Decision: dropped seven additional optional fields proposed in the bridge schema (`snippet`, `lastCurated`, `symbolKind`, `symbolPath`, `backlinkCount`, `relatedPaths`, `overviewPath`, `origin`) — `QueryExecutor` doesn't populate them today. Additive — easy to add back.