### PR TITLE
feat: [ENG-2737] HTML render layer foundation — element registry + parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "byterover-cli",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "byterover-cli",
-      "version": "3.11.0",
+      "version": "3.12.0",
       "bundleDependencies": [
         "@campfirein/brv-transport-client",
         "@campfirein/byterover-packages",
@@ -80,6 +80,7 @@
         "officeparser": "^6.0.4",
         "open": "^10.2.0",
         "openai": "^6.9.1",
+        "parse5": "^8.0.1",
         "proxy-agent": "^7.0.0",
         "react": "^19.2.1",
         "react-diff-viewer-continued": "^4.2.0",
@@ -5911,6 +5912,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5931,6 +5933,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5951,6 +5954,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5971,6 +5975,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -5991,6 +5996,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6011,6 +6017,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6031,6 +6038,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6051,6 +6059,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6071,6 +6080,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6091,6 +6101,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -6111,6 +6122,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       },
@@ -12680,6 +12692,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -20772,6 +20796,18 @@
       "integrity": "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/parseurl": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "officeparser": "^6.0.4",
     "open": "^10.2.0",
     "openai": "^6.9.1",
+    "parse5": "^8.0.1",
     "proxy-agent": "^7.0.0",
     "react": "^19.2.1",
     "react-diff-viewer-continued": "^4.2.0",

--- a/src/server/core/domain/render/element-types.ts
+++ b/src/server/core/domain/render/element-types.ts
@@ -1,0 +1,105 @@
+/**
+ * Element type definitions for the M1 HTML render layer.
+ *
+ * This file is the type-only contract between:
+ *  - the HTML parser (produces `ParsedNode` trees)
+ *  - per-element validators (consume `ElementNode`s)
+ *  - the element registry (catalogs `ElementSchema`s by `ElementName`)
+ *  - downstream consumers (T3 curate writer, T4 query reader)
+ *
+ * See `features/html-memory-conversion/milestones/01-experiment/plan.md`
+ * for the M1 vocabulary scope (5 elements). M2 expansion is purely
+ * additive — adding an element name to `ELEMENT_NAMES` and a registry
+ * entry is sufficient; no consumer needs to be touched.
+ */
+
+/**
+ * The five M1 element names. Adding to this list must be an additive
+ * operation; downstream consumers iterate the registry generically.
+ */
+export const ELEMENT_NAMES = [
+  'bv-topic',
+  'bv-rule',
+  'bv-decision',
+  'bv-bug',
+  'bv-fix',
+] as const
+
+export type ElementName = typeof ELEMENT_NAMES[number]
+
+/**
+ * Normalized AST node produced by the HTML parser. Independent of any
+ * specific parser library so we can swap implementations without
+ * touching consumers.
+ */
+export type ParsedNode = DocumentNode | ElementNode | TextNode
+
+export type ElementNode = {
+  /**
+   * Attribute map. Values are always strings (HTML attribute semantics).
+   *
+   * NOTE on key case: per the HTML5 parsing spec, attribute names are
+   * lowercased during parsing — `updatedAt` in the source becomes
+   * `updatedat` in this map. Downstream consumers (T3 writer, T4
+   * reader) MUST emit and look up attributes in lowercase. Schemas
+   * declared in per-element `schema.ts` files use lowercase to match.
+   */
+  attributes: Readonly<Record<string, string>>
+  children: readonly ParsedNode[]
+  /** Tag name, lowercased. May or may not be a registered `ElementName`. */
+  tagName: string
+  type: 'element'
+}
+
+export type TextNode = {
+  text: string
+  type: 'text'
+}
+
+export type DocumentNode = {
+  children: readonly ParsedNode[]
+  type: 'document'
+}
+
+/** A single validation issue. Field is informational (often the attribute name). */
+export type ValidationError = {
+  field: string
+  message: string
+}
+
+/**
+ * Validation outcome from a per-element validator. Discriminated union so
+ * consumers can branch without optional-undefined gymnastics.
+ */
+export type ValidationResult =
+  | {errors: readonly ValidationError[]; valid: false;}
+  | {valid: true}
+
+/**
+ * Allowed-children semantic hint. Informational only in M1 — the
+ * validator carries the enforcement; this is for documentation and the
+ * curate prompt template generator (T3).
+ */
+export type AllowedChildren = 'any' | 'block' | 'inline' | 'none'
+
+/**
+ * Per-element registry entry. The validator is the load-bearing field;
+ * everything else is metadata for the prompt template generator (T3) and
+ * the structural-axis index (T4).
+ */
+export type ElementSchema = {
+  /** Allowed-children semantic hint. Informational. */
+  allowedChildren: AllowedChildren
+  /** Human-readable description for the curate prompt template generator. */
+  description: string
+  name: ElementName
+  /** Optional attribute names. Informational; the validator enforces. */
+  optionalAttributes: readonly string[]
+  /** Required attribute names. Informational; the validator enforces. */
+  requiredAttributes: readonly string[]
+  /** Validate an `ElementNode`'s tag name + attributes. Light validation in M1 (per-attribute Zod schema); strict per ADR-007 §13 in M2. */
+  validator: (node: ElementNode) => ValidationResult
+}
+
+/** The full element registry — exactly one `ElementSchema` per `ElementName`. */
+export type ElementRegistry = Readonly<Record<ElementName, ElementSchema>>

--- a/src/server/infra/render/elements/bv-bug/schema.ts
+++ b/src/server/infra/render/elements/bv-bug/schema.ts
@@ -1,0 +1,10 @@
+import {z} from 'zod'
+
+/**
+ * Zod schema for `<bv-bug>` attributes. M1 light validation; passthrough
+ * tolerates unknown attributes (ADR-007 §13 strict validation is M2).
+ */
+export const BvBugAttributesSchema = z.object({
+  id: z.string().min(1, {message: 'id must be non-empty if present'}).optional(),
+  severity: z.enum(['low', 'medium', 'high', 'critical']).optional(),
+}).passthrough()

--- a/src/server/infra/render/elements/bv-bug/validator.ts
+++ b/src/server/infra/render/elements/bv-bug/validator.ts
@@ -1,0 +1,8 @@
+import {makeAttributeValidator} from '../make-validator.js'
+import {BvBugAttributesSchema} from './schema.js'
+
+/**
+ * Validate a `<bv-bug>` element node. M1 light validation; strict per
+ * ADR-007 §13 is M2 work.
+ */
+export const validateBvBug = makeAttributeValidator('bv-bug', BvBugAttributesSchema)

--- a/src/server/infra/render/elements/bv-decision/schema.ts
+++ b/src/server/infra/render/elements/bv-decision/schema.ts
@@ -1,0 +1,10 @@
+import {z} from 'zod'
+
+/**
+ * Zod schema for `<bv-decision>` attributes. M1 light validation;
+ * `passthrough` tolerates unknown attributes (ADR-007 §13 strict
+ * validation is M2).
+ */
+export const BvDecisionAttributesSchema = z.object({
+  id: z.string().min(1, {message: 'id must be non-empty if present'}).optional(),
+}).passthrough()

--- a/src/server/infra/render/elements/bv-decision/validator.ts
+++ b/src/server/infra/render/elements/bv-decision/validator.ts
@@ -1,0 +1,8 @@
+import {makeAttributeValidator} from '../make-validator.js'
+import {BvDecisionAttributesSchema} from './schema.js'
+
+/**
+ * Validate a `<bv-decision>` element node. M1 light validation; strict
+ * per ADR-007 §13 is M2 work.
+ */
+export const validateBvDecision = makeAttributeValidator('bv-decision', BvDecisionAttributesSchema)

--- a/src/server/infra/render/elements/bv-fix/schema.ts
+++ b/src/server/infra/render/elements/bv-fix/schema.ts
@@ -1,0 +1,9 @@
+import {z} from 'zod'
+
+/**
+ * Zod schema for `<bv-fix>` attributes. M1 light validation; passthrough
+ * tolerates unknown attributes (ADR-007 §13 strict validation is M2).
+ */
+export const BvFixAttributesSchema = z.object({
+  id: z.string().min(1, {message: 'id must be non-empty if present'}).optional(),
+}).passthrough()

--- a/src/server/infra/render/elements/bv-fix/validator.ts
+++ b/src/server/infra/render/elements/bv-fix/validator.ts
@@ -1,0 +1,8 @@
+import {makeAttributeValidator} from '../make-validator.js'
+import {BvFixAttributesSchema} from './schema.js'
+
+/**
+ * Validate a `<bv-fix>` element node. M1 light validation; strict per
+ * ADR-007 §13 is M2 work.
+ */
+export const validateBvFix = makeAttributeValidator('bv-fix', BvFixAttributesSchema)

--- a/src/server/infra/render/elements/bv-rule/schema.ts
+++ b/src/server/infra/render/elements/bv-rule/schema.ts
@@ -1,0 +1,10 @@
+import {z} from 'zod'
+
+/**
+ * Zod schema for `<bv-rule>` attributes. M1 light validation; passthrough
+ * tolerates unknown attributes (ADR-007 §13 strict validation is M2).
+ */
+export const BvRuleAttributesSchema = z.object({
+  id: z.string().min(1, {message: 'id must be non-empty if present'}).optional(),
+  severity: z.enum(['info', 'must', 'should']).optional(),
+}).passthrough()

--- a/src/server/infra/render/elements/bv-rule/validator.ts
+++ b/src/server/infra/render/elements/bv-rule/validator.ts
@@ -1,0 +1,8 @@
+import {makeAttributeValidator} from '../make-validator.js'
+import {BvRuleAttributesSchema} from './schema.js'
+
+/**
+ * Validate a `<bv-rule>` element node. M1 light validation; strict per
+ * ADR-007 §13 is M2 work.
+ */
+export const validateBvRule = makeAttributeValidator('bv-rule', BvRuleAttributesSchema)

--- a/src/server/infra/render/elements/bv-topic/schema.ts
+++ b/src/server/infra/render/elements/bv-topic/schema.ts
@@ -1,0 +1,35 @@
+import {z} from 'zod'
+
+/**
+ * Zod schema for `<bv-topic>` attributes.
+ *
+ * HTML attributes arrive as strings. Numeric and enum constraints are
+ * expressed via `z.coerce.number()` (with refinements) and `z.enum`.
+ *
+ * `passthrough` is intentional: M1 tolerates unknown attributes
+ * (warn-only behaviour). Strict validation per ADR-007 §13 is M2 work.
+ */
+export const BvTopicAttributesSchema = z.object({
+  importance: z
+    .string()
+    .regex(/^\d+$/, {message: 'importance must be an integer string "0".."100"'})
+    .refine((v) => {
+      const n = Number(v)
+      return n >= 0 && n <= 100
+    }, {message: 'importance must be in [0, 100]'})
+    .optional(),
+  maturity: z.enum(['draft', 'validated', 'core']).optional(),
+  path: z.string().min(1, {message: 'path is required and must be non-empty'}),
+  recency: z
+    .string()
+    .regex(/^[\d.]+$/, {message: 'recency must be a numeric string'})
+    .refine((v) => {
+      const n = Number(v)
+      return Number.isFinite(n) && n >= 0 && n <= 1
+    }, {message: 'recency must be in [0, 1]'})
+    .optional(),
+  // Lowercase per HTML5 attribute-name normalization (parse5 lowercases
+  // `updatedAt="..."` to `updatedat`; schema keys must match the parser
+  // output, not the source HTML). See element-types.ts attribute-case note.
+  updatedat: z.string().datetime({message: 'updatedat must be ISO-8601 datetime'}).optional(),
+}).passthrough()

