### PR TITLE
[ENG-2769] brv read <path> — single-topic render command

### DIFF
--- a/src/oclif/commands/read.ts
+++ b/src/oclif/commands/read.ts
@@ -1,0 +1,82 @@
+import {Args, Command, Flags} from '@oclif/core'
+
+import {writeJsonResponse} from '../lib/json-response.js'
+import {readTopic, resolveProjectRoot} from '../lib/read-topic.js'
+
+/**
+ * `brv read <path>` — fetch a single topic from
+ * `.brv/context-tree/<path>` as rendered markdown (HTML topics) or
+ * raw markdown (MD topics).
+ *
+ * Thin wrapper over `readTopic` from the lib module. The command
+ * is intentionally narrow: it reads one file and prints it. No
+ * caching, no batch-read, no subtree listing — those are separate
+ * primitives if/when needed.
+ *
+ * Primary consumer: the curate skill's UPDATE path, where the
+ * calling agent needs to see an existing topic's content before
+ * authoring a merged update. Today's `brv search` returns excerpts
+ * only; `brv read` exists to surface the full topic cleanly.
+ */
+export default class Read extends Command {
+  public static args = {
+    path: Args.string({
+      description: 'Topic path relative to .brv/context-tree/ (e.g., "security/auth.html")',
+      required: true,
+    }),
+  }
+  public static description = `Read a topic file from .brv/context-tree/
+
+HTML topics route through the html-renderer to produce clean markdown that preserves bv-* element semantics (severity, id, subject/value). Markdown topics pass through unchanged. Pass --raw to get source bytes regardless of format.`
+  public static examples = [
+    '<%= config.bin %> <%= command.id %> security/auth.html',
+    '<%= config.bin %> <%= command.id %> security/auth.html --format json',
+    '<%= config.bin %> <%= command.id %> security/auth.html --raw',
+  ]
+  public static flags = {
+    format: Flags.string({
+      char: 'f',
+      default: 'text',
+      description: 'Output format',
+      options: ['text', 'json'],
+    }),
+    raw: Flags.boolean({
+      default: false,
+      description: 'Return source bytes (no HTML→markdown rendering)',
+    }),
+  }
+
+  public async run(): Promise<void> {
+    const {args, flags} = await this.parse(Read)
+    const isJson = flags.format === 'json'
+
+    const projectRoot = resolveProjectRoot()
+    const result = await readTopic(projectRoot, args.path, {raw: flags.raw})
+
+    if (result.ok) {
+      if (isJson) {
+        writeJsonResponse({
+          command: 'read',
+          data: {content: result.content, format: result.format, path: result.path},
+          success: true,
+        })
+      } else {
+        this.log(result.content)
+      }
+
+      return
+    }
+
+    if (isJson) {
+      writeJsonResponse({
+        command: 'read',
+        data: {error: result.error, path: result.path},
+        success: false,
+      })
+    } else {
+      this.log(`Error (${result.error.kind}): ${result.error.message}`)
+    }
+
+    process.exitCode = 1
+  }
+}

