### PR TITLE
fix: Tier 2 direct response renders HTML topics into structured markdown

### DIFF
--- a/src/server/infra/executor/query-executor.ts
+++ b/src/server/infra/executor/query-executor.ts
@@ -24,6 +24,7 @@ import {loadSources} from '../../core/domain/source/source-schema.js'
 import {isDerivedArtifact} from '../context-tree/derived-artifact.js'
 import {FileContextTreeManifestService} from '../context-tree/file-context-tree-manifest-service.js'
 import {MarkdownOnlyFormatDetector} from '../render/format/markdown-only-format-detector.js'
+import {renderHtmlTopicForLlm} from '../render/reader/html-renderer.js'
 import {
   canRespondDirectly,
   type DirectSearchResult,
@@ -699,7 +700,26 @@ ${responseFormat}`
               const ctBase = result.originContextTreeRoot ?? join(BRV_DIR, CONTEXT_TREE_DIR)
               const ctPath = join(ctBase, result.path)
               const {content: fullContent} = await this.fileSystem!.readFile(ctPath)
-              content = fullContent
+              // HTML topics: render the typed-element document as a
+              // markdown-like string before handing it to the response
+              // formatter. Shipping raw `<bv-topic>...</bv-topic>` markup
+              // here would burn the 5000-char content budget on tags
+              // (`direct-search-responder.ts:11`) and force any
+              // downstream LLM consumer to re-parse the document. The
+              // renderer preserves bv-* element semantics (severity,
+              // subject/value, decision id) without the markup tax.
+              if (result.format === 'html') {
+                try {
+                  content = renderHtmlTopicForLlm(fullContent)
+                } catch {
+                  // Renderer is forgiving by contract — but if anything
+                  // throws, fall back to the raw bytes so we don't
+                  // blank the response on a single malformed topic.
+                  content = fullContent
+                }
+              } else {
+                content = fullContent
+              }
             } catch {
               // Use excerpt if full read fails
             }

--- a/src/server/infra/render/reader/html-renderer.ts
+++ b/src/server/infra/render/reader/html-renderer.ts
@@ -1,0 +1,174 @@
+import type {ElementNode, ParsedNode} from '../../../core/domain/render/element-types.js'
+
+import {getInnerText, parseHtml} from './html-parser.js'
+
+/**
+ * Render a parsed `<bv-topic>` document into a markdown-like string for
+ * downstream LLM consumption (Tier 2 direct response, Tier 4 agent
+ * tool reads). Strips raw markup and reduces every typed `<bv-*>`
+ * element to its semantic role plus inner text.
+ *
+ * Why this exists: shipping raw `<bv-topic ...><bv-rule severity="must">x</bv-rule>...`
+ * to the model burns tokens on tags and attribute syntax it doesn't
+ * need to reconstruct meaning. Stripping every tag (bodyText only) is
+ * the other extreme — it loses the severity / id / subject signals
+ * the typed vocabulary exists to carry. This renderer preserves
+ * element semantics in a compact, human-and-LLM-readable form.
+ *
+ * Behaviour:
+ *   - `<bv-topic>` attributes (title, summary, tags, keywords) lift to
+ *     a header block.
+ *   - Top-level children are rendered with a per-tag semantic prefix
+ *     (e.g. `- **Rule** [must]: ...`).
+ *   - Unknown / unregistered tags fall back to a generic bullet so we
+ *     don't drop content when the vocabulary grows.
+ *   - Empty inner text is skipped (no zero-content bullets).
+ *
+ * Forgiving on malformed input: missing `<bv-topic>` root → renders
+ * what's parseable; throws nothing.
+ */
+export function renderHtmlTopicForLlm(html: string): string {
+  const document = parseHtml(html)
+  const bvTopic = findFirstElement(document, 'bv-topic')
+
+  const lines: string[] = []
+  const headerLines: string[] = []
+  const topicAttributes = bvTopic?.attributes ?? {}
+
+  if (topicAttributes.title) headerLines.push(`# ${topicAttributes.title}`)
+  if (topicAttributes.summary) headerLines.push(`> ${topicAttributes.summary}`)
+  if (topicAttributes.tags) headerLines.push(`Tags: ${topicAttributes.tags}`)
+  if (topicAttributes.keywords) headerLines.push(`Keywords: ${topicAttributes.keywords}`)
+  if (topicAttributes.related) headerLines.push(`Related: ${topicAttributes.related}`)
+
+  if (headerLines.length > 0) {
+    lines.push(headerLines.join('\n'))
+  }
+
+  const children: readonly ParsedNode[] = bvTopic?.children ?? document.children
+
+  for (const child of children) {
+    if (child.type !== 'element') continue
+    const rendered = renderChild(child)
+    if (rendered) lines.push(rendered)
+  }
+
+  return lines.join('\n\n')
+}
+
+function renderChild(element: ElementNode): string {
+  const text = getInnerText(element).trim()
+  if (text.length === 0) return ''
+
+  const {attributes, tagName} = element
+
+  switch (tagName) {
+    case 'bv-author': {
+      return `**Author:** ${text}`
+    }
+
+    case 'bv-bug': {
+      const id = attributes.id ? ` (${attributes.id})` : ''
+      return `- **Bug**${id}: ${text}`
+    }
+
+    case 'bv-changes': {
+      return `**Changes:** ${text}`
+    }
+
+    case 'bv-decision': {
+      const id = attributes.id ? ` (${attributes.id})` : ''
+      return `- **Decision**${id}: ${text}`
+    }
+
+    case 'bv-dependencies': {
+      return `**Dependencies:** ${text}`
+    }
+
+    case 'bv-diagram': {
+      return `**Diagram:**\n${text}`
+    }
+
+    case 'bv-examples': {
+      return `**Examples:** ${text}`
+    }
+
+    case 'bv-fact': {
+      const parts: string[] = []
+      if (attributes.subject) parts.push(`subject=${attributes.subject}`)
+      if (attributes.category) parts.push(`category=${attributes.category}`)
+      if (attributes.value) parts.push(`value=${attributes.value}`)
+      const meta = parts.length > 0 ? ` (${parts.join(', ')})` : ''
+      return `- **Fact**${meta}: ${text}`
+    }
+
+    case 'bv-files': {
+      return `**Files:** ${text}`
+    }
+
+    case 'bv-fix': {
+      const id = attributes.id ? ` (${attributes.id})` : ''
+      return `- **Fix**${id}: ${text}`
+    }
+
+    case 'bv-flow': {
+      return `**Flow:** ${text}`
+    }
+
+    case 'bv-highlights': {
+      return `**Highlights:** ${text}`
+    }
+
+    case 'bv-pattern': {
+      return `- **Pattern:** ${text}`
+    }
+
+    case 'bv-reason': {
+      return `**Reason:** ${text}`
+    }
+
+    case 'bv-rule': {
+      const severity = attributes.severity ? `[${attributes.severity}]` : ''
+      const id = attributes.id ? ` (${attributes.id})` : ''
+      const head = severity ? `**Rule** ${severity}${id}` : `**Rule**${id}`
+      return `- ${head}: ${text}`
+    }
+
+    case 'bv-structure': {
+      return `**Structure:** ${text}`
+    }
+
+    case 'bv-task': {
+      return `**Task:** ${text}`
+    }
+
+    case 'bv-timestamp': {
+      return `**Timestamp:** ${text}`
+    }
+
+    default: {
+      // Unknown / future bv-* element. Preserve content as a generic
+      // bullet so growing the vocabulary doesn't silently drop data
+      // from rendered output. Non-bv-* elements are skipped (would
+      // typically be raw HTML the curate prompt forbids; if they
+      // sneak in, we don't want them in the LLM-facing render).
+      if (tagName.startsWith('bv-')) {
+        return `- ${text}`
+      }
+
+      return ''
+    }
+  }
+}
+
+function findFirstElement(root: ParsedNode, tagName: string): ElementNode | undefined {
+  if (root.type === 'element' && root.tagName === tagName) return root
+  if (root.type === 'element' || root.type === 'document') {
+    for (const child of root.children) {
+      const found = findFirstElement(child, tagName)
+      if (found) return found
+    }
+  }
+
+  return undefined
+}

