### PR TITLE
feat: [ENG-2512] rework billing-team resolution and fix project-switch race

### DIFF
--- a/src/oclif/commands/providers/connect.ts
+++ b/src/oclif/commands/providers/connect.ts
@@ -653,8 +653,10 @@ export default class ProviderConnect extends Command {
   }
 
   protected async setBillingPin(teamId: string | undefined, options?: DaemonClientOptions): Promise<void> {
-    await withDaemonRetry(async (client) => {
-      const request: BillingSetPinnedTeamRequest = teamId === undefined ? {} : {teamId}
+    await withDaemonRetry(async (client, projectRoot) => {
+      if (!projectRoot) throw new Error('Failed to resolve project path for billing pin.')
+      const request: BillingSetPinnedTeamRequest =
+        teamId === undefined ? {projectPath: projectRoot} : {projectPath: projectRoot, teamId}
       const response = await client.requestWithAck<BillingSetPinnedTeamResponse>(
         BillingEvents.SET_PINNED_TEAM,
         request,

--- a/src/server/infra/billing/build-status-billing.ts
+++ b/src/server/infra/billing/build-status-billing.ts
@@ -14,7 +14,6 @@ export interface BuildStatusBillingInput {
   isAuthenticated: boolean
   paidUsages: readonly BillingUsageDTO[]
   pinnedTeamId?: string
-  workspaceTeamId?: string
 }
 
 export function buildStatusBilling(input: BuildStatusBillingInput): StatusBillingDTO | undefined {
@@ -28,7 +27,6 @@ export function buildStatusBilling(input: BuildStatusBillingInput): StatusBillin
   const resolved = resolveBillingTeamId({
     paidOrganizationIds: paidIds,
     pinnedTeamId: input.pinnedTeamId,
-    workspaceTeamId: input.workspaceTeamId,
   })
 
   if (resolved === undefined) return freeSource(input.freeUserLimit)

--- a/src/server/infra/billing/resolve-billing-source.ts
+++ b/src/server/infra/billing/resolve-billing-source.ts
@@ -3,7 +3,6 @@ import type {IProviderConfigStore} from '../../core/interfaces/i-provider-config
 import type {IBillingService} from '../../core/interfaces/services/i-billing-service.js'
 import type {IAuthStateStore} from '../../core/interfaces/state/i-auth-state-store.js'
 import type {IBillingConfigStore} from '../../core/interfaces/storage/i-billing-config-store.js'
-import type {IProjectConfigStore} from '../../core/interfaces/storage/i-project-config-store.js'
 
 import {buildStatusBilling} from './build-status-billing.js'
 
@@ -13,10 +12,8 @@ export interface ResolveBillingDeps {
   authStateStore: IAuthStateStore
   billingConfigStoreFactory: (projectPath: string) => IBillingConfigStore
   billingService: IBillingService
-  projectConfigStore: IProjectConfigStore
   projectPath: string
   providerConfigStore: IProviderConfigStore
-  workspaceTeamId?: string
 }
 
 export async function resolveBillingForProject(deps: ResolveBillingDeps): Promise<StatusBillingDTO | undefined> {
@@ -33,20 +30,11 @@ export async function resolveBillingForProject(deps: ResolveBillingDeps): Promis
 
   const {sessionKey} = token
 
-  const readWorkspaceTeamId = async (): Promise<string | undefined> => {
-    if (deps.workspaceTeamId !== undefined) return deps.workspaceTeamId
-    return deps.projectConfigStore
-      .read(deps.projectPath)
-      .then((config) => config?.teamId)
-      .catch((): string | undefined => undefined)
-  }
-
-  const [pinnedTeamId, workspaceTeamId, usagesResult] = await Promise.all([
+  const [pinnedTeamId, usagesResult] = await Promise.all([
     deps
       .billingConfigStoreFactory(deps.projectPath)
       .getPinnedTeamId()
       .catch((): string | undefined => undefined),
-    readWorkspaceTeamId(),
     deps.billingService
       .getUsages(sessionKey)
       .then((usages) => ({ok: true as const, usages}))
@@ -67,6 +55,5 @@ export async function resolveBillingForProject(deps: ResolveBillingDeps): Promis
     isAuthenticated: true,
     paidUsages,
     pinnedTeamId,
-    workspaceTeamId,
   })
 }

--- a/src/server/infra/billing/resolve-billing-team.ts
+++ b/src/server/infra/billing/resolve-billing-team.ts
@@ -1,19 +1,12 @@
 export interface BillingTeamResolverInput {
   paidOrganizationIds: readonly string[]
   pinnedTeamId?: string
-  workspaceTeamId?: string
 }
 
 export function resolveBillingTeamId(input: BillingTeamResolverInput): string | undefined {
-  const { paidOrganizationIds, pinnedTeamId, workspaceTeamId } = input
+  const {paidOrganizationIds, pinnedTeamId} = input
 
   if (pinnedTeamId) return pinnedTeamId
-
-  if (workspaceTeamId && paidOrganizationIds.includes(workspaceTeamId)) {
-    return workspaceTeamId
-  }
-
   if (paidOrganizationIds.length === 1) return paidOrganizationIds[0]
-
   return undefined
 }

--- a/src/server/infra/daemon/agent-process.ts
+++ b/src/server/infra/daemon/agent-process.ts
@@ -29,7 +29,6 @@ import type {BrvConfig} from '../../core/domain/entities/brv-config.js'
 import type {
   BillingPinChangedPayload,
   BillingStateResponse,
-  PaidOrganizationsResponse,
   ProviderConfigResponse,
   TaskExecute,
 } from '../../core/domain/transport/schemas.js'
@@ -55,7 +54,6 @@ import {
   TransportStateEventNames,
   TransportTaskEventNames,
 } from '../../core/domain/transport/schemas.js'
-import {resolveBillingTeamId} from '../billing/resolve-billing-team.js'
 import {FileContextTreeArchiveService} from '../context-tree/file-context-tree-archive-service.js'
 import {RuntimeSignalStore} from '../context-tree/runtime-signal-store.js'
 import {DreamLockService} from '../dream/dream-lock-service.js'
@@ -164,9 +162,7 @@ async function activateExistingSession(sessionId: string, providerId: string): P
  */
 let cachedSessionKey = ''
 let cachedBrvConfig: BrvConfig | undefined
-let cachedTeamId = ''
 let cachedPinnedOrgId: string | undefined
-let cachedPaidOrgIds: readonly string[] = []
 let cachedSpaceId = ''
 let cachedActiveProvider = ''
 let cachedActiveModel = ''
@@ -232,20 +228,17 @@ async function start(): Promise<void> {
     sessionKey?: string
   }
 
-  const [configResult, authResult, providerResult, billingResult, paidOrgsResult] = await Promise.all([
+  const [configResult, authResult, providerResult, billingResult] = await Promise.all([
     transport.requestWithAck<ProjectConfigResponse>(TransportStateEventNames.GET_PROJECT_CONFIG, {projectPath}),
     transport.requestWithAck<AuthResponse>(TransportStateEventNames.GET_AUTH),
     transport.requestWithAck<ProviderConfigResponse>(TransportStateEventNames.GET_PROVIDER_CONFIG),
     transport.requestWithAck<BillingStateResponse>(TransportStateEventNames.GET_BILLING_CONFIG, {projectPath}),
-    transport.requestWithAck<PaidOrganizationsResponse>(TransportStateEventNames.GET_PAID_ORGANIZATIONS),
   ])
 
   cachedBrvConfig = configResult.brvConfig
-  cachedTeamId = configResult.teamId ?? ''
   cachedSpaceId = configResult.spaceId ?? ''
   cachedSessionKey = authResult.sessionKey ?? ''
   cachedPinnedOrgId = billingResult.pinnedTeamId
-  cachedPaidOrgIds = paidOrgsResult.organizationIds
 
   agentLog('Initial config loaded from state server')
 
@@ -255,7 +248,6 @@ async function start(): Promise<void> {
     (data) => {
       if (data.projectPath !== projectPath) return
       if (data.brvConfig) cachedBrvConfig = data.brvConfig
-      if (data.teamId !== undefined) cachedTeamId = data.teamId
       if (data.spaceId !== undefined) cachedSpaceId = data.spaceId
     },
   )
@@ -316,12 +308,7 @@ async function start(): Promise<void> {
     projectIdProvider: () => PROJECT,
     sessionKeyProvider: () => cachedSessionKey,
     spaceIdProvider: () => cachedSpaceId,
-    teamIdProvider: () =>
-      resolveBillingTeamId({
-        paidOrganizationIds: cachedPaidOrgIds,
-        pinnedTeamId: cachedPinnedOrgId,
-        workspaceTeamId: cachedTeamId || undefined,
-      }) ?? '',
+    teamIdProvider: () => cachedPinnedOrgId ?? '',
     transportClient: transport,
   })
 
@@ -508,12 +495,11 @@ async function executeTask(
       // Refresh config from state server to pick up changes from init/space-switch
       // (they write directly to disk, bypassing the agent's cached state)
       try {
-        const configResult = await transport.requestWithAck<{brvConfig?: BrvConfig; spaceId?: string; teamId?: string}>(
+        const configResult = await transport.requestWithAck<{brvConfig?: BrvConfig; spaceId?: string}>(
           TransportStateEventNames.GET_PROJECT_CONFIG,
           {projectPath},
         )
         if (configResult.brvConfig) cachedBrvConfig = configResult.brvConfig
-        if (configResult.teamId !== undefined) cachedTeamId = configResult.teamId
         if (configResult.spaceId !== undefined) cachedSpaceId = configResult.spaceId
       } catch {
         agentLog('Failed to refresh config before task execution')

--- a/src/server/infra/process/feature-handlers.ts
+++ b/src/server/infra/process/feature-handlers.ts
@@ -156,7 +156,6 @@ export async function setupFeatureHandlers({
     authStateStore,
     billingConfigStoreFactory,
     billingService,
-    projectConfigStore,
     providerConfigStore,
     resolveProjectPath,
     transport,

--- a/src/server/infra/transport/handlers/auth-handler.ts
+++ b/src/server/infra/transport/handlers/auth-handler.ts
@@ -13,6 +13,7 @@ import type {ProjectPathResolver} from './handler-types.js'
 
 import {
   AuthEvents,
+  type AuthGetStateRequest,
   type AuthGetStateResponse,
   type AuthLoginWithApiKeyRequest,
   type AuthLoginWithApiKeyResponse,
@@ -214,7 +215,7 @@ export class AuthHandler {
   }
 
   private setupGetState(): void {
-    this.transport.onRequest<void, AuthGetStateResponse>(AuthEvents.GET_STATE, async (_data, clientId) => {
+    this.transport.onRequest<AuthGetStateRequest, AuthGetStateResponse>(AuthEvents.GET_STATE, async (data) => {
       try {
         const token = await this.tokenStore.load()
 
@@ -222,7 +223,7 @@ export class AuthHandler {
           return {isAuthorized: false}
         }
 
-        const projectPath = this.resolveProjectPath(clientId)
+        const {projectPath} = data
         const [user, brvConfig] = await Promise.all([
           this.userService.getCurrentUser(token.sessionKey),
           projectPath ? this.projectConfigStore.read(projectPath) : Promise.resolve(),

--- a/src/server/infra/transport/handlers/billing-handler.ts
+++ b/src/server/infra/transport/handlers/billing-handler.ts
@@ -84,6 +84,7 @@ export class BillingHandler {
     this.transport.onRequest<BillingGetPinnedTeamRequest, BillingGetPinnedTeamResponse>(
       BillingEvents.GET_PINNED_TEAM,
       async (data) => {
+        if (!data.projectPath) return {error: 'projectPath is required'}
         try {
           const store = this.billingConfigStoreFactory(data.projectPath)
           const teamId = await store.getPinnedTeamId()
@@ -162,6 +163,7 @@ export class BillingHandler {
     this.transport.onRequest<BillingSetPinnedTeamRequest, BillingSetPinnedTeamResponse>(
       BillingEvents.SET_PINNED_TEAM,
       async (data) => {
+        if (!data.projectPath) return {error: 'projectPath is required', success: false}
         try {
           const {projectPath} = data
           const store = this.billingConfigStoreFactory(projectPath)

--- a/src/server/infra/transport/handlers/billing-handler.ts
+++ b/src/server/infra/transport/handlers/billing-handler.ts
@@ -4,13 +4,13 @@ import type {IProviderConfigStore} from '../../../core/interfaces/i-provider-con
 import type {IBillingService} from '../../../core/interfaces/services/i-billing-service.js'
 import type {IAuthStateStore} from '../../../core/interfaces/state/i-auth-state-store.js'
 import type {IBillingConfigStore} from '../../../core/interfaces/storage/i-billing-config-store.js'
-import type {IProjectConfigStore} from '../../../core/interfaces/storage/i-project-config-store.js'
 import type {ITransportServer} from '../../../core/interfaces/transport/i-transport-server.js'
 import type {ProjectPathResolver} from './handler-types.js'
 
 import {
   BillingEvents,
   type BillingGetFreeUserLimitResponse,
+  type BillingGetPinnedTeamRequest,
   type BillingGetPinnedTeamResponse,
   type BillingGetUsageRequest,
   type BillingGetUsageResponse,
@@ -28,7 +28,6 @@ export interface BillingHandlerDeps {
   authStateStore: IAuthStateStore
   billingConfigStoreFactory: (projectPath: string) => IBillingConfigStore
   billingService: IBillingService
-  projectConfigStore: IProjectConfigStore
   providerConfigStore: IProviderConfigStore
   resolveProjectPath: ProjectPathResolver
   transport: ITransportServer
@@ -40,7 +39,6 @@ export class BillingHandler {
   private readonly authStateStore: IAuthStateStore
   private readonly billingConfigStoreFactory: (projectPath: string) => IBillingConfigStore
   private readonly billingService: IBillingService
-  private readonly projectConfigStore: IProjectConfigStore
   private readonly providerConfigStore: IProviderConfigStore
   private readonly resolveProjectPath: ProjectPathResolver
   private readonly transport: ITransportServer
@@ -49,7 +47,6 @@ export class BillingHandler {
     this.authStateStore = deps.authStateStore
     this.billingConfigStoreFactory = deps.billingConfigStoreFactory
     this.billingService = deps.billingService
-    this.projectConfigStore = deps.projectConfigStore
     this.providerConfigStore = deps.providerConfigStore
     this.resolveProjectPath = deps.resolveProjectPath
     this.transport = deps.transport
@@ -84,12 +81,11 @@ export class BillingHandler {
   }
 
   private setupGetPinnedTeam(): void {
-    this.transport.onRequest<undefined, BillingGetPinnedTeamResponse>(
+    this.transport.onRequest<BillingGetPinnedTeamRequest, BillingGetPinnedTeamResponse>(
       BillingEvents.GET_PINNED_TEAM,
-      async (_, clientId) => {
+      async (data) => {
         try {
-          const projectPath = resolveRequiredProjectPath(this.resolveProjectPath, clientId)
-          const store = this.billingConfigStoreFactory(projectPath)
+          const store = this.billingConfigStoreFactory(data.projectPath)
           const teamId = await store.getPinnedTeamId()
           return teamId === undefined ? {} : {teamId}
         } catch (error) {
@@ -152,7 +148,6 @@ export class BillingHandler {
           authStateStore: this.authStateStore,
           billingConfigStoreFactory: this.billingConfigStoreFactory,
           billingService: this.billingService,
-          projectConfigStore: this.projectConfigStore,
           projectPath,
           providerConfigStore: this.providerConfigStore,
         })
@@ -166,9 +161,9 @@ export class BillingHandler {
   private setupSetPinnedTeam(): void {
     this.transport.onRequest<BillingSetPinnedTeamRequest, BillingSetPinnedTeamResponse>(
       BillingEvents.SET_PINNED_TEAM,
-      async (data, clientId) => {
+      async (data) => {
         try {
-          const projectPath = resolveRequiredProjectPath(this.resolveProjectPath, clientId)
+          const {projectPath} = data
           const store = this.billingConfigStoreFactory(projectPath)
           await store.setPinnedTeamId(data.teamId)
           const payload: BillingPinChangedPayload =

--- a/src/server/infra/transport/handlers/status-handler.ts
+++ b/src/server/infra/transport/handlers/status-handler.ts
@@ -150,10 +150,8 @@ export class StatusHandler {
       authStateStore: this.authStateStore,
       billingConfigStoreFactory: this.billingConfigStoreFactory,
       billingService: this.billingService,
-      projectConfigStore: this.projectConfigStore,
       projectPath: effectiveProjectPath,
       providerConfigStore: this.providerConfigStore,
-      workspaceTeamId: projectConfig?.teamId,
     })
 
     // Abstract generation queue status (written by agent process via abstract-queue.ts)

--- a/src/shared/transport/events/auth-events.ts
+++ b/src/shared/transport/events/auth-events.ts
@@ -12,6 +12,10 @@ export const AuthEvents = {
   UPDATED: 'auth:updated',
 } as const
 
+export interface AuthGetStateRequest {
+  projectPath: string
+}
+
 export interface AuthGetStateResponse {
   authToken?: AuthTokenDTO
   brvConfig?: BrvConfigDTO

--- a/src/shared/transport/events/billing-events.ts
+++ b/src/shared/transport/events/billing-events.ts
@@ -36,6 +36,10 @@ export interface BillingGetFreeUserLimitResponse {
   limit?: BillingFreeUserLimitDTO
 }
 
+export interface BillingGetPinnedTeamRequest {
+  projectPath: string
+}
+
 export interface BillingGetPinnedTeamResponse {
   error?: string
   /** When undefined, no pin is set and the consumer should fall back to its workspace default. */
@@ -43,6 +47,7 @@ export interface BillingGetPinnedTeamResponse {
 }
 
 export interface BillingSetPinnedTeamRequest {
+  projectPath: string
   /** Pass `undefined` (or omit) to clear the pin. */
   teamId?: string
 }

--- a/src/webui/features/auth/api/get-auth-state.ts
+++ b/src/webui/features/auth/api/get-auth-state.ts
@@ -2,21 +2,27 @@ import {queryOptions, useQuery} from '@tanstack/react-query'
 
 import type {QueryConfig} from '../../../lib/react-query'
 
-import {AuthEvents, type AuthGetStateResponse} from '../../../../shared/transport/events'
+import {AuthEvents, type AuthGetStateRequest, type AuthGetStateResponse} from '../../../../shared/transport/events'
 import {useTransportStore} from '../../../stores/transport-store'
 
-export const getAuthState = (): Promise<AuthGetStateResponse> => {
+export const getAuthState = (projectPath: string): Promise<AuthGetStateResponse> => {
   const {apiClient} = useTransportStore.getState()
   if (!apiClient) return Promise.reject(new Error('Not connected'))
 
-  return apiClient.request<AuthGetStateResponse>(AuthEvents.GET_STATE, undefined, {timeout: 5000})
+  return apiClient.request<AuthGetStateResponse, AuthGetStateRequest>(
+    AuthEvents.GET_STATE,
+    {projectPath},
+    {timeout: 5000},
+  )
 }
 
-export const getAuthStateQueryOptions = () =>
+export const AUTH_STATE_QUERY_ROOT = ['auth', 'state'] as const
+
+export const getAuthStateQueryOptions = (projectPath: string) =>
   queryOptions({
     gcTime: 5 * 60 * 1000,
-    queryFn: getAuthState,
-    queryKey: ['auth', 'state'],
+    queryFn: () => getAuthState(projectPath),
+    queryKey: [...AUTH_STATE_QUERY_ROOT, projectPath],
     staleTime: 60 * 1000,
   })
 
@@ -24,8 +30,10 @@ type UseGetAuthStateOptions = {
   queryConfig?: QueryConfig<typeof getAuthStateQueryOptions>
 }
 
-export const useGetAuthState = ({queryConfig}: UseGetAuthStateOptions = {}) =>
-  useQuery({
-    ...getAuthStateQueryOptions(),
+export const useGetAuthState = ({queryConfig}: UseGetAuthStateOptions = {}) => {
+  const projectPath = useTransportStore((state) => state.selectedProject)
+  return useQuery({
+    ...getAuthStateQueryOptions(projectPath),
     ...queryConfig,
   })
+}

--- a/src/webui/features/auth/api/get-auth-state.ts
+++ b/src/webui/features/auth/api/get-auth-state.ts
@@ -33,8 +33,10 @@ type UseGetAuthStateOptions = {
 
 export const useGetAuthState = ({queryConfig}: UseGetAuthStateOptions = {}) => {
   const projectPath = useTransportStore((state) => state.selectedProject)
+  const baseOptions = getAuthStateQueryOptions(projectPath)
   return useQuery({
-    ...getAuthStateQueryOptions(projectPath),
+    ...baseOptions,
     ...queryConfig,
+    enabled: baseOptions.enabled !== false && (queryConfig?.enabled ?? true),
   })
 }

--- a/src/webui/features/auth/api/get-auth-state.ts
+++ b/src/webui/features/auth/api/get-auth-state.ts
@@ -20,6 +20,7 @@ export const AUTH_STATE_QUERY_ROOT = ['auth', 'state'] as const
 
 export const getAuthStateQueryOptions = (projectPath: string) =>
   queryOptions({
+    enabled: projectPath !== '',
     gcTime: 5 * 60 * 1000,
     queryFn: () => getAuthState(projectPath),
     queryKey: [...AUTH_STATE_QUERY_ROOT, projectPath],

--- a/src/webui/features/auth/api/logout.ts
+++ b/src/webui/features/auth/api/logout.ts
@@ -6,7 +6,7 @@ import {AuthEvents, type AuthLogoutResponse} from '../../../../shared/transport/
 import {getActiveProviderConfigQueryOptions} from '../../../features/provider/api/get-active-provider-config'
 import {getProvidersQueryOptions} from '../../../features/provider/api/get-providers'
 import {useTransportStore} from '../../../stores/transport-store'
-import {getAuthStateQueryOptions} from './get-auth-state'
+import {AUTH_STATE_QUERY_ROOT} from './get-auth-state'
 
 export const logout = (): Promise<AuthLogoutResponse> => {
   const {apiClient} = useTransportStore.getState()
@@ -25,7 +25,7 @@ export const useLogout = ({mutationConfig}: UseLogoutOptions = {}) => {
 
   return useMutation({
     onSuccess(...args) {
-      queryClient.invalidateQueries({queryKey: getAuthStateQueryOptions().queryKey})
+      queryClient.invalidateQueries({queryKey: AUTH_STATE_QUERY_ROOT})
       queryClient.invalidateQueries({queryKey: getProvidersQueryOptions().queryKey})
       queryClient.invalidateQueries({queryKey: getActiveProviderConfigQueryOptions().queryKey})
       onSuccess?.(...args)

--- a/src/webui/features/auth/api/refresh-auth.ts
+++ b/src/webui/features/auth/api/refresh-auth.ts
@@ -4,7 +4,7 @@ import type {MutationConfig} from '../../../lib/react-query'
 
 import {AuthEvents, type AuthRefreshResponse} from '../../../../shared/transport/events'
 import {useTransportStore} from '../../../stores/transport-store'
-import {getAuthStateQueryOptions} from './get-auth-state'
+import {AUTH_STATE_QUERY_ROOT} from './get-auth-state'
 
 export const refreshAuth = (): Promise<AuthRefreshResponse> => {
   const {apiClient} = useTransportStore.getState()
@@ -23,7 +23,7 @@ export const useRefreshAuth = ({mutationConfig}: UseRefreshAuthOptions = {}) => 
 
   return useMutation({
     onSuccess(...args) {
-      queryClient.invalidateQueries({queryKey: getAuthStateQueryOptions().queryKey})
+      queryClient.invalidateQueries({queryKey: AUTH_STATE_QUERY_ROOT})
       onSuccess?.(...args)
     },
     ...restConfig,

--- a/src/webui/features/auth/components/auth-initializer.tsx
+++ b/src/webui/features/auth/components/auth-initializer.tsx
@@ -9,7 +9,7 @@ import {getActiveProviderConfigQueryOptions} from '../../../features/provider/ap
 import {getProvidersQueryOptions} from '../../../features/provider/api/get-providers'
 import {useProviderStore} from '../../../features/provider/stores/provider-store'
 import {useTransportStore} from '../../../stores/transport-store'
-import {getAuthStateQueryOptions, useGetAuthState} from '../api/get-auth-state'
+import {AUTH_STATE_QUERY_ROOT, useGetAuthState} from '../api/get-auth-state'
 import {useAuthStore} from '../stores/auth-store'
 
 /**
@@ -69,7 +69,7 @@ export function AuthInitializer({children}: {children: ReactNode}) {
       }
 
       if (data.isAuthorized) {
-        queryClient.invalidateQueries({queryKey: getAuthStateQueryOptions().queryKey}).catch(() => {})
+        queryClient.invalidateQueries({queryKey: AUTH_STATE_QUERY_ROOT}).catch(() => {})
       }
     })
 
@@ -81,7 +81,7 @@ export function AuthInitializer({children}: {children: ReactNode}) {
     if (connectionState !== 'connected') return
     if (reconnectCount === 0) return
 
-    queryClient.invalidateQueries({queryKey: getAuthStateQueryOptions().queryKey}).catch(() => {})
+    queryClient.invalidateQueries({queryKey: AUTH_STATE_QUERY_ROOT}).catch(() => {})
   }, [apiClient, connectionState, queryClient, reconnectCount])
 
   return <>{children}</>

--- a/src/webui/features/auth/components/auth-menu.tsx
+++ b/src/webui/features/auth/components/auth-menu.tsx
@@ -14,7 +14,7 @@ import {LogOut, User} from 'lucide-react'
 import {useEffect, useState} from 'react'
 
 import {initials} from '../../../utils/initials'
-import {getAuthStateQueryOptions} from '../api/get-auth-state'
+import {AUTH_STATE_QUERY_ROOT} from '../api/get-auth-state'
 import {useLogout} from '../api/logout'
 import {useAuthStore} from '../stores/auth-store'
 import {LoginDialog} from './login-dialog'
@@ -44,7 +44,7 @@ function AuthorizedMenu() {
 
   useEffect(() => {
     if (user) return
-    queryClient.invalidateQueries({queryKey: getAuthStateQueryOptions().queryKey}).catch(() => {})
+    queryClient.invalidateQueries({queryKey: AUTH_STATE_QUERY_ROOT}).catch(() => {})
   }, [queryClient, user])
 
   if (!user) {

--- a/src/webui/features/auth/components/login-dialog.tsx
+++ b/src/webui/features/auth/components/login-dialog.tsx
@@ -14,7 +14,7 @@ import {useEffect, useState} from 'react'
 import {toast} from 'sonner'
 
 import {useTransportStore} from '../../../stores/transport-store'
-import {getAuthStateQueryOptions} from '../api/get-auth-state'
+import {AUTH_STATE_QUERY_ROOT, getAuthStateQueryOptions} from '../api/get-auth-state'
 import {login, subscribeToLoginCompleted} from '../api/login'
 import {useAuthStore} from '../stores/auth-store'
 import {isSafeHttpUrl} from '../utils/is-safe-http-url'
@@ -37,6 +37,7 @@ export function LoginDialog({onOpenChange, open}: LoginDialogProps) {
   const isLoggingIn = useAuthStore((s) => s.isLoggingIn)
   const setLoggingIn = useAuthStore((s) => s.setLoggingIn)
   const connectionState = useTransportStore((s) => s.connectionState)
+  const selectedProject = useTransportStore((s) => s.selectedProject)
   const [state, setState] = useState<DialogState>({type: 'idle'})
 
   useEffect(() => {
@@ -52,7 +53,7 @@ export function LoginDialog({onOpenChange, open}: LoginDialogProps) {
     const unsubscribe = subscribeToLoginCompleted((data) => {
       if (data.success && data.user) {
         toast.success(`Logged in as ${data.user.email}`)
-        queryClient.invalidateQueries({queryKey: getAuthStateQueryOptions().queryKey})
+        queryClient.invalidateQueries({queryKey: AUTH_STATE_QUERY_ROOT})
         onOpenChange(false)
       } else {
         setState({message: data.error ?? 'Authentication failed', type: 'error'})
@@ -62,7 +63,7 @@ export function LoginDialog({onOpenChange, open}: LoginDialogProps) {
     })
 
     return unsubscribe
-  }, [onOpenChange, queryClient, setLoggingIn, state.type])
+  }, [onOpenChange, queryClient, selectedProject, setLoggingIn, state.type])
 
   // Fallback path: poll the daemon while waiting in case the LOGIN_COMPLETED
   // broadcast was missed (tab backgrounded, transient socket drop, etc).
@@ -73,7 +74,7 @@ export function LoginDialog({onOpenChange, open}: LoginDialogProps) {
 
     async function poll() {
       try {
-        const result = await queryClient.fetchQuery(getAuthStateQueryOptions())
+        const result = await queryClient.fetchQuery(getAuthStateQueryOptions(selectedProject))
         if (cancelled) return
         if (result.isAuthorized && result.user) {
           toast.success(`Logged in as ${result.user.email}`)

--- a/src/webui/features/project/components/project-association-initializer.tsx
+++ b/src/webui/features/project/components/project-association-initializer.tsx
@@ -3,8 +3,8 @@ import {useEffect} from 'react'
 
 import {ClientEvents} from '../../../../shared/transport/events'
 import {useTransportStore} from '../../../stores/transport-store'
-import {getAuthStateQueryOptions} from '../../auth/api/get-auth-state'
-import {getPinnedTeamQueryOptions} from '../../provider/api/get-pinned-team'
+import {AUTH_STATE_QUERY_ROOT} from '../../auth/api/get-auth-state'
+import {PINNED_TEAM_QUERY_ROOT} from '../../provider/api/get-pinned-team'
 import {listBillingUsageQueryOptions} from '../../provider/api/list-billing-usage'
 
 export function ProjectAssociationInitializer() {
@@ -23,8 +23,8 @@ export function ProjectAssociationInitializer() {
       .catch(() => {})
       .finally(() => {
         if (cancelled) return
-        queryClient.invalidateQueries({queryKey: getAuthStateQueryOptions().queryKey}).catch(() => {})
-        queryClient.invalidateQueries({queryKey: getPinnedTeamQueryOptions().queryKey}).catch(() => {})
+        queryClient.invalidateQueries({queryKey: AUTH_STATE_QUERY_ROOT}).catch(() => {})
+        queryClient.invalidateQueries({queryKey: PINNED_TEAM_QUERY_ROOT}).catch(() => {})
         queryClient.invalidateQueries({queryKey: listBillingUsageQueryOptions(true).queryKey}).catch(() => {})
       })
 

--- a/src/webui/features/provider/api/get-pinned-team.ts
+++ b/src/webui/features/provider/api/get-pinned-team.ts
@@ -34,5 +34,10 @@ type UseGetPinnedTeamOptions = {
 
 export const useGetPinnedTeam = ({queryConfig}: UseGetPinnedTeamOptions = {}) => {
   const projectPath = useTransportStore((state) => state.selectedProject)
-  return useQuery({...queryConfig, ...getPinnedTeamQueryOptions(projectPath)})
+  const baseOptions = getPinnedTeamQueryOptions(projectPath)
+  return useQuery({
+    ...baseOptions,
+    ...queryConfig,
+    enabled: baseOptions.enabled !== false && (queryConfig?.enabled ?? true),
+  })
 }

--- a/src/webui/features/provider/api/get-pinned-team.ts
+++ b/src/webui/features/provider/api/get-pinned-team.ts
@@ -2,27 +2,36 @@ import {queryOptions, useQuery} from '@tanstack/react-query'
 
 import type {QueryConfig} from '../../../lib/react-query'
 
-import {BillingEvents, type BillingGetPinnedTeamResponse} from '../../../../shared/transport/events'
+import {
+  BillingEvents,
+  type BillingGetPinnedTeamRequest,
+  type BillingGetPinnedTeamResponse,
+} from '../../../../shared/transport/events'
 import {useTransportStore} from '../../../stores/transport-store'
 
-export const PINNED_TEAM_QUERY_KEY = ['billing-pinned-team'] as const
+export const PINNED_TEAM_QUERY_ROOT = ['billing-pinned-team'] as const
 
-export const getPinnedTeam = (): Promise<BillingGetPinnedTeamResponse> => {
+export const getPinnedTeam = (projectPath: string): Promise<BillingGetPinnedTeamResponse> => {
   const {apiClient} = useTransportStore.getState()
   if (!apiClient) return Promise.reject(new Error('Not connected'))
 
-  return apiClient.request<BillingGetPinnedTeamResponse>(BillingEvents.GET_PINNED_TEAM)
+  return apiClient.request<BillingGetPinnedTeamResponse, BillingGetPinnedTeamRequest>(
+    BillingEvents.GET_PINNED_TEAM,
+    {projectPath},
+  )
 }
 
-export const getPinnedTeamQueryOptions = () =>
+export const getPinnedTeamQueryOptions = (projectPath: string) =>
   queryOptions({
-    queryFn: getPinnedTeam,
-    queryKey: [...PINNED_TEAM_QUERY_KEY],
+    queryFn: () => getPinnedTeam(projectPath),
+    queryKey: [...PINNED_TEAM_QUERY_ROOT, projectPath],
   })
 
 type UseGetPinnedTeamOptions = {
   queryConfig?: QueryConfig<typeof getPinnedTeamQueryOptions>
 }
 
-export const useGetPinnedTeam = ({queryConfig}: UseGetPinnedTeamOptions = {}) =>
-  useQuery({...queryConfig, ...getPinnedTeamQueryOptions()})
+export const useGetPinnedTeam = ({queryConfig}: UseGetPinnedTeamOptions = {}) => {
+  const projectPath = useTransportStore((state) => state.selectedProject)
+  return useQuery({...queryConfig, ...getPinnedTeamQueryOptions(projectPath)})
+}

--- a/src/webui/features/provider/api/get-pinned-team.ts
+++ b/src/webui/features/provider/api/get-pinned-team.ts
@@ -23,6 +23,7 @@ export const getPinnedTeam = (projectPath: string): Promise<BillingGetPinnedTeam
 
 export const getPinnedTeamQueryOptions = (projectPath: string) =>
   queryOptions({
+    enabled: projectPath !== '',
     queryFn: () => getPinnedTeam(projectPath),
     queryKey: [...PINNED_TEAM_QUERY_ROOT, projectPath],
   })

--- a/src/webui/features/provider/api/set-pinned-team.ts
+++ b/src/webui/features/provider/api/set-pinned-team.ts
@@ -6,24 +6,28 @@ import {
   type BillingSetPinnedTeamResponse,
 } from '../../../../shared/transport/events'
 import {useTransportStore} from '../../../stores/transport-store'
-import {PINNED_TEAM_QUERY_KEY} from './get-pinned-team'
+import {PINNED_TEAM_QUERY_ROOT} from './get-pinned-team'
 
-export const setPinnedTeam = (teamId: string | undefined): Promise<BillingSetPinnedTeamResponse> => {
+export const setPinnedTeam = (
+  projectPath: string,
+  teamId: string | undefined,
+): Promise<BillingSetPinnedTeamResponse> => {
   const {apiClient} = useTransportStore.getState()
   if (!apiClient) return Promise.reject(new Error('Not connected'))
 
   return apiClient.request<BillingSetPinnedTeamResponse, BillingSetPinnedTeamRequest>(
     BillingEvents.SET_PINNED_TEAM,
-    {teamId},
+    {projectPath, teamId},
   )
 }
 
 export const useSetPinnedTeam = () => {
   const queryClient = useQueryClient()
+  const projectPath = useTransportStore((s) => s.selectedProject)
   return useMutation({
-    mutationFn: (teamId: string | undefined) => setPinnedTeam(teamId),
+    mutationFn: (teamId: string | undefined) => setPinnedTeam(projectPath, teamId),
     async onSuccess() {
-      await queryClient.invalidateQueries({queryKey: PINNED_TEAM_QUERY_KEY})
+      await queryClient.invalidateQueries({queryKey: PINNED_TEAM_QUERY_ROOT})
     },
   })
 }

--- a/src/webui/features/provider/api/set-pinned-team.ts
+++ b/src/webui/features/provider/api/set-pinned-team.ts
@@ -23,9 +23,9 @@ export const setPinnedTeam = (
 
 export const useSetPinnedTeam = () => {
   const queryClient = useQueryClient()
-  const projectPath = useTransportStore((s) => s.selectedProject)
   return useMutation({
-    mutationFn: (teamId: string | undefined) => setPinnedTeam(projectPath, teamId),
+    mutationFn: (teamId: string | undefined) =>
+      setPinnedTeam(useTransportStore.getState().selectedProject, teamId),
     async onSuccess() {
       await queryClient.invalidateQueries({queryKey: PINNED_TEAM_QUERY_ROOT})
     },

--- a/src/webui/features/provider/components/provider-flow/login-prompt-step.tsx
+++ b/src/webui/features/provider/components/provider-flow/login-prompt-step.tsx
@@ -4,7 +4,8 @@ import {useQueryClient} from '@tanstack/react-query'
 import {ChevronLeft, ExternalLink, LoaderCircle} from 'lucide-react'
 import {useEffect, useRef, useState} from 'react'
 
-import {getAuthStateQueryOptions} from '../../../auth/api/get-auth-state'
+import {useTransportStore} from '../../../../stores/transport-store'
+import {AUTH_STATE_QUERY_ROOT, getAuthStateQueryOptions} from '../../../auth/api/get-auth-state'
 import {login, subscribeToLoginCompleted} from '../../../auth/api/login'
 import {useAuthStore} from '../../../auth/stores/auth-store'
 import {isSafeHttpUrl} from '../../../auth/utils/is-safe-http-url'
@@ -50,6 +51,7 @@ export function LoginPromptStep({onAuthenticated, onBack, popup}: LoginPromptSte
   const queryClient = useQueryClient()
   const isAuthorized = useAuthStore((s) => s.isAuthorized)
   const setLoggingIn = useAuthStore((s) => s.setLoggingIn)
+  const selectedProject = useTransportStore((s) => s.selectedProject)
   const [state, setState] = useState<InnerState>({type: 'starting'})
   const [retryCount, setRetryCount] = useState(0)
   const didStartRef = useRef(false)
@@ -115,7 +117,7 @@ export function LoginPromptStep({onAuthenticated, onBack, popup}: LoginPromptSte
 
     const unsubscribe = subscribeToLoginCompleted((data) => {
       if (data.success && data.user) {
-        queryClient.invalidateQueries({queryKey: getAuthStateQueryOptions().queryKey})
+        queryClient.invalidateQueries({queryKey: AUTH_STATE_QUERY_ROOT})
       } else {
         setState({message: data.error ?? 'Authentication failed', type: 'error'})
       }
@@ -133,10 +135,10 @@ export function LoginPromptStep({onAuthenticated, onBack, popup}: LoginPromptSte
 
     async function poll() {
       try {
-        const result = await queryClient.fetchQuery(getAuthStateQueryOptions())
+        const result = await queryClient.fetchQuery(getAuthStateQueryOptions(selectedProject))
         if (cancelled) return
         if (result.isAuthorized) {
-          queryClient.invalidateQueries({queryKey: getAuthStateQueryOptions().queryKey})
+          queryClient.invalidateQueries({queryKey: AUTH_STATE_QUERY_ROOT})
           setLoggingIn(false)
         }
       } catch {
@@ -149,7 +151,7 @@ export function LoginPromptStep({onAuthenticated, onBack, popup}: LoginPromptSte
       cancelled = true
       globalThis.clearInterval(intervalId)
     }
-  }, [queryClient, setLoggingIn, state.type])
+  }, [queryClient, selectedProject, setLoggingIn, state.type])
 
   function retry() {
     // Clear the guard and bump `retryCount` so the start effect re-runs —

--- a/src/webui/features/provider/components/provider-flow/provider-flow-dialog.tsx
+++ b/src/webui/features/provider/components/provider-flow/provider-flow-dialog.tsx
@@ -7,6 +7,7 @@ import {toast} from 'sonner'
 import type {ModelDTO, ProviderDTO} from '../../../../../shared/transport/events'
 
 import {formatError} from '../../../../lib/error-messages'
+import {useTransportStore} from '../../../../stores/transport-store'
 import {useAuthStore} from '../../../auth/stores/auth-store'
 import {useSetActiveModel} from '../../../model/api/set-active-model'
 import {TourStepBadge} from '../../../onboarding/components/tour-step-badge'
@@ -84,6 +85,7 @@ export function ProviderFlowDialog({onOpenChange, onProviderActivated, open, tou
   const oauthPopupRef = useRef<ReturnType<typeof globalThis.open>>(null)
 
   const isAuthorized = useAuthStore((s) => s.isAuthorized)
+  const projectPath = useTransportStore((s) => s.selectedProject)
   const queryClient = useQueryClient()
   const {data} = useGetProviders()
   const connectMutation = useConnectProvider()
@@ -149,7 +151,7 @@ export function ProviderFlowDialog({onOpenChange, onProviderActivated, open, tou
         toast.success(`Connected to ${provider.name}`)
         onProviderActivated?.()
 
-        const pinned = await getPinnedTeam()
+        const pinned = await getPinnedTeam(projectPath)
         const pinnedTeamId = pinned.teamId
 
         if (pinnedTeamId) {

--- a/src/webui/features/provider/components/provider-flow/provider-select-step.tsx
+++ b/src/webui/features/provider/components/provider-flow/provider-select-step.tsx
@@ -8,7 +8,6 @@ import {useMemo, useState} from 'react'
 
 import type {ProviderDTO} from '../../../../../shared/transport/types/dto'
 
-import {useAuthStore} from '../../../auth/stores/auth-store'
 import {useGetEnvironmentConfig} from '../../../config/api/get-environment-config'
 import {useGetPinnedTeam} from '../../api/get-pinned-team'
 import {useListTeams} from '../../api/list-teams'
@@ -62,17 +61,14 @@ function ExhaustedAlert({remaining, topUpUrl}: {remaining: number; topUpUrl?: st
 
 export function ProviderSelectStep({onSelect, providers}: ProviderSelectStepProps) {
   const [search, setSearch] = useState('')
-  const teamId = useAuthStore((s) => s.brvConfig?.teamId)
   const {data: pinnedData} = useGetPinnedTeam()
 
   const byteRoverActive = useMemo(
     () => providers.find((p) => p.id === BYTEROVER_PROVIDER_ID && p.isCurrent),
     [providers],
   )
-  // Reads from the same warm bulk-billing cache the header subscribes to —
-  // no extra round trip on dialog open.
   const {billingSource: usage, billingTone, paidOrg} = useBillingDisplay({
-    preferredOrgId: pinnedData?.teamId ?? teamId,
+    preferredOrgId: pinnedData?.teamId,
   })
   const isExhausted = byteRoverActive !== undefined && billingTone === 'danger' && usage !== undefined
 

--- a/src/webui/features/provider/components/provider-flow/team-select-step.tsx
+++ b/src/webui/features/provider/components/provider-flow/team-select-step.tsx
@@ -3,11 +3,11 @@ import {Button} from '@campfirein/byterover-packages/components/button'
 import {DialogDescription, DialogHeader, DialogTitle} from '@campfirein/byterover-packages/components/dialog'
 import {Skeleton} from '@campfirein/byterover-packages/components/skeleton'
 import {cn} from '@campfirein/byterover-packages/lib/utils'
-import {Check, ChevronLeft, Info, LoaderCircle} from 'lucide-react'
-import {ReactNode, useMemo, useState} from 'react'
+import {Check, ChevronLeft, LoaderCircle} from 'lucide-react'
+import {ReactNode, useEffect, useMemo, useState} from 'react'
 import {toast} from 'sonner'
 
-import type {BillingTier, BillingUsageDTO, TeamDTO} from '../../../../../shared/transport/types/dto'
+import type {BillingTier, TeamDTO} from '../../../../../shared/transport/types/dto'
 
 import {formatError} from '../../../../lib/error-messages'
 import {initials} from '../../../../utils/initials'
@@ -16,8 +16,9 @@ import {useGetPinnedTeam} from '../../api/get-pinned-team'
 import {useListBillingUsage} from '../../api/list-billing-usage'
 import {useListTeams} from '../../api/list-teams'
 import {useSetPinnedTeam} from '../../api/set-pinned-team'
+import {computeTeamPreselection} from '../../utils/compute-team-preselection'
 import {getBillingTone} from '../../utils/get-billing-tone'
-import {hasPaidTeam} from '../../utils/has-paid-team'
+import {getPaidOrganizationIds, hasPaidTeam} from '../../utils/has-paid-team'
 import {CreditsPill} from '../credits-pill'
 
 interface TeamSelectStepProps {
@@ -143,18 +144,29 @@ export function TeamSelectStep({onBack, onComplete}: TeamSelectStepProps) {
   const usageByTeam = useMemo(() => usageData?.usage ?? {}, [usageData?.usage])
 
   const pinnedOrganizationId = pinnedData?.teamId
-  const [selection, setSelection] = useState<string | undefined>(pinnedOrganizationId)
+  const paidOrganizationIds = useMemo(() => getPaidOrganizationIds(usageByTeam), [usageByTeam])
+
+  const preselection = useMemo(
+    () =>
+      computeTeamPreselection({
+        paidOrganizationIds,
+        pinnedTeamId: pinnedOrganizationId,
+        teams,
+        workspaceTeamId,
+      }),
+    [paidOrganizationIds, pinnedOrganizationId, teams, workspaceTeamId],
+  )
+
+  const [selection, setSelection] = useState<string | undefined>(preselection)
+  useEffect(() => {
+    setSelection(preselection)
+  }, [preselection])
 
   const isPersisting = setPinned.isPending
   const isLoading = teamsLoading || pinnedLoading
   const dirty = selection !== pinnedOrganizationId
-  const canConfirm = dirty && selection !== undefined && !isPersisting
-
-  const workspaceFallback = useMemo<BillingUsageDTO | undefined>(() => {
-    if (isLoading) return
-    const workspaceUsage = workspaceTeamId ? usageByTeam[workspaceTeamId] : undefined
-    return workspaceUsage && workspaceUsage.tier !== 'FREE' ? workspaceUsage : undefined
-  }, [isLoading, workspaceTeamId, usageByTeam])
+  const selectionInList = selection !== undefined && teams.some((t) => t.id === selection)
+  const canConfirm = dirty && selectionInList && !isPersisting
 
   const showFreeTierView = !isLoading && !teamsError && !hasPaidTeam(usageByTeam)
 
@@ -202,21 +214,6 @@ export function TeamSelectStep({onBack, onComplete}: TeamSelectStepProps) {
           ByteRover credits are charged to a team. Pick which team this project should bill.
         </DialogDescription>
       </DialogHeader>
-
-      <div className="border-border bg-muted/30 flex items-start gap-2 rounded-md border px-3 py-2">
-        <Info className="text-muted-foreground mt-0.5 size-3.5 shrink-0" />
-        <p className="text-muted-foreground text-xs leading-snug">
-          {workspaceFallback ? (
-            <>
-              ByteRover usage falls back to{' '}
-              <span className="text-foreground font-medium">{workspaceFallback.organizationName}</span> (matched from
-              this workspace).
-            </>
-          ) : (
-            <>ByteRover usage falls back to your free monthly credits.</>
-          )}
-        </p>
-      </div>
 
       {teamsError ? (
         <p className="text-destructive text-sm">{formatError(teamsError, 'Failed to load teams.')}</p>

--- a/src/webui/features/provider/hooks/use-billing-display.ts
+++ b/src/webui/features/provider/hooks/use-billing-display.ts
@@ -4,11 +4,13 @@ import {useAuthStore} from '../../auth/stores/auth-store'
 import {useGetFreeUserLimit} from '../api/get-free-user-limit'
 import {useListBillingUsage} from '../api/list-billing-usage'
 import {type BillingTone, type BillingToneInput, getBillingTone} from '../utils/get-billing-tone'
+import {getPaidOrganizationIds} from '../utils/has-paid-team'
 
 export interface BillingDisplay {
   billingSource?: BillingToneInput
   billingTone: BillingTone
   hasPaidTeam: boolean
+  needsPickPrompt: boolean
   paidOrg?: BillingUsageDTO
   showCreditPill: boolean
   usagesByOrg: Record<string, BillingUsageDTO>
@@ -19,24 +21,27 @@ export function useBillingDisplay({preferredOrgId}: {preferredOrgId?: string} = 
 
   const {data: usagesData} = useListBillingUsage({enabled: isAuthorized})
   const usagesByOrg = usagesData?.usage ?? {}
-  const paidUsages = Object.values(usagesByOrg).filter((u) => u.tier !== 'FREE')
-  const hasPaidTeam = paidUsages.length > 0
+  const paidOrganizationIds = getPaidOrganizationIds(usagesByOrg)
+  const hasPaidTeam = paidOrganizationIds.length > 0
 
   const {data: freeData} = useGetFreeUserLimit({
     enabled: isAuthorized && usagesData !== undefined && !hasPaidTeam,
   })
   const freeMonthly = freeData?.limit?.monthly
 
-  const autoPick = paidUsages.length === 1 ? paidUsages[0] : undefined
-  const resolvedTeam = preferredOrgId ? usagesByOrg[preferredOrgId] : autoPick
+  const pinUsage = preferredOrgId ? usagesByOrg[preferredOrgId] : undefined
+  const autoPickUsage = paidOrganizationIds.length === 1 ? usagesByOrg[paidOrganizationIds[0]] : undefined
+  const resolvedTeam = hasPaidTeam ? (pinUsage ?? autoPickUsage) : undefined
   const isPaidOrg = resolvedTeam !== undefined && resolvedTeam.tier !== 'FREE'
   const billingSource: BillingToneInput | undefined = resolvedTeam ?? freeMonthly
   const billingTone = getBillingTone(billingSource)
+  const needsPickPrompt = paidOrganizationIds.length > 1 && resolvedTeam === undefined
 
   return {
     billingSource,
     billingTone,
     hasPaidTeam,
+    needsPickPrompt,
     paidOrg: isPaidOrg ? resolvedTeam : undefined,
     showCreditPill: billingSource !== undefined,
     usagesByOrg,

--- a/src/webui/features/provider/utils/compute-team-preselection.ts
+++ b/src/webui/features/provider/utils/compute-team-preselection.ts
@@ -1,0 +1,21 @@
+import type {TeamDTO} from '../../../../shared/transport/types/dto'
+
+export function computeTeamPreselection(args: {
+  paidOrganizationIds: readonly string[]
+  pinnedTeamId?: string
+  teams: readonly TeamDTO[]
+  workspaceTeamId?: string
+}): string | undefined {
+  const {paidOrganizationIds, pinnedTeamId, teams, workspaceTeamId} = args
+
+  if (pinnedTeamId && teams.some((t) => t.id === pinnedTeamId)) {
+    return pinnedTeamId
+  }
+
+  if (paidOrganizationIds.length === 0) return undefined
+  if (paidOrganizationIds.length === 1) return paidOrganizationIds[0]
+
+  if (workspaceTeamId) return workspaceTeamId
+
+  return undefined
+}

--- a/src/webui/features/provider/utils/has-paid-team.ts
+++ b/src/webui/features/provider/utils/has-paid-team.ts
@@ -4,3 +4,10 @@ export function hasPaidTeam(usage?: Record<string, BillingUsageDTO>): boolean {
   if (!usage) return false
   return Object.values(usage).some((u) => u.tier !== 'FREE')
 }
+
+export function getPaidOrganizationIds(usage?: Record<string, BillingUsageDTO>): string[] {
+  if (!usage) return []
+  return Object.values(usage)
+    .filter((u) => u.tier !== 'FREE')
+    .map((u) => u.organizationId)
+}

--- a/src/webui/layouts/header.tsx
+++ b/src/webui/layouts/header.tsx
@@ -8,7 +8,6 @@ import {useState} from 'react'
 import logo from '../assets/logo-byterover.svg'
 import {StatusDot, type Tone as StatusDotTone} from '../components/status-dot'
 import {AuthMenu} from '../features/auth/components/auth-menu'
-import {useAuthStore} from '../features/auth/stores/auth-store'
 import {useGetEnvironmentConfig} from '../features/config/api/get-environment-config'
 import {HelpMenu} from '../features/onboarding/components/help-menu'
 import {ProjectDropdown} from '../features/project/components/project-dropdown'
@@ -60,7 +59,6 @@ export function Header() {
   const [providerDialogOpen, setProviderDialogOpen] = useState(false)
   const {data: providersData} = useGetProviders()
   const {data: activeConfig} = useGetActiveProviderConfig()
-  const teamId = useAuthStore((s) => s.brvConfig?.teamId)
   const {data: pinnedData} = useGetPinnedTeam()
 
   const activeProvider = providersData?.providers.find((p) => p.isCurrent)
@@ -69,8 +67,8 @@ export function Header() {
 
   const {data: teamsData} = useListTeams()
 
-  const {billingSource, billingTone, paidOrg, showCreditPill: hasBillingData} = useBillingDisplay({
-    preferredOrgId: pinnedData?.teamId ?? teamId,
+  const {billingSource, billingTone, needsPickPrompt, paidOrg, showCreditPill: hasBillingData} = useBillingDisplay({
+    preferredOrgId: pinnedData?.teamId,
   })
   const showCreditPill = isByteRoverActive && hasBillingData
 
@@ -78,8 +76,9 @@ export function Header() {
   const teamSlug = teamsData?.teams?.find((t) => t.id === paidOrg?.organizationId)?.slug
   const topUpUrl = buildTopUpUrl({teamSlug, webAppUrl: envConfig?.webAppUrl})
 
+  const needsAttention = !activeProvider || (isByteRoverActive && needsPickPrompt)
   let triggerToneClass = ''
-  if (!activeProvider) triggerToneClass = TRIGGER_TONE_CLASS.warn
+  if (needsAttention) triggerToneClass = TRIGGER_TONE_CLASS.warn
   else if (isByteRoverActive) triggerToneClass = TRIGGER_TONE_CLASS[billingTone]
 
   return (
@@ -132,13 +131,17 @@ export function Header() {
               {activeProvider && (
                 <StatusDot
                   className="border-background absolute -right-0.5 -bottom-0.5 size-2 border-2"
-                  tone={isByteRoverActive ? STATUS_DOT_TONE[billingTone] : 'success'}
+                  tone={
+                    isByteRoverActive && needsPickPrompt
+                      ? 'amber'
+                      : (isByteRoverActive ? STATUS_DOT_TONE[billingTone] : 'success')
+                  }
                 />
               )}
             </span>
             {providerLabel}
             {showCreditPill && billingSource && <CreditPill remaining={billingSource.remaining} tone={billingTone} />}
-            {!activeProvider && <StatusDot className="ml-1" pulsing tone="amber" />}
+            {needsAttention && <StatusDot className="ml-1" pulsing tone="amber" />}
           </TooltipTrigger>
           {!activeProvider && <TooltipContent>Configure provider to power curate & query</TooltipContent>}
           {showCreditPill && billingTone === 'danger' && (
@@ -163,6 +166,9 @@ export function Header() {
             <TooltipContent>
               Running low on credits — {formatCredits(billingSource.remaining)} remaining.
             </TooltipContent>
+          )}
+          {isByteRoverActive && needsPickPrompt && billingTone !== 'danger' && billingTone !== 'warn' && (
+            <TooltipContent>Select a team to bill your usage to.</TooltipContent>
           )}
         </Tooltip>
         <ProviderFlowDialog onOpenChange={setProviderDialogOpen} open={providerDialogOpen} />

--- a/src/webui/lib/api-client.ts
+++ b/src/webui/lib/api-client.ts
@@ -36,19 +36,35 @@ export class BrvApiClient {
     data?: TRequest,
     options?: RequestOptions,
   ): Promise<TResponse> {
+    if (!this.socket.connected) {
+      throw new Error(`Socket not connected — cannot send ${event}`)
+    }
+
     return new Promise<TResponse>((resolve, reject) => {
       let didFinish = false
       const timeout = options?.timeout ?? DEFAULT_REQUEST_TIMEOUT_MS
       const timeoutId = globalThis.setTimeout(() => {
+        if (didFinish) return
         didFinish = true
+        this.socket.off('disconnect', onDisconnect)
         reject(new Error(`Request timed out after ${timeout}ms`))
       }, timeout)
+
+      const onDisconnect = () => {
+        if (didFinish) return
+        didFinish = true
+        globalThis.clearTimeout(timeoutId)
+        reject(new Error(`Socket disconnected before ${event} acked`))
+      }
+
+      this.socket.once('disconnect', onDisconnect)
 
       this.socket.emit(event, data, (response: AckResponse<TResponse>) => {
         if (didFinish) return
 
         didFinish = true
         globalThis.clearTimeout(timeoutId)
+        this.socket.off('disconnect', onDisconnect)
 
         if (response.success) {
           resolve(response.data)

--- a/test/commands/providers/connect.test.ts
+++ b/test/commands/providers/connect.test.ts
@@ -717,7 +717,7 @@ describe('Provider Connect Command', () => {
 
       const setCall = requestStub.getCalls().find((c) => c.args[0] === BillingEvents.SET_PINNED_TEAM)
       expect(setCall, 'expected SET_PINNED_TEAM call').to.exist
-      expect(setCall!.args[1]).to.deep.equal({teamId: 'org-acme'})
+      expect(setCall!.args[1]).to.deep.equal({projectPath: '/test/project', teamId: 'org-acme'})
       expect(loggedMessages.some((m) => m.includes('Connected to ByteRover'))).to.be.true
       expect(
         loggedMessages.some((m) => m.includes('ByteRover usage on this project will be billed to Acme Corp')),

--- a/test/unit/infra/billing/build-status-billing.test.ts
+++ b/test/unit/infra/billing/build-status-billing.test.ts
@@ -76,22 +76,18 @@ describe('buildStatusBilling', () => {
     expect(result).to.deep.equal({organizationId: 'org-stale', source: 'paid'})
   })
 
-  it('returns paid when no pin and the workspace team matches a paid usage', () => {
+  it('returns free when no pin and multiple paid usages exist (server cannot disambiguate)', () => {
     const result = buildStatusBilling({
       activeProvider: 'byterover',
+      freeUserLimit: freeLimit,
       isAuthenticated: true,
       paidUsages: [
         usage({organizationId: 'org-acme', organizationName: 'Acme Corp'}),
         usage({organizationId: 'org-other', organizationName: 'Other'}),
       ],
-      workspaceTeamId: 'org-acme',
     })
 
-    expect(result).to.deep.include({
-      organizationId: 'org-acme',
-      organizationName: 'Acme Corp',
-      source: 'paid',
-    })
+    expect(result?.source).to.equal('free')
   })
 
   it('returns paid when no pin/workspace and there is exactly one paid org', () => {
@@ -130,7 +126,7 @@ describe('buildStatusBilling', () => {
     expect(result).to.deep.equal({source: 'free'})
   })
 
-  it('returns the free source when multiple paid orgs exist but none resolve (chain step 4)', () => {
+  it('returns the free source when no pin and multiple paid orgs exist', () => {
     const result = buildStatusBilling({
       activeProvider: 'byterover',
       freeUserLimit: freeLimit,
@@ -139,7 +135,6 @@ describe('buildStatusBilling', () => {
         usage({organizationId: 'org-A', organizationName: 'A'}),
         usage({organizationId: 'org-B', organizationName: 'B'}),
       ],
-      workspaceTeamId: 'org-not-paid',
     })
 
     expect(result?.source).to.equal('free')

--- a/test/unit/infra/billing/resolve-billing-source.test.ts
+++ b/test/unit/infra/billing/resolve-billing-source.test.ts
@@ -4,7 +4,6 @@ import {createSandbox, type SinonSandbox} from 'sinon'
 import type {IProviderConfigStore} from '../../../../src/server/core/interfaces/i-provider-config-store.js'
 import type {IBillingService} from '../../../../src/server/core/interfaces/services/i-billing-service.js'
 import type {IBillingConfigStore} from '../../../../src/server/core/interfaces/storage/i-billing-config-store.js'
-import type {IProjectConfigStore} from '../../../../src/server/core/interfaces/storage/i-project-config-store.js'
 
 import {resolveBillingForProject} from '../../../../src/server/infra/billing/resolve-billing-source.js'
 import {createMockAuthStateStore} from '../../../helpers/mock-factories.js'
@@ -18,9 +17,6 @@ interface Stubs {
   getFreeUserLimitStub: ReturnType<SinonSandbox['stub']>
   getPinnedStub: ReturnType<SinonSandbox['stub']>
   getUsagesStub: ReturnType<SinonSandbox['stub']>
-  projectConfigStore: IProjectConfigStore
-  projectExistsStub: ReturnType<SinonSandbox['stub']>
-  projectReadStub: ReturnType<SinonSandbox['stub']>
   providerConfigStore: IProviderConfigStore
 }
 
@@ -29,8 +25,6 @@ function makeStubs(sandbox: SinonSandbox): Stubs {
   const getFreeUserLimitStub = sandbox.stub()
   const getPinnedStub = sandbox.stub().resolves()
   const getUsagesStub = sandbox.stub().resolves([])
-  const projectExistsStub = sandbox.stub().resolves(true)
-  const projectReadStub = sandbox.stub().resolves({})
 
   return {
     billingConfigStore: {
@@ -46,14 +40,6 @@ function makeStubs(sandbox: SinonSandbox): Stubs {
     getFreeUserLimitStub,
     getPinnedStub,
     getUsagesStub,
-    projectConfigStore: {
-      exists: projectExistsStub,
-      getModifiedTime: sandbox.stub().resolves(),
-      read: projectReadStub,
-      write: sandbox.stub().resolves(),
-    } as unknown as IProjectConfigStore,
-    projectExistsStub,
-    projectReadStub,
     providerConfigStore: {
       getActiveProvider: getActiveProviderStub,
     } as unknown as IProviderConfigStore,
@@ -78,7 +64,6 @@ describe('resolveBillingForProject', () => {
       authStateStore: createMockAuthStateStore(sandbox, {isAuthenticated: false}),
       billingConfigStoreFactory: () => stubs.billingConfigStore,
       billingService: stubs.billingService,
-      projectConfigStore: stubs.projectConfigStore,
       projectPath: PROJECT,
       providerConfigStore: stubs.providerConfigStore,
     })
@@ -95,7 +80,6 @@ describe('resolveBillingForProject', () => {
       authStateStore: createMockAuthStateStore(sandbox),
       billingConfigStoreFactory: () => stubs.billingConfigStore,
       billingService: stubs.billingService,
-      projectConfigStore: stubs.projectConfigStore,
       projectPath: PROJECT,
       providerConfigStore: stubs.providerConfigStore,
     })
@@ -128,7 +112,6 @@ describe('resolveBillingForProject', () => {
       authStateStore: createMockAuthStateStore(sandbox),
       billingConfigStoreFactory: () => stubs.billingConfigStore,
       billingService: stubs.billingService,
-      projectConfigStore: stubs.projectConfigStore,
       projectPath: PROJECT,
       providerConfigStore: stubs.providerConfigStore,
     })
@@ -156,59 +139,11 @@ describe('resolveBillingForProject', () => {
       authStateStore: createMockAuthStateStore(sandbox),
       billingConfigStoreFactory: () => stubs.billingConfigStore,
       billingService: stubs.billingService,
-      projectConfigStore: stubs.projectConfigStore,
       projectPath: PROJECT,
       providerConfigStore: stubs.providerConfigStore,
     })
 
     expect(result).to.deep.equal({remaining: 950, source: 'free', total: 1000})
-  })
-
-  it('reads workspace teamId from project config and uses it for the chain', async () => {
-    const stubs = makeStubs(sandbox)
-    stubs.projectReadStub.resolves({spaceId: 'space-1', teamId: 'org-acme'})
-    stubs.getUsagesStub.resolves([
-      {
-        addOnRemaining: 0,
-        isTrialing: false,
-        limit: 100_000,
-        limitExceeded: false,
-        organizationId: 'org-acme',
-        organizationName: 'Acme Corp',
-        organizationStatus: 'ACTIVE',
-        percentUsed: 0,
-        remaining: 100_000,
-        tier: 'TEAM',
-        totalLimit: 100_000,
-        used: 0,
-      },
-      {
-        addOnRemaining: 0,
-        isTrialing: false,
-        limit: 100_000,
-        limitExceeded: false,
-        organizationId: 'org-other',
-        organizationName: 'Other',
-        organizationStatus: 'ACTIVE',
-        percentUsed: 0,
-        remaining: 100_000,
-        tier: 'PRO',
-        totalLimit: 100_000,
-        used: 0,
-      },
-    ])
-
-    const result = await resolveBillingForProject({
-      authStateStore: createMockAuthStateStore(sandbox),
-      billingConfigStoreFactory: () => stubs.billingConfigStore,
-      billingService: stubs.billingService,
-      projectConfigStore: stubs.projectConfigStore,
-      projectPath: PROJECT,
-      providerConfigStore: stubs.providerConfigStore,
-    })
-
-    expect(result?.source).to.equal('paid')
-    expect(result && result.source === 'paid' ? result.organizationId : undefined).to.equal('org-acme')
   })
 
   it('returns undefined when billing service throws', async () => {
@@ -219,7 +154,6 @@ describe('resolveBillingForProject', () => {
       authStateStore: createMockAuthStateStore(sandbox),
       billingConfigStoreFactory: () => stubs.billingConfigStore,
       billingService: stubs.billingService,
-      projectConfigStore: stubs.projectConfigStore,
       projectPath: PROJECT,
       providerConfigStore: stubs.providerConfigStore,
     })

--- a/test/unit/infra/billing/resolve-billing-team.test.ts
+++ b/test/unit/infra/billing/resolve-billing-team.test.ts
@@ -2,24 +2,19 @@ import {expect} from 'chai'
 
 import {resolveBillingTeamId} from '../../../../src/server/infra/billing/resolve-billing-team.js'
 
+/**
+ * `resolveBillingTeamId` predicts which team the BILLING SERVER will charge for the
+ * next request given the daemon-side state. It does NOT apply workspace fallback —
+ * workspace handling is a client-side pre-selection concern only. The daemon sends
+ * the pin (or nothing); the server applies its own rules.
+ */
 describe('resolveBillingTeamId', () => {
-  describe('step 1 — explicit pin wins', () => {
-    it('returns the pinned organization id when set', () => {
+  describe('pinned team', () => {
+    it('returns the pinned team when set', () => {
       expect(
         resolveBillingTeamId({
           paidOrganizationIds: ['org-A', 'org-B'],
           pinnedTeamId: 'org-pin',
-          workspaceTeamId: 'org-A',
-        }),
-      ).to.equal('org-pin')
-    })
-
-    it('returns the pin even when the workspace also matches a paid org', () => {
-      expect(
-        resolveBillingTeamId({
-          paidOrganizationIds: ['org-A'],
-          pinnedTeamId: 'org-pin',
-          workspaceTeamId: 'org-A',
         }),
       ).to.equal('org-pin')
     })
@@ -29,73 +24,28 @@ describe('resolveBillingTeamId', () => {
         resolveBillingTeamId({
           paidOrganizationIds: ['org-A'],
           pinnedTeamId: 'org-stale',
-          workspaceTeamId: undefined,
         }),
       ).to.equal('org-stale')
     })
   })
 
-  describe('step 2 — workspace match', () => {
-    it('returns the workspace team when it appears in paid orgs', () => {
-      expect(
-        resolveBillingTeamId({
-          paidOrganizationIds: ['org-A', 'org-B'],
-          pinnedTeamId: undefined,
-          workspaceTeamId: 'org-A',
-        }),
-      ).to.equal('org-A')
-    })
-
-    it('does NOT return the workspace team when it is not a paid org', () => {
-      expect(
-        resolveBillingTeamId({
-          paidOrganizationIds: ['org-A'],
-          pinnedTeamId: undefined,
-          workspaceTeamId: 'org-Z',
-        }),
-      ).to.not.equal('org-Z')
-    })
-
-    it('treats an empty-string workspace team as missing (regression guard)', () => {
-      expect(
-        resolveBillingTeamId({
-          paidOrganizationIds: ['org-A'],
-          pinnedTeamId: undefined,
-          workspaceTeamId: undefined,
-        }),
-      ).to.equal('org-A')
-    })
-  })
-
-  describe('step 3 — single paid team auto-pick', () => {
-    it('returns the single paid org when no pin and no workspace match', () => {
+  describe('server auto-pick: single paid team', () => {
+    it('returns the single paid org when no pin is set', () => {
       expect(
         resolveBillingTeamId({
           paidOrganizationIds: ['org-only'],
           pinnedTeamId: undefined,
-          workspaceTeamId: 'org-not-a-paid-team',
-        }),
-      ).to.equal('org-only')
-    })
-
-    it('returns the single paid org when there is no workspace at all', () => {
-      expect(
-        resolveBillingTeamId({
-          paidOrganizationIds: ['org-only'],
-          pinnedTeamId: undefined,
-          workspaceTeamId: undefined,
         }),
       ).to.equal('org-only')
     })
   })
 
-  describe('step 4 — free pool fallback', () => {
-    it('returns undefined when there are multiple paid orgs and no pin/workspace match', () => {
+  describe('free fallback', () => {
+    it('returns undefined when no pin and multiple paid orgs (server charges free credits)', () => {
       expect(
         resolveBillingTeamId({
           paidOrganizationIds: ['org-A', 'org-B'],
           pinnedTeamId: undefined,
-          workspaceTeamId: 'org-not-a-paid-team',
         }),
       ).to.equal(undefined)
     })
@@ -105,17 +55,6 @@ describe('resolveBillingTeamId', () => {
         resolveBillingTeamId({
           paidOrganizationIds: [],
           pinnedTeamId: undefined,
-          workspaceTeamId: 'org-anything',
-        }),
-      ).to.equal(undefined)
-    })
-
-    it('returns undefined when nothing is set at all', () => {
-      expect(
-        resolveBillingTeamId({
-          paidOrganizationIds: [],
-          pinnedTeamId: undefined,
-          workspaceTeamId: undefined,
         }),
       ).to.equal(undefined)
     })

--- a/test/unit/infra/transport/handlers/billing-handler.test.ts
+++ b/test/unit/infra/transport/handlers/billing-handler.test.ts
@@ -4,7 +4,6 @@ import {createSandbox, type SinonSandbox} from 'sinon'
 import type {IProviderConfigStore} from '../../../../../src/server/core/interfaces/i-provider-config-store.js'
 import type {IBillingService} from '../../../../../src/server/core/interfaces/services/i-billing-service.js'
 import type {IBillingConfigStore} from '../../../../../src/server/core/interfaces/storage/i-billing-config-store.js'
-import type {IProjectConfigStore} from '../../../../../src/server/core/interfaces/storage/i-project-config-store.js'
 import type {BillingFreeUserLimitDTO, BillingUsageDTO} from '../../../../../src/shared/transport/types/dto.js'
 
 import {TransportDaemonEventNames} from '../../../../../src/server/core/domain/transport/schemas.js'
@@ -73,12 +72,6 @@ describe('BillingHandler', () => {
   })
 
   function createHandler(options?: {isAuthenticated?: boolean}): BillingHandler {
-    const projectConfigStore = {
-      exists: sandbox.stub().resolves(false),
-      getModifiedTime: sandbox.stub().resolves(),
-      read: sandbox.stub().resolves({}),
-      write: sandbox.stub().resolves(),
-    } as unknown as IProjectConfigStore
     const providerConfigStore = {
       getActiveProvider: sandbox.stub().resolves(''),
     } as unknown as IProviderConfigStore
@@ -87,7 +80,6 @@ describe('BillingHandler', () => {
       authStateStore: createMockAuthStateStore(sandbox, options),
       billingConfigStoreFactory: storeFactoryStub as unknown as (projectPath: string) => IBillingConfigStore,
       billingService,
-      projectConfigStore,
       providerConfigStore,
       resolveProjectPath: resolveProjectPathStub as unknown as (clientId: string) => string | undefined,
       transport,
@@ -244,14 +236,13 @@ describe('BillingHandler', () => {
       expect(transport._handlers.has(BillingEvents.GET_PINNED_TEAM)).to.equal(true)
     })
 
-    it('resolves the project from the client and returns the persisted team id', async () => {
+    it('uses the projectPath from the request and returns the persisted team id', async () => {
       getPinnedStub.resolves('org-pinned')
       createHandler()
 
       const handler = transport._handlers.get(BillingEvents.GET_PINNED_TEAM)
-      const result = await handler!(undefined, 'client-1')
+      const result = await handler!({projectPath: PROJECT_A}, 'client-1')
 
-      expect(resolveProjectPathStub.calledOnceWith('client-1')).to.equal(true)
       expect(storeFactoryStub.calledOnceWith(PROJECT_A)).to.equal(true)
       expect(result).to.deep.equal({teamId: 'org-pinned'})
     })
@@ -261,21 +252,9 @@ describe('BillingHandler', () => {
       createHandler()
 
       const handler = transport._handlers.get(BillingEvents.GET_PINNED_TEAM)
-      const result = await handler!(undefined, 'client-1')
+      const result = await handler!({projectPath: PROJECT_A}, 'client-1')
 
       expect(result).to.deep.equal({})
-    })
-
-    it('returns an error envelope when the client has no project association', async () => {
-      resolveProjectPathStub.returns()
-      createHandler()
-
-      const handler = transport._handlers.get(BillingEvents.GET_PINNED_TEAM)
-      const result = await handler!(undefined, 'client-1')
-
-      expect(getPinnedStub.called).to.equal(false)
-      expect(result).to.have.property('error').that.matches(/project/i)
-      expect(result).to.not.have.property('teamId')
     })
 
     it('returns an error envelope when the store throws', async () => {
@@ -283,7 +262,7 @@ describe('BillingHandler', () => {
       createHandler()
 
       const handler = transport._handlers.get(BillingEvents.GET_PINNED_TEAM)
-      const result = await handler!(undefined, 'client-1')
+      const result = await handler!({projectPath: PROJECT_A}, 'client-1')
 
       expect(result).to.deep.equal({error: 'disk read error'})
     })
@@ -295,13 +274,12 @@ describe('BillingHandler', () => {
       expect(transport._handlers.has(BillingEvents.SET_PINNED_TEAM)).to.equal(true)
     })
 
-    it('writes the new pin to the resolved project store and returns success', async () => {
+    it('writes the new pin to the requested project store and returns success', async () => {
       createHandler()
 
       const handler = transport._handlers.get(BillingEvents.SET_PINNED_TEAM)
-      const result = await handler!({teamId: 'org-new'}, 'client-1')
+      const result = await handler!({projectPath: PROJECT_A, teamId: 'org-new'}, 'client-1')
 
-      expect(resolveProjectPathStub.calledOnceWith('client-1')).to.equal(true)
       expect(storeFactoryStub.calledOnceWith(PROJECT_A)).to.equal(true)
       expect(setPinnedStub.calledOnceWith('org-new')).to.equal(true)
       expect(result).to.deep.equal({success: true})
@@ -311,7 +289,7 @@ describe('BillingHandler', () => {
       createHandler()
 
       const handler = transport._handlers.get(BillingEvents.SET_PINNED_TEAM)
-      const result = await handler!({}, 'client-1')
+      const result = await handler!({projectPath: PROJECT_A}, 'client-1')
 
       expect(setPinnedStub.calledOnceWith()).to.equal(true)
       expect(result).to.deep.equal({success: true})
@@ -322,7 +300,7 @@ describe('BillingHandler', () => {
       createHandler()
 
       const handler = transport._handlers.get(BillingEvents.SET_PINNED_TEAM)
-      const result = await handler!({teamId: 'org-new'}, 'client-1')
+      const result = await handler!({projectPath: PROJECT_A, teamId: 'org-new'}, 'client-1')
 
       expect(result).to.deep.equal({error: 'disk full', success: false})
     })
@@ -331,7 +309,7 @@ describe('BillingHandler', () => {
       createHandler()
 
       const handler = transport._handlers.get(BillingEvents.SET_PINNED_TEAM)
-      await handler!({teamId: 'org-new'}, 'client-1')
+      await handler!({projectPath: PROJECT_A, teamId: 'org-new'}, 'client-1')
 
       expect(
         transport.broadcast.calledOnceWith(TransportDaemonEventNames.BILLING_PIN_CHANGED, {
@@ -345,7 +323,7 @@ describe('BillingHandler', () => {
       createHandler()
 
       const handler = transport._handlers.get(BillingEvents.SET_PINNED_TEAM)
-      await handler!({}, 'client-1')
+      await handler!({projectPath: PROJECT_A}, 'client-1')
 
       expect(
         transport.broadcast.calledOnceWith(TransportDaemonEventNames.BILLING_PIN_CHANGED, {
@@ -359,7 +337,7 @@ describe('BillingHandler', () => {
       createHandler()
 
       const handler = transport._handlers.get(BillingEvents.SET_PINNED_TEAM)
-      await handler!({organizationId: 'org-new'}, 'client-1')
+      await handler!({projectPath: PROJECT_A, teamId: 'org-new'}, 'client-1')
 
       expect(transport.broadcast.called).to.equal(false)
     })

--- a/test/unit/infra/transport/handlers/billing-handler.test.ts
+++ b/test/unit/infra/transport/handlers/billing-handler.test.ts
@@ -266,6 +266,17 @@ describe('BillingHandler', () => {
 
       expect(result).to.deep.equal({error: 'disk read error'})
     })
+
+    it('returns an error envelope when projectPath is empty', async () => {
+      createHandler()
+
+      const handler = transport._handlers.get(BillingEvents.GET_PINNED_TEAM)
+      const result = await handler!({projectPath: ''}, 'client-1')
+
+      expect(storeFactoryStub.called).to.equal(false)
+      expect(getPinnedStub.called).to.equal(false)
+      expect(result).to.have.property('error').that.matches(/projectPath/i)
+    })
   })
 
   describe('billing:setPinnedTeam', () => {
@@ -340,6 +351,19 @@ describe('BillingHandler', () => {
       await handler!({projectPath: PROJECT_A, teamId: 'org-new'}, 'client-1')
 
       expect(transport.broadcast.called).to.equal(false)
+    })
+
+    it('returns an error envelope when projectPath is empty', async () => {
+      createHandler()
+
+      const handler = transport._handlers.get(BillingEvents.SET_PINNED_TEAM)
+      const result = await handler!({projectPath: '', teamId: 'org-new'}, 'client-1')
+
+      expect(storeFactoryStub.called).to.equal(false)
+      expect(setPinnedStub.called).to.equal(false)
+      expect(transport.broadcast.called).to.equal(false)
+      expect(result).to.have.property('error').that.matches(/projectPath/i)
+      expect(result).to.have.property('success', false)
     })
   })
 

--- a/test/unit/webui/features/provider/utils/compute-team-preselection.test.ts
+++ b/test/unit/webui/features/provider/utils/compute-team-preselection.test.ts
@@ -1,0 +1,95 @@
+import {expect} from 'chai'
+
+import type {TeamDTO} from '../../../../../../src/shared/transport/types/dto'
+
+import {computeTeamPreselection} from '../../../../../../src/webui/features/provider/utils/compute-team-preselection'
+
+function makeTeam(id: string): TeamDTO {
+  return {avatarUrl: '', displayName: id, id, isDefault: false, name: id, slug: id}
+}
+
+describe('computeTeamPreselection', () => {
+  describe('valid pin wins', () => {
+    it('returns the pinned team when it exists in the team list', () => {
+      const result = computeTeamPreselection({
+        paidOrganizationIds: ['A', 'B'],
+        pinnedTeamId: 'A',
+        teams: [makeTeam('A'), makeTeam('B')],
+      })
+      expect(result).to.equal('A')
+    })
+
+    it('returns the pinned team even when it is on the free tier (user can re-pick)', () => {
+      const result = computeTeamPreselection({
+        paidOrganizationIds: ['A'],
+        pinnedTeamId: 'C',
+        teams: [makeTeam('A'), makeTeam('C')],
+      })
+      expect(result).to.equal('C')
+    })
+  })
+
+  describe('stale pin → fall through', () => {
+    it('returns undefined when pin is not in the current team list and no auto-pick applies', () => {
+      const result = computeTeamPreselection({
+        paidOrganizationIds: ['A', 'B'],
+        pinnedTeamId: 'stale-id',
+        teams: [makeTeam('A'), makeTeam('B')],
+      })
+      expect(result).to.equal(undefined)
+    })
+
+    it('falls through to single-paid auto-pick when pin is stale', () => {
+      const result = computeTeamPreselection({
+        paidOrganizationIds: ['only'],
+        pinnedTeamId: 'stale-id',
+        teams: [makeTeam('only')],
+      })
+      expect(result).to.equal('only')
+    })
+  })
+
+  describe('no pin', () => {
+    it('returns undefined when there are no paid teams', () => {
+      const result = computeTeamPreselection({
+        paidOrganizationIds: [],
+        teams: [makeTeam('free-A')],
+      })
+      expect(result).to.equal(undefined)
+    })
+
+    it('returns the single paid team when there is exactly one paid team', () => {
+      const result = computeTeamPreselection({
+        paidOrganizationIds: ['only'],
+        teams: [makeTeam('only')],
+      })
+      expect(result).to.equal('only')
+    })
+
+    it('returns the workspace team when there are multiple paid teams and workspace is paid', () => {
+      const result = computeTeamPreselection({
+        paidOrganizationIds: ['A', 'B'],
+        teams: [makeTeam('A'), makeTeam('B')],
+        workspaceTeamId: 'A',
+      })
+      expect(result).to.equal('A')
+    })
+
+    it('returns the workspace team even when workspace is on the free tier', () => {
+      const result = computeTeamPreselection({
+        paidOrganizationIds: ['A', 'B'],
+        teams: [makeTeam('A'), makeTeam('B'), makeTeam('free-workspace')],
+        workspaceTeamId: 'free-workspace',
+      })
+      expect(result).to.equal('free-workspace')
+    })
+
+    it('returns undefined when there are multiple paid teams and no workspace', () => {
+      const result = computeTeamPreselection({
+        paidOrganizationIds: ['A', 'B'],
+        teams: [makeTeam('A'), makeTeam('B')],
+      })
+      expect(result).to.equal(undefined)
+    })
+  })
+})

--- a/test/unit/webui/lib/api-client.test.ts
+++ b/test/unit/webui/lib/api-client.test.ts
@@ -23,22 +23,26 @@ function makeStubSocket(
 }
 
 interface ControllableSocket extends Socket {
+  offCalls: Array<{event: string; handler: () => void}>
   triggerDisconnect: () => void
 }
 
 function makeControllableSocket(options: {connected?: boolean; emitAck?: boolean} = {}): ControllableSocket {
   const {connected = true, emitAck = false} = options
   let disconnectHandler: (() => void) | undefined
+  const offCalls: Array<{event: string; handler: () => void}> = []
   const socket = {
     connected,
     emit(_event: string, _data: unknown, callback: (response: unknown) => void) {
       if (emitAck) callback({data: 'ok', success: true})
       return socket
     },
-    off(_event: string, _handler: () => void) {
+    off(event: string, handler: () => void) {
+      offCalls.push({event, handler})
       disconnectHandler = undefined
       return socket
     },
+    offCalls,
     once(event: string, handler: () => void) {
       if (event === 'disconnect') disconnectHandler = handler
       return socket
@@ -106,5 +110,24 @@ describe('BrvApiClient.request', () => {
     const client = new BrvApiClient(socket)
     const result = await client.request<string>('vc:push')
     expect(result).to.equal('ok')
+  })
+
+  it('removes the disconnect listener after a successful ack', async () => {
+    const socket = makeControllableSocket({connected: true, emitAck: true})
+    const client = new BrvApiClient(socket)
+    await client.request<string>('vc:push')
+    expect(socket.offCalls.some((c) => c.event === 'disconnect')).to.equal(true)
+  })
+
+  it('removes the disconnect listener after a timeout', async () => {
+    const socket = makeControllableSocket({connected: true, emitAck: false})
+    const client = new BrvApiClient(socket)
+    try {
+      await client.request('vc:push', undefined, {timeout: 5})
+      expect.fail('request should have rejected')
+    } catch (error) {
+      expect((error as Error).message).to.match(/timed out/i)
+      expect(socket.offCalls.some((c) => c.event === 'disconnect')).to.equal(true)
+    }
   })
 })

--- a/test/unit/webui/lib/api-client.test.ts
+++ b/test/unit/webui/lib/api-client.test.ts
@@ -9,8 +9,15 @@ function makeStubSocket(
   ack: {code?: string; error?: string; success: boolean} | {data: unknown; success: true},
 ): Socket {
   return {
+    connected: true,
     emit(_event: string, _data: unknown, callback: (response: unknown) => void) {
       callback(ack)
+      return this
+    },
+    off() {
+      return this
+    },
+    once() {
       return this
     },
   } as unknown as Socket

--- a/test/unit/webui/lib/api-client.test.ts
+++ b/test/unit/webui/lib/api-client.test.ts
@@ -4,7 +4,6 @@ import {expect} from 'chai'
 
 import {BrvApiClient} from '../../../../src/webui/lib/api-client.js'
 
-/** Tiny socket stub that captures emits and lets us drive the ack callback. */
 function makeStubSocket(
   ack: {code?: string; error?: string; success: boolean} | {data: unknown; success: true},
 ): Socket {
@@ -21,6 +20,34 @@ function makeStubSocket(
       return this
     },
   } as unknown as Socket
+}
+
+interface ControllableSocket extends Socket {
+  triggerDisconnect: () => void
+}
+
+function makeControllableSocket(options: {connected?: boolean; emitAck?: boolean} = {}): ControllableSocket {
+  const {connected = true, emitAck = false} = options
+  let disconnectHandler: (() => void) | undefined
+  const socket = {
+    connected,
+    emit(_event: string, _data: unknown, callback: (response: unknown) => void) {
+      if (emitAck) callback({data: 'ok', success: true})
+      return socket
+    },
+    off(_event: string, _handler: () => void) {
+      disconnectHandler = undefined
+      return socket
+    },
+    once(event: string, handler: () => void) {
+      if (event === 'disconnect') disconnectHandler = handler
+      return socket
+    },
+    triggerDisconnect() {
+      disconnectHandler?.()
+    },
+  } as unknown as ControllableSocket
+  return socket
 }
 
 describe('BrvApiClient.request', () => {
@@ -49,5 +76,35 @@ describe('BrvApiClient.request', () => {
       expect(error).to.be.instanceOf(Error)
       expect((error as Error & {code?: string}).code).to.be.undefined
     }
+  })
+
+  it('rejects synchronously when socket is not connected', async () => {
+    const client = new BrvApiClient(makeControllableSocket({connected: false}))
+    try {
+      await client.request('vc:push')
+      expect.fail('request should have rejected')
+    } catch (error) {
+      expect((error as Error).message).to.match(/not connected/i)
+    }
+  })
+
+  it('rejects fast when socket disconnects before the ack arrives', async () => {
+    const socket = makeControllableSocket({connected: true, emitAck: false})
+    const client = new BrvApiClient(socket)
+    const requestPromise = client.request('vc:push')
+    socket.triggerDisconnect()
+    try {
+      await requestPromise
+      expect.fail('request should have rejected')
+    } catch (error) {
+      expect((error as Error).message).to.match(/disconnected/i)
+    }
+  })
+
+  it('resolves normally when the ack arrives before disconnect', async () => {
+    const socket = makeControllableSocket({connected: true, emitAck: true})
+    const client = new BrvApiClient(socket)
+    const result = await client.request<string>('vc:push')
+    expect(result).to.equal('ok')
   })
 })


### PR DESCRIPTION
## Summary
- Slim daemon-side `resolveBillingTeamId` to a pure prediction helper (pin / single-paid / undefined) — the workspace fallback is now a UI-only pre-selection hint.
- Thread `projectPath` through `billing:getPinnedTeam`, `billing:setPinnedTeam`, and `auth:getState` so the daemon resolves the project from the request body, not per-client state.
- Add `computeTeamPreselection` so the team picker visually pre-selects a row without writing the pin until the user clicks Confirm.
- Fix project-switch race in `BrvApiClient.request`: pre-check `socket.connected` and fast-fail on disconnect so in-flight requests don't silently wait the full 5s timeout during socket teardown.
- Header: drop workspace fallback; fall through to auto-pick on stale pin; ignore pin entirely when the user has no paid teams.
- Picker: disable Confirm when the selection isn't in the team list (stale workspace id or removed team).

## Test plan
- [ ] Case 1 — 0 paid teams: header shows free monthly credits, no tooltip.
- [ ] Case 2 — 1 paid team, no pin: header shows that team, picker pre-selects with Confirm disabled.
- [ ] Case 3 — 1 paid team + pin: same as 2 with explicit pin.
- [ ] Case 4 — 2+ paid, no pin, no workspace: amber pulse + "Select a team" tooltip; no row pre-selected.
- [ ] Case 5 — 2+ paid, no pin, paid workspace: workspace row pre-selected; Confirm flips header on click.
- [ ] Case 6 — 2+ paid, no pin, free workspace: same as 5 with free badge.
- [ ] Case 7 — pinned team valid: shown in header, Confirm disabled.
- [ ] Case 8 — pinned team stale: no row pre-selected; header falls through to auto-pick if 1 paid, otherwise amber.
- [ ] Case 9 — pinned team downgraded to free: still pre-selected; header shows 0/red (intentional — explicit user choice).
- [ ] Project switch A → B → A: header reflects the new project immediately without needing reload or dialog open.
- [ ] Confirm disabled when selection refers to a team no longer in the list.