--- a/src/oclif/lib/read-topic.ts
+++ b/src/oclif/lib/read-topic.ts
@@ -1,0 +1,136 @@
+import {existsSync} from 'node:fs'
+import {readFile} from 'node:fs/promises'
+import {isAbsolute, join, resolve as pathResolve, sep as pathSep} from 'node:path'
+
+import {BRV_DIR, CONTEXT_TREE_DIR} from '../../server/constants.js'
+import {renderHtmlTopicForLlm} from '../../server/infra/render/reader/html-renderer.js'
+
+/**
+ * Read a single topic file from `.brv/context-tree/<relPath>` and
+ * return its content (rendered or raw). Consumed by `brv read` and
+ * by any other tool that needs a focused single-topic fetch — the
+ * curate skill's UPDATE path is the canonical caller, since today's
+ * `brv search` returns excerpts only.
+ *
+ * Behaviour:
+ *   - `.html` topic → routed through `renderHtmlTopicForLlm` to give
+ *     the calling agent clean markdown (severity / id / subject /
+ *     value preserved, raw `<bv-*>` markup stripped). With `raw: true`,
+ *     the source bytes pass through unchanged.
+ *   - `.md` (or any non-`.html`) topic → source bytes pass through
+ *     unchanged. Markdown is already markdown; no rendering layer.
+ *
+ * Path safety:
+ *   - Rejects absolute paths.
+ *   - Rejects `..` / `.` segments.
+ *   - Defence-in-depth: resolved path must stay inside the
+ *     `.brv/context-tree/` root.
+ */
+
+export type ReadTopicResult =
+  | {content: string; format: 'html' | 'markdown'; ok: true; path: string}
+  | {error: ReadTopicError; ok: false; path: string}
+
+export type ReadTopicError =
+  | {kind: 'not-found'; message: string}
+  | {kind: 'read-failed'; message: string}
+  | {kind: 'unsafe-path'; message: string}
+
+export type ReadTopicOptions = {
+  /** When true, return the source bytes unchanged (no HTML→markdown render). */
+  raw?: boolean
+}
+
+/**
+ * Read a topic from `<projectRoot>/.brv/context-tree/<relPath>`.
+ *
+ * `relPath` is the path relative to `.brv/context-tree/` —
+ * matches the shape the search service emits in `results[].path`
+ * and the shape the curate envelope's `filePath` carries on `done`.
+ */
+export async function readTopic(
+  projectRoot: string,
+  relPath: string,
+  options: ReadTopicOptions = {},
+): Promise<ReadTopicResult> {
+  const safety = checkPathSafety(relPath)
+  if (!safety.ok) {
+    return {error: {kind: 'unsafe-path', message: safety.message}, ok: false, path: relPath}
+  }
+
+  const contextTreeRoot = pathResolve(projectRoot, BRV_DIR, CONTEXT_TREE_DIR)
+  const fullPath = pathResolve(contextTreeRoot, relPath)
+
+  // Defence-in-depth: after resolve(), confirm the absolute path is
+  // still inside the context-tree root. Catches edge-case traversals
+  // that slip past the segment check (e.g. on case-insensitive FS
+  // or with unicode normalisation surprises).
+  if (!fullPath.startsWith(contextTreeRoot + pathSep) && fullPath !== contextTreeRoot) {
+    return {
+      error: {kind: 'unsafe-path', message: `Resolved path escapes context-tree root: ${relPath}`},
+      ok: false,
+      path: relPath,
+    }
+  }
+
+  if (!existsSync(fullPath)) {
+    return {
+      error: {kind: 'not-found', message: `Topic not found at .brv/context-tree/${relPath}`},
+      ok: false,
+      path: relPath,
+    }
+  }
+
+  let raw: string
+  try {
+    raw = await readFile(fullPath, 'utf8')
+  } catch (error) {
+    return {
+      error: {kind: 'read-failed', message: error instanceof Error ? error.message : String(error)},
+      ok: false,
+      path: relPath,
+    }
+  }
+
+  const format = relPath.toLowerCase().endsWith('.html') ? 'html' : 'markdown'
+  const content = format === 'html' && !options.raw ? renderHtmlTopicForLlm(raw) : raw
+
+  return {content, format, ok: true, path: relPath}
+}
+
+function checkPathSafety(relPath: string): {message: string; ok: false} | {ok: true} {
+  if (relPath.length === 0) {
+    return {message: 'Path is empty.', ok: false}
+  }
+
+  if (isAbsolute(relPath)) {
+    return {message: `Path must be relative to .brv/context-tree/, got absolute: ${relPath}`, ok: false}
+  }
+
+  const normalized = relPath.replaceAll('\\', '/').replace(/^\/+/, '')
+  const segments = normalized.split('/').filter((s) => s.length > 0)
+  for (const segment of segments) {
+    if (segment === '..' || segment === '.') {
+      return {message: `Path may not contain "${segment}" segment: ${relPath}`, ok: false}
+    }
+  }
+
+  return {ok: true}
+}
+
+/**
+ * Convenience helper for the CLI: resolve the project root from
+ * cwd, then read. Wraps `readTopic` so callers don't repeat the
+ * walk-up logic.
+ *
+ * Importing the existing `resolveProjectRoot` from `curate-session`
+ * (where it already lives) instead of duplicating the walk-up,
+ * keeping changes additive — no other module is touched by this
+ * feature.
+ */
+export {resolveProjectRoot} from './curate-session.js'
+
+/** Re-export `join` so call sites that need to log the absolute path can compose it. */
+export function topicAbsolutePath(projectRoot: string, relPath: string): string {
+  return join(projectRoot, BRV_DIR, CONTEXT_TREE_DIR, relPath)
+}

