### PR TITLE
fix: drop esbuild peer:true entries from lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5911,7 +5911,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5932,7 +5931,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5953,7 +5951,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5974,7 +5971,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5995,7 +5991,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6016,7 +6011,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6037,7 +6031,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6058,7 +6051,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6079,7 +6071,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6100,7 +6091,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6121,7 +6111,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       },


### PR DESCRIPTION
## Description
Removes 11 `"peer": true` entries on `@esbuild/<platform>` native binding packages from `package-lock.json`. After this change, the proj branch's lockfile is byte-identical to `main`'s.

## Motivation
Those entries were introduced incidentally by an earlier `npm install` running with a different npm CLI version that re-resolves esbuild's `optionalDependencies` as peer entries. They are descriptive metadata only — they do not affect what `npm ci` or `npm install` actually installs.

The codex bot flagged the noise on the proj→main PR (review thread on `package-lock.json:5914`):
> "harmless but dirties the PR's scope"

This PR removes the noise so proj→main carries zero lockfile churn.

## Implementation
- `git checkout origin/main -- package-lock.json` to take the upstream blob verbatim.
- Verified: `git diff HEAD origin/main -- package-lock.json` is empty (blob hash `be804e70…` on both sides).
- Verified: `git diff HEAD <pre-rebase-parent-of-the-feature-commit> -- package-lock.json` is also empty — i.e., the lockfile is exactly what it was before the feature work landed.
- Verified: `npm ci --dry-run` succeeds against the reverted lockfile, confirming manifest/lockfile consistency.

## Test plan
- [x] `npm ci --dry-run` passes locally
- [ ] Reviewer: confirm CI's `install` job stays green
- [ ] Reviewer: confirm `git diff main..proj/surface-curate-query-claude -- package-lock.json` is empty after merge

## Breaking changes
None. The diff is purely subtractive on inert metadata; no dependency versions or resolutions change.

## Follow-up
The root cause is `npm install` being used in a context where `npm ci` would have been correct. Saved as a personal workflow rule. A repo-wide durable fix would be pinning the npm CLI version (via `engines.npm` or volta) so this kind of resolution noise can't reappear from local installs — out of scope for this PR.