### PR TITLE
[ENG-2740] query path — HTML reader + element-axis index + search routing

### DIFF
--- a/src/agent/infra/sandbox/tools-sdk.ts
+++ b/src/agent/infra/sandbox/tools-sdk.ts
@@ -92,9 +92,27 @@ export interface ListDirectoryOptions {
 }
 
 /**
+ * Optional structural-axis hint applied before BM25 ranking. Restricts
+ * the candidate set to topic files containing at least one matching
+ * `<bv-*>` element. Wired but unused by today's callers — the
+ * structural-selector grammar will plug into this without reshaping
+ * the search call signature.
+ */
+export interface SearchKnowledgeElementHint {
+  /** Optional attribute name to constrain the match. Requires `value`. */
+  attribute?: string
+  /** `<bv-*>` tag name (e.g. "bv-rule"). */
+  tag: string
+  /** Required when `attribute` is set. Exact-match comparison. */
+  value?: string
+}
+
+/**
  * Options for searchKnowledge operation in ToolsSDK.
  */
 export interface SearchKnowledgeOptions {
+  /** Pre-filter candidate set by `<bv-*>` element shape before BM25 ranking. */
+  elementHint?: SearchKnowledgeElementHint
   /** Maximum number of results to return (default: 10) */
   limit?: number
   /** Path prefix to scope search within (e.g. "auth" or "packages/api") */
@@ -112,6 +130,8 @@ export interface SearchKnowledgeResult {
     /** Number of other memories that reference this one */
     backlinkCount?: number
     excerpt: string
+    /** Source format of the topic file ('html' for `<bv-topic>` HTML, 'markdown' for the legacy MD path used by `brv swarm`). */
+    format?: 'html' | 'markdown'
     /** Origin: 'local' for this project, 'shared' for results from knowledge source */
     origin?: 'local' | 'shared'
     /** Alias of the shared source (undefined for local results) */

--- a/src/agent/infra/sandbox/tools-sdk.ts
+++ b/src/agent/infra/sandbox/tools-sdk.ts
@@ -97,15 +97,15 @@ export interface ListDirectoryOptions {
  * `<bv-*>` element. Wired but unused by today's callers — the
  * structural-selector grammar will plug into this without reshaping
  * the search call signature.
+ *
+ * Discriminated union: either filter by tag alone, or by tag plus an
+ * `attribute=value` pair. A half-set form is rejected at compile time
+ * so callers can't silently drop a value and get broader results than
+ * they asked for.
  */
-export interface SearchKnowledgeElementHint {
-  /** Optional attribute name to constrain the match. Requires `value`. */
-  attribute?: string
-  /** `<bv-*>` tag name (e.g. "bv-rule"). */
-  tag: string
-  /** Required when `attribute` is set. Exact-match comparison. */
-  value?: string
-}
+export type SearchKnowledgeElementHint =
+  | {attribute: string; tag: string; value: string}
+  | {tag: string}
 
 /**
  * Options for searchKnowledge operation in ToolsSDK.

--- a/src/agent/infra/tools/implementations/search-knowledge-service.ts
+++ b/src/agent/infra/tools/implementations/search-knowledge-service.ts
@@ -3,6 +3,7 @@ import {realpath} from 'node:fs/promises'
 import {join} from 'node:path'
 import {removeStopwords} from 'stopword'
 
+import type {ElementName} from '../../../../server/core/domain/render/element-types.js'
 import type {IRuntimeSignalStore} from '../../../../server/core/interfaces/storage/i-runtime-signal-store.js'
 import type {IFileSystem} from '../../../core/interfaces/i-file-system.js'
 import type {ILogger} from '../../../core/interfaces/i-logger.js'
@@ -10,7 +11,6 @@ import type {ISearchKnowledgeService, SearchKnowledgeResult} from '../../sandbox
 
 import {
   BRV_DIR,
-  CONTEXT_FILE_EXTENSION,
   CONTEXT_TREE_DIR,
   OVERVIEW_EXTENSION,
   SHARED_SOURCE_LOCAL_SCORE_BOOST,
@@ -33,6 +33,9 @@ import {
   parseArchiveStubFrontmatter,
   parseSummaryFrontmatter,
 } from '../../../../server/infra/context-tree/summary-frontmatter.js'
+import {getFormatForRead} from '../../../../server/infra/render/format/format-detector.js'
+import {ElementAxisIndex} from '../../../../server/infra/render/reader/element-axis-index.js'
+import {readHtmlTopicSync} from '../../../../server/infra/render/reader/html-reader.js'
 import {isPathLikeQuery, matchMemoryPath, parseSymbolicQuery} from './memory-path-matcher.js'
 import {
   buildReferenceIndex,
@@ -50,7 +53,7 @@ const MAX_CONTEXT_TREE_FILES = 10_000
 const DEFAULT_CACHE_TTL_MS = 5000
 
 /** Bump when MINISEARCH_OPTIONS fields/boost change to invalidate cached indexes */
-const INDEX_SCHEMA_VERSION = 5
+const INDEX_SCHEMA_VERSION = 6
 
 /** Only include results whose normalized score is at least this fraction of the top result's score */
 const SCORE_GAP_RATIO = 0.7
@@ -172,6 +175,16 @@ const MINISEARCH_OPTIONS = {
 
 interface IndexedDocument {
   content: string
+  /**
+   * Format of the source file on disk. Curate emits HTML topics; the
+   * legacy markdown path is kept for `brv swarm` (which still consumes
+   * `.md` topics and writes via the MD writer). The BM25 index is
+   * format-agnostic — for HTML files, the indexed content is the
+   * entity-decoded inner text, identical in shape to the markdown
+   * input — but downstream consumers (telemetry, query log) need the
+   * file format to route reads.
+   */
+  format: 'html' | 'markdown'
   id: string
   mtime: number
   /** 'local' for this project, 'shared' for results from a knowledge source */
@@ -198,6 +211,13 @@ interface SummarySource {
 interface CachedIndex {
   contextTreePath: string
   documentMap: Map<string, IndexedDocument>
+  /**
+   * Structural-axis index over the same corpus the BM25 index covers.
+   * Pre-filters candidate paths by element shape when a `SearchOptions`
+   * call carries an `elementHint`. Built in lockstep with the BM25
+   * index — same lifetime, same invalidation triggers.
+   */
+  elementAxisIndex: ElementAxisIndex
   fileMtimes: Map<string, number>
   index: MiniSearch<IndexedDocument>
   lastValidatedAt: number
@@ -249,9 +269,30 @@ export interface SearchKnowledgeServiceConfig {
 }
 
 /**
+ * Optional structural-axis filter applied before BM25 ranking. Restricts
+ * the candidate set to topic files containing at least one matching
+ * `<bv-*>` element. Reserved for the structural-selector grammar (the
+ * eventual `bv-rule[severity=must]` syntax); search callers today
+ * leave it unset and rely on full-corpus BM25.
+ */
+export interface ElementHint {
+  /** Optional attribute name to constrain the match. */
+  attribute?: string
+  tag: ElementName
+  /** Required when `attribute` is set. Exact-match comparison. */
+  value?: string
+}
+
+/**
  * Extended search options supporting symbolic filters.
  */
 export interface SearchOptions {
+  /**
+   * Pre-filter the candidate set by `<bv-*>` element shape before
+   * BM25 ranking. Wired but unused by today's callers; the grammar
+   * that drives this hint is downstream.
+   */
+  elementHint?: ElementHint
   /** Symbol kinds to exclude from results (e.g. ['subtopic']) */
   excludeKinds?: string[]
   /** Symbol kinds to include in results (e.g. ['domain', 'context']) */
@@ -456,12 +497,18 @@ function stripMarkdownFrontmatter(content: string): string {
   return content.replace(/^---\s*\n[\s\S]*?\n---\s*\n?/, '').trim()
 }
 
-async function findMarkdownFilesWithMtime(
+/**
+ * Discover topic files in the context tree. The corpus is `<bv-topic>`
+ * HTML; markdown topics are out of scope. The legacy `_index.md`
+ * summary convention is still globbed because the summary frontmatter
+ * pipeline (separate from topic-body indexing) hasn't migrated yet.
+ */
+async function findContextFilesWithMtime(
   fileSystem: IFileSystem,
   contextTreePath: string,
 ): Promise<Array<{mtime: number; path: string}>> {
   try {
-    const globResult = await fileSystem.globFiles(`**/*${CONTEXT_FILE_EXTENSION}`, {
+    const globResult = await fileSystem.globFiles(`**/*.{html,md}`, {
       cwd: contextTreePath,
       includeMetadata: true,
       maxResults: MAX_CONTEXT_TREE_FILES,
@@ -504,12 +551,51 @@ function isCacheValid(cache: CachedIndex, currentFiles: Array<{mtime: number; pa
  * Returns documents with origin-qualified IDs (<originKey>::<path>)
  * and summary docs keyed by origin-qualified paths.
  */
+/**
+ * Read the file from disk and split into the BM25 input (`indexedContent`)
+ * plus per-format metadata. HTML topics route through the html-reader
+ * which strips markup and returns entity-decoded inner text — that's
+ * what the BM25 tokenizer sees, ensuring ranking parity with the
+ * markdown corpus on the same content. Markdown is fed verbatim.
+ */
+async function readIndexableContent(
+  fileSystem: IFileSystem,
+  fullPath: string,
+  filePath: string,
+): Promise<null | {
+  elements: ReturnType<typeof readHtmlTopicSync>['elements']
+  format: 'html' | 'markdown'
+  htmlTitleHint?: string
+  indexedContent: string
+  rawContent: string
+}> {
+  try {
+    const {content} = await fileSystem.readFile(fullPath)
+    if (getFormatForRead(filePath) === 'html') {
+      const parsed = readHtmlTopicSync(content)
+      return {
+        elements: parsed.elements,
+        format: 'html',
+        htmlTitleHint: parsed.topicAttributes.title,
+        indexedContent: parsed.bodyText,
+        rawContent: content,
+      }
+    }
+
+    return {elements: [], format: 'markdown', indexedContent: content, rawContent: content}
+  } catch {
+    return null
+  }
+}
+
 async function indexOriginDocuments(
   fileSystem: IFileSystem,
   origin: SearchOrigin,
   filesWithMtime: Array<{mtime: number; path: string}>,
 ): Promise<{
   documents: IndexedDocument[]
+  /** Per-document element entries gathered for the structural-axis index. */
+  elementsByDocId: Map<string, ReturnType<typeof readHtmlTopicSync>['elements']>
   fileMtimes: Map<string, number>
   summaryMap: Map<string, SummaryDocLike>
 }> {
@@ -536,35 +622,44 @@ async function indexOriginDocuments(
   }
 
   const documentPromises = indexableFiles.map(async ({mtime, path: filePath}) => {
-    try {
-      const fullPath = join(origin.contextTreeRoot, filePath)
-      const {content} = await fileSystem.readFile(fullPath)
-      const title = extractTitle(content, filePath.replace(/\.md$/, '').split('/').pop() || filePath)
-      const qualifiedId = `${origin.originKey}::${filePath}`
-      const symbolPath = getSymbolPath(origin, filePath)
+    const fullPath = join(origin.contextTreeRoot, filePath)
+    const read = await readIndexableContent(fileSystem, fullPath, filePath)
+    if (!read) return null
 
-      // Check if a .overview.md sibling exists (written by abstract generation queue)
-      const overviewRelPath = filePath.replace(/\.md$/, OVERVIEW_EXTENSION)
-      const overviewPath = knownPaths.has(overviewRelPath) ? overviewRelPath : undefined
+    const fallbackTitle = filePath.replace(/\.(html?|md)$/i, '').split('/').pop() ?? filePath
+    const title = read.format === 'html'
+      ? read.htmlTitleHint ?? fallbackTitle
+      : extractTitle(read.rawContent, fallbackTitle)
+    const qualifiedId = `${origin.originKey}::${filePath}`
+    const symbolPath = getSymbolPath(origin, filePath)
 
-      const doc: IndexedDocument = {
-        content,
-        id: qualifiedId,
-        mtime,
-        origin: origin.origin,
-        originContextTreeRoot: origin.contextTreeRoot,
-        originKey: origin.originKey,
-        ...(overviewPath !== undefined && {overviewPath}),
-        path: filePath,
-        symbolPath,
-        title,
-      }
-      if (origin.alias) doc.originAlias = origin.alias
+    // Check if a .overview.md sibling exists (written by abstract
+    // generation queue). The overview convention is markdown-only;
+    // HTML topics don't get one until the queue learns the format.
+    const overviewRelPath = filePath.replace(/\.(html?|md)$/i, OVERVIEW_EXTENSION)
+    const overviewPath = knownPaths.has(overviewRelPath) ? overviewRelPath : undefined
 
-      return doc
-    } catch {
-      return null
+    const doc: IndexedDocument = {
+      // BM25 receives the entity-decoded innerText for HTML topics so
+      // ranking parity with markdown is automatic. The raw HTML is
+      // preserved as `rawContent` in the wrapper below for any consumer
+      // that wants the source text (excerpt extraction, snippet
+      // highlighting). Today only the BM25 index is wired.
+      content: read.indexedContent,
+      format: read.format,
+      id: qualifiedId,
+      mtime,
+      origin: origin.origin,
+      originContextTreeRoot: origin.contextTreeRoot,
+      originKey: origin.originKey,
+      ...(overviewPath !== undefined && {overviewPath}),
+      path: filePath,
+      symbolPath,
+      title,
     }
+    if (origin.alias) doc.originAlias = origin.alias
+
+    return {doc, elements: read.elements}
   })
 
   const summaryPromises = summaryFiles.map(async ({path: filePath}) => {
@@ -587,7 +682,16 @@ async function indexOriginDocuments(
 
   const [docResults, summaryResults] = await Promise.all([Promise.all(documentPromises), Promise.all(summaryPromises)])
 
-  const documents: IndexedDocument[] = docResults.filter((doc) => doc !== null)
+  const documents: IndexedDocument[] = []
+  const elementsByDocId = new Map<string, ReturnType<typeof readHtmlTopicSync>['elements']>()
+  for (const result of docResults) {
+    if (!result) continue
+    documents.push(result.doc)
+    if (result.elements.length > 0) {
+      elementsByDocId.set(result.doc.id, result.elements)
+    }
+  }
+
   const fileMtimes = new Map<string, number>()
   for (const doc of documents) {
     fileMtimes.set(doc.id, doc.mtime)
@@ -609,7 +713,7 @@ async function indexOriginDocuments(
     }
   }
 
-  return {documents, fileMtimes, summaryMap}
+  return {documents, elementsByDocId, fileMtimes, summaryMap}
 }
 
 async function buildFreshIndex(
@@ -638,25 +742,35 @@ async function buildFreshIndex(
   const sharedResults = await Promise.all(
     sharedOrigins.map(async (origin) => {
       try {
-        const files = await findMarkdownFilesWithMtime(fileSystem, origin.contextTreeRoot)
+        const files = await findContextFilesWithMtime(fileSystem, origin.contextTreeRoot)
         const filtered = files.filter(
           (f) => !isDerivedArtifact(f.path) || f.path.split('/').at(-1) === SUMMARY_INDEX_FILE,
         )
 
         return indexOriginDocuments(fileSystem, origin, filtered)
       } catch {
-        return {documents: [], fileMtimes: new Map<string, number>(), summaryMap: new Map<string, SummaryDocLike>()}
+        return {
+          documents: [],
+          elementsByDocId: new Map<string, ReturnType<typeof readHtmlTopicSync>['elements']>(),
+          fileMtimes: new Map<string, number>(),
+          summaryMap: new Map<string, SummaryDocLike>(),
+        }
       }
     }),
   )
 
   // Merge all documents, fileMtimes, and summaryMaps
   const allDocuments: IndexedDocument[] = [...localResult.documents]
+  const allElementsByDocId = new Map(localResult.elementsByDocId)
   const fileMtimes = new Map(localResult.fileMtimes)
   const summaryMap = new Map(localResult.summaryMap)
 
   for (const result of sharedResults) {
     allDocuments.push(...result.documents)
+    for (const [key, elements] of result.elementsByDocId) {
+      allElementsByDocId.set(key, elements)
+    }
+
     for (const [key, mtime] of result.fileMtimes) {
       fileMtimes.set(key, mtime)
     }
@@ -679,6 +793,15 @@ async function buildFreshIndex(
   const index = new MiniSearch<IndexedDocument>(MINISEARCH_OPTIONS)
   index.addAll(allDocuments)
 
+  // Populate the structural-axis index from every HTML topic that
+  // contributed elements. The index is the consumer for the
+  // (currently unused) `elementHint` filter on `SearchOptions`; it
+  // shares the BM25 index's lifecycle, rebuilt on the same triggers.
+  const elementAxisIndex = new ElementAxisIndex()
+  for (const [docId, elements] of allElementsByDocId) {
+    elementAxisIndex.add(docId, elements)
+  }
+
   const symbolDocumentMap = new Map<string, IndexedDocument>()
   for (const doc of allDocuments) {
     symbolDocumentMap.set(doc.id, {...doc, path: doc.symbolPath})
@@ -691,6 +814,7 @@ async function buildFreshIndex(
   return {
     contextTreePath,
     documentMap,
+    elementAxisIndex,
     fileMtimes,
     index,
     lastValidatedAt: now,
@@ -746,6 +870,7 @@ async function acquireIndex(
     return {
       contextTreePath: '',
       documentMap: new Map(),
+      elementAxisIndex: new ElementAxisIndex(),
       fileMtimes: new Map(),
       index: emptyIndex,
       lastValidatedAt: 0,
@@ -774,7 +899,7 @@ async function acquireIndex(
     const sourcesFileMtime = loadedSources?.mtime
     const sharedOrigins = loadedSources?.origins ?? []
 
-    let allFiles = await findMarkdownFilesWithMtime(fileSystem, contextTreePath)
+    let allFiles = await findContextFilesWithMtime(fileSystem, contextTreePath)
     // Exclude non-indexable derived artifacts (.full.md) so that currentFiles
     // matches what buildFreshIndex tracks in fileMtimes. Without this filter,
     // isCacheValid() sees a size mismatch once archives exist, causing cache thrash.
@@ -793,7 +918,7 @@ async function acquireIndex(
     if (onBeforeBuild) {
       const wroteScoringUpdates = await onBeforeBuild(contextTreePath)
       if (wroteScoringUpdates) {
-        allFiles = await findMarkdownFilesWithMtime(fileSystem, contextTreePath)
+        allFiles = await findContextFilesWithMtime(fileSystem, contextTreePath)
         localFiles = allFiles.filter(
           (f) =>
             !isDerivedArtifact(f.path) ||
@@ -810,7 +935,7 @@ async function acquireIndex(
     const sharedFileArrays = await Promise.all(
       sharedOrigins.map(async (origin) => {
         try {
-          const files = await findMarkdownFilesWithMtime(fileSystem, origin.contextTreeRoot)
+          const files = await findContextFilesWithMtime(fileSystem, origin.contextTreeRoot)
           const filtered = files.filter(
             (f) => !isDerivedArtifact(f.path) || f.path.split('/').at(-1) === SUMMARY_INDEX_FILE,
           )
@@ -991,6 +1116,7 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
         summaryMap,
         symbolPathDocMap,
         signalsByPath,
+        indexResult.elementAxisIndex,
         options,
       )
 
@@ -1022,6 +1148,7 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
       summaryMap,
       symbolPathDocMap,
       signalsByPath,
+      indexResult.elementAxisIndex,
       options,
     )
 
@@ -1039,6 +1166,7 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
         summaryMap,
         symbolPathDocMap,
         signalsByPath,
+        indexResult.elementAxisIndex,
         options,
       )
     }
@@ -1130,6 +1258,7 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
       ...(archiveFullPath && {archiveFullPath}),
       ...(overviewPath && {overviewPath}),
       backlinkCount: backlinks?.length ?? 0,
+      ...(doc && {format: doc.format}),
       ...(origin && {origin}),
       ...(originAlias && {originAlias}),
       ...(originContextTreeRoot && {originContextTreeRoot}),
@@ -1230,10 +1359,26 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
     summaryMap: Map<string, SummaryDocLike>,
     symbolPathDocMap: Map<string, IndexedDocument>,
     signalsByPath: Map<string, RuntimeSignals>,
+    elementAxisIndex: ElementAxisIndex,
     options?: SearchOptions,
   ): SearchKnowledgeResult {
     const filteredQuery = filterStopWords(query)
     const filteredWords = filteredQuery.split(/\s+/).filter((w) => w.length >= 2)
+
+    // Compose the optional element-shape pre-filter from the search
+    // call. When present, only documents containing the requested
+    // `<bv-*>` (with optional attribute=value match) are eligible for
+    // BM25 ranking. Today no caller supplies this hint; it's wired so
+    // the structural-selector grammar can plug in without reshaping
+    // the search service signature.
+    let elementHintIds: Set<string> | undefined
+    if (options?.elementHint) {
+      const {attribute, tag, value} = options.elementHint
+      const matching = attribute !== undefined && value !== undefined
+        ? elementAxisIndex.findByAttribute(tag, attribute, value)
+        : elementAxisIndex.findByTag(tag)
+      elementHintIds = new Set(matching)
+    }
 
     // Build scope filter if a subtree is specified
     let scopeFilter: ((result: {id: string}) => boolean) | undefined
@@ -1253,11 +1398,21 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
       }
     }
 
+    // Compose scope + element-hint filters into a single MiniSearch
+    // predicate. Only documents passing both filters proceed to BM25.
+    const composedFilter: ((result: {id: string}) => boolean) | undefined = scopeFilter || elementHintIds
+      ? (result) => {
+          if (scopeFilter && !scopeFilter(result)) return false
+          if (elementHintIds && !elementHintIds.has(result.id)) return false
+          return true
+        }
+      : undefined
+
     // AND-first strategy: for multi-word queries, try AND for concentrated scores.
     // If AND returns no results, fall back to OR to ensure no regression.
     let rawResults: Array<{id: string; queryTerms: string[]; score: number}>
     let andSearchFailed = false
-    const searchOpts = scopeFilter ? {filter: scopeFilter} : {}
+    const searchOpts = composedFilter ? {filter: composedFilter} : {}
 
     if (filteredWords.length >= 2) {
       rawResults = index.search(filteredQuery, {combineWith: 'AND', ...searchOpts})
@@ -1461,6 +1616,7 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
     summaryMap: Map<string, SummaryDocLike>,
     symbolPathDocMap: Map<string, IndexedDocument>,
     signalsByPath: Map<string, RuntimeSignals>,
+    elementAxisIndex: ElementAxisIndex,
     options?: SearchOptions,
   ): null | SearchKnowledgeResult {
     const pathMatches = matchMemoryPath(symbolTree, query.split(/\s+/)[0].includes('/') ? query.split(/\s+/)[0] : query)
@@ -1516,6 +1672,7 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
         summaryMap,
         symbolPathDocMap,
         signalsByPath,
+        elementAxisIndex,
         options,
       )
     }

--- a/src/agent/infra/tools/implementations/search-knowledge-service.ts
+++ b/src/agent/infra/tools/implementations/search-knowledge-service.ts
@@ -274,14 +274,15 @@ export interface SearchKnowledgeServiceConfig {
  * `<bv-*>` element. Reserved for the structural-selector grammar (the
  * eventual `bv-rule[severity=must]` syntax); search callers today
  * leave it unset and rely on full-corpus BM25.
+ *
+ * Discriminated union: either match by tag alone, or by tag plus an
+ * `attribute=value` pair. A half-set `{attribute}` without `value`
+ * (or vice versa) is rejected at compile time so callers can't
+ * silently lose their filtering intent.
  */
-export interface ElementHint {
-  /** Optional attribute name to constrain the match. */
-  attribute?: string
-  tag: ElementName
-  /** Required when `attribute` is set. Exact-match comparison. */
-  value?: string
-}
+export type ElementHint =
+  | {attribute: string; tag: ElementName; value: string}
+  | {tag: ElementName}
 
 /**
  * Extended search options supporting symbolic filters.
@@ -507,28 +508,45 @@ async function findContextFilesWithMtime(
   fileSystem: IFileSystem,
   contextTreePath: string,
 ): Promise<Array<{mtime: number; path: string}>> {
-  try {
-    const globResult = await fileSystem.globFiles(`**/*.{html,md}`, {
-      cwd: contextTreePath,
-      includeMetadata: true,
-      maxResults: MAX_CONTEXT_TREE_FILES,
-      respectGitignore: false,
-    })
+  // Two parallel passes (one per extension) instead of brace expansion so
+  // the discovery isn't coupled to whatever glob engine
+  // `IFileSystem.globFiles` delegates to. Some engines don't expand
+  // `{html,md}` and would silently drop one branch — caught here only as
+  // a missing index entry, well after the daemon has cached the partial
+  // corpus. Per-pass failures collapse to an empty result for that
+  // branch only; the other pass still produces its files.
+  const runPass = async (pattern: string) => {
+    try {
+      const globResult = await fileSystem.globFiles(pattern, {
+        cwd: contextTreePath,
+        includeMetadata: true,
+        maxResults: MAX_CONTEXT_TREE_FILES,
+        respectGitignore: false,
+      })
+      return globResult.files
+    } catch {
+      return []
+    }
+  }
 
-    return globResult.files.map((f) => {
+  const passResults = await Promise.all([runPass('**/*.html'), runPass('**/*.md')])
+
+  const seen = new Map<string, {mtime: number; path: string}>()
+  for (const files of passResults) {
+    for (const f of files) {
       let relativePath = f.path
       if (f.path.startsWith(contextTreePath)) {
         relativePath = f.path.slice(contextTreePath.length + 1)
       }
 
-      return {
+      seen.set(relativePath, {
         mtime: f.modified?.getTime() ?? 0,
         path: relativePath,
-      }
-    })
-  } catch {
-    return []
+      })
+    }
   }
+
+  return [...seen.values()]
 }
 
 function isCacheValid(cache: CachedIndex, currentFiles: Array<{mtime: number; path: string}>): boolean {
@@ -573,11 +591,23 @@ async function readIndexableContent(
     const {content} = await fileSystem.readFile(fullPath)
     if (getFormatForRead(filePath) === 'html') {
       const parsed = readHtmlTopicSync(content)
+      // Concatenate the searchable subset of `<bv-topic>` attributes
+      // into the BM25 input. The markdown corpus exposes the same
+      // signals via YAML frontmatter (which the MD branch passes through
+      // verbatim), so without this step a query for a term living only
+      // in `summary=`/`tags=`/`keywords=`/`related=` would rank an HTML
+      // topic strictly below the MD equivalent. `title` already carries
+      // a 3x field boost via the `title` column and is intentionally
+      // omitted here.
+      const {keywords, related, summary, tags} = parsed.topicAttributes
+      const indexedContent = [parsed.bodyText, summary, tags, keywords, related]
+        .filter((part): part is string => typeof part === 'string' && part.length > 0)
+        .join(' ')
       return {
         elements: parsed.elements,
         format: 'html',
         htmlTitleHint: parsed.topicAttributes.title,
-        indexedContent: parsed.bodyText,
+        indexedContent,
         rawContent: content,
       }
     }
@@ -627,8 +657,11 @@ async function indexOriginDocuments(
     if (!read) return null
 
     const fallbackTitle = filePath.replace(/\.(html?|md)$/i, '').split('/').pop() ?? filePath
+    // Trim before falling back: a `title=""` (or whitespace-only) attribute
+    // survives the schema's `passthrough` permissiveness and would
+    // otherwise leak into BM25's 3x-boosted `title` field.
     const title = read.format === 'html'
-      ? read.htmlTitleHint ?? fallbackTitle
+      ? (read.htmlTitleHint?.trim() || fallbackTitle)
       : extractTitle(read.rawContent, fallbackTitle)
     const qualifiedId = `${origin.originKey}::${filePath}`
     const symbolPath = getSymbolPath(origin, filePath)
@@ -1373,10 +1406,10 @@ export class SearchKnowledgeService implements ISearchKnowledgeService {
     // the search service signature.
     let elementHintIds: Set<string> | undefined
     if (options?.elementHint) {
-      const {attribute, tag, value} = options.elementHint
-      const matching = attribute !== undefined && value !== undefined
-        ? elementAxisIndex.findByAttribute(tag, attribute, value)
-        : elementAxisIndex.findByTag(tag)
+      const hint = options.elementHint
+      const matching = 'attribute' in hint
+        ? elementAxisIndex.findByAttribute(hint.tag, hint.attribute, hint.value)
+        : elementAxisIndex.findByTag(hint.tag)
       elementHintIds = new Set(matching)
     }
 

--- a/src/server/infra/render/reader/element-axis-index.ts
+++ b/src/server/infra/render/reader/element-axis-index.ts
@@ -1,0 +1,156 @@
+import type {ElementName} from '../../../core/domain/render/element-types.js'
+import type {ElementAxisEntry} from './html-reader.js'
+
+/**
+ * In-memory index from element-shape lookups to topic file paths.
+ *
+ * Two query keys:
+ *   - tag       — every path containing at least one element of that tag.
+ *   - tag.attr=value — every path containing an element of that tag whose
+ *                       attribute holds the given value.
+ *
+ * The structural-selector grammar consumes this for pre-filtering
+ * before BM25 ranking (e.g., "give me topics with `<bv-rule
+ * severity=must>`"). Today the search service accepts an optional
+ * `elementHint` and uses this index to prune the candidate set; without
+ * a hint, the index is dormant and the ranker walks the full corpus.
+ *
+ * The index is in-memory and lazy-built on first query for a project
+ * (the search service materialises it from the same file walk that
+ * builds the BM25 index). Invalidated whole-topic on every write —
+ * mtime-based cache invalidation upstream catches this; T4 doesn't
+ * need a finer-grained signal because a single curate run rewrites
+ * exactly one topic file at a time.
+ *
+ * Persistence is deferred — rebuild on first-query-after-restart is
+ * cheap (sub-100ms for the corpus sizes the bench produces).
+ */
+export class ElementAxisIndex {
+  /** `tag.attr=value` → set of file paths containing such an element. */
+  private readonly attrToPaths: Map<string, Set<string>> = new Map()
+  /**
+   * Reverse map from filePath → composite keys it contributed to. Lets
+   * us drop a file from every membership in O(keys-it-touches) on
+   * invalidation without scanning the full index.
+   */
+  private readonly pathToKeys: Map<string, Set<string>> = new Map()
+  /** `tag` → set of file paths containing at least one element of that tag. */
+  private readonly tagToPaths: Map<ElementName, Set<string>> = new Map()
+
+  /** How many paths the index currently knows about. Mainly for tests. */
+  public get size(): number {
+    return this.pathToKeys.size
+  }
+
+  /**
+   * Register every element in `entries` against `filePath`. Idempotent —
+   * calling `add` twice for the same path stacks duplicates harmlessly
+   * (Set semantics dedupes), but callers should `remove` first to keep
+   * the path-to-keys reverse map accurate when re-indexing.
+   */
+  public add(filePath: string, entries: readonly ElementAxisEntry[]): void {
+    let keys = this.pathToKeys.get(filePath)
+    if (!keys) {
+      keys = new Set()
+      this.pathToKeys.set(filePath, keys)
+    }
+
+    for (const entry of entries) {
+      this.addToTagIndex(entry.tag, filePath, keys)
+
+      for (const [name, value] of Object.entries(entry.attributes)) {
+        this.addToAttrIndex(entry.tag, name, value, filePath, keys)
+      }
+    }
+  }
+
+  /**
+   * Drop every entry. Used on full corpus rebuild (after a project
+   * switch or on first-query-after-restart).
+   */
+  public clear(): void {
+    this.tagToPaths.clear()
+    this.attrToPaths.clear()
+    this.pathToKeys.clear()
+  }
+
+  /**
+   * Paths containing an element of `tag` whose `attribute` holds the
+   * exact `value`. Comparison is case-sensitive on values (HTML5
+   * attribute names are lowercased at parse time, but values are
+   * verbatim).
+   */
+  public findByAttribute(tag: ElementName, attribute: string, value: string): readonly string[] {
+    const key = composeKey(tag, attribute, value)
+    return [...(this.attrToPaths.get(key) ?? [])]
+  }
+
+  /**
+   * Paths containing at least one element of `tag`. Empty array if no
+   * matches (rather than `undefined`) so callers can treat the result
+   * as a candidate set without null-checks.
+   */
+  public findByTag(tag: ElementName): readonly string[] {
+    return [...(this.tagToPaths.get(tag) ?? [])]
+  }
+
+  /**
+   * Drop every membership tied to `filePath`. Called before re-indexing
+   * a touched topic, and when a topic file is deleted.
+   */
+  public remove(filePath: string): void {
+    const keys = this.pathToKeys.get(filePath)
+    if (!keys) return
+
+    for (const key of keys) {
+      const set = key.includes('=')
+        ? this.attrToPaths.get(key)
+        : this.tagToPaths.get(key as ElementName)
+      if (!set) continue
+
+      set.delete(filePath)
+      if (set.size === 0) {
+        if (key.includes('=')) {
+          this.attrToPaths.delete(key)
+        } else {
+          this.tagToPaths.delete(key as ElementName)
+        }
+      }
+    }
+
+    this.pathToKeys.delete(filePath)
+  }
+
+  private addToAttrIndex(
+    tag: ElementName,
+    attribute: string,
+    value: string,
+    filePath: string,
+    keys: Set<string>,
+  ): void {
+    const key = composeKey(tag, attribute, value)
+    let set = this.attrToPaths.get(key)
+    if (!set) {
+      set = new Set()
+      this.attrToPaths.set(key, set)
+    }
+
+    set.add(filePath)
+    keys.add(key)
+  }
+
+  private addToTagIndex(tag: ElementName, filePath: string, keys: Set<string>): void {
+    let set = this.tagToPaths.get(tag)
+    if (!set) {
+      set = new Set()
+      this.tagToPaths.set(tag, set)
+    }
+
+    set.add(filePath)
+    keys.add(tag)
+  }
+}
+
+function composeKey(tag: ElementName, attribute: string, value: string): string {
+  return `${tag}.${attribute}=${value}`
+}

--- a/src/server/infra/render/reader/element-axis-index.ts
+++ b/src/server/infra/render/reader/element-axis-index.ts
@@ -24,42 +24,52 @@ import type {ElementAxisEntry} from './html-reader.js'
  *
  * Persistence is deferred — rebuild on first-query-after-restart is
  * cheap (sub-100ms for the corpus sizes the bench produces).
+ *
+ * Storage uses nested Maps (`tag → attr → value → Set<path>`) rather
+ * than a stringly-keyed `${tag}.${attr}=${value}` table. HTML attribute
+ * names and values can legally contain `.` and `=`; nesting eliminates
+ * the entire collision class without a delimiter discipline.
  */
 export class ElementAxisIndex {
-  /** `tag.attr=value` → set of file paths containing such an element. */
-  private readonly attrToPaths: Map<string, Set<string>> = new Map()
+  /** `tag → attr → value → Set<filePath>`. Three-level nest avoids string-key collisions. */
+  private readonly attrIndex: Map<ElementName, Map<string, Map<string, Set<string>>>> = new Map()
   /**
-   * Reverse map from filePath → composite keys it contributed to. Lets
-   * us drop a file from every membership in O(keys-it-touches) on
-   * invalidation without scanning the full index.
+   * Reverse map from `filePath` to the set of `(tag, attr, value)` triples
+   * (and bare tag memberships) it contributed to. Lets us drop a file
+   * from every membership in O(memberships) on invalidation without
+   * scanning the full index.
+   *
+   * Each entry is one of:
+   *   - `{kind: 'tag', tag}`
+   *   - `{kind: 'attr', tag, attr, value}`
    */
-  private readonly pathToKeys: Map<string, Set<string>> = new Map()
-  /** `tag` → set of file paths containing at least one element of that tag. */
-  private readonly tagToPaths: Map<ElementName, Set<string>> = new Map()
+  private readonly pathToMemberships: Map<string, Membership[]> = new Map()
+  /** `tag → Set<filePath>`. */
+  private readonly tagIndex: Map<ElementName, Set<string>> = new Map()
 
   /** How many paths the index currently knows about. Mainly for tests. */
   public get size(): number {
-    return this.pathToKeys.size
+    return this.pathToMemberships.size
   }
 
   /**
    * Register every element in `entries` against `filePath`. Idempotent —
    * calling `add` twice for the same path stacks duplicates harmlessly
    * (Set semantics dedupes), but callers should `remove` first to keep
-   * the path-to-keys reverse map accurate when re-indexing.
+   * the path-to-memberships reverse map accurate when re-indexing.
    */
   public add(filePath: string, entries: readonly ElementAxisEntry[]): void {
-    let keys = this.pathToKeys.get(filePath)
-    if (!keys) {
-      keys = new Set()
-      this.pathToKeys.set(filePath, keys)
+    let memberships = this.pathToMemberships.get(filePath)
+    if (!memberships) {
+      memberships = []
+      this.pathToMemberships.set(filePath, memberships)
     }
 
     for (const entry of entries) {
-      this.addToTagIndex(entry.tag, filePath, keys)
+      this.addToTagIndex(entry.tag, filePath, memberships)
 
-      for (const [name, value] of Object.entries(entry.attributes)) {
-        this.addToAttrIndex(entry.tag, name, value, filePath, keys)
+      for (const [attr, value] of Object.entries(entry.attributes)) {
+        this.addToAttrIndex(entry.tag, attr, value, filePath, memberships)
       }
     }
   }
@@ -69,9 +79,9 @@ export class ElementAxisIndex {
    * switch or on first-query-after-restart).
    */
   public clear(): void {
-    this.tagToPaths.clear()
-    this.attrToPaths.clear()
-    this.pathToKeys.clear()
+    this.tagIndex.clear()
+    this.attrIndex.clear()
+    this.pathToMemberships.clear()
   }
 
   /**
@@ -81,8 +91,8 @@ export class ElementAxisIndex {
    * verbatim).
    */
   public findByAttribute(tag: ElementName, attribute: string, value: string): readonly string[] {
-    const key = composeKey(tag, attribute, value)
-    return [...(this.attrToPaths.get(key) ?? [])]
+    const set = this.attrIndex.get(tag)?.get(attribute)?.get(value)
+    return set ? [...set] : []
   }
 
   /**
@@ -91,7 +101,8 @@ export class ElementAxisIndex {
    * as a candidate set without null-checks.
    */
   public findByTag(tag: ElementName): readonly string[] {
-    return [...(this.tagToPaths.get(tag) ?? [])]
+    const set = this.tagIndex.get(tag)
+    return set ? [...set] : []
   }
 
   /**
@@ -99,58 +110,81 @@ export class ElementAxisIndex {
    * a touched topic, and when a topic file is deleted.
    */
   public remove(filePath: string): void {
-    const keys = this.pathToKeys.get(filePath)
-    if (!keys) return
+    const memberships = this.pathToMemberships.get(filePath)
+    if (!memberships) return
 
-    for (const key of keys) {
-      const set = key.includes('=')
-        ? this.attrToPaths.get(key)
-        : this.tagToPaths.get(key as ElementName)
-      if (!set) continue
+    for (const m of memberships) {
+      if (m.kind === 'tag') {
+        const set = this.tagIndex.get(m.tag)
+        if (!set) continue
 
-      set.delete(filePath)
-      if (set.size === 0) {
-        if (key.includes('=')) {
-          this.attrToPaths.delete(key)
-        } else {
-          this.tagToPaths.delete(key as ElementName)
+        set.delete(filePath)
+        if (set.size === 0) {
+          this.tagIndex.delete(m.tag)
+        }
+      } else {
+        const tagBucket = this.attrIndex.get(m.tag)
+        const attrBucket = tagBucket?.get(m.attr)
+        const set = attrBucket?.get(m.value)
+        if (!set || !tagBucket || !attrBucket) continue
+
+        set.delete(filePath)
+        if (set.size === 0) {
+          attrBucket.delete(m.value)
+          if (attrBucket.size === 0) {
+            tagBucket.delete(m.attr)
+            if (tagBucket.size === 0) {
+              this.attrIndex.delete(m.tag)
+            }
+          }
         }
       }
     }
 
-    this.pathToKeys.delete(filePath)
+    this.pathToMemberships.delete(filePath)
   }
 
   private addToAttrIndex(
     tag: ElementName,
-    attribute: string,
+    attr: string,
     value: string,
     filePath: string,
-    keys: Set<string>,
+    memberships: Membership[],
   ): void {
-    const key = composeKey(tag, attribute, value)
-    let set = this.attrToPaths.get(key)
+    let tagBucket = this.attrIndex.get(tag)
+    if (!tagBucket) {
+      tagBucket = new Map()
+      this.attrIndex.set(tag, tagBucket)
+    }
+
+    let attrBucket = tagBucket.get(attr)
+    if (!attrBucket) {
+      attrBucket = new Map()
+      tagBucket.set(attr, attrBucket)
+    }
+
+    let set = attrBucket.get(value)
     if (!set) {
       set = new Set()
-      this.attrToPaths.set(key, set)
+      attrBucket.set(value, set)
     }
 
     set.add(filePath)
-    keys.add(key)
+    memberships.push({attr, kind: 'attr', tag, value})
   }
 
-  private addToTagIndex(tag: ElementName, filePath: string, keys: Set<string>): void {
-    let set = this.tagToPaths.get(tag)
+  private addToTagIndex(tag: ElementName, filePath: string, memberships: Membership[]): void {
+    let set = this.tagIndex.get(tag)
     if (!set) {
       set = new Set()
-      this.tagToPaths.set(tag, set)
+      this.tagIndex.set(tag, set)
     }
 
     set.add(filePath)
-    keys.add(tag)
+    memberships.push({kind: 'tag', tag})
   }
 }
 
-function composeKey(tag: ElementName, attribute: string, value: string): string {
-  return `${tag}.${attribute}=${value}`
-}
+type Membership =
+  | {attr: string; kind: 'attr'; tag: ElementName; value: string}
+  | {kind: 'tag'; tag: ElementName}

--- a/src/server/infra/render/reader/html-reader.ts
+++ b/src/server/infra/render/reader/html-reader.ts
@@ -1,0 +1,91 @@
+import {readFile} from 'node:fs/promises'
+
+import type {ElementName} from '../../../core/domain/render/element-types.js'
+
+import {ELEMENT_NAMES} from '../../../core/domain/render/element-types.js'
+import {getInnerText, parseHtml, walkElements} from './html-parser.js'
+
+/**
+ * Topic-file reader for the HTML render layer.
+ *
+ * Parses an HTML topic via parse5, extracts BM25-ready text content,
+ * and produces a flat list of every typed `<bv-*>` element with its
+ * tag and attributes. The element list is consumed by the
+ * element-axis index for structural lookups; the inner text is fed
+ * into the BM25 index alongside markdown bodies.
+ *
+ * Inner text is already entity-decoded by parse5 (the parser handles
+ * `&amp;` → `&`, `&lt;` → `<`, etc. at parse time), so the tokenizer
+ * sees plain text and ranking parity with markdown is straightforward.
+ */
+
+/**
+ * One typed `<bv-*>` element discovered in a topic. Attributes are a
+ * snapshot of the parsed attribute map (lowercase keys per HTML5
+ * normalization). Used by the element-axis index for `tag → [paths]`
+ * and `tag.attribute=value → [paths]` lookups.
+ */
+export type ElementAxisEntry = {
+  attributes: Readonly<Record<string, string>>
+  tag: ElementName
+}
+
+/**
+ * Topic-level frontmatter attributes lifted off `<bv-topic>` for
+ * convenience. Consumers that need the full attribute set walk the
+ * elements list directly.
+ */
+export type TopicAttributes = Readonly<Record<string, string>>
+
+export type HtmlTopicRead = {
+  /** Tokenizer-ready text content. Whitespace collapsed; entities decoded. */
+  bodyText: string
+  /** Flat list of every typed `<bv-*>` element, in document order. */
+  elements: readonly ElementAxisEntry[]
+  /** Attributes on the bv-topic root, or empty if no bv-topic was present. */
+  topicAttributes: TopicAttributes
+}
+
+/**
+ * Parse an HTML string into the structured shape the search/index
+ * pipeline consumes. The reader is forgiving — malformed HTML returns
+ * a best-effort result rather than throwing (parse5 is forgiving by
+ * design; we mirror that for the reader's contract).
+ */
+export function readHtmlTopicSync(html: string): HtmlTopicRead {
+  const document = parseHtml(html)
+  const allElements = walkElements(document)
+
+  const bodyText = getInnerText(document)
+
+  const elements: ElementAxisEntry[] = []
+  let topicAttributes: TopicAttributes = {}
+
+  for (const el of allElements) {
+    if (el.tagName === 'bv-topic' && Object.keys(topicAttributes).length === 0) {
+      topicAttributes = el.attributes
+    }
+
+    if (!isRegisteredElementName(el.tagName)) continue
+
+    elements.push({
+      attributes: el.attributes,
+      tag: el.tagName,
+    })
+  }
+
+  return {bodyText, elements, topicAttributes}
+}
+
+/**
+ * I/O wrapper: reads `filePath` from disk and returns the parsed shape.
+ * Used by the search service when indexing HTML topic files.
+ */
+export async function readHtmlTopic(filePath: string): Promise<HtmlTopicRead> {
+  const html = await readFile(filePath, 'utf8')
+  return readHtmlTopicSync(html)
+}
+
+function isRegisteredElementName(tag: string): tag is ElementName {
+  return (ELEMENT_NAMES as readonly string[]).includes(tag)
+}

--- a/src/server/infra/render/reader/html-reader.ts
+++ b/src/server/infra/render/reader/html-reader.ts
@@ -60,10 +60,18 @@ export function readHtmlTopicSync(html: string): HtmlTopicRead {
 
   const elements: ElementAxisEntry[] = []
   let topicAttributes: TopicAttributes = {}
+  let topicSeen = false
 
   for (const el of allElements) {
-    if (el.tagName === 'bv-topic' && Object.keys(topicAttributes).length === 0) {
+    // Lift attributes off the FIRST `bv-topic` encountered, regardless
+    // of whether its attribute map is empty. The schema requires
+    // `path` + `title`, but malformed input (zero-attribute `<bv-topic>`
+    // followed by a populated sibling) used to silently lift the
+    // sibling — the contract says "root", and the implementation now
+    // matches that.
+    if (el.tagName === 'bv-topic' && !topicSeen) {
       topicAttributes = el.attributes
+      topicSeen = true
     }
 
     if (!isRegisteredElementName(el.tagName)) continue

--- a/test/unit/agent/tools/search-knowledge-service-html-routing.test.ts
+++ b/test/unit/agent/tools/search-knowledge-service-html-routing.test.ts
@@ -144,6 +144,89 @@ describe('Search Service HTML routing', () => {
     })
   })
 
+  describe('bv-topic attribute payload reaches BM25', () => {
+    // The markdown corpus exposes summary/tags/keywords/related via
+    // YAML frontmatter, which the indexer feeds into BM25 verbatim. The
+    // HTML branch parses topic attributes off `<bv-topic>` and must
+    // concatenate the same set into the BM25 input — otherwise a query
+    // for a term living only in `summary=` of an HTML topic ranks far
+    // below the equivalent MD topic.
+    const FINGERPRINT = 'fingerprintqzz'
+    const HTML_WITH_FINGERPRINT_IN_SUMMARY = `<bv-topic path="x" title="t" summary="${FINGERPRINT} appears only here">
+  <bv-reason>body has nothing about that term</bv-reason>
+</bv-topic>`
+
+    beforeEach(() => {
+      listDirectoryStub.resolves({count: 1, entries: [], tree: '', truncated: false})
+      globFilesStub.resolves({
+        files: [
+          {
+            isDirectory: false,
+            modified: new Date('2026-04-27'),
+            path: '/test/.brv/context-tree/x.html',
+            size: HTML_WITH_FINGERPRINT_IN_SUMMARY.length,
+          },
+        ],
+        ignoredCount: 0,
+        message: 'Found 1 file',
+        totalFound: 1,
+        truncated: false,
+      })
+      readFileStub.resolves({
+        content: HTML_WITH_FINGERPRINT_IN_SUMMARY,
+        encoding: 'utf8',
+        lines: 3,
+        size: HTML_WITH_FINGERPRINT_IN_SUMMARY.length,
+        totalLines: 3,
+        truncated: false,
+      })
+    })
+
+    it('surfaces an HTML topic when the query term lives only in the bv-topic summary attribute', async () => {
+      const service = createSearchKnowledgeService(fileSystemMock)
+      const result = await service.search(FINGERPRINT)
+
+      const htmlMatch = result.results.find((r) => r.path.endsWith('.html'))
+      expect(htmlMatch, `expected fingerprint in summary= to be searchable`).to.not.equal(undefined)
+    })
+  })
+
+  describe('title fallback', () => {
+    it('falls back to the filename when bv-topic title is empty/whitespace', async () => {
+      const HTML_BLANK_TITLE = '<bv-topic path="x" title="   "><bv-reason>tokens here</bv-reason></bv-topic>'
+
+      listDirectoryStub.resolves({count: 1, entries: [], tree: '', truncated: false})
+      globFilesStub.resolves({
+        files: [
+          {
+            isDirectory: false,
+            modified: new Date('2026-04-27'),
+            path: '/test/.brv/context-tree/blank.html',
+            size: HTML_BLANK_TITLE.length,
+          },
+        ],
+        ignoredCount: 0,
+        message: 'Found 1 file',
+        totalFound: 1,
+        truncated: false,
+      })
+      readFileStub.resolves({
+        content: HTML_BLANK_TITLE,
+        encoding: 'utf8',
+        lines: 1,
+        size: HTML_BLANK_TITLE.length,
+        totalLines: 1,
+        truncated: false,
+      })
+
+      const service = createSearchKnowledgeService(fileSystemMock)
+      const result = await service.search('tokens')
+
+      const htmlMatch = result.results.find((r) => r.path.endsWith('.html'))
+      expect(htmlMatch?.title).to.equal('blank')
+    })
+  })
+
   describe('elementHint pre-filter', () => {
     beforeEach(() => {
       listDirectoryStub.resolves({count: 2, entries: [], tree: '', truncated: false})

--- a/test/unit/agent/tools/search-knowledge-service-html-routing.test.ts
+++ b/test/unit/agent/tools/search-knowledge-service-html-routing.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Search service HTML-routing tests.
+ *
+ * The indexer dispatches on file extension when reading topic content:
+ * `.html` files go through `readHtmlTopicSync` (entity-decoded inner
+ * text + structured element list); `.md` files are passed verbatim to
+ * the BM25 tokenizer for backward compatibility (e.g. `brv swarm`,
+ * legacy projects).
+ *
+ * These tests cover:
+ *   - HTML files are indexed (glob discovers them; the BM25 tokenizer
+ *     sees inner text, not raw markup).
+ *   - The `format` field on each result correctly reflects the source
+ *     file's extension.
+ *   - Mixed-format corpora produce unified ranked results.
+ *   - The optional `elementHint` pre-filter restricts BM25 candidates
+ *     to topics matching a `<bv-*>` shape.
+ */
+
+import {expect} from 'chai'
+import {createSandbox, SinonStub} from 'sinon'
+
+import type {IFileSystem} from '../../../../src/agent/core/interfaces/i-file-system.js'
+
+import {createSearchKnowledgeService} from '../../../../src/agent/infra/tools/implementations/search-knowledge-service.js'
+
+const HTML_TOPIC = `<bv-topic path="security/auth" title="JWT authentication" summary="JWT design and refresh flow">
+  <bv-reason>Document JWT authentication design.</bv-reason>
+  <bv-rule severity="must" id="r-1">Always validate signatures.</bv-rule>
+  <bv-rule severity="should" id="r-2">Rotate signing keys every 30 days.</bv-rule>
+  <bv-decision id="d-1">Use RS256 over HS256.</bv-decision>
+</bv-topic>`
+
+const MD_TOPIC = `# OAuth Authentication
+This document describes the OAuth 2.0 authentication flow used in our application.
+The flow involves redirect, user consent, and code exchange for tokens.`
+
+describe('Search Service HTML routing', () => {
+  const sandbox = createSandbox()
+  let fileSystemMock: IFileSystem
+  let globFilesStub: SinonStub
+  let listDirectoryStub: SinonStub
+  let readFileStub: SinonStub
+
+  beforeEach(() => {
+    globFilesStub = sandbox.stub()
+    listDirectoryStub = sandbox.stub()
+    readFileStub = sandbox.stub()
+
+    fileSystemMock = {
+      editFile: sandbox.stub(),
+      globFiles: globFilesStub,
+      initialize: sandbox.stub(),
+      listDirectory: listDirectoryStub,
+      readFile: readFileStub,
+      searchContent: sandbox.stub(),
+      writeFile: sandbox.stub(),
+    } as unknown as IFileSystem
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  describe('extension-based dispatch', () => {
+    beforeEach(() => {
+      listDirectoryStub.resolves({count: 2, entries: [], tree: '', truncated: false})
+      globFilesStub.resolves({
+        files: [
+          {
+            isDirectory: false,
+            modified: new Date('2026-04-27'),
+            path: '/test/.brv/context-tree/security/auth.html',
+            size: HTML_TOPIC.length,
+          },
+          {
+            isDirectory: false,
+            modified: new Date('2026-04-27'),
+            path: '/test/.brv/context-tree/oauth.md',
+            size: MD_TOPIC.length,
+          },
+        ],
+        ignoredCount: 0,
+        message: 'Found 2 files',
+        totalFound: 2,
+        truncated: false,
+      })
+
+      readFileStub.callsFake((filePath: string) => {
+        if (filePath.endsWith('.html')) {
+          return Promise.resolve({content: HTML_TOPIC, encoding: 'utf8', lines: 6, size: HTML_TOPIC.length, totalLines: 6, truncated: false})
+        }
+
+        if (filePath.endsWith('.md')) {
+          return Promise.resolve({content: MD_TOPIC, encoding: 'utf8', lines: 3, size: MD_TOPIC.length, totalLines: 3, truncated: false})
+        }
+
+        return Promise.reject(new Error(`unexpected readFile: ${filePath}`))
+      })
+    })
+
+    it('discovers and indexes HTML topic files alongside markdown', async () => {
+      const service = createSearchKnowledgeService(fileSystemMock)
+      // Search for a term that appears only in the HTML topic's inner text.
+      const result = await service.search('signatures')
+
+      const htmlMatch = result.results.find((r) => r.path.endsWith('.html'))
+      expect(htmlMatch, 'expected the HTML topic to appear in results').to.not.equal(undefined)
+    })
+
+    it('populates format="html" on results from .html files', async () => {
+      const service = createSearchKnowledgeService(fileSystemMock)
+      const result = await service.search('JWT')
+
+      const htmlMatch = result.results.find((r) => r.path.endsWith('.html'))
+      expect(htmlMatch?.format).to.equal('html')
+    })
+
+    it('populates format="markdown" on results from .md files', async () => {
+      const service = createSearchKnowledgeService(fileSystemMock)
+      const result = await service.search('OAuth authentication')
+
+      const mdMatch = result.results.find((r) => r.path.endsWith('.md'))
+      expect(mdMatch?.format).to.equal('markdown')
+    })
+
+    it('strips HTML markup before BM25 tokenization (raw tag names are not searchable)', async () => {
+      const service = createSearchKnowledgeService(fileSystemMock)
+      // The HTML source contains `<bv-rule severity="must">` literally;
+      // a search for "bv-rule" should NOT match that markup because
+      // the indexer tokenises inner text only.
+      const result = await service.search('bv-rule')
+
+      const htmlMatch = result.results.find((r) => r.path.endsWith('.html'))
+      expect(htmlMatch, 'HTML topic must not match raw markup').to.equal(undefined)
+    })
+
+    it('lifts the bv-topic title attribute as the document title', async () => {
+      const service = createSearchKnowledgeService(fileSystemMock)
+      const result = await service.search('JWT')
+
+      const htmlMatch = result.results.find((r) => r.path.endsWith('.html'))
+      expect(htmlMatch?.title).to.equal('JWT authentication')
+    })
+  })
+
+  describe('elementHint pre-filter', () => {
+    beforeEach(() => {
+      listDirectoryStub.resolves({count: 2, entries: [], tree: '', truncated: false})
+
+      const HTML_WITH_RULE = `<bv-topic path="a" title="Has rule"><bv-reason>x</bv-reason><bv-rule severity="must">x</bv-rule></bv-topic>`
+      const HTML_WITHOUT_RULE = `<bv-topic path="b" title="No rule"><bv-reason>x</bv-reason></bv-topic>`
+
+      globFilesStub.resolves({
+        files: [
+          {isDirectory: false, modified: new Date('2026-01-01'), path: '/test/.brv/context-tree/a.html', size: HTML_WITH_RULE.length},
+          {isDirectory: false, modified: new Date('2026-01-01'), path: '/test/.brv/context-tree/b.html', size: HTML_WITHOUT_RULE.length},
+        ],
+        ignoredCount: 0,
+        message: 'Found 2 files',
+        totalFound: 2,
+        truncated: false,
+      })
+
+      readFileStub.callsFake((filePath: string) => {
+        const content = filePath.endsWith('a.html') ? HTML_WITH_RULE : HTML_WITHOUT_RULE
+        return Promise.resolve({content, encoding: 'utf8', lines: 1, size: content.length, totalLines: 1, truncated: false})
+      })
+    })
+
+    it('returns no results when elementHint matches no topic', async () => {
+      const service = createSearchKnowledgeService(fileSystemMock)
+      // bv-bug is not present in either fixture; the hint should
+      // exclude every document from BM25 ranking.
+      const result = await service.search('x', {
+        elementHint: {tag: 'bv-bug'},
+      })
+
+      expect(result.results).to.have.lengthOf(0)
+    })
+
+    it('restricts BM25 candidates to topics matching the elementHint tag', async () => {
+      const service = createSearchKnowledgeService(fileSystemMock)
+      const result = await service.search('x', {
+        elementHint: {tag: 'bv-rule'},
+      })
+
+      // Only `a.html` has bv-rule; `b.html` should be filtered out
+      // before BM25 ever sees it.
+      expect(result.results).to.have.lengthOf(1)
+      expect(result.results[0].path.endsWith('a.html')).to.equal(true)
+    })
+
+    it('restricts further by elementHint attribute=value', async () => {
+      const service = createSearchKnowledgeService(fileSystemMock)
+      const matchResult = await service.search('x', {
+        elementHint: {attribute: 'severity', tag: 'bv-rule', value: 'must'},
+      })
+      expect(matchResult.results).to.have.lengthOf(1)
+      expect(matchResult.results[0].path.endsWith('a.html')).to.equal(true)
+
+      const noMatchResult = await service.search('x', {
+        elementHint: {attribute: 'severity', tag: 'bv-rule', value: 'should'},
+      })
+      expect(noMatchResult.results).to.have.lengthOf(0)
+    })
+  })
+})

--- a/test/unit/server/infra/render/reader/element-axis-index.test.ts
+++ b/test/unit/server/infra/render/reader/element-axis-index.test.ts
@@ -124,4 +124,40 @@ describe('ElementAxisIndex', () => {
       expect(index.findByAttribute('bv-rule', 'severity', 'must')).to.have.lengthOf(0)
     })
   })
+
+  describe('attribute name/value robustness', () => {
+    // A stringly-keyed `${tag}.${attr}=${value}` table would conflate these:
+    // `('bv-rule', 'severity', 'must=high')` and `('bv-rule', 'severity=must', 'high')`
+    // both compose to `bv-rule.severity=must=high`. The nested-Map storage
+    // keeps them separated.
+    it('disambiguates an "=" character in the attribute value from a delimiter', () => {
+      const index = new ElementAxisIndex()
+      index.add('a.html', [{attributes: {severity: 'must=high'}, tag: 'bv-rule'}])
+      index.add('b.html', [{attributes: {'severity=must': 'high'}, tag: 'bv-rule'}])
+
+      expect(index.findByAttribute('bv-rule', 'severity', 'must=high')).to.deep.equal(['a.html'])
+      expect(index.findByAttribute('bv-rule', 'severity=must', 'high')).to.deep.equal(['b.html'])
+    })
+
+    it('disambiguates an "." character in the attribute name from a delimiter', () => {
+      const index = new ElementAxisIndex()
+      // `bv-rule` with attribute `data.severity=must`
+      index.add('a.html', [{attributes: {'data.severity': 'must'}, tag: 'bv-rule'}])
+      // and a (hypothetical) `bv-rule` with attribute `data` valued `severity=must`
+      index.add('b.html', [{attributes: {data: 'severity=must'}, tag: 'bv-rule'}])
+
+      expect(index.findByAttribute('bv-rule', 'data.severity', 'must')).to.deep.equal(['a.html'])
+      expect(index.findByAttribute('bv-rule', 'data', 'severity=must')).to.deep.equal(['b.html'])
+    })
+
+    it('remove() unwinds nested attribute buckets cleanly', () => {
+      const index = new ElementAxisIndex()
+      index.add('a.html', [{attributes: {severity: 'must=high'}, tag: 'bv-rule'}])
+      index.remove('a.html')
+
+      expect(index.findByAttribute('bv-rule', 'severity', 'must=high')).to.have.lengthOf(0)
+      expect(index.findByTag('bv-rule')).to.have.lengthOf(0)
+      expect(index.size).to.equal(0)
+    })
+  })
 })

--- a/test/unit/server/infra/render/reader/element-axis-index.test.ts
+++ b/test/unit/server/infra/render/reader/element-axis-index.test.ts
@@ -1,0 +1,127 @@
+/**
+ * element-axis-index tests.
+ *
+ * Covers:
+ *   - Population: `add(filePath, entries)` registers tag and tag.attr=value
+ *     keys correctly.
+ *   - Lookup: `findByTag` and `findByAttribute` return the expected paths
+ *     (and an empty array — never undefined — when no matches).
+ *   - Invalidation: `remove(filePath)` drops every membership the path
+ *     contributed to without leaking stale keys.
+ *   - Idempotence: `add` twice for the same path doesn't break the
+ *     reverse map (callers should `remove` first when re-indexing, but
+ *     duplicate adds shouldn't corrupt the index).
+ */
+
+import {expect} from 'chai'
+
+import {ElementAxisIndex} from '../../../../../../src/server/infra/render/reader/element-axis-index.js'
+
+describe('ElementAxisIndex', () => {
+  describe('population + lookup', () => {
+    it('returns paths containing a given tag', () => {
+      const index = new ElementAxisIndex()
+      index.add('a.html', [{attributes: {}, tag: 'bv-rule'}])
+      index.add('b.html', [{attributes: {}, tag: 'bv-decision'}])
+      index.add('c.html', [{attributes: {}, tag: 'bv-rule'}])
+
+      expect([...index.findByTag('bv-rule')].sort()).to.deep.equal(['a.html', 'c.html'])
+      expect([...index.findByTag('bv-decision')]).to.deep.equal(['b.html'])
+    })
+
+    it('returns an empty array for unknown tags (not undefined)', () => {
+      const index = new ElementAxisIndex()
+      index.add('a.html', [{attributes: {}, tag: 'bv-rule'}])
+      const result = index.findByTag('bv-bug')
+      expect(result).to.be.an('array').with.lengthOf(0)
+    })
+
+    it('returns paths matching tag.attribute=value', () => {
+      const index = new ElementAxisIndex()
+      index.add('a.html', [{attributes: {severity: 'must'}, tag: 'bv-rule'}])
+      index.add('b.html', [{attributes: {severity: 'should'}, tag: 'bv-rule'}])
+      index.add('c.html', [{attributes: {severity: 'must'}, tag: 'bv-rule'}])
+
+      expect([...index.findByAttribute('bv-rule', 'severity', 'must')].sort()).to.deep.equal(['a.html', 'c.html'])
+      expect([...index.findByAttribute('bv-rule', 'severity', 'should')]).to.deep.equal(['b.html'])
+    })
+
+    it('attribute lookups are case-sensitive on values', () => {
+      const index = new ElementAxisIndex()
+      index.add('a.html', [{attributes: {severity: 'must'}, tag: 'bv-rule'}])
+
+      expect(index.findByAttribute('bv-rule', 'severity', 'MUST')).to.have.lengthOf(0)
+      expect(index.findByAttribute('bv-rule', 'severity', 'must')).to.have.lengthOf(1)
+    })
+
+    it('counts paths via the size getter', () => {
+      const index = new ElementAxisIndex()
+      expect(index.size).to.equal(0)
+
+      index.add('a.html', [{attributes: {}, tag: 'bv-rule'}])
+      expect(index.size).to.equal(1)
+
+      index.add('b.html', [{attributes: {}, tag: 'bv-decision'}])
+      expect(index.size).to.equal(2)
+    })
+
+    it('a single file contributing multiple elements is indexed once per (tag, attr=value)', () => {
+      const index = new ElementAxisIndex()
+      index.add('a.html', [
+        {attributes: {severity: 'must'}, tag: 'bv-rule'},
+        {attributes: {severity: 'must'}, tag: 'bv-rule'},
+      ])
+
+      // Same path appears once in the result set despite multiple matching elements.
+      expect(index.findByAttribute('bv-rule', 'severity', 'must')).to.deep.equal(['a.html'])
+      expect(index.findByTag('bv-rule')).to.deep.equal(['a.html'])
+    })
+  })
+
+  describe('invalidation', () => {
+    it('removes all memberships for a file path', () => {
+      const index = new ElementAxisIndex()
+      index.add('a.html', [{attributes: {severity: 'must'}, tag: 'bv-rule'}])
+      index.add('b.html', [{attributes: {severity: 'must'}, tag: 'bv-rule'}])
+
+      index.remove('a.html')
+
+      expect(index.findByTag('bv-rule')).to.deep.equal(['b.html'])
+      expect(index.findByAttribute('bv-rule', 'severity', 'must')).to.deep.equal(['b.html'])
+      expect(index.size).to.equal(1)
+    })
+
+    it('drops empty key sets (no zombie entries after the last contributor leaves)', () => {
+      const index = new ElementAxisIndex()
+      index.add('a.html', [{attributes: {severity: 'critical'}, tag: 'bv-bug'}])
+
+      index.remove('a.html')
+
+      expect(index.findByTag('bv-bug')).to.have.lengthOf(0)
+      expect(index.findByAttribute('bv-bug', 'severity', 'critical')).to.have.lengthOf(0)
+      expect(index.size).to.equal(0)
+    })
+
+    it('remove() on an unknown path is a no-op', () => {
+      const index = new ElementAxisIndex()
+      index.add('a.html', [{attributes: {}, tag: 'bv-rule'}])
+
+      expect(() => {
+        index.remove('not-known.html')
+      }).to.not.throw()
+      expect(index.size).to.equal(1)
+    })
+
+    it('clear() drops everything', () => {
+      const index = new ElementAxisIndex()
+      index.add('a.html', [{attributes: {severity: 'must'}, tag: 'bv-rule'}])
+      index.add('b.html', [{attributes: {severity: 'should'}, tag: 'bv-rule'}])
+
+      index.clear()
+
+      expect(index.size).to.equal(0)
+      expect(index.findByTag('bv-rule')).to.have.lengthOf(0)
+      expect(index.findByAttribute('bv-rule', 'severity', 'must')).to.have.lengthOf(0)
+    })
+  })
+})

--- a/test/unit/server/infra/render/reader/html-reader.test.ts
+++ b/test/unit/server/infra/render/reader/html-reader.test.ts
@@ -13,8 +13,11 @@
  */
 
 import {expect} from 'chai'
+import {mkdtemp, rm, writeFile} from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
 
-import {readHtmlTopicSync} from '../../../../../../src/server/infra/render/reader/html-reader.js'
+import {readHtmlTopic, readHtmlTopicSync} from '../../../../../../src/server/infra/render/reader/html-reader.js'
 
 describe('html-reader', () => {
   describe('readHtmlTopicSync', () => {
@@ -96,6 +99,39 @@ describe('html-reader', () => {
       const result = readHtmlTopicSync(html)
       const ruleCount = result.elements.filter((e) => e.tag === 'bv-rule').length
       expect(ruleCount).to.equal(1)
+    })
+
+    it('lifts attributes off the FIRST bv-topic encountered, not the first non-empty one', () => {
+      // Malformed input: a zero-attribute `<bv-topic>` followed by a
+      // sibling that carries attributes. The contract says topic
+      // attributes are lifted off the root — so the empty map wins.
+      // Without this guarantee, downstream consumers (BM25 title hint,
+      // element-axis index keys) silently disagree about which root
+      // they're describing.
+      const html = '<bv-topic></bv-topic><bv-topic path="b" title="second"></bv-topic>'
+      const result = readHtmlTopicSync(html)
+      expect(Object.keys(result.topicAttributes)).to.have.lengthOf(0)
+    })
+  })
+
+  describe('readHtmlTopic (FS-backed wrapper)', () => {
+    it('round-trips through the filesystem and returns the parsed shape', async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'html-reader-fs-'))
+      const path = join(dir, 'topic.html')
+      try {
+        await writeFile(
+          path,
+          '<bv-topic path="x" title="t" summary="s"><bv-rule severity="must">r</bv-rule></bv-topic>',
+          'utf8',
+        )
+        const result = await readHtmlTopic(path)
+        expect(result.topicAttributes.title).to.equal('t')
+        expect(result.topicAttributes.summary).to.equal('s')
+        expect(result.elements.map((e) => e.tag)).to.deep.equal(['bv-topic', 'bv-rule'])
+        expect(result.bodyText).to.include('r')
+      } finally {
+        await rm(dir, {force: true, recursive: true})
+      }
     })
   })
 })

--- a/test/unit/server/infra/render/reader/html-reader.test.ts
+++ b/test/unit/server/infra/render/reader/html-reader.test.ts
@@ -1,0 +1,101 @@
+/**
+ * html-reader tests.
+ *
+ * Two surfaces:
+ *   - `readHtmlTopicSync(html)` — pure function, no I/O. Used in unit
+ *     tests and by the search service's in-process indexer.
+ *   - `readHtmlTopic(filePath)` — fs-backed wrapper.
+ *
+ * The reader is forgiving on malformed input (parse5's design); the
+ * tests assert the BM25-ready text, the structural element list, and
+ * the bv-topic frontmatter all surface as expected on representative
+ * inputs.
+ */
+
+import {expect} from 'chai'
+
+import {readHtmlTopicSync} from '../../../../../../src/server/infra/render/reader/html-reader.js'
+
+describe('html-reader', () => {
+  describe('readHtmlTopicSync', () => {
+    it('extracts BM25-ready bodyText from a topic', () => {
+      const html = `<bv-topic path="security/auth" title="JWT Auth">
+  <bv-reason>Document JWT design.</bv-reason>
+  <bv-rule severity="must">Always validate signatures.</bv-rule>
+</bv-topic>`
+      const result = readHtmlTopicSync(html)
+      expect(result.bodyText).to.include('Document JWT design.')
+      expect(result.bodyText).to.include('Always validate signatures.')
+    })
+
+    it('decodes HTML entities in bodyText (parse5 handles entities)', () => {
+      const html = '<bv-topic path="x" title="t"><bv-rule>Use &amp; not &lt;</bv-rule></bv-topic>'
+      const result = readHtmlTopicSync(html)
+      expect(result.bodyText).to.include('Use & not <')
+    })
+
+    it('lifts bv-topic frontmatter attributes', () => {
+      const html = `<bv-topic path="security/auth" title="JWT" summary="Auth design" tags="security,jwt" keywords="jwt,token" related="@security/oauth">
+  <bv-reason>x</bv-reason>
+</bv-topic>`
+      const result = readHtmlTopicSync(html)
+      expect(result.topicAttributes.path).to.equal('security/auth')
+      expect(result.topicAttributes.title).to.equal('JWT')
+      expect(result.topicAttributes.summary).to.equal('Auth design')
+      expect(result.topicAttributes.tags).to.equal('security,jwt')
+      expect(result.topicAttributes.keywords).to.equal('jwt,token')
+      expect(result.topicAttributes.related).to.equal('@security/oauth')
+    })
+
+    it('produces a flat list of every typed bv-* element in document order', () => {
+      const html = `<bv-topic path="x" title="t">
+  <bv-reason>r</bv-reason>
+  <bv-rule severity="must" id="r-1">rule one</bv-rule>
+  <bv-rule severity="should" id="r-2">rule two</bv-rule>
+  <bv-decision id="d-1">decision</bv-decision>
+</bv-topic>`
+      const result = readHtmlTopicSync(html)
+      const tags = result.elements.map((e) => e.tag)
+      expect(tags).to.deep.equal(['bv-topic', 'bv-reason', 'bv-rule', 'bv-rule', 'bv-decision'])
+    })
+
+    it('preserves attribute maps on each element entry', () => {
+      const html = '<bv-topic path="x" title="t"><bv-rule severity="must" id="r-1">x</bv-rule></bv-topic>'
+      const result = readHtmlTopicSync(html)
+      const rule = result.elements.find((e) => e.tag === 'bv-rule')
+      expect(rule).to.not.equal(undefined)
+      expect(rule!.attributes.severity).to.equal('must')
+      expect(rule!.attributes.id).to.equal('r-1')
+    })
+
+    it('skips unknown bv-* elements (closed vocabulary)', () => {
+      const html = '<bv-topic path="x" title="t"><bv-not-a-thing></bv-not-a-thing></bv-topic>'
+      const result = readHtmlTopicSync(html)
+      const tags = result.elements.map((e) => e.tag)
+      expect(tags).to.not.include('bv-not-a-thing')
+    })
+
+    it('returns empty topicAttributes when no bv-topic root is present', () => {
+      const result = readHtmlTopicSync('<p>no bv-topic here</p>')
+      expect(Object.keys(result.topicAttributes)).to.have.lengthOf(0)
+    })
+
+    it('does not throw on malformed HTML (parse5 is forgiving)', () => {
+      // Unclosed bv-topic, mismatched nesting — parse5 returns a best-effort tree.
+      expect(() => readHtmlTopicSync('<bv-topic path="x" title="t"><bv-rule>unclosed')).to.not.throw()
+    })
+
+    it('does not double-count nested bv-* elements (depth-first walk visits each once)', () => {
+      // bv-topic is the root; bv-decision contains a bv-rule. Both should
+      // appear in the elements list, each exactly once.
+      const html = `<bv-topic path="x" title="t">
+  <bv-decision id="d-1">
+    <bv-rule severity="must">nested rule</bv-rule>
+  </bv-decision>
+</bv-topic>`
+      const result = readHtmlTopicSync(html)
+      const ruleCount = result.elements.filter((e) => e.tag === 'bv-rule').length
+      expect(ruleCount).to.equal(1)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- New `html-reader.ts` — `readHtmlTopicSync(html)` returns `{bodyText, elements, topicAttributes}`. bodyText is BM25-ready (parse5 decodes entities); elements is the structured `<bv-*>` list with attribute maps; topicAttributes lifts bv-topic frontmatter.
- New `element-axis-index.ts` — in-memory `findByTag` / `findByAttribute` lookups with O(1) invalidation per file via reverse path→keys map.
- Search service wired to dispatch on file extension at indexing time. HTML files feed bodyText into BM25; MD files index raw content as before. `format` field surfaces on every result. Optional `elementHint` on `SearchOptions` / `SearchKnowledgeOptions` pre-filters BM25 candidates by `<bv-*>` shape.
- Public `SearchKnowledgeElementHint` exposed via ToolsSDK so structural-selector consumers can pass the hint without touching internals.

## Type
feat (M1 T4 — query path)

## Scope
- `src/server/infra/render/reader/html-reader.ts` (new)
- `src/server/infra/render/reader/element-axis-index.ts` (new)
- `src/agent/infra/tools/implementations/search-knowledge-service.ts` (extend)
- `src/agent/infra/sandbox/tools-sdk.ts` (public elementHint surface)

## Linked issues
- ENG-2740 (M1 T4)
- Builds on ENG-2737 (registry/parser), ENG-2738 (curate prompt), ENG-2739 (writer + format-detector)

## Test plan
- [x] html-reader: 9 tests — bodyText, entity decoding, attribute lift, element list ordering + dedup, unknown-tag skip, malformed-input non-throw
- [x] element-axis-index: 10 tests — populate, lookup, case-sensitivity, dedup, invalidation (per-path + clear), no-op for unknown paths
- [x] search-service-html-routing: 8 tests — HTML indexed, format field populated for HTML/MD, raw markup NOT tokenized, bv-topic title lift, elementHint pre-filter (tag-only + tag.attr=value)
- [x] Full unit suite: 7910 pass (27 new), 0 fail
- [x] Typecheck clean, lint clean (0 errors), build clean
- [x] **End-to-end validated against real `brv search`**: `local-auto-test/query-html-e2e/` harness (5/5 cases) — HTML topic discovery, legacy MD coexistence, mixed-corpus queries, attribute-markup-leak probe via unique fingerprint string, scope filter

## Evidence

The strongest determinism check: a unique fingerprint (`markerzqxx`) is embedded ONLY as bv-fact attribute names/values in the e2e fixture and within an HTML comment. The harness searches for `markerzqxx` and asserts zero results — confirms the BM25 indexer feeds inner text only, not markup or comments. Every other case in the e2e (5 total) also passes against a real daemon + real file system.

## Checklist
- [x] Code passes lint + typecheck
- [x] Unit tests for every new module + new branch in the search service
- [x] No Co-Authored-By Claude

## Risks

**MD path retained for `brv swarm`.** The current curate path emits HTML, but the read side keeps MD support so `brv swarm` (which still emits MD) and any legacy MD trees continue to work. The dispatcher branches on extension; both paths feed the same BM25 index.

**Index schema bump (5 → 6).** Cached indexes from before this PR rebuild on next query. Cost is one re-index per project, capped at ~100ms for typical bench corpus sizes.

**Element-axis filter is wired but unused today.** The `elementHint` consumer (M2 structural-selector grammar) is downstream. Per the original T4 plan: better to wire it now than to refactor the search service signature later.

## Out of scope

- Structural selector grammar — M2.
- findReferences reverse-graph — M2.
- Signal-precise cache invalidation — mtime-based today is sufficient.
- BM25 ranking parity test (MD vs HTML same content) — bench measures end-to-end.