### PR TITLE
fix: extension-aware format detector + byterover tokens + curate prompt

### DIFF
--- a/src/agent/infra/http/internal-llm-http-service.ts
+++ b/src/agent/infra/http/internal-llm-http-service.ts
@@ -191,10 +191,16 @@ export class ByteRoverLlmHttpService {
   private *extractContentFromResponse(response: GenerateContentResponse): Generator<GenerateContentChunk> {
     const {candidates} = response
     if (!candidates || candidates.length === 0) {
+      // Gemini emits this shape on safety-filter blocks (with
+      // `usageMetadata` populated); Claude on refusals. Forward the
+      // backend response so `LoggingContentGenerator` can still surface
+      // billable tokens even on no-content outcomes — same contract as
+      // the empty-parts and full-content terminating chunks below.
       yield {
         content: '',
         finishReason: 'stop',
         isComplete: true,
+        rawResponse: response,
       }
       return
     }

--- a/src/agent/infra/http/internal-llm-http-service.ts
+++ b/src/agent/infra/http/internal-llm-http-service.ts
@@ -203,11 +203,17 @@ export class ByteRoverLlmHttpService {
     const parts = candidate?.content?.parts
     const finishReason = this.mapFinishReason((candidate as {finishReason?: string})?.finishReason ?? 'STOP')
 
+    // Forward the full backend response on the terminating chunk so
+    // `LoggingContentGenerator` can extract token usage via
+    // `pickRawUsage()` (`.usage ?? .usageMetadata`). Without this the
+    // streaming path emits no `llmservice:usage` event and QueryLogEntry
+    // has no token counts for ByteRover-provider runs.
     if (!parts || parts.length === 0) {
       yield {
         content: '',
         finishReason,
         isComplete: true,
+        rawResponse: response,
       }
       return
     }
@@ -241,6 +247,7 @@ export class ByteRoverLlmHttpService {
       content: textParts.join('').trimEnd(),
       finishReason,
       isComplete: true,
+      rawResponse: response,
       toolCalls:
         functionCalls.length > 0
           ? functionCalls.map((fc, index) => ({

--- a/src/agent/resources/prompts/curate-detail-preservation.yml
+++ b/src/agent/resources/prompts/curate-detail-preservation.yml
@@ -5,97 +5,95 @@ prompt: |
 
   When curating content from files or folders, actively look for and preserve:
 
-  **Diagrams (MUST PRESERVE in narrative.diagrams array):**
-  - Mermaid diagrams (```mermaid ... ```) - store with type: "mermaid"
-  - PlantUML diagrams (@startuml ... @enduml) - store with type: "plantuml"
-  - ASCII art diagrams (box drawings, flow charts using |, -, +, >, arrows) - store with type: "ascii"
-  - Sequence diagrams, state diagrams, class diagrams, ER diagrams - identify the format and store accordingly
+  **Diagrams (MUST PRESERVE in `<bv-diagram>` elements):**
+  - Mermaid diagrams (```mermaid ... ```) — emit `<bv-diagram type="mermaid">` with the body verbatim
+  - PlantUML diagrams (@startuml ... @enduml) — emit `<bv-diagram type="plantuml">`
+  - ASCII art diagrams (box drawings, flow charts using |, -, +, >, arrows) — emit `<bv-diagram type="ascii">`
+  - Sequence / state / class / ER diagrams — identify the format and use the matching `type` attribute (`mermaid`, `plantuml`, `dot`, `graphviz`, or `other`)
   - ALWAYS preserve diagram content EXACTLY as-is, character for character
-  - NEVER paraphrase or describe a diagram in text instead of storing it
-  - NEVER skip a diagram because "it's too complex" - store it verbatim
+  - NEVER paraphrase or describe a diagram in text instead of emitting `<bv-diagram>`
+  - NEVER skip a diagram because "it's too complex" — emit it verbatim
 
   **Tables (MUST PRESERVE):**
-  - Markdown tables - preserve the full table in narrative.structure or narrative.highlights
-  - Include column headers and ALL rows - do not summarize table content
-  - If a table has 20 rows, store all 20 rows
+  - Markdown tables — preserve the full table inside `<bv-structure>` or `<bv-highlights>` (block-content elements that allow `<table>`, `<ul>`, `<p>`)
+  - Include column headers and ALL rows — do not summarize table content
+  - If a table has 20 rows, preserve all 20 rows
 
   **Step-by-step Procedures:**
-  - Numbered instructions - store in narrative.rules with original numbering
-  - Decision trees - store as diagrams (ascii type) or in narrative.structure
-  - Workflows - capture in rawConcept.flow AND as diagrams if visual representation exists
+  - Numbered instructions — emit each as a `<bv-rule>` (use `severity` and `id` attributes when applicable) or, for purely procedural steps, as `<bv-task>` elements
+  - Decision trees — emit as `<bv-diagram type="ascii">` or as a structured walkthrough inside `<bv-structure>`
+  - Workflows — capture as `<bv-flow>` AND as `<bv-diagram>` if a visual representation exists
 
   **API Signatures and Interfaces:**
-  - Function signatures with parameter types - store in narrative.structure
-  - Interface definitions - preserve exact TypeScript/language syntax in snippets
-  - Request/response schemas - store complete schema, not summaries
+  - Function signatures with parameter types — preserve in `<bv-structure>` or `<bv-examples>`
+  - Interface definitions — preserve exact TypeScript / language syntax inside `<bv-examples>` using fenced `<pre><code>` blocks
+  - Request / response schemas — emit complete schema, not summaries
 
   **Code Examples:**
-  - Inline code examples from documentation - store in narrative.examples with full code
-  - Configuration examples - preserve exact syntax and values
-  - Command-line examples - store complete commands with flags
+  - Inline code examples from documentation — emit inside `<bv-examples>` with full code in `<pre><code>` blocks
+  - Configuration examples — preserve exact syntax and values
+  - Command-line examples — preserve complete commands with flags
 
   **Detection Heuristics:**
-  - Lines containing box-drawing characters (U+2500-U+257F, or ASCII +--+, |  |) = ASCII diagram
-  - Fenced blocks with language tag "mermaid", "plantuml", "dot", "graphviz" = diagram
-  - Content between @startuml/@enduml = PlantUML diagram
-  - Arrow patterns (-->, ==>, ->, =>), combined with indentation = flow/sequence diagram
+  - Lines containing box-drawing characters (U+2500–U+257F, or ASCII `+--+`, `|  |`) = ASCII diagram
+  - Fenced blocks with language tag `mermaid`, `plantuml`, `dot`, `graphviz` = diagram
+  - Content between `@startuml` / `@enduml` = PlantUML diagram
+  - Arrow patterns (`-->`, `==>`, `->`, `=>`) combined with indentation = flow / sequence diagram
 
   **Storage Rules for Diagrams:**
-  - One diagram per entry in the narrative.diagrams array
-  - Always set the `type` field correctly (mermaid, plantuml, ascii, other)
-  - Use `title` field when the diagram has a caption or label nearby
+  - One `<bv-diagram>` per diagram. Do NOT combine multiple diagrams into a single element.
+  - Always set the `type` attribute (`mermaid`, `plantuml`, `ascii`, `dot`, `graphviz`, `other`)
+  - Use the `title` attribute when the diagram has a caption or label nearby
   - Example:
-    ```javascript
-    narrative: {
-      diagrams: [
-        {
-          type: "mermaid",
-          title: "Authentication Flow",
-          content: "graph TD\n  A[Request] --> B{Has Token?}\n  B -->|Yes| C[Validate]\n  B -->|No| D[Reject]"
-        }
-      ]
-    }
+    ```
+    <bv-diagram type="mermaid" title="Authentication Flow">
+    graph TD
+      A[Request] --> B{Has Token?}
+      B -->|Yes| C[Validate]
+      B -->|No| D[Reject]
+    </bv-diagram>
     ```
 
   ## Non-Code Content Preservation
 
   **Meeting Notes and Decisions (MUST PRESERVE):**
-  - Decision text with full rationale - store in narrative.rules or narrative.highlights
-  - Action items with assignees and deadlines - store in narrative.examples
-  - Voting results and priority rankings - preserve exact numbers
-  - Status updates and blockers - store in narrative.dependencies
+  - Decision text with full rationale — emit as `<bv-decision>` (one per decision; use the `id` attribute for cross-references). Inside, use block content (`<p>`, `<ul>`, `<li>`) to preserve full prose.
+  - Action items with assignees and deadlines — emit as `<bv-task>` (one per item) or as facts under `<bv-fact category="team">` when stating an assignment as a durable fact.
+  - Voting results and priority rankings — preserve exact numbers inside `<bv-highlights>` or as `<bv-fact>` siblings (`subject`, `value`).
+  - Status updates and blockers — emit blockers as `<bv-dependencies>` and current status as `<bv-fact>` siblings.
 
   **Process Documentation:**
-  - Workflow steps with all conditions - store in rawConcept.flow and narrative.rules
-  - Metrics and KPIs with exact values - store in narrative.highlights
-  - Timeline and milestone information - store in narrative.structure
+  - Workflow steps with all conditions — emit the high-level flow as `<bv-flow>` and individual rules as `<bv-rule>` siblings
+  - Metrics and KPIs with exact values — preserve as `<bv-fact>` (use `subject` for the metric name and `value` for the value) or inside `<bv-highlights>`
+  - Timeline and milestone information — preserve inside `<bv-structure>` with full chronology
 
   ## Factual Statement Preservation
 
-  **Facts (MUST EXTRACT in content.facts array):**
-  - Personal information stated by the user (e.g., "My name is Andy") - store each as a separate fact with category: "personal"
-  - Project configuration values, versions, ports, URLs - preserve exact values with category: "project"
-  - Team conventions and processes - store with category: "convention"
-  - Preferences and opinions expressed as directives - store with category: "preference"
-  - Team structure and roles - store with category: "team"
-  - Environment and infrastructure details - store with category: "environment"
-  - Use `subject` field for the key concept in snake_case (e.g., "user_name", "database_version")
-  - Use `value` field for the extracted value (e.g., "Andy", "PostgreSQL 15")
+  **Facts (MUST EXTRACT as `<bv-fact>` siblings):**
+  - Personal information stated by the user (e.g., "My name is Andy") — emit each as a separate `<bv-fact category="personal" subject="user_name" value="Andy">My name is Andy.</bv-fact>`
+  - Project configuration values, versions, ports, URLs — preserve exact values with `category="project"`
+  - Team conventions and processes — emit with `category="convention"`
+  - Preferences and opinions expressed as directives — emit with `category="preference"`
+  - Team structure and roles — emit with `category="team"`
+  - Environment and infrastructure details — emit with `category="environment"`
+  - Use the `subject` attribute for the key concept in snake_case (e.g., `user_name`, `database_version`)
+  - Use the `value` attribute for the extracted value (e.g., `Andy`, `PostgreSQL 15`)
+  - The element's text content is the canonical statement — preserve the exact wording of the factual claim
   - Do NOT infer facts that were not explicitly stated
-  - Do NOT merge multiple facts into one compound statement
-  - ALWAYS preserve the exact wording of the factual claim in `statement`
+  - Do NOT merge multiple facts into one compound `<bv-fact>` element — one fact per element
 
   ## General Detail Preservation
 
   **Completeness over conciseness:**
-  - If a document lists 15 items, store all 15
+  - If a document lists 15 items, emit all 15 (as `<bv-rule>` / `<bv-fact>` / `<bv-task>` siblings depending on the item kind)
   - If a config file has 30 settings, capture all relevant ones
-  - If there are multiple code examples, store each one
+  - If there are multiple code examples, emit each one inside `<bv-examples>`
   - Preserve original formatting, indentation, and structure where possible
 
   **Do NOT:**
   - Summarize detailed content into brief descriptions
-  - Pick "representative examples" instead of storing all items
+  - Pick "representative examples" instead of preserving all items
   - Omit sections because they seem "less important"
   - Flatten hierarchical content into flat descriptions
+  - Mention or store JSON-schema field names like `narrative.rules`, `rawConcept.flow`, or `content.facts` — these belong to a deprecated curate-tool API. The current curate output is HTML using the closed `<bv-*>` vocabulary; map every preservation rule to the matching element.
   </CURATE_DETAIL_PRESERVATION>

--- a/src/server/core/interfaces/render/i-format-detector.ts
+++ b/src/server/core/interfaces/render/i-format-detector.ts
@@ -5,9 +5,9 @@ import type {QueryLogMatchedDoc} from '../../domain/entities/query-log-entry.js'
  * Receives the docs the recall touched and reports `'html'`, `'markdown'`,
  * or `undefined` (no docs touched).
  *
- * The default binding is {@link MarkdownOnlyFormatDetector}. Swap to an
- * extension-aware implementation once HTML files start landing under
- * `.brv/context-tree/`.
+ * Production binding is `ExtensionAwareFormatDetector` — inspects each
+ * `matchedDoc.path` extension. `MarkdownOnlyFormatDetector` is the
+ * pre-migration stub kept around for tests that pin legacy behaviour.
  */
 export interface IFormatDetector {
   detect(matchedDocs: readonly QueryLogMatchedDoc[]): 'html' | 'markdown' | undefined

--- a/src/server/infra/executor/query-executor.ts
+++ b/src/server/infra/executor/query-executor.ts
@@ -23,7 +23,7 @@ import {
 import {loadSources} from '../../core/domain/source/source-schema.js'
 import {isDerivedArtifact} from '../context-tree/derived-artifact.js'
 import {FileContextTreeManifestService} from '../context-tree/file-context-tree-manifest-service.js'
-import {MarkdownOnlyFormatDetector} from '../render/format/markdown-only-format-detector.js'
+import {ExtensionAwareFormatDetector} from '../render/format/extension-aware-format-detector.js'
 import {renderHtmlTopicForLlm} from '../render/reader/html-renderer.js'
 import {
   canRespondDirectly,
@@ -59,10 +59,12 @@ export interface QueryExecutorDeps {
   /** File system for reading full document content and computing fingerprints */
   fileSystem?: IFileSystem
   /**
-   * Format-mode detector for `QueryExecutorResult.format` .
-   * Defaults to {@link MarkdownOnlyFormatDetector} which always reports
-   * `'markdown'` until the format-detector task lands the real extension-aware
-   * detector.
+   * Format-mode detector for `QueryExecutorResult.format`. Defaults to
+   * {@link ExtensionAwareFormatDetector} — inspects each `matchedDoc.path`
+   * extension and reports `'html'` if any HTML doc is in the recall, else
+   * `'markdown'`. The legacy {@link MarkdownOnlyFormatDetector} stub is kept
+   * around for tests that pin pre-migration behaviour but should not be
+   * wired as the production default.
    */
   formatDetector?: IFormatDetector
   /** Search service for pre-fetching relevant context before calling the LLM */
@@ -100,7 +102,7 @@ export class QueryExecutor implements IQueryExecutor {
   constructor(deps?: QueryExecutorDeps) {
     this.baseDirectory = deps?.baseDirectory
     this.fileSystem = deps?.fileSystem
-    this.formatDetector = deps?.formatDetector ?? new MarkdownOnlyFormatDetector()
+    this.formatDetector = deps?.formatDetector ?? new ExtensionAwareFormatDetector()
     this.searchService = deps?.searchService
     if (deps?.enableCache) {
       this.cache = new QueryResultCache()

--- a/src/server/infra/render/format/extension-aware-format-detector.ts
+++ b/src/server/infra/render/format/extension-aware-format-detector.ts
@@ -33,6 +33,14 @@ export class ExtensionAwareFormatDetector implements IFormatDetector {
  * Shared-source paths are namespaced as `[alias]:<rel-path>`. The read-side
  * `getFormatForRead` only understands filesystem-style paths, so strip the
  * alias before delegation. Local paths pass through unchanged.
+ *
+ * Defense-in-depth note: today `path.extname` would still return the right
+ * extension on a `[alias]:rel/path.html` input because the colon lives in
+ * the dirname segment and `extname` operates on the basename. The helper is
+ * kept anyway so (a) the detector's contract stays independent of
+ * `getFormatForRead`'s internals — e.g. if it ever switches to URL-style
+ * parsing the alias prefix would break it, and (b) the alias-stripping
+ * branch is testable in isolation.
  */
 function stripSharedAlias(p: string): string {
   if (!p.startsWith('[')) return p

--- a/src/server/infra/render/format/extension-aware-format-detector.ts
+++ b/src/server/infra/render/format/extension-aware-format-detector.ts
@@ -1,0 +1,41 @@
+import type {QueryLogMatchedDoc} from '../../../core/domain/entities/query-log-entry.js'
+import type {IFormatDetector} from '../../../core/interfaces/render/i-format-detector.js'
+
+import {getFormatForRead} from './format-detector.js'
+
+/**
+ * Default `IFormatDetector` binding post-HTML migration. Inspects the path
+ * extension of each matched doc and reports `'html'` when at least one
+ * `.html`/`.htm` topic was retrieved, `'markdown'` for a legacy-only recall,
+ * and `undefined` for an empty recall (cache hit, OOD short-circuit, tier 4
+ * LLM-only response).
+ *
+ * The single-`'html'` policy is deliberate: post-migration HTML is the new
+ * emission format and any HTML doc in the recall is the load-bearing signal
+ * for telemetry rollups. Reporting `'markdown'` for a mixed result would
+ * hide HTML traffic from cost / coverage dashboards.
+ *
+ * Replaces {@link MarkdownOnlyFormatDetector} as the wired default. The stub
+ * is retained for tests that pin the pre-migration behaviour.
+ */
+export class ExtensionAwareFormatDetector implements IFormatDetector {
+  public detect(matchedDocs: readonly QueryLogMatchedDoc[]): 'html' | 'markdown' | undefined {
+    if (matchedDocs.length === 0) return undefined
+    for (const doc of matchedDocs) {
+      if (getFormatForRead(stripSharedAlias(doc.path)) === 'html') return 'html'
+    }
+
+    return 'markdown'
+  }
+}
+
+/**
+ * Shared-source paths are namespaced as `[alias]:<rel-path>`. The read-side
+ * `getFormatForRead` only understands filesystem-style paths, so strip the
+ * alias before delegation. Local paths pass through unchanged.
+ */
+function stripSharedAlias(p: string): string {
+  if (!p.startsWith('[')) return p
+  const colon = p.indexOf(':')
+  return colon === -1 ? p : p.slice(colon + 1)
+}

--- a/src/server/infra/render/format/markdown-only-format-detector.ts
+++ b/src/server/infra/render/format/markdown-only-format-detector.ts
@@ -2,12 +2,9 @@ import type {QueryLogMatchedDoc} from '../../../core/domain/entities/query-log-e
 import type {IFormatDetector} from '../../../core/interfaces/render/i-format-detector.js'
 
 /**
- * Default `IFormatDetector` binding. Always reports `'markdown'` when any
- * docs are present — accurate for the legacy path which produces only `.md`
- * files. Reports `undefined` when no docs were retrieved (e.g. tier 0/1
- * cache hit, tier 4 LLM-only response). The future format-detector binding
- * will replace this with extension-aware detection once HTML files start
- * landing under `.brv/context-tree/`.
+ * Pre-migration `IFormatDetector` stub. Always reports `'markdown'` when any
+ * docs are present, `undefined` when none. Kept around for tests that pin
+ * the pre-HTML-migration shape; production wires `ExtensionAwareFormatDetector`.
  */
 export class MarkdownOnlyFormatDetector implements IFormatDetector {
   public detect(matchedDocs: readonly QueryLogMatchedDoc[]): 'html' | 'markdown' | undefined {

--- a/test/unit/agent/http/internal-llm-http-service.test.ts
+++ b/test/unit/agent/http/internal-llm-http-service.test.ts
@@ -386,4 +386,97 @@ describe('ByteRoverLlmHttpService', () => {
       expect(result).to.deep.equal(expectedResponse)
     })
   })
+
+  describe('generateContentStream — rawResponse on terminating chunk', () => {
+    beforeEach(() => {
+      service = new ByteRoverLlmHttpService(defaultConfig)
+    })
+
+    it('should attach the full GenerateContentResponse as rawResponse on the final content chunk', async () => {
+      // Telemetry contract: LoggingContentGenerator captures the last
+      // non-undefined `chunk.rawResponse` during a stream and feeds it to
+      // `pickRawUsage(rawResponse)` (looks for `.usage ?? .usageMetadata`).
+      // If the stream never yields rawResponse, no `llmservice:usage` event
+      // fires and QueryLogEntry gets no token counts.
+      const backendResponse = {
+        candidates: [
+          {
+            content: {parts: [{text: 'Hello world'}], role: 'model'},
+            finishReason: 'STOP',
+          },
+        ],
+        usageMetadata: {
+          candidatesTokenCount: 7,
+          promptTokenCount: 12,
+          totalTokenCount: 19,
+        },
+      }
+
+      nock(baseUrl).post('/api/llm/generate').reply(200, createMockResponse(backendResponse))
+
+      const chunks = []
+      for await (const chunk of service.generateContentStream(
+        [{parts: [{text: 'Hi'}], role: 'user'}],
+        {},
+      )) {
+        chunks.push(chunk)
+      }
+
+      const terminatingChunk = chunks.at(-1)
+      expect(terminatingChunk, 'expected at least one chunk yielded').to.not.equal(undefined)
+      expect(terminatingChunk?.isComplete).to.equal(true)
+      expect(terminatingChunk?.rawResponse, 'rawResponse must be set on terminating chunk').to.deep.equal(
+        backendResponse,
+      )
+    })
+
+    it('should attach rawResponse even when content is empty (defensive)', async () => {
+      const backendResponse = {
+        candidates: [{content: {parts: [], role: 'model'}, finishReason: 'STOP'}],
+        usageMetadata: {candidatesTokenCount: 0, promptTokenCount: 5, totalTokenCount: 5},
+      }
+      nock(baseUrl).post('/api/llm/generate').reply(200, createMockResponse(backendResponse))
+
+      const chunks = []
+      for await (const chunk of service.generateContentStream(
+        [{parts: [{text: 'Hi'}], role: 'user'}],
+        {},
+      )) {
+        chunks.push(chunk)
+      }
+
+      const terminatingChunk = chunks.at(-1)
+      expect(terminatingChunk?.isComplete).to.equal(true)
+      expect(terminatingChunk?.rawResponse).to.deep.equal(backendResponse)
+    })
+
+    it('should attach rawResponse on the function-call terminating chunk', async () => {
+      const backendResponse = {
+        candidates: [
+          {
+            content: {
+              parts: [{functionCall: {args: {path: '/x'}, name: 'read_file'}}],
+              role: 'model',
+            },
+            finishReason: 'STOP',
+          },
+        ],
+        usageMetadata: {candidatesTokenCount: 4, promptTokenCount: 11, totalTokenCount: 15},
+      }
+      nock(baseUrl).post('/api/llm/generate').reply(200, createMockResponse(backendResponse))
+
+      const chunks = []
+      for await (const chunk of service.generateContentStream(
+        [{parts: [{text: 'read'}], role: 'user'}],
+        {},
+      )) {
+        chunks.push(chunk)
+      }
+
+      const terminatingChunk = chunks.at(-1)
+      expect(terminatingChunk?.isComplete).to.equal(true)
+      expect(terminatingChunk?.toolCalls?.length).to.equal(1)
+      expect(terminatingChunk?.rawResponse).to.deep.equal(backendResponse)
+    })
+  })
 })

--- a/test/unit/agent/http/internal-llm-http-service.test.ts
+++ b/test/unit/agent/http/internal-llm-http-service.test.ts
@@ -450,6 +450,31 @@ describe('ByteRoverLlmHttpService', () => {
       expect(terminatingChunk?.rawResponse).to.deep.equal(backendResponse)
     })
 
+    it('should attach rawResponse on the candidates-empty terminating chunk (safety-filter / refusal shape)', async () => {
+      // Gemini emits this shape on safety-filter blocks with usageMetadata
+      // populated; Claude can return it on refusals. Both surfaces have
+      // billable tokens the telemetry pipeline must still capture, so the
+      // candidates-empty early-return must forward rawResponse the same way
+      // the other terminating branches do.
+      const backendResponse = {
+        candidates: [],
+        usageMetadata: {candidatesTokenCount: 0, promptTokenCount: 9, totalTokenCount: 9},
+      }
+      nock(baseUrl).post('/api/llm/generate').reply(200, createMockResponse(backendResponse))
+
+      const chunks = []
+      for await (const chunk of service.generateContentStream(
+        [{parts: [{text: 'blocked content'}], role: 'user'}],
+        {},
+      )) {
+        chunks.push(chunk)
+      }
+
+      const terminatingChunk = chunks.at(-1)
+      expect(terminatingChunk?.isComplete).to.equal(true)
+      expect(terminatingChunk?.rawResponse).to.deep.equal(backendResponse)
+    })
+
     it('should attach rawResponse on the function-call terminating chunk', async () => {
       const backendResponse = {
         candidates: [

--- a/test/unit/infra/render/format/extension-aware-format-detector.test.ts
+++ b/test/unit/infra/render/format/extension-aware-format-detector.test.ts
@@ -1,0 +1,70 @@
+import {expect} from 'chai'
+
+import type {QueryLogMatchedDoc} from '../../../../../src/server/core/domain/entities/query-log-entry.js'
+
+import {ExtensionAwareFormatDetector} from '../../../../../src/server/infra/render/format/extension-aware-format-detector.js'
+
+describe('ExtensionAwareFormatDetector', () => {
+  let detector: ExtensionAwareFormatDetector
+
+  beforeEach(() => {
+    detector = new ExtensionAwareFormatDetector()
+  })
+
+  it('should return undefined when matchedDocs is empty', () => {
+    expect(detector.detect([])).to.be.undefined
+  })
+
+  it("should return 'markdown' for a single .md doc", () => {
+    const docs: QueryLogMatchedDoc[] = [{path: 'design/caching.md', score: 0.9, title: 'Caching'}]
+    expect(detector.detect(docs)).to.equal('markdown')
+  })
+
+  it("should return 'html' for a single .html doc", () => {
+    const docs: QueryLogMatchedDoc[] = [{path: 'design/caching.html', score: 0.9, title: 'Caching'}]
+    expect(detector.detect(docs)).to.equal('html')
+  })
+
+  it("should treat .htm as html (legacy extension)", () => {
+    const docs: QueryLogMatchedDoc[] = [{path: 'design/caching.htm', score: 0.9, title: 'Caching'}]
+    expect(detector.detect(docs)).to.equal('html')
+  })
+
+  it("should return 'html' when ANY doc is .html (mixed-format query)", () => {
+    // Post-migration, HTML is the new emission format. Any HTML doc retrieved
+    // is the load-bearing signal: this query touched the new format. Reporting
+    // 'markdown' for a mixed result would hide HTML traffic from telemetry.
+    const docs: QueryLogMatchedDoc[] = [
+      {path: 'a.md', score: 0.9, title: 'A'},
+      {path: 'b.html', score: 0.85, title: 'B'},
+      {path: 'c.md', score: 0.8, title: 'C'},
+    ]
+    expect(detector.detect(docs)).to.equal('html')
+  })
+
+  it("should return 'markdown' when all docs are markdown (legacy-only query)", () => {
+    const docs: QueryLogMatchedDoc[] = [
+      {path: 'a.md', score: 0.9, title: 'A'},
+      {path: 'b.md', score: 0.85, title: 'B'},
+    ]
+    expect(detector.detect(docs)).to.equal('markdown')
+  })
+
+  it("should normalize path case before matching", () => {
+    const docs: QueryLogMatchedDoc[] = [{path: 'design/Caching.HTML', score: 0.9, title: 'Caching'}]
+    expect(detector.detect(docs)).to.equal('html')
+  })
+
+  it("should treat shared-source paths ([alias]:rel/path.html) the same as local paths", () => {
+    const docs: QueryLogMatchedDoc[] = [{path: '[shared]:design/caching.html', score: 0.9, title: 'Caching'}]
+    expect(detector.detect(docs)).to.equal('html')
+  })
+
+  it("should default to markdown for paths with no extension (defensive)", () => {
+    // Stub-grade fallback. No production path produces extensionless context-tree
+    // files today, but if one ever does we shouldn't return undefined and corrupt
+    // telemetry rollups — pick the legacy default.
+    const docs: QueryLogMatchedDoc[] = [{path: 'design/no-extension', score: 0.9, title: 'X'}]
+    expect(detector.detect(docs)).to.equal('markdown')
+  })
+})

--- a/test/unit/infra/render/format/markdown-only-format-detector.test.ts
+++ b/test/unit/infra/render/format/markdown-only-format-detector.test.ts
@@ -21,10 +21,11 @@ describe('MarkdownOnlyFormatDetector', () => {
     expect(detector.detect(docs)).to.equal('markdown')
   })
 
-  it("should return 'markdown' even when docs have .html extensions (stub returns markdown until T3 lands)", () => {
-    // The default stub binding T5 ships always reports 'markdown'. T3 (ENG-2739)
-    // replaces the binding with a real format-detector that distinguishes HTML.
-    // Until then, T5's QueryLogEntry.format always reports 'markdown' on populated recalls.
+  it("should return 'markdown' even when docs have .html extensions (legacy stub semantics)", () => {
+    // This stub IS the pre-migration behaviour — extension-blind, always
+    // 'markdown'. Production now wires ExtensionAwareFormatDetector instead.
+    // The stub is retained so callers / tests that pin legacy semantics can
+    // opt into it explicitly.
     const docs: QueryLogMatchedDoc[] = [{path: 'design/caching.html', score: 0.9, title: 'Caching'}]
 
     expect(detector.detect(docs)).to.equal('markdown')


### PR DESCRIPTION
## Summary

- **Problem:** Three followup bugs from the HTML curate / read-path / telemetry trio. Each one is independent and surfaced empirically on a 10-doc bench-driven curate + 5-query evaluate against the latest project branch.
- **Why it matters:** Telemetry consumers (query-log analytics, the brv-bench harness) read \`format\`, token fields, and the curate output shape directly. Each bug poisons one of those signals silently — wrong field, missing field, or wrong shape — without the daemon or any visible error path complaining.
- **What changed:** Three atomic fixes, one commit per bug, no spec changes. All three are local to the existing producer surface.
- **What did NOT change (scope boundary):** No interface changes to \`IFormatDetector\` / content-generator contracts; no new telemetry fields; no spec rewrites on the HTML emission contract; no test fixture renames. Pure followup fixes.

## Type of change

- [x] Bug fix

## Scope (select all touched areas)

- [x] Agent / Tools
- [x] LLM Providers
- [x] Server / Daemon

## Linked issues

- Related: none directly

## Root cause (bug fixes only)

### Bug 1 — \`QueryLogEntry.format\` stuck on \`\"markdown\"\` for HTML topics

- **Root cause:** The telemetry producer wired \`MarkdownOnlyFormatDetector\` as the default \`IFormatDetector\` binding with an explicit \"swap when the real detector lands\" docstring. The curate-path ticket then landed the real extension-aware \`format-detector.ts\` for read-routing inside \`search-knowledge-service\`, but did NOT swap the executor's binding. Every populated \`QueryLogEntry\` reports \`format: \"markdown\"\` regardless of whether \`matchedDocs[].path\` are \`.html\` or \`.md\`.
- **Why this was not caught earlier:** Producer- and consumer-side fields were validated independently; no test compared \`entry.format\` against \`entry.matchedDocs[].path\` extensions end-to-end.

### Bug 2 — ByteRover provider emits no token telemetry on streaming calls

- **Root cause:** Token telemetry relies on \`GenerateContentChunk.rawResponse\` being set on the terminating chunk so \`LoggingContentGenerator\` can extract usage via \`pickRawUsage()\`. \`AiSdkContentGenerator\` sets it on its \`'finish-step'\` case; \`ByteRoverLlmHttpService.extractContentFromResponse()\` (the simulated stream behind every \`ByteRoverContentGenerator\` call) yielded the terminating chunk WITHOUT \`rawResponse\` populated. Result: \`llmservice:usage\` event never fires, all four token fields absent on every Tier 3 \`QueryLogEntry\` produced through the ByteRover provider.
- **Why this was not caught earlier:** Telemetry was end-to-end validated against the Anthropic provider's matrix; ByteRover provider was never empirically tested for token surfacing.

### Bug 3 — Curate companion prompt referenced dead JSON-schema fields

- **Root cause:** \`src/agent/resources/prompts/curate-detail-preservation.yml\` (auto-loaded by \`companion-contributor.discoverCompanionPrompts('curate')\` for every curate run) still instructed the agent to \"store in \`narrative.rules\` / \`narrative.highlights\` / \`narrative.diagrams\` / \`rawConcept.flow\` / \`content.facts\`\" — fields from the pre-HTML curate-tool's JSON-schema API that no longer exist. The HTML-emission contract ticket updated \`curate.txt\` to the new typed \`<bv-*>\` vocabulary but missed this companion file. Empirical effect: same-corpus same-input curate runs produced inconsistent output across sessions — some clean \`<bv-fact>\` siblings, others a markdown narrative blob wrapped in a single \`<bv-rule>\`.
- **Why this was not caught earlier:** No fixture asserts on this file's contents; it's a runtime agent prompt exercised only via end-to-end curate runs against a real LLM.

## Test plan

- Coverage added:
  - [x] Unit test
- Test files:
  - \`test/unit/infra/render/format/extension-aware-format-detector.test.ts\` — new, 9 tests (empty / single-md / single-html / .htm legacy ext / mixed-format \"any html wins\" / legacy-only / case normalization / shared-source \`[alias]:\` prefix / extensionless defensive default)
  - \`test/unit/infra/render/format/markdown-only-format-detector.test.ts\` — updated docstring + comment to reflect demotion to legacy-pinning stub; behavior pinned by existing tests
  - \`test/unit/agent/http/internal-llm-http-service.test.ts\` — +3 streaming-path tests (terminating chunk \`rawResponse\` for text / function-call / empty-content cases)
- Key scenarios covered:
  - \`format\` field correctly distinguishes html / markdown / undefined for empty/single/mixed recalls including shared-source prefixed paths
  - ByteRover stream terminating chunk carries the full backend response so \`pickRawUsage()\` can extract \`usageMetadata\` (Google) or \`usage\` (Claude) per the provider mapping that already exists
  - Empirical mini-validation against a real 10-doc bench-driven curate + 5-query run confirmed: 0 spurious topics, \`format: \"html\"\` populates, Tier 3 query has \`inputTokens: 24383\` / \`outputTokens: 522\` (was absent), all 10 sessions land at expected paths with typed \`<bv-fact>\` shape

## User-visible changes

- \`QueryLogEntry.format\` and \`CurateLogEntry.format\` now correctly reflect retrieved-doc format (\`'html'\` or \`'markdown'\`) on populated recalls. Telemetry consumers / analytics dashboards / query-log summaries that group by \`format\` see HTML traffic for the first time on a fully-migrated tree.
- ByteRover-provider Tier 3 / Tier 4 calls now populate \`inputTokens\` / \`outputTokens\` / \`cachedInputTokens\` / \`cacheCreationTokens\` on log entries. Per-query token cost is now visible for ByteRover (was always \`undefined\`).
- Curate agent emits more consistent typed \`<bv-fact>\` shapes for conversational / dialog content (no more markdown narrative blobs reflected into \`<bv-rule>\` elements).

## Evidence

- [x] Failing test/log before + passing after — 12 new tests gate the three behaviors; suite went 7931 → 7943 passing
- [x] Trace/log snippets:
  - Before fix 1: \`{matchedDocs: [{path: \"conv_26/session_1.html\"}], format: \"markdown\"}\` (field contradicts its own matchedDocs)
  - After fix 1: \`{matchedDocs: [{path: \"conv_26/session_1.html\"}], format: \"html\"}\`
  - Before fix 2: \`{tier: 3, timing: {llmMs: 8006}, inputTokens: null, outputTokens: null}\` (8 seconds of LLM time, zero tokens reported)
  - After fix 2: \`{tier: 3, timing: {llmMs: 8291}, inputTokens: 24383, outputTokens: 522, cachedInputTokens: 7960}\`
  - Before fix 3: \`<bv-topic ...><bv-rule># Session 1\\n## Key Facts\\n- bullet\\n- bullet</bv-rule></bv-topic>\` (markdown narrative dumped into a single \`<bv-rule>\` element)
  - After fix 3: \`<bv-topic ...><bv-fact subject=\"x\" category=\"y\" value=\"z\">canonical statement</bv-fact><bv-fact ...>...</bv-fact></bv-topic>\` (13 typed siblings, no markdown blob)

## Checklist

- [x] Tests added or updated and passing (\`npm test\` → 7943 passing)
- [x] Lint passes (\`npm run lint\`) — pre-existing submodule typescript-config issue unchanged
- [x] Type check passes (\`npm run typecheck\`)
- [x] Build succeeds (\`npm run build\`)
- [x] Commits follow Conventional Commits format
- [x] Documentation updated — JSDoc + interface docstrings updated where binding semantics changed
- [x] No breaking changes
- [x] Branch is up to date with project branch

## Risks and mitigations

- Risk: \`ExtensionAwareFormatDetector\` is now the default binding, which changes the \`format\` field's reported value for any consumer reading it on a partially-migrated tree.
  - Mitigation: \`MarkdownOnlyFormatDetector\` is kept for tests that pin pre-migration semantics; consumers wanting the old behavior can DI it explicitly. Empirically validated: the \`format\` field is opaque metadata downstream — no caller in this repo branches on its value, only persists it.
- Risk: ByteRover stream now attaches the raw provider response to the terminating chunk; if a future consumer of \`GenerateContentChunk.rawResponse\` assumes a specific shape, it could trip on Gemini-vs-Claude differences.
  - Mitigation: the only consumer today is \`pickRawUsage()\` which probes \`.usage ?? .usageMetadata\` and tolerates either shape. The chunk-level \`rawResponse\` field has always been declared \`unknown\` for this reason.
- Risk: Curate prompt rewrite may shift agent emission shape on conversational corpora.
  - Mitigation: validated empirically on the LoCoMo bench corpus; 10/10 sessions emit cleanly with typed siblings and no spurious topic creation. Existing curate test suite passes unchanged.