--- a/test/unit/oclif/lib/read-topic.test.ts
+++ b/test/unit/oclif/lib/read-topic.test.ts
@@ -1,0 +1,146 @@
+/**
+ * read-topic tests.
+ *
+ * Pin the contract `brv read` exposes:
+ *   - HTML topics route through the html-renderer (clean markdown,
+ *     element semantics preserved, no raw <bv-*> markup leaks).
+ *   - Markdown topics pass through unchanged.
+ *   - `--raw` returns source bytes regardless of format.
+ *   - Path traversal / absolute paths / missing files return
+ *     structured errors (not throws).
+ */
+
+import {expect} from 'chai'
+import {mkdir, mkdtemp, rm, writeFile} from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+
+import {readTopic} from '../../../../src/oclif/lib/read-topic.js'
+import {BRV_DIR, CONTEXT_TREE_DIR} from '../../../../src/server/constants.js'
+
+const VALID_HTML_TOPIC = `<bv-topic path="security/auth" title="JWT authentication" summary="JWT design.">
+  <bv-reason>Document JWT.</bv-reason>
+  <bv-rule severity="must" id="r-validate">Always validate JWT signatures.</bv-rule>
+  <bv-decision id="d-rs256">Use RS256.</bv-decision>
+</bv-topic>`
+
+const MD_TOPIC = `# Legacy onboarding
+
+Step 1: install brv.
+Step 2: run \`brv init\`.`
+
+describe('readTopic', () => {
+  let projectRoot: string
+
+  beforeEach(async () => {
+    projectRoot = await mkdtemp(join(tmpdir(), 'read-topic-'))
+    const ctRoot = join(projectRoot, BRV_DIR, CONTEXT_TREE_DIR)
+    await mkdir(join(ctRoot, 'security'), {recursive: true})
+    await mkdir(join(ctRoot, 'legacy'), {recursive: true})
+    await writeFile(join(ctRoot, 'security/auth.html'), VALID_HTML_TOPIC, 'utf8')
+    await writeFile(join(ctRoot, 'legacy/onboarding.md'), MD_TOPIC, 'utf8')
+  })
+
+  afterEach(async () => {
+    await rm(projectRoot, {force: true, recursive: true})
+  })
+
+  describe('HTML topics', () => {
+    it('renders an HTML topic to structured markdown by default', async () => {
+      const result = await readTopic(projectRoot, 'security/auth.html')
+
+      expect(result.ok).to.equal(true)
+      if (result.ok) {
+        expect(result.format).to.equal('html')
+        expect(result.path).to.equal('security/auth.html')
+        // bv-* markup must be stripped; element semantics survive.
+        expect(result.content).to.not.match(/<bv-/)
+        expect(result.content).to.include('- **Rule** [must] (r-validate): Always validate JWT signatures.')
+        expect(result.content).to.include('- **Decision** (d-rs256): Use RS256.')
+      }
+    })
+
+    it('returns source HTML bytes verbatim when raw=true', async () => {
+      const result = await readTopic(projectRoot, 'security/auth.html', {raw: true})
+
+      expect(result.ok).to.equal(true)
+      if (result.ok) {
+        expect(result.format).to.equal('html')
+        expect(result.content).to.equal(VALID_HTML_TOPIC)
+      }
+    })
+  })
+
+  describe('Markdown topics', () => {
+    it('passes markdown through unchanged regardless of raw flag', async () => {
+      for (const opts of [{}, {raw: true}, {raw: false}]) {
+        // eslint-disable-next-line no-await-in-loop
+        const result = await readTopic(projectRoot, 'legacy/onboarding.md', opts)
+
+        expect(result.ok, `opts=${JSON.stringify(opts)}`).to.equal(true)
+        if (result.ok) {
+          expect(result.format).to.equal('markdown')
+          expect(result.content).to.equal(MD_TOPIC)
+        }
+      }
+    })
+  })
+
+  describe('error paths', () => {
+    it('returns not-found for a missing file', async () => {
+      const result = await readTopic(projectRoot, 'does/not/exist.html')
+
+      expect(result.ok).to.equal(false)
+      if (!result.ok) {
+        expect(result.error.kind).to.equal('not-found')
+        expect(result.error.message).to.include('does/not/exist.html')
+      }
+    })
+
+    it('rejects empty path', async () => {
+      const result = await readTopic(projectRoot, '')
+
+      expect(result.ok).to.equal(false)
+      if (!result.ok) {
+        expect(result.error.kind).to.equal('unsafe-path')
+      }
+    })
+
+    it('rejects absolute paths', async () => {
+      const result = await readTopic(projectRoot, '/etc/passwd')
+
+      expect(result.ok).to.equal(false)
+      if (!result.ok) {
+        expect(result.error.kind).to.equal('unsafe-path')
+        expect(result.error.message).to.match(/absolute/i)
+      }
+    })
+
+    it('rejects traversal segments (..) at any position', async () => {
+      const cases = [
+        '../../etc/passwd',
+        'security/../../etc/passwd',
+        '..',
+        '../sibling-project/file',
+      ]
+
+      for (const path of cases) {
+        // eslint-disable-next-line no-await-in-loop
+        const result = await readTopic(projectRoot, path)
+        expect(result.ok, `case: ${path}`).to.equal(false)
+        if (!result.ok) {
+          expect(result.error.kind, `case: ${path}`).to.equal('unsafe-path')
+        }
+      }
+    })
+
+    it('rejects current-dir segments (.) anywhere in the path', async () => {
+      const result = await readTopic(projectRoot, 'security/./auth.html')
+
+      expect(result.ok).to.equal(false)
+      if (!result.ok) {
+        expect(result.error.kind).to.equal('unsafe-path')
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Summary

New `brv read <path>` command — fetches one topic from `.brv/context-tree/<path>` and prints it. HTML topics route through the html-renderer for clean markdown; MD topics pass through verbatim. JSON envelope available for tool consumers; `--raw` returns source bytes.

Primary consumer: the curate skill's UPDATE path. When the calling agent detects an existing topic via `brv search`, it needs the **full content** to author a merged update — and search returns excerpts only. `brv read` is the focused single-topic fetch the SKILL.md flow already references in its loop.

## Type
feat (M1 5/5 — single-topic read command)

## Scope — additive only

- ✅ `src/oclif/commands/read.ts` (new) — thin CLI wrapper
- ✅ `src/oclif/lib/read-topic.ts` (new) — testable lib module
- ✅ `test/unit/oclif/lib/read-topic.test.ts` (new) — 8 tests
- ❌ No existing module modified
- ❌ No CLI flag added to other commands

Imports `resolveProjectRoot` from the existing curate-session lib and `renderHtmlTopicForLlm` from the existing html-renderer module — no modifications to either.

## Surface

```
brv read security/auth.html             # rendered markdown (default)
brv read security/auth.html --format json   # {ok, content, format, path}
brv read security/auth.html --raw       # source HTML bytes
brv read legacy/onboarding.md           # markdown unchanged
```

JSON envelope:
```json
{
  "command": "read",
  "data": { "content": "…", "format": "html"|"markdown", "path": "…" },
  "success": true
}
```

Error envelope:
```json
{
  "command": "read",
  "data": { "error": { "kind": "unsafe-path"|"not-found"|"read-failed", "message": "…" }, "path": "…" },
  "success": false
}
```

## Behaviour

| Input | `--raw=false` (default) | `--raw=true` |
|---|---|---|
| `.html` topic | Rendered markdown via `renderHtmlTopicForLlm` | Source HTML bytes |
| `.md` topic | Source markdown unchanged | Source markdown unchanged |

## Path safety (defence in depth)

1. Reject empty input
2. Reject absolute paths
3. Reject any segment that is `..` or `.`
4. After `path.resolve`, confirm the absolute path stays under `.brv/context-tree/` — catches traversals that slip past the segment check (case-insensitive FS, unicode normalisation edge cases)

## Live verification

Tested against the HTML topic written by the prior TKT 04 demo session (`infra/kubernetes_istio.html`):

```
$ brv read infra/kubernetes_istio.html
# Kubernetes + Istio deployment stack
> Production deployment runs on Kubernetes 1.30 with Istio as the service mesh — Istio fronts inter-service auth and observability.
Tags: infra,kubernetes,istio,service-mesh
Keywords: …

**Reason:** Capture the deployment platform stack…

- **Fact** (subject=kubernetes_version, category=convention, value=1.30): Production clusters run Kubernetes 1.30.
- **Fact** (subject=service_mesh, category=convention, value=istio): …
- **Decision** (d-istio-for-mesh): Use Istio for the service mesh…
```

Element semantics survive (`severity`, `id`, `subject`, `value`); no raw `<bv-*>` markup.

```
$ brv read ../../etc/passwd --format json
→ { "success": false, "data": { "error": { "kind": "unsafe-path", "message": "Path may not contain \"..\" segment: ../../etc/passwd" } } }

$ brv read does/not/exist.html --format json
→ { "success": false, "data": { "error": { "kind": "not-found", "message": "Topic not found at .brv/context-tree/does/not/exist.html" } } }
```

## Tests

8 unit tests in `test/unit/oclif/lib/read-topic.test.ts`:

- HTML rendering preserves bv-* element semantics, strips markup
- `--raw` returns source HTML bytes verbatim
- Markdown topics pass through unchanged regardless of `--raw`
- Missing file → `kind: not-found`
- Empty path → `kind: unsafe-path`
- Absolute path → `kind: unsafe-path`
- 4 traversal variants (`../../etc/passwd`, `security/../../etc/passwd`, `..`, `../sibling`) → `kind: unsafe-path`
- `.` segment anywhere → `kind: unsafe-path`

Plus 7995 pass overall.

## Linked

- ENG-2769 (M1 5/5 — concludes the M1 milestone)
- Sibling tickets: ENG-2765 (protocol), ENG-2766 (state machine), ENG-2767 (prompts), ENG-2768 (skill)

## Checklist

- [x] Lint, typecheck, build clean
- [x] Unit tests cover all error kinds + both formats + `--raw`
- [x] Live verified end-to-end against real CLI
- [x] No existing module modified (additive only)