--- a/src/server/infra/render/elements/bv-topic/schema.ts
+++ b/src/server/infra/render/elements/bv-topic/schema.ts
@@ -4,10 +4,11 @@ import {z} from 'zod'
  * Zod schema for `<bv-topic>` attributes.
  *
  * HTML attributes arrive as strings. Numeric and enum constraints are
- * expressed via `z.coerce.number()` (with refinements) and `z.enum`.
+ * expressed via regex + refine, since HTML never gives us native numbers.
  *
- * `passthrough` is intentional: M1 tolerates unknown attributes
- * (warn-only behaviour). Strict validation per ADR-007 §13 is M2 work.
+ * `passthrough` is intentional: M1 is permissive on unknown attributes
+ * (parse-and-skip — no warning is emitted). Strict validation per
+ * ADR-007 §13 is M2 work.
  */
 export const BvTopicAttributesSchema = z.object({
   importance: z
@@ -22,14 +23,16 @@ export const BvTopicAttributesSchema = z.object({
   path: z.string().min(1, {message: 'path is required and must be non-empty'}),
   recency: z
     .string()
-    .regex(/^[\d.]+$/, {message: 'recency must be a numeric string'})
+    .regex(/^\d+(\.\d+)?$/, {message: 'recency must be a numeric string'})
     .refine((v) => {
       const n = Number(v)
-      return Number.isFinite(n) && n >= 0 && n <= 1
+      return n >= 0 && n <= 1
     }, {message: 'recency must be in [0, 1]'})
     .optional(),
   // Lowercase per HTML5 attribute-name normalization (parse5 lowercases
   // `updatedAt="..."` to `updatedat`; schema keys must match the parser
   // output, not the source HTML). See element-types.ts attribute-case note.
-  updatedat: z.string().datetime({message: 'updatedat must be ISO-8601 datetime'}).optional(),
+  // `offset: true` accepts explicit timezone offsets like `+02:00` (e.g.
+  // from `git log --date=iso-strict`), not only `Z`.
+  updatedat: z.string().datetime({message: 'updatedat must be ISO-8601 datetime', offset: true}).optional(),
 }).passthrough()

--- a/src/server/infra/render/elements/bv-topic/validator.ts
+++ b/src/server/infra/render/elements/bv-topic/validator.ts
@@ -1,0 +1,9 @@
+import {makeAttributeValidator} from '../make-validator.js'
+import {BvTopicAttributesSchema} from './schema.js'
+
+/**
+ * Validate a `<bv-topic>` element node. Light validation per M1
+ * (per-attribute Zod schema in `./schema.ts`); strict per ADR-007 §13
+ * is M2 work.
+ */
+export const validateBvTopic = makeAttributeValidator('bv-topic', BvTopicAttributesSchema)

--- a/src/server/infra/render/elements/make-validator.ts
+++ b/src/server/infra/render/elements/make-validator.ts
@@ -1,0 +1,43 @@
+import type {z} from 'zod'
+
+import type {ElementNode, ValidationError, ValidationResult} from '../../../core/domain/render/element-types.js'
+
+/**
+ * Build an element validator from a tag name and a Zod attribute schema.
+ *
+ * Every M1 element validator follows the same shape:
+ *   1. Reject if `node.tagName` doesn't match the expected tag.
+ *   2. Run the per-element Zod schema against `node.attributes`.
+ *   3. Map any Zod issues to `ValidationError` records.
+ *
+ * Centralizing the shape here means M2's vocabulary expansion (12 more
+ * elements per Andy's proposal §11) is purely additive — each new
+ * element is a `schema.ts` + a one-line `validator.ts` binding. No
+ * branching logic per element type until/unless an element legitimately
+ * needs custom validation beyond attributes.
+ */
+export function makeAttributeValidator(
+  tagName: string,
+  schema: z.ZodTypeAny,
+): (node: ElementNode) => ValidationResult {
+  return (node) => {
+    if (node.tagName !== tagName) {
+      const errors: ValidationError[] = [{
+        field: 'tagName',
+        message: `expected tagName "${tagName}", got "${node.tagName}"`,
+      }]
+      return {errors, valid: false}
+    }
+
+    const parsed = schema.safeParse(node.attributes)
+    if (!parsed.success) {
+      const errors: ValidationError[] = parsed.error.issues.map((issue) => ({
+        field: issue.path.join('.') || 'attributes',
+        message: issue.message,
+      }))
+      return {errors, valid: false}
+    }
+
+    return {valid: true}
+  }
+}

--- a/src/server/infra/render/elements/registry.ts
+++ b/src/server/infra/render/elements/registry.ts
@@ -1,0 +1,73 @@
+import type {ElementRegistry} from '../../../core/domain/render/element-types.js'
+
+import {validateBvBug} from './bv-bug/validator.js'
+import {validateBvDecision} from './bv-decision/validator.js'
+import {validateBvFix} from './bv-fix/validator.js'
+import {validateBvRule} from './bv-rule/validator.js'
+import {validateBvTopic} from './bv-topic/validator.js'
+
+/**
+ * The M1 element registry — single source of truth for the 5-element
+ * vocabulary. M2 vocabulary expansion (12 more elements per Andy's
+ * proposal §11) is **purely additive**: add a new entry here and a new
+ * `<name>/{schema,validator}.ts` pair under `elements/`. No consumer
+ * (writer, reader, indexer, prompt template generator) needs to be
+ * touched — they all walk this registry generically.
+ *
+ * The data-driven shape is the production-track guardrail. If you find
+ * yourself writing `switch (elementName)` anywhere in the render layer,
+ * push back: that pattern doesn't scale to M2's vocabulary expansion.
+ */
+export const ELEMENT_REGISTRY: ElementRegistry = {
+  'bv-bug': {
+    allowedChildren: 'block',
+    description:
+      'A bug runbook entry (symptom, root cause, fix). Optional `id` and `severity` ' +
+      '(low|medium|high|critical). Typically paired with a sibling `<bv-fix>`.',
+    name: 'bv-bug',
+    optionalAttributes: ['id', 'severity'],
+    requiredAttributes: [],
+    validator: validateBvBug,
+  },
+  'bv-decision': {
+    allowedChildren: 'block',
+    description:
+      'A decision record (with rationale and evidence). Optional `id` for ' +
+      'cross-referencing.',
+    name: 'bv-decision',
+    optionalAttributes: ['id'],
+    requiredAttributes: [],
+    validator: validateBvDecision,
+  },
+  'bv-fix': {
+    allowedChildren: 'block',
+    description:
+      'A fix runbook entry (steps to resolve a bug). Optional `id`. Typically the ' +
+      'sibling of a `<bv-bug>`.',
+    name: 'bv-fix',
+    optionalAttributes: ['id'],
+    requiredAttributes: [],
+    validator: validateBvFix,
+  },
+  'bv-rule': {
+    allowedChildren: 'inline',
+    description:
+      'A rule statement the agent should follow. Optional `severity` (info|must|should) ' +
+      'and `id` for cross-referencing.',
+    name: 'bv-rule',
+    optionalAttributes: ['severity', 'id'],
+    requiredAttributes: [],
+    validator: validateBvRule,
+  },
+  'bv-topic': {
+    allowedChildren: 'any',
+    description:
+      'Root container per topic file. Carries file-level metadata as attributes ' +
+      '(importance, maturity, recency, updatedat). Required: `path`. Note: ' +
+      'attribute names MUST be lowercase — HTML5 normalizes them at parse time.',
+    name: 'bv-topic',
+    optionalAttributes: ['importance', 'maturity', 'recency', 'updatedat'],
+    requiredAttributes: ['path'],
+    validator: validateBvTopic,
+  },
+}

--- a/src/server/infra/render/reader/html-parser.ts
+++ b/src/server/infra/render/reader/html-parser.ts
@@ -1,0 +1,179 @@
+import {type DefaultTreeAdapterMap, parseFragment, serialize} from 'parse5'
+
+import type {DocumentNode, ElementNode, ParsedNode} from '../../../core/domain/render/element-types.js'
+
+/**
+ * HTML parser wrapper around parse5.
+ *
+ * Produces a normalized AST (`DocumentNode` / `ElementNode` /
+ * `TextNode`) independent of parse5's internal types so consumers
+ * (T4 query reader, T3 round-trip validation, future indexers) can
+ * iterate without coupling to a specific HTML library.
+ *
+ * Why parse5 — it's the W3C-spec parser used by jsdom; widely vetted;
+ * forgiving on malformed input by design (a feature for migration
+ * tooling, neutral for M1 light validation).
+ *
+ * v1 parses everything as a fragment (no `<html>`/`<head>`/`<body>`
+ * wrapper required). M2 may add document-level parsing if topic files
+ * grow document-shaped headers; the wrapper gives us room.
+ */
+
+type Parse5DocumentFragment = DefaultTreeAdapterMap['documentFragment']
+type Parse5Node = DefaultTreeAdapterMap['node']
+type Parse5Element = DefaultTreeAdapterMap['element']
+type Parse5TextNode = DefaultTreeAdapterMap['textNode']
+
+/**
+ * Parse an HTML string into a normalized `DocumentNode`. parse5's
+ * forgiving mode means malformed input returns a best-effort tree
+ * rather than throwing.
+ */
+export function parseHtml(html: string): DocumentNode {
+  const fragment: Parse5DocumentFragment = parseFragment(html)
+  const children = fragment.childNodes
+    .map((c) => convertNode(c))
+    .filter((n): n is ParsedNode => n !== undefined)
+  return {children, type: 'document'}
+}
+
+/**
+ * Walk a parsed tree depth-first, returning every element node in
+ * document order. Used by element-axis indexing (T4) and by validators
+ * that need to find typed elements anywhere in the tree.
+ */
+export function walkElements(root: ParsedNode): ElementNode[] {
+  const out: ElementNode[] = []
+  walk(root, out)
+  return out
+}
+
+function walk(node: ParsedNode, out: ElementNode[]): void {
+  if (node.type === 'element') out.push(node)
+  if (node.type === 'element' || node.type === 'document') {
+    for (const child of node.children) walk(child, out)
+  }
+}
+
+/**
+ * Concatenate all text-node descendants of an element into a single
+ * string. Used to extract BM25-ready text content from typed elements
+ * (T4). HTML entities are already decoded by parse5, so the output is
+ * usable verbatim by the tokenizer.
+ */
+export function getInnerText(node: ParsedNode): string {
+  if (node.type === 'text') return node.text
+  if (node.type === 'element' || node.type === 'document') {
+    return node.children.map((c) => getInnerText(c)).join('')
+  }
+
+  return ''
+}
+
+/**
+ * Serialize a normalized tree back to HTML. Used for round-trip
+ * validation in tests and for the writer's emit path (T3).
+ *
+ * Note: serialization is semantically equivalent, not byte-equivalent.
+ * Whitespace, attribute quoting, and self-closing tag style may
+ * normalize.
+ */
+export function serializeHtml(root: DocumentNode): string {
+  // Convert our normalized tree back to parse5's shape, then call serialize.
+  const fragment = toParse5Fragment(root)
+  return serialize(fragment)
+}
+
+// ----- internal: parse5 → normalized -----
+
+function convertNode(node: Parse5Node): ParsedNode | undefined {
+  if (isTextNode(node)) {
+    return {text: node.value, type: 'text'}
+  }
+
+  if (isElementNode(node)) {
+    const attributes: Record<string, string> = {}
+    for (const attr of node.attrs) {
+      attributes[attr.name] = attr.value
+    }
+
+    const children = node.childNodes
+      .map((c) => convertNode(c))
+      .filter((c): c is ParsedNode => c !== undefined)
+
+    return {
+      attributes,
+      children,
+      tagName: node.tagName.toLowerCase(),
+      type: 'element',
+    }
+  }
+
+  // Skip comments, doctype, processing instructions, etc. for M1.
+  return undefined
+}
+
+function isTextNode(node: Parse5Node): node is Parse5TextNode {
+  return node.nodeName === '#text'
+}
+
+function isElementNode(node: Parse5Node): node is Parse5Element {
+  return 'tagName' in node && 'attrs' in node && 'childNodes' in node
+}
+
+// ----- internal: normalized → parse5 (for serialize) -----
+
+type MutableParse5Element = {
+  attrs: Array<{name: string; value: string}>
+  childNodes: Array<MutableParse5Element | MutableParse5Text>
+  namespaceURI: string
+  nodeName: string
+  parentNode: null
+  tagName: string
+}
+
+type MutableParse5Text = {
+  nodeName: '#text'
+  parentNode: null
+  value: string
+}
+
+type MutableParse5Fragment = {
+  childNodes: Array<MutableParse5Element | MutableParse5Text>
+  nodeName: '#document-fragment'
+}
+
+const HTML_NS = 'http://www.w3.org/1999/xhtml'
+
+function toParse5Fragment(doc: DocumentNode): Parse5DocumentFragment {
+  const fragment: MutableParse5Fragment = {
+    childNodes: doc.children.map((c) => toParse5Node(c)).filter((n): n is MutableParse5Element | MutableParse5Text => n !== undefined),
+    nodeName: '#document-fragment',
+  }
+  // parse5's serialize accepts any object with nodeName + childNodes; type
+  // assertion is the contained boundary between our normalized tree and
+  // parse5's expected input.
+  return fragment as unknown as Parse5DocumentFragment
+}
+
+function toParse5Node(node: ParsedNode): MutableParse5Element | MutableParse5Text | undefined {
+  if (node.type === 'text') {
+    return {nodeName: '#text', parentNode: null, value: node.text}
+  }
+
+  if (node.type === 'element') {
+    return {
+      attrs: Object.entries(node.attributes).map(([name, value]) => ({name, value})),
+      childNodes: node.children
+        .map((c) => toParse5Node(c))
+        .filter((n): n is MutableParse5Element | MutableParse5Text => n !== undefined),
+      namespaceURI: HTML_NS,
+      nodeName: node.tagName,
+      parentNode: null,
+      tagName: node.tagName,
+    }
+  }
+
+  // DocumentNode shouldn't appear inside a tree (it's the root only)
+  return undefined
+}

--- a/src/server/infra/render/reader/html-parser.ts
+++ b/src/server/infra/render/reader/html-parser.ts
@@ -1,4 +1,4 @@
-import {type DefaultTreeAdapterMap, parseFragment, serialize} from 'parse5'
+import {defaultTreeAdapter, type DefaultTreeAdapterMap, html as htmlNs, parseFragment, serialize} from 'parse5'
 
 import type {DocumentNode, ElementNode, ParsedNode} from '../../../core/domain/render/element-types.js'
 
@@ -60,14 +60,30 @@ function walk(node: ParsedNode, out: ElementNode[]): void {
  * string. Used to extract BM25-ready text content from typed elements
  * (T4). HTML entities are already decoded by parse5, so the output is
  * usable verbatim by the tokenizer.
+ *
+ * Inserts a space between sibling element-children so adjacent block
+ * boundaries don't merge tokens (e.g., compact `<p>foo.</p><p>bar.</p>`
+ * yields `foo. bar.` rather than `foo.bar.`). Whitespace runs are
+ * collapsed and the result is trimmed so existing whitespace in the
+ * source isn't doubled.
  */
 export function getInnerText(node: ParsedNode): string {
+  return collapseWhitespace(getInnerTextRaw(node))
+}
+
+function getInnerTextRaw(node: ParsedNode): string {
   if (node.type === 'text') return node.text
   if (node.type === 'element' || node.type === 'document') {
-    return node.children.map((c) => getInnerText(c)).join('')
+    // Insert a space at every child boundary; the outer collapseWhitespace
+    // step then normalises any resulting double spaces.
+    return node.children.map((c) => getInnerTextRaw(c)).join(' ')
   }
 
   return ''
+}
+
+function collapseWhitespace(text: string): string {
+  return text.replaceAll(/\s+/g, ' ').trim()
 }
 
 /**
@@ -86,6 +102,16 @@ export function serializeHtml(root: DocumentNode): string {
 
 // ----- internal: parse5 → normalized -----
 
+/**
+ * Convert a parse5 node into our normalized AST.
+ *
+ * Known limitation — `<template>` element content is not extracted. parse5
+ * places template children in a separate `.content` DocumentFragment per
+ * the HTML5 spec rather than under `childNodes`; our consumers (T3 writer,
+ * T4 reader) do not use `<template>`, so the M1 converter ignores that
+ * branch. If the curate vocabulary ever adopts `<template>`, the converter
+ * must read `defaultTreeAdapter.getTemplateContent(node)`.
+ */
 function convertNode(node: Parse5Node): ParsedNode | undefined {
   if (isTextNode(node)) {
     return {text: node.value, type: 'text'}
@@ -123,57 +149,31 @@ function isElementNode(node: Parse5Node): node is Parse5Element {
 
 // ----- internal: normalized → parse5 (for serialize) -----
 
-type MutableParse5Element = {
-  attrs: Array<{name: string; value: string}>
-  childNodes: Array<MutableParse5Element | MutableParse5Text>
-  namespaceURI: string
-  nodeName: string
-  parentNode: null
-  tagName: string
-}
-
-type MutableParse5Text = {
-  nodeName: '#text'
-  parentNode: null
-  value: string
-}
-
-type MutableParse5Fragment = {
-  childNodes: Array<MutableParse5Element | MutableParse5Text>
-  nodeName: '#document-fragment'
-}
-
-const HTML_NS = 'http://www.w3.org/1999/xhtml'
-
+/**
+ * Build a parse5 DocumentFragment from our normalized tree using
+ * `defaultTreeAdapter`. The adapter's factories return the exact node
+ * shapes parse5's serializer expects, so no structural casting is needed.
+ */
 function toParse5Fragment(doc: DocumentNode): Parse5DocumentFragment {
-  const fragment: MutableParse5Fragment = {
-    childNodes: doc.children.map((c) => toParse5Node(c)).filter((n): n is MutableParse5Element | MutableParse5Text => n !== undefined),
-    nodeName: '#document-fragment',
-  }
-  // parse5's serialize accepts any object with nodeName + childNodes; type
-  // assertion is the contained boundary between our normalized tree and
-  // parse5's expected input.
-  return fragment as unknown as Parse5DocumentFragment
+  const fragment = defaultTreeAdapter.createDocumentFragment()
+  appendChildren(fragment, doc.children)
+  return fragment
 }
 
-function toParse5Node(node: ParsedNode): MutableParse5Element | MutableParse5Text | undefined {
-  if (node.type === 'text') {
-    return {nodeName: '#text', parentNode: null, value: node.text}
-  }
-
-  if (node.type === 'element') {
-    return {
-      attrs: Object.entries(node.attributes).map(([name, value]) => ({name, value})),
-      childNodes: node.children
-        .map((c) => toParse5Node(c))
-        .filter((n): n is MutableParse5Element | MutableParse5Text => n !== undefined),
-      namespaceURI: HTML_NS,
-      nodeName: node.tagName,
-      parentNode: null,
-      tagName: node.tagName,
+function appendChildren(
+  parent: DefaultTreeAdapterMap['parentNode'],
+  children: readonly ParsedNode[],
+): void {
+  for (const child of children) {
+    if (child.type === 'text') {
+      const textNode = defaultTreeAdapter.createTextNode(child.text)
+      defaultTreeAdapter.appendChild(parent, textNode)
+    } else if (child.type === 'element') {
+      const attrs = Object.entries(child.attributes).map(([name, value]) => ({name, value}))
+      const element = defaultTreeAdapter.createElement(child.tagName, htmlNs.NS.HTML, attrs)
+      appendChildren(element, child.children)
+      defaultTreeAdapter.appendChild(parent, element)
     }
+    // 'document' nodes shouldn't appear inside a tree (it's the root only).
   }
-
-  // DocumentNode shouldn't appear inside a tree (it's the root only)
-  return undefined
 }

--- a/test/fixtures/render/sample-topic.html
+++ b/test/fixtures/render/sample-topic.html
@@ -1,0 +1,35 @@
+<bv-topic path="security/auth" importance="89" maturity="core" recency="0.97" updatedAt="2026-04-27T08:17:42Z">
+  <h1>Authentication and Authorization</h1>
+
+  <p>Project-wide rules and decisions for the auth subsystem. JWTs are signed with RS256; refresh tokens are sliding-expiry with a 24-hour window.</p>
+
+  <bv-rule severity="must" id="r-jwt-401">
+    Failed token validation MUST return 401 Unauthorized — never 403, never 500.
+  </bv-rule>
+
+  <bv-rule severity="should" id="r-rotate-rs256-keys">
+    The RS256 signing key SHOULD rotate every 30 days. Old keys remain in the JWKS until tokens signed with them expire.
+  </bv-rule>
+
+  <bv-decision id="d-rs256-over-hs256">
+    <p>Use RS256 (asymmetric), not HS256 (shared-secret).</p>
+    <p>Rationale: public-key validation lets downstream services verify tokens without holding the signing secret. Scales across services without rotating shared secrets.</p>
+  </bv-decision>
+
+  <bv-bug severity="critical" id="b-2026-04-15-auth-leak">
+    <p><strong>Symptom:</strong> Logged-out users could still access protected routes for up to 5 minutes.</p>
+    <p><strong>Root cause:</strong> Refresh-token revocation was being read from a stale cache; the cache TTL was longer than the access-token expiry.</p>
+  </bv-bug>
+
+  <bv-fix id="f-2026-04-15-revoke-on-logout">
+    <p>On logout, evict the user's refresh-token entry from the revocation cache synchronously before responding to the client. The cache is now read-through with a 30-second TTL; revocations bypass it entirely.</p>
+    <ul>
+      <li>Updated <code>logout-handler.ts:42</code> to call <code>revocationCache.invalidate(userId)</code> before <code>response.send()</code>.</li>
+      <li>Added integration test <code>logout-revocation.test.ts</code> covering the post-logout 401 path.</li>
+    </ul>
+  </bv-fix>
+
+  <bv-rule severity="info" id="r-token-expiry-doc">
+    Document access-token expiry on every public API endpoint.
+  </bv-rule>
+</bv-topic>

--- a/test/unit/server/infra/render/elements/bv-bug.test.ts
+++ b/test/unit/server/infra/render/elements/bv-bug.test.ts
@@ -1,0 +1,75 @@
+/**
+ * bv-bug validator tests.
+ *
+ * A bug runbook entry. Optional attributes:
+ *   - `id` — optional; non-empty string if present
+ *   - `severity` — optional; one of {"low","medium","high","critical"}
+ */
+
+import {expect} from 'chai'
+
+import type {ElementNode} from '../../../../../../src/server/core/domain/render/element-types.js'
+
+import {validateBvBug} from '../../../../../../src/server/infra/render/elements/bv-bug/validator.js'
+
+function makeNode(attributes: Record<string, string>, tagName = 'bv-bug'): ElementNode {
+  return {attributes, children: [], tagName, type: 'element'}
+}
+
+describe('bv-bug validator', () => {
+  describe('valid', () => {
+    it('accepts an empty attribute set (all optional)', () => {
+      expect(validateBvBug(makeNode({})).valid).to.equal(true)
+    })
+
+    it('accepts id only', () => {
+      expect(validateBvBug(makeNode({id: 'auth-leak-2026-04'})).valid).to.equal(true)
+    })
+
+    it('accepts severity only ("critical")', () => {
+      expect(validateBvBug(makeNode({severity: 'critical'})).valid).to.equal(true)
+    })
+
+    it('accepts severity "low"', () => {
+      expect(validateBvBug(makeNode({severity: 'low'})).valid).to.equal(true)
+    })
+
+    it('accepts severity "medium"', () => {
+      expect(validateBvBug(makeNode({severity: 'medium'})).valid).to.equal(true)
+    })
+
+    it('accepts severity "high"', () => {
+      expect(validateBvBug(makeNode({severity: 'high'})).valid).to.equal(true)
+    })
+
+    it('accepts id + severity together', () => {
+      expect(validateBvBug(makeNode({id: 'b1', severity: 'high'})).valid).to.equal(true)
+    })
+
+    it('tolerates unknown attributes (warn-only — M1 light validation)', () => {
+      expect(validateBvBug(makeNode({severity: 'high', someFutureAttr: 'x'})).valid).to.equal(true)
+    })
+  })
+
+  describe('invalid', () => {
+    it('rejects empty id', () => {
+      expect(validateBvBug(makeNode({id: ''})).valid).to.equal(false)
+    })
+
+    it('rejects unknown severity value', () => {
+      expect(validateBvBug(makeNode({severity: 'minor'})).valid).to.equal(false)
+    })
+
+    it('rejects severity in wrong case (case-sensitive enum)', () => {
+      expect(validateBvBug(makeNode({severity: 'HIGH'})).valid).to.equal(false)
+    })
+
+    it('rejects wrong tag name', () => {
+      const result = validateBvBug(makeNode({}, 'bv-fix'))
+      expect(result.valid).to.equal(false)
+      if (!result.valid) {
+        expect(result.errors.some((e) => e.field === 'tagName')).to.equal(true)
+      }
+    })
+  })
+})

--- a/test/unit/server/infra/render/elements/bv-bug.test.ts
+++ b/test/unit/server/infra/render/elements/bv-bug.test.ts
@@ -46,7 +46,7 @@ describe('bv-bug validator', () => {
       expect(validateBvBug(makeNode({id: 'b1', severity: 'high'})).valid).to.equal(true)
     })
 
-    it('tolerates unknown attributes (warn-only — M1 light validation)', () => {
+    it('tolerates unknown attributes (parse-and-skip — M1 light validation)', () => {
       expect(validateBvBug(makeNode({severity: 'high', someFutureAttr: 'x'})).valid).to.equal(true)
     })
   })

--- a/test/unit/server/infra/render/elements/bv-decision.test.ts
+++ b/test/unit/server/infra/render/elements/bv-decision.test.ts
@@ -25,7 +25,7 @@ describe('bv-decision validator', () => {
       expect(validateBvDecision(makeNode({id: 'rs256-over-hs256'})).valid).to.equal(true)
     })
 
-    it('tolerates unknown attributes (warn-only — M1 light validation)', () => {
+    it('tolerates unknown attributes (parse-and-skip — M1 light validation)', () => {
       expect(validateBvDecision(makeNode({id: 'd1', someFutureAttr: 'x'})).valid).to.equal(true)
     })
 

--- a/test/unit/server/infra/render/elements/bv-decision.test.ts
+++ b/test/unit/server/infra/render/elements/bv-decision.test.ts
@@ -1,0 +1,80 @@
+/**
+ * bv-decision validator tests.
+ *
+ * A decision record. Optional attributes:
+ *   - `id` — optional; non-empty string if present
+ */
+
+import {expect} from 'chai'
+
+import type {ElementNode} from '../../../../../../src/server/core/domain/render/element-types.js'
+
+import {validateBvDecision} from '../../../../../../src/server/infra/render/elements/bv-decision/validator.js'
+
+function makeNode(attributes: Record<string, string>, tagName = 'bv-decision'): ElementNode {
+  return {attributes, children: [], tagName, type: 'element'}
+}
+
+describe('bv-decision validator', () => {
+  describe('valid', () => {
+    it('accepts an empty attribute set (all optional)', () => {
+      expect(validateBvDecision(makeNode({})).valid).to.equal(true)
+    })
+
+    it('accepts id only', () => {
+      expect(validateBvDecision(makeNode({id: 'rs256-over-hs256'})).valid).to.equal(true)
+    })
+
+    it('tolerates unknown attributes (warn-only — M1 light validation)', () => {
+      expect(validateBvDecision(makeNode({id: 'd1', someFutureAttr: 'x'})).valid).to.equal(true)
+    })
+
+    it('accepts ids with mixed casing and dashes (no enforced format in M1)', () => {
+      expect(validateBvDecision(makeNode({id: 'D-001-AcceptRS256'})).valid).to.equal(true)
+    })
+
+    it('accepts ids with numbers', () => {
+      expect(validateBvDecision(makeNode({id: 'd-2026-04-27'})).valid).to.equal(true)
+    })
+  })
+
+  describe('invalid', () => {
+    it('rejects empty id', () => {
+      expect(validateBvDecision(makeNode({id: ''})).valid).to.equal(false)
+    })
+
+    it('rejects wrong tag name', () => {
+      const result = validateBvDecision(makeNode({}, 'bv-rule'))
+      expect(result.valid).to.equal(false)
+      if (!result.valid) {
+        expect(result.errors.some((e) => e.field === 'tagName')).to.equal(true)
+      }
+    })
+  })
+
+  describe('error reporting', () => {
+    it('returns a populated errors list on failure', () => {
+      const result = validateBvDecision(makeNode({id: ''}))
+      expect(result.valid).to.equal(false)
+      if (!result.valid) {
+        expect(result.errors).to.have.lengthOf.greaterThan(0)
+      }
+    })
+
+    it('reports the failing field name', () => {
+      const result = validateBvDecision(makeNode({id: ''}))
+      expect(result.valid).to.equal(false)
+      if (!result.valid) {
+        expect(result.errors[0].field).to.equal('id')
+      }
+    })
+
+    it('reports a non-empty error message', () => {
+      const result = validateBvDecision(makeNode({}, 'wrong-tag'))
+      expect(result.valid).to.equal(false)
+      if (!result.valid) {
+        expect(result.errors[0].message).to.include('tagName')
+      }
+    })
+  })
+})

--- a/test/unit/server/infra/render/elements/bv-fix.test.ts
+++ b/test/unit/server/infra/render/elements/bv-fix.test.ts
@@ -1,0 +1,80 @@
+/**
+ * bv-fix validator tests.
+ *
+ * A fix runbook entry. Optional attributes:
+ *   - `id` — optional; non-empty string if present
+ */
+
+import {expect} from 'chai'
+
+import type {ElementNode} from '../../../../../../src/server/core/domain/render/element-types.js'
+
+import {validateBvFix} from '../../../../../../src/server/infra/render/elements/bv-fix/validator.js'
+
+function makeNode(attributes: Record<string, string>, tagName = 'bv-fix'): ElementNode {
+  return {attributes, children: [], tagName, type: 'element'}
+}
+
+describe('bv-fix validator', () => {
+  describe('valid', () => {
+    it('accepts an empty attribute set (all optional)', () => {
+      expect(validateBvFix(makeNode({})).valid).to.equal(true)
+    })
+
+    it('accepts id only', () => {
+      expect(validateBvFix(makeNode({id: 'fix-jwt-rotation-2026-04-30'})).valid).to.equal(true)
+    })
+
+    it('tolerates unknown attributes (warn-only — M1 light validation)', () => {
+      expect(validateBvFix(makeNode({id: 'f1', someFutureAttr: 'x'})).valid).to.equal(true)
+    })
+
+    it('accepts ids with mixed casing and dashes', () => {
+      expect(validateBvFix(makeNode({id: 'F-001-RotateJWT'})).valid).to.equal(true)
+    })
+
+    it('accepts ids with numbers', () => {
+      expect(validateBvFix(makeNode({id: 'f-2026-04-30'})).valid).to.equal(true)
+    })
+  })
+
+  describe('invalid', () => {
+    it('rejects empty id', () => {
+      expect(validateBvFix(makeNode({id: ''})).valid).to.equal(false)
+    })
+
+    it('rejects wrong tag name', () => {
+      const result = validateBvFix(makeNode({}, 'bv-bug'))
+      expect(result.valid).to.equal(false)
+      if (!result.valid) {
+        expect(result.errors.some((e) => e.field === 'tagName')).to.equal(true)
+      }
+    })
+  })
+
+  describe('error reporting', () => {
+    it('returns at least one error on failure', () => {
+      const result = validateBvFix(makeNode({id: ''}))
+      expect(result.valid).to.equal(false)
+      if (!result.valid) {
+        expect(result.errors).to.have.lengthOf.greaterThan(0)
+      }
+    })
+
+    it('reports the id field name', () => {
+      const result = validateBvFix(makeNode({id: ''}))
+      expect(result.valid).to.equal(false)
+      if (!result.valid) {
+        expect(result.errors[0].field).to.equal('id')
+      }
+    })
+
+    it('reports a non-empty error message for tag mismatch', () => {
+      const result = validateBvFix(makeNode({}, 'wrong-tag'))
+      expect(result.valid).to.equal(false)
+      if (!result.valid) {
+        expect(result.errors[0].message).to.include('tagName')
+      }
+    })
+  })
+})

--- a/test/unit/server/infra/render/elements/bv-fix.test.ts
+++ b/test/unit/server/infra/render/elements/bv-fix.test.ts
@@ -25,7 +25,7 @@ describe('bv-fix validator', () => {
       expect(validateBvFix(makeNode({id: 'fix-jwt-rotation-2026-04-30'})).valid).to.equal(true)
     })
 
-    it('tolerates unknown attributes (warn-only — M1 light validation)', () => {
+    it('tolerates unknown attributes (parse-and-skip — M1 light validation)', () => {
       expect(validateBvFix(makeNode({id: 'f1', someFutureAttr: 'x'})).valid).to.equal(true)
     })
 

--- a/test/unit/server/infra/render/elements/bv-rule.test.ts
+++ b/test/unit/server/infra/render/elements/bv-rule.test.ts
@@ -1,0 +1,74 @@
+/**
+ * bv-rule validator tests.
+ *
+ * A rule statement. Optional attributes:
+ *   - `severity` — optional; one of {"info","must","should"}
+ *   - `id` — optional; non-empty string if present
+ */
+
+import {expect} from 'chai'
+
+import type {ElementNode} from '../../../../../../src/server/core/domain/render/element-types.js'
+
+import {validateBvRule} from '../../../../../../src/server/infra/render/elements/bv-rule/validator.js'
+
+function makeNode(attributes: Record<string, string>, tagName = 'bv-rule'): ElementNode {
+  return {attributes, children: [], tagName, type: 'element'}
+}
+
+describe('bv-rule validator', () => {
+  describe('valid', () => {
+    it('accepts an empty attribute set (all optional)', () => {
+      expect(validateBvRule(makeNode({})).valid).to.equal(true)
+    })
+
+    it('accepts severity="must"', () => {
+      expect(validateBvRule(makeNode({severity: 'must'})).valid).to.equal(true)
+    })
+
+    it('accepts severity="info"', () => {
+      expect(validateBvRule(makeNode({severity: 'info'})).valid).to.equal(true)
+    })
+
+    it('accepts severity="should"', () => {
+      expect(validateBvRule(makeNode({severity: 'should'})).valid).to.equal(true)
+    })
+
+    it('accepts id only', () => {
+      expect(validateBvRule(makeNode({id: 'r-jwt-401'})).valid).to.equal(true)
+    })
+
+    it('accepts severity + id together', () => {
+      expect(validateBvRule(makeNode({id: 'r-jwt-401', severity: 'must'})).valid).to.equal(true)
+    })
+
+    it('tolerates unknown attributes (warn-only — M1 light validation)', () => {
+      expect(validateBvRule(makeNode({severity: 'must', someFutureAttr: 'x'})).valid).to.equal(true)
+    })
+  })
+
+  describe('invalid', () => {
+    it('rejects unknown severity value', () => {
+      const result = validateBvRule(makeNode({severity: 'critical'}))
+      expect(result.valid).to.equal(false)
+    })
+
+    it('rejects empty id', () => {
+      const result = validateBvRule(makeNode({id: ''}))
+      expect(result.valid).to.equal(false)
+    })
+
+    it('rejects severity in wrong case (case-sensitive enum)', () => {
+      const result = validateBvRule(makeNode({severity: 'MUST'}))
+      expect(result.valid).to.equal(false)
+    })
+
+    it('rejects wrong tag name', () => {
+      const result = validateBvRule(makeNode({}, 'bv-decision'))
+      expect(result.valid).to.equal(false)
+      if (!result.valid) {
+        expect(result.errors.some((e) => e.field === 'tagName')).to.equal(true)
+      }
+    })
+  })
+})

--- a/test/unit/server/infra/render/elements/bv-rule.test.ts
+++ b/test/unit/server/infra/render/elements/bv-rule.test.ts
@@ -42,7 +42,7 @@ describe('bv-rule validator', () => {
       expect(validateBvRule(makeNode({id: 'r-jwt-401', severity: 'must'})).valid).to.equal(true)
     })
 
-    it('tolerates unknown attributes (warn-only — M1 light validation)', () => {
+    it('tolerates unknown attributes (parse-and-skip — M1 light validation)', () => {
       expect(validateBvRule(makeNode({severity: 'must', someFutureAttr: 'x'})).valid).to.equal(true)
     })
   })

--- a/test/unit/server/infra/render/elements/bv-topic.test.ts
+++ b/test/unit/server/infra/render/elements/bv-topic.test.ts
@@ -1,0 +1,117 @@
+/**
+ * bv-topic validator tests.
+ *
+ * The root container element. Carries file-level metadata as attributes:
+ *   - `path` — required; non-empty string identifying the topic
+ *   - `importance` — optional; integer string "0".."100"
+ *   - `maturity` — optional; one of {"draft","validated","core"}
+ *   - `recency` — optional; numeric string "0".."1"
+ *   - `updatedat` — optional; ISO-8601 datetime
+ *
+ * Light validation per M1 (ADR-007 §13 strict validation is M2).
+ * Unknown attributes are tolerated (warn-only behaviour); test confirms
+ * tolerance, not absence.
+ */
+
+import {expect} from 'chai'
+
+import type {ElementNode} from '../../../../../../src/server/core/domain/render/element-types.js'
+
+import {validateBvTopic} from '../../../../../../src/server/infra/render/elements/bv-topic/validator.js'
+
+function makeNode(attributes: Record<string, string>, tagName = 'bv-topic'): ElementNode {
+  return {attributes, children: [], tagName, type: 'element'}
+}
+
+describe('bv-topic validator', () => {
+  describe('valid', () => {
+    it('accepts the minimum: only `path` set', () => {
+      const result = validateBvTopic(makeNode({path: 'security/auth'}))
+      expect(result.valid).to.equal(true)
+    })
+
+    it('accepts all optional attributes set together', () => {
+      const result = validateBvTopic(makeNode({
+        importance: '89',
+        maturity: 'core',
+        path: 'security/auth',
+        recency: '0.97',
+        updatedat: '2026-04-27T08:17:42Z',
+      }))
+      expect(result.valid).to.equal(true)
+    })
+
+    it('tolerates unknown attributes (warn-only — M1 light validation)', () => {
+      const result = validateBvTopic(makeNode({path: 'x', someFutureAttr: 'whatever'}))
+      expect(result.valid).to.equal(true)
+    })
+
+    it('accepts importance = "0"', () => {
+      const result = validateBvTopic(makeNode({importance: '0', path: 'x'}))
+      expect(result.valid).to.equal(true)
+    })
+
+    it('accepts importance = "100"', () => {
+      const result = validateBvTopic(makeNode({importance: '100', path: 'x'}))
+      expect(result.valid).to.equal(true)
+    })
+  })
+
+  describe('invalid', () => {
+    it('rejects missing `path`', () => {
+      const result = validateBvTopic(makeNode({}))
+      expect(result.valid).to.equal(false)
+      if (!result.valid) {
+        expect(result.errors.some((e) => e.field === 'path')).to.equal(true)
+      }
+    })
+
+    it('rejects empty `path`', () => {
+      const result = validateBvTopic(makeNode({path: ''}))
+      expect(result.valid).to.equal(false)
+    })
+
+    it('rejects non-numeric importance', () => {
+      const result = validateBvTopic(makeNode({importance: 'high', path: 'x'}))
+      expect(result.valid).to.equal(false)
+    })
+
+    it('rejects out-of-range importance (>100)', () => {
+      const result = validateBvTopic(makeNode({importance: '101', path: 'x'}))
+      expect(result.valid).to.equal(false)
+    })
+
+    it('rejects out-of-range importance (negative)', () => {
+      const result = validateBvTopic(makeNode({importance: '-1', path: 'x'}))
+      expect(result.valid).to.equal(false)
+    })
+
+    it('rejects unknown maturity tier', () => {
+      const result = validateBvTopic(makeNode({maturity: 'experimental', path: 'x'}))
+      expect(result.valid).to.equal(false)
+    })
+
+    it('rejects malformed updatedat', () => {
+      const result = validateBvTopic(makeNode({path: 'x', updatedat: 'yesterday'}))
+      expect(result.valid).to.equal(false)
+    })
+
+    it('rejects non-numeric recency', () => {
+      const result = validateBvTopic(makeNode({path: 'x', recency: 'high'}))
+      expect(result.valid).to.equal(false)
+    })
+
+    it('rejects recency outside [0, 1]', () => {
+      const result = validateBvTopic(makeNode({path: 'x', recency: '1.5'}))
+      expect(result.valid).to.equal(false)
+    })
+
+    it('rejects wrong tag name (defensive — registry should never call wrong validator)', () => {
+      const result = validateBvTopic(makeNode({path: 'x'}, 'bv-rule'))
+      expect(result.valid).to.equal(false)
+      if (!result.valid) {
+        expect(result.errors.some((e) => e.field === 'tagName')).to.equal(true)
+      }
+    })
+  })
+})

--- a/test/unit/server/infra/render/elements/bv-topic.test.ts
+++ b/test/unit/server/infra/render/elements/bv-topic.test.ts
@@ -9,8 +9,8 @@
  *   - `updatedat` — optional; ISO-8601 datetime
  *
  * Light validation per M1 (ADR-007 §13 strict validation is M2).
- * Unknown attributes are tolerated (warn-only behaviour); test confirms
- * tolerance, not absence.
+ * Unknown attributes are tolerated (parse-and-skip — no warning emitted in
+ * M1); test confirms tolerance, not absence.
  */
 
 import {expect} from 'chai'
@@ -41,7 +41,7 @@ describe('bv-topic validator', () => {
       expect(result.valid).to.equal(true)
     })
 
-    it('tolerates unknown attributes (warn-only — M1 light validation)', () => {
+    it('tolerates unknown attributes (parse-and-skip — M1 light validation)', () => {
       const result = validateBvTopic(makeNode({path: 'x', someFutureAttr: 'whatever'}))
       expect(result.valid).to.equal(true)
     })
@@ -94,6 +94,31 @@ describe('bv-topic validator', () => {
     it('rejects malformed updatedat', () => {
       const result = validateBvTopic(makeNode({path: 'x', updatedat: 'yesterday'}))
       expect(result.valid).to.equal(false)
+    })
+
+    it('accepts updatedat with a positive timezone offset', () => {
+      // ISO-8601 with explicit offset (e.g. from `git log --date=iso-strict`)
+      const result = validateBvTopic(makeNode({path: 'x', updatedat: '2026-04-27T08:17:42+02:00'}))
+      expect(result.valid).to.equal(true)
+    })
+
+    it('accepts updatedat with a negative timezone offset', () => {
+      const result = validateBvTopic(makeNode({path: 'x', updatedat: '2026-04-27T08:17:42-08:00'}))
+      expect(result.valid).to.equal(true)
+    })
+
+    it('rejects pathological recency values that pass the regex but are not numbers', () => {
+      // The previous regex `[\d.]+` accepts ".", "..1", "1..2" etc.
+      // Validator should reject these as not-finite-numeric.
+      expect(validateBvTopic(makeNode({path: 'x', recency: '.'})).valid).to.equal(false)
+      expect(validateBvTopic(makeNode({path: 'x', recency: '..1'})).valid).to.equal(false)
+      expect(validateBvTopic(makeNode({path: 'x', recency: '1..2'})).valid).to.equal(false)
+    })
+
+    it('accepts well-formed recency values', () => {
+      expect(validateBvTopic(makeNode({path: 'x', recency: '0'})).valid).to.equal(true)
+      expect(validateBvTopic(makeNode({path: 'x', recency: '0.5'})).valid).to.equal(true)
+      expect(validateBvTopic(makeNode({path: 'x', recency: '1'})).valid).to.equal(true)
     })
 
     it('rejects non-numeric recency', () => {

--- a/test/unit/server/infra/render/elements/registry.test.ts
+++ b/test/unit/server/infra/render/elements/registry.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Element registry tests.
+ *
+ * The registry is the single source of truth for the M1 element
+ * vocabulary. Every consumer (curate writer, query reader, prompt
+ * template generator) walks the registry generically. M2 vocabulary
+ * expansion is purely additive — new entries only.
+ */
+
+import {expect} from 'chai'
+
+import type {ElementName, ElementNode} from '../../../../../../src/server/core/domain/render/element-types.js'
+
+import {ELEMENT_NAMES} from '../../../../../../src/server/core/domain/render/element-types.js'
+import {ELEMENT_REGISTRY} from '../../../../../../src/server/infra/render/elements/registry.js'
+
+function makeNode(tagName: string, attributes: Record<string, string> = {}): ElementNode {
+  return {attributes, children: [], tagName, type: 'element'}
+}
+
+describe('ELEMENT_REGISTRY', () => {
+  describe('shape', () => {
+    it('contains exactly 5 entries (M1 vocabulary)', () => {
+      expect(Object.keys(ELEMENT_REGISTRY)).to.have.lengthOf(5)
+    })
+
+    it('has one entry per `ElementName` listed in `ELEMENT_NAMES`', () => {
+      for (const name of ELEMENT_NAMES) {
+        expect(ELEMENT_REGISTRY[name], `expected entry for ${name}`).to.not.equal(undefined)
+      }
+    })
+
+    it('every entry exposes `name`, `validator`, `description`, `requiredAttributes`, `optionalAttributes`, `allowedChildren`', () => {
+      for (const name of ELEMENT_NAMES) {
+        const entry = ELEMENT_REGISTRY[name]
+        expect(entry.name).to.equal(name)
+        expect(typeof entry.validator).to.equal('function')
+        expect(typeof entry.description).to.equal('string')
+        expect(entry.description.length).to.be.greaterThan(0)
+        expect(Array.isArray(entry.requiredAttributes)).to.equal(true)
+        expect(Array.isArray(entry.optionalAttributes)).to.equal(true)
+        expect(['any', 'block', 'inline', 'none']).to.include(entry.allowedChildren)
+      }
+    })
+  })
+
+  describe('validators are wired correctly', () => {
+    it('bv-topic validator accepts a valid bv-topic node', () => {
+      const result = ELEMENT_REGISTRY['bv-topic'].validator(makeNode('bv-topic', {path: 'x'}))
+      expect(result.valid).to.equal(true)
+    })
+
+    it('bv-topic validator rejects a wrong-tag node', () => {
+      const result = ELEMENT_REGISTRY['bv-topic'].validator(makeNode('bv-rule'))
+      expect(result.valid).to.equal(false)
+    })
+
+    it('bv-rule validator accepts an empty bv-rule node', () => {
+      const result = ELEMENT_REGISTRY['bv-rule'].validator(makeNode('bv-rule'))
+      expect(result.valid).to.equal(true)
+    })
+
+    it('bv-decision validator accepts a bv-decision node with id', () => {
+      const result = ELEMENT_REGISTRY['bv-decision'].validator(makeNode('bv-decision', {id: 'd1'}))
+      expect(result.valid).to.equal(true)
+    })
+
+    it('bv-bug validator accepts a bv-bug node with severity', () => {
+      const result = ELEMENT_REGISTRY['bv-bug'].validator(makeNode('bv-bug', {severity: 'high'}))
+      expect(result.valid).to.equal(true)
+    })
+
+    it('bv-fix validator accepts a bv-fix node', () => {
+      const result = ELEMENT_REGISTRY['bv-fix'].validator(makeNode('bv-fix'))
+      expect(result.valid).to.equal(true)
+    })
+  })
+
+  describe('metadata for downstream consumers', () => {
+    it('bv-topic declares `path` as a required attribute', () => {
+      expect(ELEMENT_REGISTRY['bv-topic'].requiredAttributes).to.include('path')
+    })
+
+    it('bv-rule declares `severity` as an optional attribute', () => {
+      expect(ELEMENT_REGISTRY['bv-rule'].optionalAttributes).to.include('severity')
+    })
+
+    it('bv-bug declares `severity` as an optional attribute', () => {
+      expect(ELEMENT_REGISTRY['bv-bug'].optionalAttributes).to.include('severity')
+    })
+
+    it('every element has a non-trivial description for the prompt template generator', () => {
+      for (const name of ELEMENT_NAMES) {
+        expect(ELEMENT_REGISTRY[name].description.length).to.be.greaterThan(20)
+      }
+    })
+  })
+
+  describe('readonly contract', () => {
+    it('registry is structurally Readonly<Record<ElementName, ElementSchema>>', () => {
+      // Compile-time guard via the type. Runtime sanity check: keys are exactly ELEMENT_NAMES.
+      const keys = Object.keys(ELEMENT_REGISTRY).sort() as ElementName[]
+      const expected = [...ELEMENT_NAMES].sort()
+      expect(keys).to.deep.equal(expected)
+    })
+  })
+})

--- a/test/unit/server/infra/render/reader/html-parser.test.ts
+++ b/test/unit/server/infra/render/reader/html-parser.test.ts
@@ -1,0 +1,198 @@
+/**
+ * HTML parser wrapper tests.
+ *
+ * The parser produces a normalized AST (`ParsedNode`) independent of any
+ * specific HTML library. M1 uses parse5 underneath; consumers see only
+ * `ElementNode` / `TextNode` / `DocumentNode`.
+ *
+ * Key invariants:
+ *   - Tag names are lowercased
+ *   - Attributes are a string-only map
+ *   - Whitespace-only text between elements is preserved (consumers
+ *     decide whether to drop it)
+ *   - Malformed input does not throw — parse5's forgiving parser
+ *     returns a best-effort tree
+ */
+
+import {expect} from 'chai'
+
+import type {ElementNode} from '../../../../../../src/server/core/domain/render/element-types.js'
+
+import {getInnerText, parseHtml, serializeHtml, walkElements} from '../../../../../../src/server/infra/render/reader/html-parser.js'
+
+describe('html-parser', () => {
+describe('parseHtml', () => {
+  describe('basic parsing', () => {
+    it('parses a single bv-topic element', () => {
+      const html = '<bv-topic path="security-auth"></bv-topic>'
+      const result = parseHtml(html)
+      const elements = walkElements(result)
+      expect(elements.length).to.be.greaterThan(0)
+      const topic = elements.find((e) => e.tagName === 'bv-topic')
+      expect(topic, 'expected bv-topic element').to.not.equal(undefined)
+      expect(topic!.attributes.path).to.equal('security-auth')
+    })
+
+    it('lowercases tag names regardless of input case', () => {
+      const result = parseHtml('<BV-TOPIC path="x"></BV-TOPIC>')
+      const elements = walkElements(result)
+      expect(elements.find((e) => e.tagName === 'bv-topic')).to.not.equal(undefined)
+    })
+
+    it('preserves attribute string values verbatim', () => {
+      const result = parseHtml('<bv-topic path="security/auth" importance="89"></bv-topic>')
+      const topic = walkElements(result).find((e) => e.tagName === 'bv-topic')!
+      expect(topic.attributes.path).to.equal('security/auth')
+      expect(topic.attributes.importance).to.equal('89')
+    })
+
+    it('parses nested elements', () => {
+      const html = `
+        <bv-topic path="x">
+          <bv-rule severity="must" id="r1">Test rule</bv-rule>
+        </bv-topic>
+      `
+      const result = parseHtml(html)
+      const elements = walkElements(result)
+      expect(elements.find((e) => e.tagName === 'bv-rule')).to.not.equal(undefined)
+    })
+
+    it('parses sibling elements at root level', () => {
+      const html = '<bv-rule>A</bv-rule><bv-rule>B</bv-rule>'
+      const result = parseHtml(html)
+      const rules = walkElements(result).filter((e) => e.tagName === 'bv-rule')
+      expect(rules.length).to.equal(2)
+    })
+
+    it('handles standard HTML5 tags (h1, p, ul, li) alongside bv-* elements', () => {
+      const html = `
+        <bv-topic path="x">
+          <h1>Title</h1>
+          <p>Narrative.</p>
+          <ul><li>Item</li></ul>
+        </bv-topic>
+      `
+      const result = parseHtml(html)
+      const elements = walkElements(result)
+      const tagNames = elements.map((e) => e.tagName)
+      expect(tagNames).to.include('h1')
+      expect(tagNames).to.include('p')
+      expect(tagNames).to.include('ul')
+      expect(tagNames).to.include('li')
+    })
+  })
+
+  describe('malformed input handling', () => {
+    it('does not throw on empty string', () => {
+      expect(() => parseHtml('')).to.not.throw()
+    })
+
+    it('does not throw on plain text', () => {
+      expect(() => parseHtml('just some text without tags')).to.not.throw()
+    })
+
+    it('does not throw on unclosed tags', () => {
+      expect(() => parseHtml('<bv-topic path="x"><bv-rule>unclosed')).to.not.throw()
+    })
+
+    it('does not throw on mismatched nesting', () => {
+      expect(() => parseHtml('<bv-topic path="x"><bv-rule></bv-topic></bv-rule>')).to.not.throw()
+    })
+
+    it('does not throw on broken attribute syntax', () => {
+      expect(() => parseHtml('<bv-topic path=>...</bv-topic>')).to.not.throw()
+    })
+
+    it('does not throw on unknown tags', () => {
+      const result = parseHtml('<some-future-tag attr="x">content</some-future-tag>')
+      const elements = walkElements(result)
+      // parse5 is forgiving — unknown tags are still parsed as elements
+      expect(elements.find((e) => e.tagName === 'some-future-tag')).to.not.equal(undefined)
+    })
+  })
+})
+
+describe('walkElements', () => {
+  it('returns elements in document order (depth-first)', () => {
+    const result = parseHtml('<bv-topic path="x"><bv-rule id="a"/><bv-decision id="b"/></bv-topic>')
+    const elements = walkElements(result)
+    const names = elements
+      .filter((e) => e.tagName.startsWith('bv-'))
+      .map((e) => e.tagName)
+    expect(names).to.deep.equal(['bv-topic', 'bv-rule', 'bv-decision'])
+  })
+
+  it('includes nested elements at any depth', () => {
+    const html = '<bv-topic path="x"><div><span><bv-rule id="r1"/></span></div></bv-topic>'
+    const result = parseHtml(html)
+    const elements = walkElements(result)
+    expect(elements.find((e) => e.tagName === 'bv-rule')).to.not.equal(undefined)
+  })
+
+  it('returns empty array on empty document', () => {
+    const result = parseHtml('')
+    expect(walkElements(result)).to.be.an('array')
+  })
+})
+
+describe('getInnerText', () => {
+  it('extracts text content from a simple element', () => {
+    const node: ElementNode = {
+      attributes: {},
+      children: [{text: 'Some rule text', type: 'text'}],
+      tagName: 'bv-rule',
+      type: 'element',
+    }
+    expect(getInnerText(node)).to.equal('Some rule text')
+  })
+
+  it('concatenates text from nested elements', () => {
+    const result = parseHtml('<bv-topic path="x"><p>First.</p><p>Second.</p></bv-topic>')
+    const topic = walkElements(result).find((e) => e.tagName === 'bv-topic')!
+    const innerText = getInnerText(topic)
+    expect(innerText).to.include('First.')
+    expect(innerText).to.include('Second.')
+  })
+
+  it('decodes HTML entities (e.g. &amp; → &)', () => {
+    const result = parseHtml('<bv-rule>Foo &amp; bar</bv-rule>')
+    const rule = walkElements(result).find((e) => e.tagName === 'bv-rule')!
+    expect(getInnerText(rule)).to.include('Foo & bar')
+  })
+
+  it('returns empty string for an element with no text descendants', () => {
+    const node: ElementNode = {attributes: {}, children: [], tagName: 'bv-rule', type: 'element'}
+    expect(getInnerText(node)).to.equal('')
+  })
+})
+
+describe('serializeHtml', () => {
+  it('round-trips a simple bv-topic with attributes', () => {
+    const html = '<bv-topic path="security-auth" importance="89"></bv-topic>'
+    const tree = parseHtml(html)
+    const out = serializeHtml(tree)
+    // Re-parse the output; semantic equivalence is what we test, not
+    // byte-exactness (whitespace / quoting may normalize)
+    const reparsed = parseHtml(out)
+    const topic = walkElements(reparsed).find((e) => e.tagName === 'bv-topic')!
+    expect(topic.attributes.path).to.equal('security-auth')
+    expect(topic.attributes.importance).to.equal('89')
+  })
+
+  it('round-trips nested elements semantically', () => {
+    const html = '<bv-topic path="x"><bv-rule severity="must" id="r1">Be careful</bv-rule></bv-topic>'
+    const tree = parseHtml(html)
+    const reparsed = parseHtml(serializeHtml(tree))
+    const elements = walkElements(reparsed)
+    const rule = elements.find((e) => e.tagName === 'bv-rule')!
+    expect(rule.attributes.severity).to.equal('must')
+    expect(rule.attributes.id).to.equal('r1')
+    expect(getInnerText(rule)).to.include('Be careful')
+  })
+
+  it('does not throw on serialising a parse result of malformed input', () => {
+    const tree = parseHtml('<bv-topic path="x"><bv-rule>unclosed')
+    expect(() => serializeHtml(tree)).to.not.throw()
+  })
+})
+})

--- a/test/unit/server/infra/render/reader/html-parser.test.ts
+++ b/test/unit/server/infra/render/reader/html-parser.test.ts
@@ -164,6 +164,30 @@ describe('getInnerText', () => {
     const node: ElementNode = {attributes: {}, children: [], tagName: 'bv-rule', type: 'element'}
     expect(getInnerText(node)).to.equal('')
   })
+
+  it('does not merge tokens across adjacent block elements (compact source)', () => {
+    // Compact source — no whitespace between tags. Without inserting a separator
+    // at element boundaries, BM25 would see "foo.bar." as a single token. This
+    // is the exact case that occurs when the curate writer (T3) emits compact
+    // HTML.
+    const result = parseHtml('<bv-topic path="x"><p>foo.</p><p>bar.</p></bv-topic>')
+    const topic = walkElements(result).find((e) => e.tagName === 'bv-topic')!
+    const innerText = getInnerText(topic)
+    // "foo." and "bar." must be tokenizable separately — they cannot be
+    // adjacent in the output.
+    expect(/foo\.\S*bar\./.test(innerText), `expected separator between "foo." and "bar." in: ${JSON.stringify(innerText)}`).to.equal(false)
+    expect(innerText).to.include('foo.')
+    expect(innerText).to.include('bar.')
+  })
+
+  it('does not merge tokens across adjacent typed bv-* elements', () => {
+    // Same concern, between bv-rule and bv-decision when the curate writer
+    // emits them as compact siblings.
+    const result = parseHtml('<bv-topic path="x"><bv-rule>alpha</bv-rule><bv-decision>beta</bv-decision></bv-topic>')
+    const topic = walkElements(result).find((e) => e.tagName === 'bv-topic')!
+    const innerText = getInnerText(topic)
+    expect(/alpha\S*beta/.test(innerText), `expected separator between "alpha" and "beta" in: ${JSON.stringify(innerText)}`).to.equal(false)
+  })
 })
 
 describe('serializeHtml', () => {

--- a/test/unit/server/infra/render/sample-topic-roundtrip.test.ts
+++ b/test/unit/server/infra/render/sample-topic-roundtrip.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Sample-topic round-trip test.
+ *
+ * Verifies that the M1 5-element vocabulary, applied to a realistic
+ * topic file, parses cleanly, validates per-element, and round-trips
+ * (parse → walk → re-serialize) without semantic loss.
+ *
+ * This is the closest M1 proxy for "could a real curated topic survive
+ * the pipeline?" — useful before T3 wires the writer to disk.
+ */
+
+import {expect} from 'chai'
+import {readFileSync} from 'node:fs'
+import {join} from 'node:path'
+
+import type {ElementName} from '../../../../../src/server/core/domain/render/element-types.js'
+
+import {ELEMENT_NAMES} from '../../../../../src/server/core/domain/render/element-types.js'
+import {ELEMENT_REGISTRY} from '../../../../../src/server/infra/render/elements/registry.js'
+import {getInnerText, parseHtml, serializeHtml, walkElements} from '../../../../../src/server/infra/render/reader/html-parser.js'
+
+const FIXTURE_PATH = join(process.cwd(), 'test/fixtures/render/sample-topic.html')
+
+function loadFixture(): string {
+  return readFileSync(FIXTURE_PATH, 'utf8')
+}
+
+function isRegisteredElementName(tag: string): tag is ElementName {
+  return (ELEMENT_NAMES as readonly string[]).includes(tag)
+}
+
+describe('sample-topic.html round-trip', () => {
+  describe('parse', () => {
+    it('parses without errors', () => {
+      const html = loadFixture()
+      expect(() => parseHtml(html)).to.not.throw()
+    })
+
+    it('contains exactly one bv-topic element', () => {
+      const elements = walkElements(parseHtml(loadFixture()))
+      const topics = elements.filter((e) => e.tagName === 'bv-topic')
+      expect(topics).to.have.lengthOf(1)
+    })
+
+    it('contains all 5 M1 element types at least once', () => {
+      const elements = walkElements(parseHtml(loadFixture()))
+      const tagSet = new Set(elements.map((e) => e.tagName))
+      for (const name of ELEMENT_NAMES) {
+        expect(tagSet.has(name), `expected at least one ${name}`).to.equal(true)
+      }
+    })
+
+    it('preserves the bv-topic root attributes', () => {
+      const elements = walkElements(parseHtml(loadFixture()))
+      const topic = elements.find((e) => e.tagName === 'bv-topic')!
+      expect(topic.attributes.path).to.equal('security/auth')
+      expect(topic.attributes.importance).to.equal('89')
+      expect(topic.attributes.maturity).to.equal('core')
+      expect(topic.attributes.updatedat).to.equal('2026-04-27T08:17:42Z')
+    })
+  })
+
+  describe('validate', () => {
+    it('every bv-* element in the fixture passes its registered validator', () => {
+      const elements = walkElements(parseHtml(loadFixture()))
+      for (const el of elements) {
+        if (!isRegisteredElementName(el.tagName)) continue
+        const result = ELEMENT_REGISTRY[el.tagName].validator(el)
+        expect(
+          result.valid,
+          `expected ${el.tagName} (id=${el.attributes.id ?? 'n/a'}) to validate; errors: ${JSON.stringify(result.valid ? [] : result.errors)}`,
+        ).to.equal(true)
+      }
+    })
+  })
+
+  describe('round-trip (parse → serialize → re-parse)', () => {
+    it('produces semantically equivalent output', () => {
+      const original = parseHtml(loadFixture())
+      const out = serializeHtml(original)
+      const reparsed = parseHtml(out)
+
+      const originalElements = walkElements(original)
+      const reparsedElements = walkElements(reparsed)
+
+      // Same element count after round-trip
+      expect(reparsedElements.length).to.equal(originalElements.length)
+
+      // Tag-name sequence preserved
+      expect(reparsedElements.map((e) => e.tagName)).to.deep.equal(
+        originalElements.map((e) => e.tagName),
+      )
+    })
+
+    it('preserves attribute values across round-trip', () => {
+      const original = parseHtml(loadFixture())
+      const reparsed = parseHtml(serializeHtml(original))
+
+      const originalTopic = walkElements(original).find((e) => e.tagName === 'bv-topic')!
+      const reparsedTopic = walkElements(reparsed).find((e) => e.tagName === 'bv-topic')!
+      expect(reparsedTopic.attributes).to.deep.equal(originalTopic.attributes)
+    })
+
+    it('preserves innerText (text content) across round-trip', () => {
+      const original = parseHtml(loadFixture())
+      const reparsed = parseHtml(serializeHtml(original))
+
+      const originalText = getInnerText(original)
+      const reparsedText = getInnerText(reparsed)
+
+      // Whitespace may normalize, but every word from the original should remain
+      const wordsOriginal = originalText.split(/\s+/).filter(Boolean)
+      const reparsedSet = new Set(reparsedText.split(/\s+/).filter(Boolean))
+      const missing = wordsOriginal.filter((w) => !reparsedSet.has(w))
+      expect(missing, `words lost in round-trip: ${missing.join(', ')}`).to.have.lengthOf(0)
+    })
+  })
+
+  describe('innerText for BM25', () => {
+    it('contains expected substrings from each element type', () => {
+      const elements = walkElements(parseHtml(loadFixture()))
+      const topic = elements.find((e) => e.tagName === 'bv-topic')!
+      const innerText = getInnerText(topic)
+
+      // Sample of expected content from each element
+      expect(innerText).to.include('401 Unauthorized')
+      expect(innerText).to.include('RS256')
+      expect(innerText).to.include('refresh')
+      expect(innerText).to.include('logout')
+    })
+  })
+})

--- a/test/unit/server/infra/render/sample-topic-roundtrip.test.ts
+++ b/test/unit/server/infra/render/sample-topic-roundtrip.test.ts
@@ -58,6 +58,18 @@ describe('sample-topic.html round-trip', () => {
       expect(topic.attributes.maturity).to.equal('core')
       expect(topic.attributes.updatedat).to.equal('2026-04-27T08:17:42Z')
     })
+
+    it('lowercases attribute names per HTML5 spec (updatedAt → updatedat)', () => {
+      // Regression: the fixture intentionally uses camelCase `updatedAt=` to
+      // exercise parse5's HTML5 attribute-name normalization. Schemas and
+      // consumers must look up the lowercase key; the camelCase key must
+      // not survive parsing.
+      const fixture = loadFixture()
+      expect(fixture, 'fixture should contain camelCase source').to.include('updatedAt=')
+      const topic = walkElements(parseHtml(fixture)).find((e) => e.tagName === 'bv-topic')!
+      expect(topic.attributes.updatedat).to.not.equal(undefined)
+      expect(topic.attributes.updatedAt).to.equal(undefined)
+    })
   })
 
   describe('validate', () => {


### PR DESCRIPTION
## Summary

- **Problem:** M1 (HTML Memory Conversion experiment) needs a typed element vocabulary and an HTML parser so downstream tasks can read/write HTML context-tree files. T1 is the keystone — every downstream M1 task (T3 curate writer, T4 query reader, T5 telemetry, T7 bench) depends on this foundation.
- **Why it matters:** The format-hypothesis benchmark only runs if the HTML reader/writer/registry exists. Production-track scalability matters even more: M2's vocabulary expansion (Andy's 12 additional elements per `features/dnc-html/design.md` §11) must be **purely additive** — no consumer code changes when new elements register.
- **What changed:**
  - 5-element vocabulary (`bv-topic`, `bv-rule`, `bv-decision`, `bv-bug`, `bv-fix`) with per-element Zod schemas + validators
  - Data-driven `ELEMENT_REGISTRY` consumed generically by future writer/reader/prompt-template-generator
  - `makeAttributeValidator` factory eliminates per-element boilerplate; reduces M2's 12 additional validators to one-line bindings
  - HTML parser wrapper around parse5: `parseHtml`, `walkElements`, `getInnerText`, `serializeHtml`. Parser-library-agnostic at the API boundary (`DocumentNode` / `ElementNode` / `TextNode` are domain types, not parse5 types)
  - Sample fixture (`test/fixtures/render/sample-topic.html`) exercising all 5 elements
  - Documented HTML5 attribute-case normalization (`updatedAt` → `updatedat` at parse time) — a real correctness gotcha for T3/T4
- **What did NOT change (scope boundary):**
  - No HTML writer (T3)
  - No HTML reader integration with search (T4)
  - No format detector or feature flag (T3)
  - No element-axis index (T4)
  - No telemetry (T5)
  - No curate prompt update (T3)
  - No vocabulary beyond the 5 in scope (M2 adds 12 more elements; the registry's data-driven shape makes this purely additive)
  - Strict validation per ADR-007 §13 — M2

## Type of change

- [x] New feature

## Scope (select all touched areas)

- [x] Server / Daemon
- [x] Shared (constants, types, transport events)

## Linked issues

- Closes ENG-2737
- Parent project: HTML Memory Conversion M1 (`features/html-memory-conversion/milestones/01-experiment/plan.md`)
- Long-term blueprint: `features/dnc-html/` (Andy's full proposal — gated on M1 result)

## Root cause (bug fixes only, otherwise write `N/A`)

N/A — this is a feature.

## Test plan

- Coverage added:
  - [x] Unit test
  - [x] Integration test (round-trip on sample fixture)
- Test files:
  - `test/unit/server/infra/render/elements/bv-topic.test.ts` — 15 cases
  - `test/unit/server/infra/render/elements/bv-rule.test.ts` — 11 cases
  - `test/unit/server/infra/render/elements/bv-decision.test.ts` — 12 cases
  - `test/unit/server/infra/render/elements/bv-bug.test.ts` — 12 cases
  - `test/unit/server/infra/render/elements/bv-fix.test.ts` — 11 cases
  - `test/unit/server/infra/render/elements/registry.test.ts` — 14 cases (shape, wiring, metadata)
  - `test/unit/server/infra/render/reader/html-parser.test.ts` — 22 cases (parse, walk, innerText, serialize round-trip, malformed input)
  - `test/unit/server/infra/render/sample-topic-roundtrip.test.ts` — 9 cases (end-to-end with all 5 elements)
- Key scenarios covered:
  - Each element's required + optional attributes (valid + invalid)
  - Attribute value type validation (enums, integer ranges, datetime, non-empty strings)
  - Tag-name mismatch defense
  - HTML parser handles malformed input without throwing (empty, plain text, unclosed tags, mismatched nesting, broken attribute syntax, unknown tags)
  - HTML entity decoding (`&amp;` → `&`)
  - Round-trip: parse → walk → serialize → re-parse preserves all elements, attributes, and innerText words

## User-visible changes

None — pure additive scaffolding. No CLI, MCP, or TUI surface changes. The new code is reachable only by future M1 tasks (T3–T7).

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

### AC walk

| AC from `01-define-structure.md` | Evidence |
|---|---|
| `ELEMENT_REGISTRY` exported with exactly 5 entries | `registry.test.ts:23` — `expect(Object.keys(ELEMENT_REGISTRY)).to.have.lengthOf(5)` ✓ |
| Each of 5 elements has `<name>/{schema,validator}.ts` | 10 files exist under `src/server/infra/render/elements/` ✓ |
| Each validator has ≥10 cases | bv-topic 15, bv-rule 11, bv-decision 12, bv-bug 12, bv-fix 11 ✓ |
| Parser round-trips a sample with all 5 elements | `sample-topic-roundtrip.test.ts` 9/9 ✓ |
| Parser handles malformed input gracefully (no crash) | 6 malformed-input cases all assert `.to.not.throw()` ✓ |
| Sample fixture committed | `test/fixtures/render/sample-topic.html` ✓ |
| Round-trip semantically equivalent | 3 round-trip tests (element count, attributes, words preserved) ✓ |
| Typecheck, lint, build clean | tsc clean; 0 lint errors; build clean ✓ |
| Existing tests pass | 7715 passing (= prior baseline + 106 new), 0 failing ✓ |

### Test output snippet

```
$ npm test
  7715 passing (20s)
  16 pending

$ npm run lint
✖ 242 problems (0 errors, 242 warnings)  # warnings = pre-existing baseline

$ npm run typecheck
> tsc --noEmit && tsc --noEmit -p src/webui/tsconfig.json
# clean

$ npm run build
✓ built in 2.75s
```

## Checklist

- [x] Tests added/updated and passing (`npm test`)
- [x] Lint passes (0 errors)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow Conventional Commits format
- [x] No `Co-Authored-By` footer
- [x] No LLM/Claude/Anthropic attribution in commit body
- [x] Documentation updated where relevant (inline JSDoc; M1 plan doc unchanged)
- [x] No breaking changes
- [x] Branch is up to date with `proj/html-mem-conversion`

## Risks and mitigations

- **Risk: parse5 dependency surface.** parse5@^8.0.1 is a runtime dep adding ~200KB. Justified because robust HTML tag-soup parsing is non-trivial; parse5 is the W3C-spec parser used by jsdom, widely vetted. No alternative inline implementation would be safe.
  - **Mitigation:** Pinned to ^8.0.1; types ship in-tree (no `@types/parse5` needed); parser is wrapped behind a domain-types boundary so swapping is a one-file change in M2 if needed.

- **Risk: HTML5 attribute-case normalization is a sharp-edge for downstream consumers.** parse5 lowercases `updatedAt="..."` → `updatedat`. Schema keys must match parser output, not source HTML.
  - **Mitigation:** Documented in `ElementNode` JSDoc (`element-types.ts:38-46`); bv-topic schema and registry metadata both use lowercase `updatedat`; T3's PR will inherit this guidance via the registry as the single source of truth for attribute names.

- **Risk: `makeAttributeValidator` factory abstracts the validator shape; M2 elements with custom validation (e.g. allowed-children enforcement) would need to escape the abstraction.**
  - **Mitigation:** The factory is the right shape for the 5 + 12 attribute-only validators forecast in Andy's proposal §11. If/when an element legitimately needs custom validation logic, that element's `validator.ts` can hand-roll a function returning `ValidationResult` directly. The registry consumer doesn't care about implementation — it only calls the validator function.

- **Risk: Tree-walking and serialization are non-trivial; subtle bugs could surface in T3/T4 once they consume the parser.**
  - **Mitigation:** Round-trip test asserts every word of a 5-element fixture survives `parse → walk → serialize → re-parse`. 22 dedicated parser tests cover edge cases (empty input, malformed input, entity decoding, deeply nested elements). Future T3/T4 tests will exercise more paths.