### PR TITLE
fix: [ENG-2676] strip derived-artifact paths from related: frontmatter

### DIFF
--- a/src/agent/infra/tools/implementations/curate-tool.ts
+++ b/src/agent/infra/tools/implementations/curate-tool.ts
@@ -997,7 +997,7 @@ async function executeUpdate(
 
     // Extract previous summary from existing file's frontmatter (for review UI)
     const existingParsed = existingContent ? MarkdownWriter.parseContent(existingContent, title) : null
-    if (existingParsed?.relations) {
+    if (existingParsed?.relations?.length) {
       // Drop legacy dangling refs before conflict-detection; otherwise resolver unions them back.
       existingParsed.relations = existingParsed.relations.filter((r) => !isExcludedFromSync(r))
     }

--- a/src/agent/infra/tools/implementations/curate-tool.ts
+++ b/src/agent/infra/tools/implementations/curate-tool.ts
@@ -20,6 +20,7 @@ import {
   type RuntimeSignals,
 } from '../../../../server/core/domain/knowledge/runtime-signals-schema.js'
 import {warnSidecarFailure} from '../../../../server/core/domain/knowledge/sidecar-logging.js'
+import {isExcludedFromSync} from '../../../../server/infra/context-tree/derived-artifact.js'
 import {toSnakeCase} from '../../../../server/utils/file-helpers.js'
 import {deriveImpactFromLoss, detectStructuralLoss} from '../../../core/domain/knowledge/conflict-detector.js'
 import {resolveStructuralLoss} from '../../../core/domain/knowledge/conflict-resolver.js'
@@ -358,16 +359,22 @@ type SubtopicContext = z.infer<typeof SubtopicContextSchema>
 type Content = z.infer<typeof ContentSchema>
 
 /**
- * Filter out non-existent files from rawConcept.files.
- * Returns a new content object with only valid file paths.
+ * Filter out non-existent files from rawConcept.files and derived-artifact
+ * paths from relations.
  */
 async function filterValidFiles(content: Content): Promise<Content> {
-  if (!content.rawConcept?.files || content.rawConcept.files.length === 0) {
-    return content
+  // Drop relations that won't be pushed — they'd be dangling refs on remote.
+  const cleanedRelations = content.relations?.filter((r) => !isExcludedFromSync(r))
+  const withCleanRelations: Content = cleanedRelations === content.relations
+    ? content
+    : {...content, relations: cleanedRelations}
+
+  if (!withCleanRelations.rawConcept?.files || withCleanRelations.rawConcept.files.length === 0) {
+    return withCleanRelations
   }
 
   const checks = await Promise.all(
-    content.rawConcept.files.map(async (filePath) => {
+    withCleanRelations.rawConcept.files.map(async (filePath) => {
       // Skip filesystem validation for URLs and document references
       if (filePath.includes('://')) return true
       // Skip entries that look like document references (no path separators, contain spaces)
@@ -376,13 +383,13 @@ async function filterValidFiles(content: Content): Promise<Content> {
     }),
   )
 
-  const validFiles = content.rawConcept.files.filter((_, i) => checks[i])
+  const validFiles = withCleanRelations.rawConcept.files.filter((_, i) => checks[i])
 
   // Return content with filtered files (empty array if none exist)
   return {
-    ...content,
+    ...withCleanRelations,
     rawConcept: {
-      ...content.rawConcept,
+      ...withCleanRelations.rawConcept,
       files: validFiles.length > 0 ? validFiles : undefined,
     },
   }

--- a/src/agent/infra/tools/implementations/curate-tool.ts
+++ b/src/agent/infra/tools/implementations/curate-tool.ts
@@ -997,6 +997,11 @@ async function executeUpdate(
 
     // Extract previous summary from existing file's frontmatter (for review UI)
     const existingParsed = existingContent ? MarkdownWriter.parseContent(existingContent, title) : null
+    if (existingParsed?.relations) {
+      // Drop legacy dangling refs before conflict-detection; otherwise resolver unions them back.
+      existingParsed.relations = existingParsed.relations.filter((r) => !isExcludedFromSync(r))
+    }
+
     const previousSummary = existingParsed?.summary
 
     // Detect structural loss and auto-resolve: merge back anything the LLM dropped

--- a/src/server/infra/dream/operations/consolidate.ts
+++ b/src/server/infra/dream/operations/consolidate.ts
@@ -622,9 +622,11 @@ async function executeCrossReference(action: ConsolidationAction, ctx: ActionCon
   }
 
   // For each file, add the other files to its related frontmatter
+  // Skip derived-artifact targets so we never write related: onto them.
+  const eligibleFiles = action.files.filter((f) => !isExcludedFromSync(f))
   await Promise.all(
-    action.files.map((file) => {
-      const otherFiles = action.files.filter((f) => f !== file)
+    eligibleFiles.map((file) => {
+      const otherFiles = eligibleFiles.filter((f) => f !== file)
       return addRelatedLinks(join(contextTreeDir, file), otherFiles)
     }),
   )
@@ -664,9 +666,13 @@ async function addRelatedLinks(filePath: string, relatedPaths: string[]): Promis
       try {
         const parsed = yamlLoad(yamlBlock) as null | Record<string, unknown>
         if (parsed && typeof parsed === 'object') {
+          const hadRelated = Array.isArray(parsed.related)
           const existing = (Array.isArray(parsed.related) ? (parsed.related as string[]) : [])
             .filter((p) => !isExcludedFromSync(p))
-          parsed.related = [...new Set([...existing, ...incoming])]
+          const merged = [...new Set([...existing, ...incoming])]
+          // Don't introduce a related: [] key into a file that didn't have one.
+          if (!hadRelated && merged.length === 0) return
+          parsed.related = merged
           const newYaml = yamlDump(parsed, {flowLevel: 1, lineWidth: -1, sortKeys: false}).trimEnd()
           await atomicWrite(filePath, `---\n${newYaml}\n---\n${body}`)
           return

--- a/src/server/infra/dream/operations/consolidate.ts
+++ b/src/server/infra/dream/operations/consolidate.ts
@@ -23,6 +23,7 @@ import type {ConsolidationAction} from '../dream-response-schemas.js'
 import type {DreamState, PendingMerge} from '../dream-state-schema.js'
 
 import {warnSidecarFailure} from '../../../core/domain/knowledge/sidecar-logging.js'
+import {isExcludedFromSync} from '../../context-tree/derived-artifact.js'
 import {ConsolidateResponseSchema} from '../dream-response-schemas.js'
 import {parseDreamResponse} from '../parse-dream-response.js'
 
@@ -639,6 +640,9 @@ async function executeCrossReference(action: ConsolidationAction, ctx: ActionCon
 }
 
 async function addRelatedLinks(filePath: string, relatedPaths: string[]): Promise<void> {
+  // Skip paths that won't be pushed — they'd be dangling refs on remote.
+  const incoming = relatedPaths.filter((p) => !isExcludedFromSync(p))
+
   let content: string
   try {
     content = await readFile(filePath, 'utf8')
@@ -660,8 +664,9 @@ async function addRelatedLinks(filePath: string, relatedPaths: string[]): Promis
       try {
         const parsed = yamlLoad(yamlBlock) as null | Record<string, unknown>
         if (parsed && typeof parsed === 'object') {
-          const existing = Array.isArray(parsed.related) ? (parsed.related as string[]) : []
-          parsed.related = [...new Set([...existing, ...relatedPaths])]
+          const existing = (Array.isArray(parsed.related) ? (parsed.related as string[]) : [])
+            .filter((p) => !isExcludedFromSync(p))
+          parsed.related = [...new Set([...existing, ...incoming])]
           const newYaml = yamlDump(parsed, {flowLevel: 1, lineWidth: -1, sortKeys: false}).trimEnd()
           await atomicWrite(filePath, `---\n${newYaml}\n---\n${body}`)
           return
@@ -673,7 +678,7 @@ async function addRelatedLinks(filePath: string, relatedPaths: string[]): Promis
   }
 
   // No existing frontmatter — add one with related field
-  const yaml = yamlDump({related: relatedPaths}, {flowLevel: 1, lineWidth: -1, sortKeys: false}).trimEnd()
+  const yaml = yamlDump({related: incoming}, {flowLevel: 1, lineWidth: -1, sortKeys: false}).trimEnd()
   await atomicWrite(filePath, `---\n${yaml}\n---\n${content}`)
 }
 

--- a/src/server/infra/dream/operations/consolidate.ts
+++ b/src/server/infra/dream/operations/consolidate.ts
@@ -677,7 +677,8 @@ async function addRelatedLinks(filePath: string, relatedPaths: string[]): Promis
     }
   }
 
-  // No existing frontmatter — add one with related field
+  // No existing frontmatter — add one with related field, unless filter left nothing to add.
+  if (incoming.length === 0) return
   const yaml = yamlDump({related: incoming}, {flowLevel: 1, lineWidth: -1, sortKeys: false}).trimEnd()
   await atomicWrite(filePath, `---\n${yaml}\n---\n${content}`)
 }

--- a/test/unit/agent/tools/curate-tool.test.ts
+++ b/test/unit/agent/tools/curate-tool.test.ts
@@ -660,6 +660,9 @@ describe('Curate Tool', () => {
       ].join('\n')
       await fs.writeFile(seedPath, seed, 'utf8')
 
+      // Proposed retains the legitimate sibling; only the filtered abstract
+      // would otherwise look "lost". With the fix, lostRelations = 0 and
+      // impact stays 'low'. Without the fix, lostRelations = 1 → 'high'.
       const result = (await tool.execute({
         basePath,
         operations: [
@@ -667,7 +670,7 @@ describe('Curate Tool', () => {
             confidence: 'high',
             content: {
               keywords: [],
-              relations: ['operations/cafe/ingredient_sourcing.md'],
+              relations: ['operations/cafe/sunrise_cafe_menu.md', 'operations/cafe/ingredient_sourcing.md'],
               snippets: ['updated notes'],
               tags: [],
             },
@@ -681,6 +684,7 @@ describe('Curate Tool', () => {
       })) as CurateOutput
 
       expect(result.applied[0].status).to.equal('success')
+      expect(result.applied[0].impact).to.equal('low')
       const written = await fs.readFile(seedPath, 'utf8')
       expect(written).to.include('operations/cafe/sunrise_cafe_menu.md')
       expect(written).to.include('operations/cafe/ingredient_sourcing.md')

--- a/test/unit/agent/tools/curate-tool.test.ts
+++ b/test/unit/agent/tools/curate-tool.test.ts
@@ -600,6 +600,44 @@ describe('Curate Tool', () => {
     })
   })
 
+  describe('Relations filtering', () => {
+    it('drops derived-artifact paths (.abstract.md, .overview.md) from relations on ADD', async () => {
+      const tool = createCurateTool()
+
+      const result = (await tool.execute({
+        basePath,
+        operations: [
+          {
+            confidence: 'high',
+            content: {
+              keywords: [],
+              relations: [
+                'operations/cafe/sunrise_cafe_menu.md',
+                'operations/cafe/sunrise_cafe_menu.abstract.md',
+                'operations/cafe/sunrise_cafe_menu.overview.md',
+              ],
+              snippets: ['weekend brunch service'],
+              tags: [],
+            },
+            impact: 'low',
+            path: 'operations/cafe',
+            reason: 'testing relations filter',
+            title: 'Weekend Brunch',
+            type: 'ADD',
+          },
+        ],
+      })) as CurateOutput
+
+      expect(result.applied[0].status).to.equal('success')
+
+      const writtenPath = join(basePath, 'operations/cafe/weekend_brunch.md')
+      const content = await fs.readFile(writtenPath, 'utf8')
+      expect(content).to.include('operations/cafe/sunrise_cafe_menu.md')
+      expect(content).to.not.include('sunrise_cafe_menu.abstract.md')
+      expect(content).to.not.include('sunrise_cafe_menu.overview.md')
+    })
+  })
+
   describe('Multiple Operations', () => {
     it('should process multiple operations and return accurate summary', async () => {
       const tool = createCurateTool()

--- a/test/unit/agent/tools/curate-tool.test.ts
+++ b/test/unit/agent/tools/curate-tool.test.ts
@@ -636,6 +636,56 @@ describe('Curate Tool', () => {
       expect(content).to.not.include('sunrise_cafe_menu.abstract.md')
       expect(content).to.not.include('sunrise_cafe_menu.overview.md')
     })
+
+    it('strips legacy derived-artifact entries from existing related: on UPDATE (conflict-resolver path)', async () => {
+      // Pre-seed a file whose related: already contains a stale .abstract.md
+      // entry (legacy data from before the fix). UPDATE must not union it
+      // back through resolveStructuralLoss.
+      const tool = createCurateTool()
+      const targetDir = join(basePath, 'operations/cafe')
+      await fs.mkdir(targetDir, {recursive: true})
+      const seedPath = join(targetDir, 'menu_notes.md')
+      const seed = [
+        '---',
+        'title: Menu Notes',
+        'summary: original notes',
+        'tags: []',
+        'related: [operations/cafe/sunrise_cafe_menu.md, operations/cafe/sunrise_cafe_menu.abstract.md]',
+        'keywords: []',
+        "createdAt: '2026-04-01T00:00:00.000Z'",
+        "updatedAt: '2026-04-10T00:00:00.000Z'",
+        '---',
+        '## Reason\nseed',
+        '## Raw Concept\n**Task:** seed',
+      ].join('\n')
+      await fs.writeFile(seedPath, seed, 'utf8')
+
+      const result = (await tool.execute({
+        basePath,
+        operations: [
+          {
+            confidence: 'high',
+            content: {
+              keywords: [],
+              relations: ['operations/cafe/ingredient_sourcing.md'],
+              snippets: ['updated notes'],
+              tags: [],
+            },
+            impact: 'low',
+            path: 'operations/cafe',
+            reason: 'testing UPDATE relations filter',
+            title: 'Menu Notes',
+            type: 'UPDATE',
+          },
+        ],
+      })) as CurateOutput
+
+      expect(result.applied[0].status).to.equal('success')
+      const written = await fs.readFile(seedPath, 'utf8')
+      expect(written).to.include('operations/cafe/sunrise_cafe_menu.md')
+      expect(written).to.include('operations/cafe/ingredient_sourcing.md')
+      expect(written).to.not.include('sunrise_cafe_menu.abstract.md')
+    })
   })
 
   describe('Multiple Operations', () => {

--- a/test/unit/infra/dream/operations/consolidate.test.ts
+++ b/test/unit/infra/dream/operations/consolidate.test.ts
@@ -305,6 +305,33 @@ describe('consolidate', () => {
     expect(oauth).to.include('auth/jwt.md')
   })
 
+  it('CROSS_REFERENCE drops derived-artifact paths and cleans pre-existing dangling refs', async () => {
+    // Pre-seed jwt.md with a stale reference to an .abstract.md sibling — it
+    // shouldn't be there (push filtering would strip the file) and the next
+    // CROSS_REFERENCE touch should clean it up.
+    await createMdFile(ctxDir, 'auth/jwt.md', '# JWT', {
+      keywords: [], related: ['auth/legacy.abstract.md'], tags: [], title: 'JWT',
+    })
+    await createMdFile(ctxDir, 'auth/oauth.md', '# OAuth', {keywords: [], related: [], tags: [], title: 'OAuth'})
+
+    // LLM groups jwt.md with both a real sibling AND derived artifacts that
+    // should never end up in `related:` because they don't sync to remote.
+    agent.executeOnSession.resolves(llmResponse([{
+      files: ['auth/jwt.md', 'auth/oauth.md', 'auth/intro.overview.md', 'auth/intro.abstract.md'],
+      reason: 'Cross-reference auth topics',
+      type: 'CROSS_REFERENCE',
+    }]))
+
+    await consolidate(['auth/jwt.md', 'auth/oauth.md'], deps)
+
+    const jwt = await readFile(join(ctxDir, 'auth/jwt.md'), 'utf8')
+    expect(jwt).to.include('auth/oauth.md')
+    expect(jwt).to.not.include('auth/intro.overview.md')
+    expect(jwt).to.not.include('auth/intro.abstract.md')
+    // Pre-existing dangling ref opportunistically cleaned
+    expect(jwt).to.not.include('auth/legacy.abstract.md')
+  })
+
   it('returns empty operations for SKIP actions', async () => {
     await createMdFile(ctxDir, 'auth/unrelated.md', '# Unrelated')
 


### PR DESCRIPTION
`*.abstract.md` and `*.overview.md` (and other derived artifacts) are excluded from the push payload via isExcludedFromSync(). When they landed in a doc's `related:` field, the parent doc shipped to remote with dangling references to siblings that were never sent.

Two write paths could produce them; both now filter:

- consolidate.ts `addRelatedLinks` (dream's CROSS_REFERENCE) filters incoming AND pre-existing entries, so each touch opportunistically cleans up legacy dangling refs.
- curate-tool.ts `filterValidFiles` drops excluded paths from `relations` before MarkdownWriter writes them — covers both ADD and UPDATE since both call sites share the helper.

Pre-existing dangling refs in untouched docs are out of scope; a separate migration can scrub them.

## Summary

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [ ] Agent / Tools
- [ ] LLM Providers
- [ ] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes #
- Related #

## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause:
- Why this was not caught earlier:

## Test plan

- Coverage added:
  - [ ] Unit test
  - [ ] Integration test
  - [ ] Manual verification only
- Test file(s):
- Key scenario(s) covered:

## User-visible changes

List user-visible changes (including defaults, config, or CLI output).
If none, write `None`.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording

## Checklist

- [ ] Tests added or updated and passing (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Type check passes (`npm run typecheck`)
- [ ] Build succeeds (`npm run build`)
- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or clearly documented above)
- [ ] Branch is up to date with `main`

## Risks and mitigations

List real risks for this PR. If none, write `None`.

- Risk:
  - Mitigation:
