### PR TITLE
Proj/surface curate query claude

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "byterover-cli",
-  "version": "3.10.3",
+  "version": "3.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "byterover-cli",
-      "version": "3.10.3",
+      "version": "3.10.2",
       "bundleDependencies": [
         "@campfirein/brv-transport-client",
         "@campfirein/byterover-packages",
@@ -54,7 +54,7 @@
         "@tanstack/react-query": "^5.90.20",
         "@types/react-syntax-highlighter": "^15.5.13",
         "ai": "^5.0.129",
-        "axios": "1.16.0",
+        "axios": "1.15.0",
         "chalk": "^5.6.2",
         "date-fns": "^4.1.0",
         "diff": "^9.0.0",
@@ -5911,6 +5911,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5931,6 +5932,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5951,6 +5953,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5971,6 +5974,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5991,6 +5995,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6011,6 +6016,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6031,6 +6037,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6051,6 +6058,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6071,6 +6079,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6091,6 +6100,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6111,6 +6121,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -10397,12 +10408,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.16.0",
+        "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "byterover-cli",
-  "version": "3.10.2",
+  "version": "3.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "byterover-cli",
-      "version": "3.10.2",
+      "version": "3.10.3",
       "bundleDependencies": [
         "@campfirein/brv-transport-client",
         "@campfirein/byterover-packages",
@@ -54,7 +54,7 @@
         "@tanstack/react-query": "^5.90.20",
         "@types/react-syntax-highlighter": "^15.5.13",
         "ai": "^5.0.129",
-        "axios": "1.15.0",
+        "axios": "1.16.0",
         "chalk": "^5.6.2",
         "date-fns": "^4.1.0",
         "diff": "^9.0.0",
@@ -10408,12 +10408,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5911,7 +5911,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5932,7 +5931,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5953,7 +5951,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5974,7 +5971,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5995,7 +5991,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6016,7 +6011,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6037,7 +6031,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6058,7 +6051,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6079,7 +6071,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6100,7 +6091,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6121,7 +6111,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },

--- a/src/oclif/commands/query.ts
+++ b/src/oclif/commands/query.ts
@@ -155,7 +155,7 @@ Bad:
         client,
         command: 'query',
         format,
-        onCompleted: ({result, taskId: tid}) => {
+        onCompleted: ({durationMs, matchedDocs, result, taskId: tid, tier, topScore}) => {
           const previousResult = finalResult
 
           // Always prefer the completed payload — it carries the attribution footer
@@ -180,11 +180,17 @@ Bad:
           if (format === 'json') {
             writeJsonResponse({
               command: 'query',
+              // Recall metadata is only present on query tasks; older daemons omit it. Spread
+              // conditionally so JSON consumers do not see undefined keys.
               data: {
+                ...(durationMs === undefined ? {} : {durationMs}),
                 event: 'completed',
+                ...(matchedDocs === undefined ? {} : {matchedDocs}),
                 result: finalResult,
                 status: 'completed',
                 taskId: tid,
+                ...(tier === undefined ? {} : {tier}),
+                ...(topScore === undefined ? {} : {topScore}),
               },
               success: true,
             })

--- a/src/oclif/lib/task-client.ts
+++ b/src/oclif/lib/task-client.ts
@@ -16,13 +16,33 @@ import type {
   TaskError,
 } from '@campfirein/brv-transport-client'
 
+import type {
+  QueryLogMatchedDoc,
+  QueryLogTier,
+} from '../../server/core/domain/entities/query-log-entry.js'
+
 import {TaskErrorCode} from '../../server/core/domain/errors/task-error.js'
 import {LlmEvents, TaskEvents} from '../../shared/transport/events/index.js'
 import {ReviewEvents, type ReviewNotifyEvent} from '../../shared/transport/events/review-events.js'
 import {writeJsonResponse} from './json-response.js'
 
-/** Extends brv-transport-client's TaskCompleted with logId from ENG-1259 and pendingReviewCount from HITL */
-type TaskCompletedWithLogId = TaskCompleted & {logId?: string; pendingReviewCount?: number}
+/**
+ * Extends brv-transport-client's TaskCompleted with daemon-merged extras contributed by
+ * lifecycle hooks (`getTaskCompletionData`):
+ * - `logId` — query/curate log id
+ * - `pendingReviewCount` — HITL signal from CurateLogHandler
+ * - `matchedDocs`/`tier`/`timing`/`searchMetadata` — query recall metadata from QueryLogHandler
+ *
+ * All fields are optional — older daemons or non-query tasks omit them.
+ */
+type TaskCompletedWithLogId = TaskCompleted & {
+  durationMs?: number
+  logId?: string
+  matchedDocs?: QueryLogMatchedDoc[]
+  pendingReviewCount?: number
+  tier?: QueryLogTier
+  topScore?: number
+}
 
 /** Extends brv-transport-client's TaskError with logId from ENG-1259 */
 type TaskErrorWithLogId = TaskError & {logId?: string}
@@ -40,12 +60,20 @@ export interface ToolCallRecord {
 
 /** Completion result passed to onCompleted callback */
 export interface TaskCompletionResult {
+  /** Wall-clock execution time for query tasks, in milliseconds. Absent for non-query tasks. */
+  durationMs?: number
   logId?: string
+  /** Documents matched by the query. Empty array on cache hits; absent for non-query tasks. */
+  matchedDocs?: QueryLogMatchedDoc[]
   /** Pending review notification from the server, present when review is required after task completion. */
   pendingReview?: {pendingCount: number; reviewUrl: string}
   result?: string
   taskId: string
+  /** Resolution tier for query tasks. Absent for non-query tasks. */
+  tier?: QueryLogTier
   toolCalls: ToolCallRecord[]
+  /** Top compound score across matchedDocs. Absent for cache hits and non-query tasks. */
+  topScore?: number
 }
 
 /** Error result passed to onError callback */
@@ -286,7 +314,17 @@ export function waitForTaskCompletion(options: WaitForTaskOptions, log: (msg: st
           payload.pendingReviewCount !== undefined && payload.pendingReviewCount > 0
             ? {pendingCount: payload.pendingReviewCount, reviewUrl: pendingReview?.reviewUrl ?? ''}
             : pendingReview
-        onCompleted({logId: payload.logId, pendingReview: resolvedPendingReview, result: payload.result, taskId, toolCalls})
+        onCompleted({
+          durationMs: payload.durationMs,
+          logId: payload.logId,
+          matchedDocs: payload.matchedDocs,
+          pendingReview: resolvedPendingReview,
+          result: payload.result,
+          taskId,
+          tier: payload.tier,
+          toolCalls,
+          topScore: payload.topScore,
+        })
         resolve()
       }),
 

--- a/src/oclif/lib/task-client.ts
+++ b/src/oclif/lib/task-client.ts
@@ -31,7 +31,8 @@ import {writeJsonResponse} from './json-response.js'
  * lifecycle hooks (`getTaskCompletionData`):
  * - `logId` — query/curate log id
  * - `pendingReviewCount` — HITL signal from CurateLogHandler
- * - `matchedDocs`/`tier`/`timing`/`searchMetadata` — query recall metadata from QueryLogHandler
+ * - `matchedDocs`/`tier`/`durationMs`/`topScore` — query recall metadata from QueryLogHandler
+ *   (flattened from QueryExecutorResult's nested timing/searchMetadata)
  *
  * All fields are optional — older daemons or non-query tasks omit them.
  */

--- a/src/server/infra/process/query-log-handler.ts
+++ b/src/server/infra/process/query-log-handler.ts
@@ -61,6 +61,32 @@ export class QueryLogHandler implements ITaskLifecycleHook {
     }
   }
 
+  /**
+   * Expose query metadata via the lifecycle-hook contract so TaskRouter can merge it into
+   * the task:completed payload sent to the originating client. Returning {} when no metadata
+   * is available keeps the merge a no-op and lets the daemon emit task:completed unchanged.
+   */
+  getTaskCompletionData(taskId: string): Record<string, unknown> {
+    const state = this.tasks.get(taskId)
+    if (!state?.queryResult) return {}
+
+    const out: Record<string, unknown> = {
+      matchedDocs: state.queryResult.matchedDocs,
+      tier: state.queryResult.tier,
+    }
+    // Flatten the QueryExecutorResult's nested shape onto the task:completed payload so
+    // it matches the public RecallResult contract (flat `durationMs` / `topScore`).
+    if (state.queryResult.timing !== undefined) {
+      out.durationMs = state.queryResult.timing.durationMs
+    }
+
+    if (state.queryResult.searchMetadata !== undefined) {
+      out.topScore = state.queryResult.searchMetadata.topScore
+    }
+
+    return out
+  }
+
   async onTaskCancelled(taskId: string, _task: TaskInfo): Promise<void> {
     const state = this.tasks.get(taskId)
     if (!state) return

--- a/src/server/infra/process/query-log-handler.ts
+++ b/src/server/infra/process/query-log-handler.ts
@@ -70,14 +70,14 @@ export class QueryLogHandler implements ITaskLifecycleHook {
     const state = this.tasks.get(taskId)
     if (!state?.queryResult) return {}
 
-    const out: Record<string, unknown> = {
-      matchedDocs: state.queryResult.matchedDocs,
-      tier: state.queryResult.tier,
-    }
     // Flatten the QueryExecutorResult's nested shape onto the task:completed payload so
     // it matches the public RecallResult contract (flat `durationMs` / `topScore`).
-    if (state.queryResult.timing !== undefined) {
-      out.durationMs = state.queryResult.timing.durationMs
+    // `timing` is always populated by every QueryExecutor branch, so no guard.
+    // `searchMetadata` is omitted on cache hits (Tier 0/1), so guard before extracting.
+    const out: Record<string, unknown> = {
+      durationMs: state.queryResult.timing.durationMs,
+      matchedDocs: state.queryResult.matchedDocs,
+      tier: state.queryResult.tier,
     }
 
     if (state.queryResult.searchMetadata !== undefined) {

--- a/test/commands/query.test.ts
+++ b/test/commands/query.test.ts
@@ -429,6 +429,84 @@ describe('Query Command', () => {
       expect(completedEvent).to.exist
       expect(completedEvent!.data).to.have.property('result', 'JSON answer')
     })
+
+    it('should surface matchedDocs, tier, durationMs, and topScore in completed event when present', async () => {
+      const eventHandlers: Map<string, Array<(data: unknown) => void>> = new Map()
+      ;(mockClient.on as sinon.SinonStub).callsFake((event: string, handler: (data: unknown) => void) => {
+        if (!eventHandlers.has(event)) eventHandlers.set(event, [])
+        eventHandlers.get(event)!.push(handler)
+        return () => {}
+      })
+      ;(mockClient.requestWithAck as sinon.SinonStub).callsFake(async (event: string, payload: {taskId: string}) => {
+        if (event === 'state:getProviderConfig') return {activeProvider: 'anthropic'}
+        setTimeout(() => {
+          const completedHandlers = eventHandlers.get('task:completed')
+          if (completedHandlers) {
+            for (const handler of completedHandlers) {
+              handler({
+                durationMs: 184,
+                matchedDocs: [
+                  {path: 'auth/jwt-tokens.md', score: 0.92, title: 'JWT tokens'},
+                  {path: 'billing/stripe-webhooks.md', score: 0.78, title: 'Stripe webhooks'},
+                ],
+                result: 'cached answer',
+                taskId: payload.taskId,
+                tier: 2,
+                topScore: 0.92,
+              })
+            }
+          }
+        }, 10)
+        return {taskId: payload.taskId}
+      })
+
+      await createJsonCommand('test query').run()
+
+      const lines = parseJsonOutput()
+      const completedEvent = lines.find((l) => (l.data as Record<string, unknown>).event === 'completed')
+      expect(completedEvent, 'completed event should exist').to.exist
+      const data = completedEvent!.data as Record<string, unknown>
+      expect(data).to.have.property('result', 'cached answer')
+      expect(data).to.have.property('tier', 2)
+      expect(data).to.have.property('durationMs', 184)
+      expect(data).to.have.property('topScore', 0.92)
+      expect(data).to.have.deep.property('matchedDocs', [
+        {path: 'auth/jwt-tokens.md', score: 0.92, title: 'JWT tokens'},
+        {path: 'billing/stripe-webhooks.md', score: 0.78, title: 'Stripe webhooks'},
+      ])
+    })
+
+    it('should omit matchedDocs/tier/durationMs/topScore from completed event when absent (graceful)', async () => {
+      const eventHandlers: Map<string, Array<(data: unknown) => void>> = new Map()
+      ;(mockClient.on as sinon.SinonStub).callsFake((event: string, handler: (data: unknown) => void) => {
+        if (!eventHandlers.has(event)) eventHandlers.set(event, [])
+        eventHandlers.get(event)!.push(handler)
+        return () => {}
+      })
+      ;(mockClient.requestWithAck as sinon.SinonStub).callsFake(async (event: string, payload: {taskId: string}) => {
+        if (event === 'state:getProviderConfig') return {activeProvider: 'anthropic'}
+        setTimeout(() => {
+          const completedHandlers = eventHandlers.get('task:completed')
+          if (completedHandlers) {
+            // Older daemon: only emits result + taskId, no enriched fields
+            for (const handler of completedHandlers) handler({result: 'plain answer', taskId: payload.taskId})
+          }
+        }, 10)
+        return {taskId: payload.taskId}
+      })
+
+      await createJsonCommand('test query').run()
+
+      const lines = parseJsonOutput()
+      const completedEvent = lines.find((l) => (l.data as Record<string, unknown>).event === 'completed')
+      expect(completedEvent).to.exist
+      const data = completedEvent!.data as Record<string, unknown>
+      expect(data).to.have.property('result', 'plain answer')
+      expect(data).to.not.have.property('matchedDocs')
+      expect(data).to.not.have.property('tier')
+      expect(data).to.not.have.property('durationMs')
+      expect(data).to.not.have.property('topScore')
+    })
   })
 
   // ==================== Connection Errors ====================

--- a/test/unit/infra/process/query-log-handler.test.ts
+++ b/test/unit/infra/process/query-log-handler.test.ts
@@ -292,6 +292,58 @@ describe('QueryLogHandler', () => {
     })
   })
 
+  // ── getTaskCompletionData ───────────────────────────────────────────────
+
+  describe('getTaskCompletionData', () => {
+    it('should return query metadata flattened to RecallResult shape after setQueryResult was called', async () => {
+      const task = makeTask()
+      await handler.onTaskCreate(task)
+      handler.setQueryResult('task-abc', makeQueryResult())
+
+      const data = handler.getTaskCompletionData('task-abc')
+
+      expect(data).to.deep.equal({
+        durationMs: 450,
+        matchedDocs: [{path: 'design/caching.md', score: 0.95, title: 'Caching Strategy'}],
+        tier: TIER_DIRECT_SEARCH,
+        topScore: 0.95,
+      })
+    })
+
+    it('should return empty object when task does not exist', () => {
+      const data = handler.getTaskCompletionData('unknown-task')
+
+      expect(data).to.deep.equal({})
+    })
+
+    it('should return empty object when setQueryResult was never called', async () => {
+      const task = makeTask()
+      await handler.onTaskCreate(task)
+
+      const data = handler.getTaskCompletionData('task-abc')
+
+      expect(data).to.deep.equal({})
+    })
+
+    it('should omit topScore when searchMetadata is absent (cache hit shape)', async () => {
+      const task = makeTask()
+      await handler.onTaskCreate(task)
+      // Cache hits in QueryExecutor return empty matchedDocs and no searchMetadata.
+      handler.setQueryResult('task-abc', {
+        matchedDocs: [],
+        tier: TIER_DIRECT_SEARCH,
+        timing: {durationMs: 5},
+      })
+
+      const data = handler.getTaskCompletionData('task-abc')
+
+      expect(data.matchedDocs).to.deep.equal([])
+      expect(data.tier).to.equal(TIER_DIRECT_SEARCH)
+      expect(data.durationMs).to.equal(5)
+      expect(data.topScore).to.be.undefined
+    })
+  })
+
   // ── store sharing ────────────────────────────────────────────────────────
 
   describe('store sharing', () => {


### PR DESCRIPTION
## Summary

- Problem: `brv query --format json` returned only the response text, dropping 10+ retrieval metadata signals (matched paths, scores, resolution tier, timing) that QueryExecutor already computes internally.
- Why it matters: Downstream consumers — `brv-bridge` and the ByteRover Claude plugin — need this metadata to surface visible evidence of memory retrieval to the user. Today recall runs silently every turn; the user has no signal that ByteRover is working or what it retrieved. Surfacing this metadata is the foundation for the broader "Surface ByteRover in Claude Code" initiative (ENG-2537).
- What changed: Extends the `brv query --format json` envelope with `matchedDocs[]`, `tier`, `durationMs`, and `topScore`. Plumbed via the existing query-log lifecycle hook + task-completed event so older daemons degrade gracefully.
- What did NOT change (scope boundary): `--format text` (default) output is byte-identical. No retrieval/scoring logic touched. No agent prompt or tool-response changes. No new fields exposed beyond the four above (richer per-doc fields like `symbolKind`, `backlinkCount`, `relatedPaths` deferred until consumers demonstrate need).

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [ ] Agent / Tools
- [ ] LLM Providers
- [x] Server / Daemon
- [x] Shared (constants, types, transport events)
- [x] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes ENG-2615
- Parent ticket: ENG-2537 (surface ByteRover in Claude Code)
- Related #608 (merged into this branch)

## Root cause (bug fixes only, otherwise write `N/A`)

N/A — this is a feature.

## Test plan

- Coverage added:
  - [x] Unit test
  - [ ] Integration test
  - [ ] Manual verification only
- Test file(s):
  - `test/unit/infra/process/query-log-handler.test.ts` — 4 new cases on `getTaskCompletionData`
  - `test/commands/query.test.ts` — 2 new cases on the query command's JSON envelope
- Key scenario(s) covered:
  - `getTaskCompletionData` returns full structured payload when all fields present
  - `getTaskCompletionData` handles no-task / no-result / partial cache-hit shapes
  - `brv query --format json` surfaces the new fields when daemon emits them
  - `brv query --format json` gracefully omits the fields when daemon doesn't emit them (older daemon compat)

## User-visible changes

None directly. `brv query` text-mode output unchanged. JSON-mode output is additive — consumers that ignore unknown fields are unaffected.

This unlocks user-visible changes in downstream layers:
- `brv-bridge` will pass these fields through (Task 2).
- `brv-claude-plugin` will surface a "🧠 Retrieved N memories…" line in the Claude Code chat panel via the hook `systemMessage` primitive (Task 3).

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording

Sample output after this change:
```json
{
  "command": "query",
  "data": {
    "result": "...",
    "matchedDocs": [
      {"path": "auth/jwt/token.md", "score": 0.92, "title": "...", "snippet": "..."}
    ],
    "tier": 2,
    "durationMs": 47,
    "topScore": 0.92
  },
  "success": true,
  "timestamp": "..."
}