--- a/test/unit/infra/executor/query-executor.test.ts
+++ b/test/unit/infra/executor/query-executor.test.ts
@@ -302,6 +302,66 @@ describe('QueryExecutor', () => {
         expect(result.timing.durationMs).to.be.at.least(0)
         expect(result.response).to.include(ATTRIBUTION_FOOTER)
       })
+
+      it('renders HTML topics into structured markdown before formatting the direct response', async () => {
+        // For HTML results, the executor reads the full file and routes
+        // it through `renderHtmlTopicForLlm` so that downstream
+        // `formatDirectResponse` ships markdown, not raw `<bv-*>`
+        // markup. Locks the Tier 2 contract: the user-facing response
+        // never contains tag/attribute syntax for HTML topics.
+        const agent = createMockAgent()
+        const fileSystem = createMockFileSystem()
+        ;(fileSystem.readFile as SinonStub).resolves({
+          content: `<bv-topic path="security/auth" title="JWT auth" summary="JWT design">
+            <bv-reason>Document JWT design.</bv-reason>
+            <bv-rule severity="must" id="r-1">Always validate signatures.</bv-rule>
+            <bv-decision id="d-1">Use RS256 over HS256.</bv-decision>
+          </bv-topic>`,
+          encoding: 'utf8',
+        })
+        const searchResult = makeSearchResult({
+          format: 'html',
+          path: 'security/auth.html',
+          score: 0.95,
+          title: 'JWT auth',
+        })
+        const searchService = createMockSearchService([searchResult])
+        const executor = new QueryExecutor({fileSystem, searchService})
+
+        const result = await executor.executeWithAgent(agent, {query: 'jwt auth', taskId: TASK_ID})
+
+        expect(result.tier).to.equal(TIER_DIRECT_SEARCH)
+        // No raw bv-* markup or attribute syntax leaks into the response.
+        expect(result.response).to.not.match(/<bv-/)
+        expect(result.response).to.not.match(/\s\w+="/)
+        // Structured render preserves element semantics (severity, id).
+        expect(result.response).to.include('- **Rule** [must] (r-1): Always validate signatures.')
+        expect(result.response).to.include('- **Decision** (d-1): Use RS256 over HS256.')
+        expect(result.response).to.include('**Reason:** Document JWT design.')
+      })
+
+      it('passes markdown topics through unchanged (no renderer applied)', async () => {
+        const agent = createMockAgent()
+        const fileSystem = createMockFileSystem()
+        ;(fileSystem.readFile as SinonStub).resolves({
+          content: '# Auth\n\nSome markdown body about auth.',
+          encoding: 'utf8',
+        })
+        const searchResult = makeSearchResult({
+          format: 'markdown',
+          path: 'topics/auth.md',
+          score: 0.95,
+          title: 'Auth',
+        })
+        const searchService = createMockSearchService([searchResult])
+        const executor = new QueryExecutor({fileSystem, searchService})
+
+        const result = await executor.executeWithAgent(agent, {query: 'auth', taskId: TASK_ID})
+
+        expect(result.tier).to.equal(TIER_DIRECT_SEARCH)
+        // Markdown body survives verbatim — no renderer rewrites it.
+        expect(result.response).to.include('Some markdown body about auth.')
+      })
     })
 
     describe('Tier 3: optimized LLM with prefetched context', () => {

--- a/test/unit/server/infra/render/reader/html-renderer.test.ts
+++ b/test/unit/server/infra/render/reader/html-renderer.test.ts
@@ -1,0 +1,141 @@
+/**
+ * html-renderer tests.
+ *
+ * `renderHtmlTopicForLlm` is the bridge between an indexed `<bv-topic>`
+ * document and the markdown-shaped string the Tier 2 direct-response
+ * formatter (and any other LLM-facing consumer) reads. The tests below
+ * lock the contract on:
+ *   - tag-level semantic prefixing (e.g. `bv-rule[severity=must]` →
+ *     `- **Rule** [must]: …`)
+ *   - bv-topic frontmatter lift (title / summary / tags / keywords /
+ *     related)
+ *   - graceful behaviour on malformed / partial input (parse5-driven
+ *     forgiveness mirrors the rest of the reader pipeline)
+ *   - no `<bv-*>` markup or attribute syntax in the rendered output
+ */
+
+import {expect} from 'chai'
+
+import {renderHtmlTopicForLlm} from '../../../../../../src/server/infra/render/reader/html-renderer.js'
+
+describe('renderHtmlTopicForLlm', () => {
+  it('lifts bv-topic frontmatter into a header block', () => {
+    const html = `<bv-topic path="security/auth" title="JWT Auth" summary="JWT design" tags="security,jwt" keywords="jwt,refresh" related="@security/oauth"></bv-topic>`
+    const out = renderHtmlTopicForLlm(html)
+
+    expect(out).to.include('# JWT Auth')
+    expect(out).to.include('> JWT design')
+    expect(out).to.include('Tags: security,jwt')
+    expect(out).to.include('Keywords: jwt,refresh')
+    expect(out).to.include('Related: @security/oauth')
+  })
+
+  it('omits header lines for absent attributes (no empty `> ` etc.)', () => {
+    const html = '<bv-topic path="x" title="t"></bv-topic>'
+    const out = renderHtmlTopicForLlm(html)
+
+    expect(out).to.equal('# t')
+  })
+
+  it('renders bv-rule with severity and id metadata', () => {
+    const html = `<bv-topic path="x" title="t">
+      <bv-rule severity="must" id="r-validate">Always validate JWT signatures.</bv-rule>
+    </bv-topic>`
+    const out = renderHtmlTopicForLlm(html)
+
+    expect(out).to.include('- **Rule** [must] (r-validate): Always validate JWT signatures.')
+  })
+
+  it('renders bv-fact with subject/category/value metadata', () => {
+    const html = `<bv-topic path="x" title="t">
+      <bv-fact subject="signing_algorithm" category="convention" value="RS256">All service-to-service JWTs are signed with RS256.</bv-fact>
+    </bv-topic>`
+    const out = renderHtmlTopicForLlm(html)
+
+    expect(out).to.include(
+      '- **Fact** (subject=signing_algorithm, category=convention, value=RS256): All service-to-service JWTs are signed with RS256.',
+    )
+  })
+
+  it('renders bv-decision with id metadata', () => {
+    const html = `<bv-topic path="x" title="t">
+      <bv-decision id="d-rs256">Use RS256 over HS256.</bv-decision>
+    </bv-topic>`
+    const out = renderHtmlTopicForLlm(html)
+
+    expect(out).to.include('- **Decision** (d-rs256): Use RS256 over HS256.')
+  })
+
+  it('renders bv-reason / bv-task as labelled blocks', () => {
+    const html = `<bv-topic path="x" title="t">
+      <bv-reason>Document JWT design.</bv-reason>
+      <bv-task>Capture decisions and operating rules.</bv-task>
+    </bv-topic>`
+    const out = renderHtmlTopicForLlm(html)
+
+    expect(out).to.include('**Reason:** Document JWT design.')
+    expect(out).to.include('**Task:** Capture decisions and operating rules.')
+  })
+
+  it('output contains no `<bv-*>` markup or attribute syntax', () => {
+    const html = `<bv-topic path="x" title="t" summary="s">
+      <bv-rule severity="must" id="r-1">x</bv-rule>
+      <bv-decision id="d-1">y</bv-decision>
+      <bv-fact subject="s" value="v">z</bv-fact>
+    </bv-topic>`
+    const out = renderHtmlTopicForLlm(html)
+
+    // No tag openings
+    expect(out).to.not.match(/<bv-/)
+    // No attribute syntax (`name="value"`) — the renderer pulls
+    // attribute payload into prose like `[must]` and `(subject=s)`,
+    // never as raw `attr="value"`.
+    expect(out).to.not.match(/\s\w+="/)
+  })
+
+  it('skips elements with empty inner text (no zero-content bullets)', () => {
+    const html = `<bv-topic path="x" title="t">
+      <bv-rule severity="must"></bv-rule>
+      <bv-decision>has content</bv-decision>
+    </bv-topic>`
+    const out = renderHtmlTopicForLlm(html)
+
+    expect(out).to.include('Decision')
+    expect(out).to.include('has content')
+    // The empty bv-rule should not produce a stray `- **Rule** [must]: ` line
+    expect(out.split('\n').filter((line) => line.trim() === '- **Rule** [must]:')).to.have.lengthOf(0)
+  })
+
+  it('falls back to a generic bullet for unknown bv-* tags (vocabulary-additive)', () => {
+    // `bv-future-element` isn't in today's registry; the renderer
+    // shouldn't drop it — the vocabulary is intentionally additive.
+    const html = `<bv-topic path="x" title="t">
+      <bv-future-element>future content here</bv-future-element>
+    </bv-topic>`
+    const out = renderHtmlTopicForLlm(html)
+
+    expect(out).to.include('- future content here')
+  })
+
+  it('does not throw on malformed HTML (parse5 is forgiving)', () => {
+    expect(() => renderHtmlTopicForLlm('<bv-topic path="x" title="t"><bv-rule>unclosed')).to.not.throw()
+  })
+
+  it('returns an empty string when given empty input (no bv-topic, no children)', () => {
+    expect(renderHtmlTopicForLlm('')).to.equal('')
+  })
+
+  it('produces deterministic output for a representative full topic', () => {
+    const html = `<bv-topic path="security/auth" title="JWT auth" summary="JWT design.">
+      <bv-reason>Document JWT.</bv-reason>
+      <bv-rule severity="must" id="r-1">Validate signatures.</bv-rule>
+      <bv-decision id="d-1">Use RS256.</bv-decision>
+      <bv-fact subject="alg" value="RS256">All service tokens use RS256.</bv-fact>
+    </bv-topic>`
+    const out = renderHtmlTopicForLlm(html)
+
+    expect(out).to.equal(
+      '# JWT auth\n> JWT design.\n\n**Reason:** Document JWT.\n\n- **Rule** [must] (r-1): Validate signatures.\n\n- **Decision** (d-1): Use RS256.\n\n- **Fact** (subject=alg, value=RS256): All service tokens use RS256.',
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- New `renderHtmlTopicForLlm(html)` walks a parsed `<bv-topic>` tree and emits a markdown-shaped string. Each `<bv-*>` gets a semantic prefix (`- **Rule** [must] (r-1): …`, `- **Fact** (subject=alg, value=RS256): …`, etc.). Frontmatter (title / summary / tags / keywords / related) lifts to a header block.
- `query-executor.ts` Tier 2 (`tryDirectSearchResponse`) routes HTML results through the renderer before handing them to `formatDirectResponse`. Markdown results pass through verbatim.
- Forgiving on malformed input (parse5-driven, matches the rest of the reader pipeline). On any throw we fall back to raw bytes so a single bad topic can't blank the response.

## Type
fix (M1 follow-up — Tier 2 HTML parity)

## Scope
- `src/server/infra/render/reader/html-renderer.ts` (new)
- `src/server/infra/executor/query-executor.ts` (Tier 2 branch)

## Why this exists

Tier 2 (`brv query`'s direct-search response — no LLM) reads the full file and ships the bytes back to the user via `formatDirectResponse`. For HTML topics that's raw `<bv-topic ...><bv-rule severity=\"must\">…</bv-rule>…` markup. Two consequences observed during the multi-tier retrieval audit:

1. The 5000-char content budget (`direct-search-responder.ts:11`) burns on tags and attribute syntax before reaching meaningful text. Long topics truncate mid-element.
2. Any LLM-shaped consumer downstream (Tier 4 agent re-reads, the bench harness, third-party integrations) re-parses the HTML. Wasted tokens; lossy semantics.

Stripping every tag (bodyText only) loses the typed-element signals the format exists to carry — severity on rules, subject/value on facts, id on decisions. The renderer keeps both: clean text, plus the structured metadata the vocabulary was designed to surface.

## Test plan

- [x] `renderHtmlTopicForLlm`: 12 tests — frontmatter lift, per-tag rendering (rule/fact/decision/reason/task), no markup leak, empty-element skip, unknown-tag fallback, malformed-input non-throw, deterministic snapshot
- [x] `query-executor` Tier 2: 2 new tests — HTML branch routes through renderer + asserts no `<bv-` / `attr=\"\"` in response; MD branch regression guard
- [x] Full suite: 7931 pass (+15), 0 fail
- [x] Typecheck, lint, build clean

## Out of scope (not a Tier 2 issue)

- **Stage 2** — title fallback in `memory-symbol-tree.ts:262` strips only `.md`. Affects every tier (HTML topics render as `auth.html` in tree node names).
- **Stage 6** — parent-propagation excerpts (`getSummarySource`) hardcode `_index.md` / `context.md`. Pure-HTML directories fall through.
- **Stage 6** — backlink relation extraction. `<bv-topic related=...>` attribute payload doesn't reach `buildReferenceIndex` today.
- **Tier 4** — agent's tool-driven reads (`expand_knowledge` etc.) still see raw HTML. Same fix pattern would apply, but lives in a different code path.

These each warrant their own focused PR before the M1 HTML-vs-MD bench is apples-to-apples.

## Checklist

- [x] Code passes lint + typecheck
- [x] Unit tests for renderer + Tier 2 wiring + MD regression guard