### PR TITLE
fix: tool-mode write-time overwrite guard

### DIFF
--- a/docs/curate-protocol.md
+++ b/docs/curate-protocol.md
@@ -89,6 +89,7 @@ Every kickoff and continuation call returns the same JSON envelope under the sta
 |---|---|---|---|
 | `missing-content` | Kickoff | **terminal** | Kickoff invoked without a context argument; no session created |
 | `missing-response` | Continuation | **terminal** | `--session` invoked without `--response`; session unaffected |
+| `invalid-flag-combination` | Continuation | **terminal** | Emitted before any session lookup when a flag is used outside its supported call shape. Today the only producer is `--overwrite` passed without `--session` (legacy curate path does not honour `--overwrite`). |
 | `unknown-session` | Continuation | **terminal** | Session id doesn't exist, was already completed, or fails uuid validation |
 | `empty-response` | Continuation | **transient** (session kept live) | Continuation received an empty `--response`; caller retries with the same `sessionId` |
 | `retry-cap-exceeded` | Continuation | **terminal** | `MAX_ATTEMPTS = 4` (1 generate + 3 corrections) reached without valid HTML; session cleared. Accompanied by the validation errors that pushed the session over the cap. |

--- a/docs/curate-protocol.md
+++ b/docs/curate-protocol.md
@@ -27,6 +27,14 @@ brv curate --session <sessionId> --response "<calling agent's output>" --format 
 
 Presence of `--session` always means tool-mode continuation. The env var is not consulted on continuation calls.
 
+### Overwrite intent — `--overwrite` on continuation
+
+```bash
+brv curate --session <sessionId> --response "<calling agent's output>" --overwrite --format json
+```
+
+Default behavior: the writer refuses to clobber an existing topic at the resolved path and returns a `path-exists` correction step carrying the prior file's content. Pass `--overwrite` only when the calling agent has consciously decided to replace prior content. The flag is consumed on the continuation it appears on; subsequent continuations in the same session must repeat it if they still want to overwrite.
+
 ### `--format text` fallback
 
 Both kickoff and continuation accept `--format text` for shell users. The output is a terse human digest. The primary consumer (the calling agent) uses `--format json`.
@@ -90,6 +98,7 @@ Every kickoff and continuation call returns the same JSON envelope under the sta
 | `unsafe-path` | Continuation | **transient** (correction) | `<bv-topic path>` contains `..` or `.` segments |
 | `unknown-element` | Continuation | **transient** (correction) | Response contains a `<bv-*>` tag outside the closed registry; `tag` field carries the offending name |
 | `attribute-validation` | Continuation | **transient** (correction) | An element's attributes failed its registered validator. `tag` carries the element, `attribute` the offending field. |
+| `path-exists` | Continuation | **transient** (correction) | A topic already exists at the resolved path and `--overwrite` was not passed. The envelope error carries `existingContent` (the prior file's bytes); the correction prompt inlines the same content inside an `<existing-topic path="…">…</existing-topic>` block so the calling agent can merge new content into existing structure. The guard does not clear by re-emitting different content — `--overwrite` is required to write at this path. Default workflow: merge `existingContent` with the new content and re-emit with `--overwrite`. Alternative: choose a different `<bv-topic path>` (no `--overwrite` needed). |
 
 **Terminal vs transient.** Terminal failures end the session — the caller cannot retry the same `sessionId` and must start a new kickoff. Transient failures keep the session alive on disk; the envelope echoes the `sessionId` back and the caller is expected to issue a corrected continuation against it.
 

--- a/src/oclif/commands/curate/index.ts
+++ b/src/oclif/commands/curate/index.ts
@@ -27,6 +27,7 @@ type CurateFlags = {
   files?: string[]
   folder?: string[]
   format?: 'json' | 'text'
+  overwrite?: boolean
   response?: string
   session?: string
   timeout?: number
@@ -97,6 +98,15 @@ Bad examples:
       description: 'Output format (text or json)',
       options: ['text', 'json'],
     }),
+    overwrite: Flags.boolean({
+      // Tool-mode continuation only. When set, the orchestrator passes
+      // `confirmOverwrite: true` to the writer, bypassing the
+      // `path-exists` guard. The default (false) refuses to clobber an
+      // existing topic; the calling agent receives a `correct-html`
+      // step carrying the existing content for merging.
+      default: false,
+      description: 'Allow overwriting an existing topic on tool-mode continuation (pairs with --session)',
+    }),
     response: Flags.string({
       // Pairs with --session for tool-mode continuation. The opaque
       // text is interpreted by the orchestrator per the step it last
@@ -129,6 +139,7 @@ Bad examples:
       files: rawFlags.files,
       folder: rawFlags.folder,
       format: rawFlags.format === 'json' ? 'json' : rawFlags.format === 'text' ? 'text' : undefined,
+      overwrite: rawFlags.overwrite,
       response: rawFlags.response,
       session: rawFlags.session,
       timeout: rawFlags.timeout,
@@ -352,6 +363,7 @@ Bad examples:
     }
 
     const envelope = await continueSession({
+      confirmOverwrite: flags.overwrite ?? false,
       projectRoot: resolveProjectRoot(),
       response: flags.response,
       sessionId,

--- a/src/oclif/commands/curate/index.ts
+++ b/src/oclif/commands/curate/index.ts
@@ -146,6 +146,27 @@ Bad examples:
     }
     const format: 'json' | 'text' = flags.format ?? 'text'
 
+    // `--overwrite` is meaningful only on tool-mode continuation. The
+    // legacy agent-driven path has its own pendingReview machinery and
+    // does not consult this flag. Reject early so the user doesn't
+    // believe overwrite semantics took effect on a legacy curate.
+    if (flags.overwrite && flags.session === undefined) {
+      this.emitToolModeEnvelope(
+        {
+          errors: [
+            {
+              kind: 'invalid-flag-combination',
+              message: '--overwrite requires --session (tool-mode continuation). On a legacy curate run, this flag has no effect; remove it or pair it with --session <id>.',
+            },
+          ],
+          ok: false,
+          status: 'failed',
+        },
+        format,
+      )
+      return
+    }
+
     // Tool-mode dispatch — runs before the legacy provider check and
     // task lifecycle. Continuation is implied by --session; kickoff
     // requires the BRV_CURATE_TOOL_MODE env var (TKT 02 replaces with

--- a/src/oclif/lib/curate-session.ts
+++ b/src/oclif/lib/curate-session.ts
@@ -80,10 +80,13 @@ const SESSION_ID_RE = /^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$
 export type CurateSessionError = {
   attribute?: string
   /**
-   * Present on `kind: 'path-exists'` only. Carries the prior file's
-   * full bytes so the calling agent can merge new content into the
-   * existing topic instead of silently clobbering it. Mirrors what is
-   * embedded inline into the correction prompt.
+   * Present on `kind: 'path-exists'` when the prior file was readable.
+   * Carries the existing file's full bytes so the calling agent can
+   * merge new content into the existing topic instead of silently
+   * clobbering it. Mirrors what is embedded inline into the correction
+   * prompt. Absent (`undefined`) when the file exists but its content
+   * could not be read — consumers MUST treat that as "prior content
+   * unavailable", NOT as "topic is empty".
    */
   existingContent?: string
   kind: string

--- a/src/oclif/lib/curate-session.ts
+++ b/src/oclif/lib/curate-session.ts
@@ -79,6 +79,13 @@ const SESSION_ID_RE = /^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$
 /** Flat error shape carried in the envelope's `errors` array. */
 export type CurateSessionError = {
   attribute?: string
+  /**
+   * Present on `kind: 'path-exists'` only. Carries the prior file's
+   * full bytes so the calling agent can merge new content into the
+   * existing topic instead of silently clobbering it. Mirrors what is
+   * embedded inline into the correction prompt.
+   */
+  existingContent?: string
   kind: string
   message: string
   tag?: string
@@ -146,6 +153,14 @@ type KickoffOptions = {
 }
 
 type ContinueOptions = {
+  /**
+   * Opt-in to clobber an existing topic at the resolved path. Default
+   * `false`: the writer's overwrite guard surfaces `path-exists` as a
+   * correctable validation error. Set `true` only when the calling
+   * agent has consciously decided to replace prior content (today
+   * surfaced via the `--overwrite` flag on `brv curate --session …`).
+   */
+  confirmOverwrite?: boolean
   projectRoot: string
   response: string
   sessionId: string
@@ -186,7 +201,7 @@ export async function kickoffSession(options: KickoffOptions): Promise<CurateSes
  * with `failed` once the retry cap is exhausted.
  */
 export async function continueSession(options: ContinueOptions): Promise<CurateSessionEnvelope> {
-  const {projectRoot, response, sessionId} = options
+  const {confirmOverwrite = false, projectRoot, response, sessionId} = options
 
   // Reject non-uuid session ids before any path join — see SESSION_ID_RE
   // for the threat model. Same `kind` as "session not found" because
@@ -214,7 +229,7 @@ export async function continueSession(options: ContinueOptions): Promise<CurateS
   // and atomically write to `.brv/context-tree/<topic.path>.html`. On
   // validation failure no file lands on disk.
   const contextTreeRoot = join(projectRoot, BRV_DIR, CONTEXT_TREE_DIR)
-  const writeResult = await writeHtmlTopic({contextTreeRoot, rawHtml: response})
+  const writeResult = await writeHtmlTopic({confirmOverwrite, contextTreeRoot, rawHtml: response})
 
   state.attempts += 1
   state.lastResponse = response
@@ -286,6 +301,14 @@ function mapWriterError(err: HtmlWriteError): CurateSessionError {
   switch (err.kind) {
     case 'attribute-validation': {
       return {attribute: err.field, kind: 'attribute-validation', message: err.message, tag: err.tag}
+    }
+
+    case 'path-exists': {
+      // Surface the prior content in a structured field so JSON-driven
+      // consumers can merge without re-parsing the prompt; the same
+      // content is also inlined into the correction prompt for LLM-
+      // driven callers.
+      return {existingContent: err.existingContent, kind: 'path-exists', message: err.message}
     }
 
     case 'unknown-bv-element': {

--- a/src/server/core/domain/render/curate-prompt-builder.ts
+++ b/src/server/core/domain/render/curate-prompt-builder.ts
@@ -97,6 +97,24 @@ export function buildCorrectionPrompt(options: {
     ? 'No structured errors were reported. Re-emit the document carefully and double-check every required attribute.'
     : errors.map((err) => `- **${err.kind}** — ${err.message} ${kindToFixHint(err)}`.trim()).join('\n')
 
+  // When the writer's overwrite guard fired, inline the prior file's
+  // bytes so the calling LLM can merge new content into the existing
+  // structure without parsing JSON. Multiple `path-exists` errors in
+  // a single response would be unusual (one topic per response), but
+  // we render each separately so the prompt is unambiguous.
+  const pathExistsErrors = errors.filter((e): e is Extract<HtmlWriteError, {kind: 'path-exists'}> => e.kind === 'path-exists')
+  const existingTopicBlock = pathExistsErrors.length === 0
+    ? ''
+    : ['', '# Existing topic on disk', '',
+        'A topic already exists at the path you chose. Decide between merging into it (preferred — preserves prior facts) or asking the user to confirm replacement.',
+        '',
+        ...pathExistsErrors.flatMap((err) => [
+          `<existing-topic path="${err.topicPath}">`,
+          err.existingContent,
+          '</existing-topic>',
+        ]),
+      ].join('\n')
+
   return [
     'The HTML you produced failed validation. Fix the errors below and return the corrected document.',
     '',
@@ -107,6 +125,7 @@ export function buildCorrectionPrompt(options: {
     '# Errors to fix',
     '',
     fixInstructions,
+    existingTopicBlock,
     '',
     '# Original user intent',
     '',
@@ -210,6 +229,10 @@ function kindToFixHint(err: HtmlWriteError): string {
 
     case 'multiple-bv-topic': {
       return 'Merge the topics into one `<bv-topic>` — only one root element per response.'
+    }
+
+    case 'path-exists': {
+      return 'Either merge your new content into the existing topic above and re-emit, or rerun this continuation with `--overwrite` to replace it entirely.'
     }
 
     case 'unknown-bv-element': {

--- a/src/server/core/domain/render/curate-prompt-builder.ts
+++ b/src/server/core/domain/render/curate-prompt-builder.ts
@@ -99,16 +99,24 @@ export function buildCorrectionPrompt(options: {
 
   // When the writer's overwrite guard fired, inline the prior file's
   // bytes so the calling LLM can merge new content into the existing
-  // structure without parsing JSON. Multiple `path-exists` errors in
-  // a single response would be unusual (one topic per response), but
-  // we render each separately so the prompt is unambiguous.
-  const pathExistsErrors = errors.filter((e): e is Extract<HtmlWriteError, {kind: 'path-exists'}> => e.kind === 'path-exists')
-  const existingTopicBlock = pathExistsErrors.length === 0
+  // structure without parsing JSON. We only render the block when the
+  // prior content was readable — otherwise an empty `<existing-topic>`
+  // would lead the LLM to conclude the prior topic was empty and
+  // produce a merge with no carryover, defeating the guard's purpose.
+  // Multiple `path-exists` errors in a single response would be unusual
+  // (one topic per response), but we render each separately so the
+  // prompt is unambiguous.
+  type PathExistsError = Extract<HtmlWriteError, {kind: 'path-exists'}>
+  const pathExistsErrors = errors.filter((e): e is PathExistsError => e.kind === 'path-exists')
+  const readableExistingTopics = pathExistsErrors.filter(
+    (err): err is PathExistsError & {existingContent: string} => err.existingContent !== undefined,
+  )
+  const existingTopicBlock = readableExistingTopics.length === 0
     ? ''
     : ['', '# Existing topic on disk', '',
         'A topic already exists at the path you chose. Decide between merging into it (preferred — preserves prior facts) or asking the user to confirm replacement.',
         '',
-        ...pathExistsErrors.flatMap((err) => [
+        ...readableExistingTopics.flatMap((err) => [
           `<existing-topic path="${err.topicPath}">`,
           err.existingContent,
           '</existing-topic>',

--- a/src/server/infra/executor/curate-executor.ts
+++ b/src/server/infra/executor/curate-executor.ts
@@ -304,7 +304,13 @@ export class CurateExecutor implements ICurateExecutor {
 
     let writeResult
     try {
-      writeResult = await writeHtmlTopic({contextTreeRoot, rawHtml: response})
+      // `confirmOverwrite: true` bypasses the writer's path-exists guard.
+      // The legacy in-daemon agent path has its own supervisory context:
+      // the agent runs search + read before deciding to write, and the
+      // surrounding executor lifecycle drives `pendingReview` snapshot /
+      // approval for UPDATE operations. The guard is intended specifically
+      // for tool mode where the calling agent lacks that machinery.
+      writeResult = await writeHtmlTopic({confirmOverwrite: true, contextTreeRoot, rawHtml: response})
     } catch (error) {
       // Hard error (path traversal, I/O failure). Surface as `failed`
       // status; the executor's caller logs the error.

--- a/src/server/infra/render/writer/html-writer.ts
+++ b/src/server/infra/render/writer/html-writer.ts
@@ -48,6 +48,7 @@ export type HtmlWriteFailure = {
 export type HtmlWriteResult = HtmlWriteFailure | HtmlWriteSuccess
 
 export type HtmlWriteError =
+  | {existingContent: string; kind: 'path-exists'; message: string; topicPath: string}
   | {field: string; kind: 'attribute-validation'; message: string; tag: ElementName}
   | {kind: 'missing-bv-topic'; message: string}
   | {kind: 'missing-path-attribute'; message: string}
@@ -56,6 +57,15 @@ export type HtmlWriteError =
   | {kind: 'unsafe-path'; message: string}
 
 export type HtmlWriteOptions = {
+  /**
+   * Opt-in to clobber an existing topic at the resolved path. Default
+   * `false`: the writer refuses to overwrite and returns a structured
+   * `path-exists` error carrying the existing file's content so the
+   * caller can merge. Set `true` only when the caller has consciously
+   * decided to replace prior content (e.g. via a `--overwrite` flag
+   * from the calling agent).
+   */
+  confirmOverwrite?: boolean
   /**
    * Project root directory. The topic file is written to
    * `<contextTreeRoot>/<topic.path>.html` relative to this root.
@@ -77,7 +87,7 @@ export type HtmlWriteOptions = {
  * agent is not allowed to choose its own timestamps.
  */
 export async function writeHtmlTopic(options: HtmlWriteOptions): Promise<HtmlWriteResult> {
-  const {contextTreeRoot, rawHtml} = options
+  const {confirmOverwrite = false, contextTreeRoot, rawHtml} = options
   const cleaned = stripCodeFenceWrapper(rawHtml)
 
   const validation = validateHtmlTopic(cleaned)
@@ -86,6 +96,29 @@ export async function writeHtmlTopic(options: HtmlWriteOptions): Promise<HtmlWri
   }
 
   const filePath = topicPathToFilePath(contextTreeRoot, validation.topicPath)
+
+  // Overwrite guard. The default policy is "refuse to clobber" — surface
+  // a structured `path-exists` error carrying the existing file's content
+  // so the caller (today: tool-mode orchestrator) can route the calling
+  // agent to merge instead of silently losing prior facts. An explicit
+  // `confirmOverwrite: true` from the caller is the only way through.
+  if (!confirmOverwrite && existsSync(filePath)) {
+    const existingContent = readExistingFileSafe(filePath) ?? ''
+    return {
+      errors: [
+        {
+          existingContent,
+          kind: 'path-exists',
+          message:
+            `A topic already exists at "${validation.topicPath}". Pass --overwrite to replace it, `
+            + 'or merge the new content into the existing topic and re-emit.',
+          topicPath: validation.topicPath,
+        },
+      ],
+      ok: false,
+    }
+  }
+
   const now = new Date().toISOString()
   const createdAt = readExistingTopicAttribute(filePath, 'createdat') ?? now
   const stamped = setBvTopicAttributes(cleaned, {createdat: createdAt, updatedat: now})
@@ -275,5 +308,21 @@ function readExistingTopicAttribute(filePath: string, attrName: string): null | 
     return attrMatch ? attrMatch[1] : null
   } catch {
     return null
+  }
+}
+
+/**
+ * Read a file's full contents, returning `undefined` on any I/O error.
+ * Used by the overwrite guard to surface the prior file content into a
+ * `path-exists` error envelope. Errors here are swallowed deliberately:
+ * the guard's purpose is to prevent silent clobber, and surfacing
+ * partial / unreadable content as an empty string is acceptable
+ * (the caller still sees the structural `path-exists` signal).
+ */
+function readExistingFileSafe(filePath: string): string | undefined {
+  try {
+    return readFileSync(filePath, 'utf8')
+  } catch {
+    return undefined
   }
 }

--- a/src/server/infra/render/writer/html-writer.ts
+++ b/src/server/infra/render/writer/html-writer.ts
@@ -48,7 +48,16 @@ export type HtmlWriteFailure = {
 export type HtmlWriteResult = HtmlWriteFailure | HtmlWriteSuccess
 
 export type HtmlWriteError =
-  | {existingContent: string; kind: 'path-exists'; message: string; topicPath: string}
+  /**
+   * Existing topic at the resolved path blocked the write because
+   * `confirmOverwrite` was not set. `existingContent` carries the prior
+   * file's bytes when readable; it is `undefined` when the file exists
+   * but cannot be read (perms change, concurrent unlink, dangling
+   * symlink). Consumers MUST NOT assume `existingContent === undefined`
+   * means "topic is empty" — it means "couldn't read prior content,
+   * merge requires re-fetching".
+   */
+  | {existingContent: string | undefined; kind: 'path-exists'; message: string; topicPath: string}
   | {field: string; kind: 'attribute-validation'; message: string; tag: ElementName}
   | {kind: 'missing-bv-topic'; message: string}
   | {kind: 'missing-path-attribute'; message: string}
@@ -102,16 +111,33 @@ export async function writeHtmlTopic(options: HtmlWriteOptions): Promise<HtmlWri
   // so the caller (today: tool-mode orchestrator) can route the calling
   // agent to merge instead of silently losing prior facts. An explicit
   // `confirmOverwrite: true` from the caller is the only way through.
+  //
+  // NOTE on TOCTOU: a small race exists between `existsSync` here and
+  // `writeFileAtomic` below. In practice tool-mode curate is serialised
+  // by the daemon's per-project task pipeline and the per-session
+  // orchestrator state machine (only one continuation in flight per
+  // session). A concurrent writer on a different session targeting the
+  // same path is the only window; with `tmp+rename` atomic semantics
+  // the worst case is a single write losing on the rename, never a
+  // partial file.
   if (!confirmOverwrite && existsSync(filePath)) {
-    const existingContent = readExistingFileSafe(filePath) ?? ''
+    // existingContent may be undefined if the file exists but is
+    // unreadable (perms change, concurrent unlink, broken symlink). We
+    // pass that through verbatim — the prompt builder skips the inline
+    // block when undefined so the agent does not see an empty
+    // <existing-topic> and conclude the prior topic was empty (which
+    // would lead to a different silent-clobber path).
+    const existingContent = readExistingFileSafe(filePath)
     return {
       errors: [
         {
           existingContent,
           kind: 'path-exists',
-          message:
-            `A topic already exists at "${validation.topicPath}". Pass --overwrite to replace it, `
-            + 'or merge the new content into the existing topic and re-emit.',
+          message: existingContent === undefined
+            ? `A topic already exists at "${validation.topicPath}" but its content could not be read. `
+              + 'Pass --overwrite to replace it (will clobber), or investigate the file before retrying.'
+            : `A topic already exists at "${validation.topicPath}". Pass --overwrite to replace it, `
+              + 'or merge the new content into the existing topic and re-emit.',
           topicPath: validation.topicPath,
         },
       ],

--- a/src/server/templates/skill/SKILL.md
+++ b/src/server/templates/skill/SKILL.md
@@ -140,6 +140,10 @@ The session protocol is request → response → request, all via `brv curate` i
 4. **Branch on `status`:**
    - `done` → topic written. Report `data.filePath` (relative to `.brv/context-tree/`) to the user. Done.
    - `needs-llm-step` with `step: "correct-html"` → validation failed. Read `data.prompt` and `data.errors[]`, regenerate corrected HTML, continue with another `--session/--response` call.
+     - If `data.errors[]` includes `kind: "path-exists"`, a topic already exists at the path you chose. The error carries `existingContent` (also embedded inline in `data.prompt` as `<existing-topic path="…">…</existing-topic>`). The guard does NOT clear by re-emitting different content — to write at this path you MUST pass `--overwrite` on the next continuation. Three options:
+       1. **Default — merge + overwrite (preserves prior facts)**: combine `existingContent` with your new content and re-emit the merged HTML with `--overwrite`. Every prior fact stays in the topic.
+       2. **Different path (no overwrite needed)**: if the collision was accidental, pick a different `<bv-topic path>` and re-emit without `--overwrite`.
+       3. **Replace (data-destructive)**: re-emit with `--overwrite` carrying ONLY your new content. ONLY do this when the user has explicitly told you to replace prior content — it clobbers facts the user previously curated.
    - `failed` → surface `data.errors[].message` to the user. If `kind: "retry-cap-exceeded"`, your HTML still didn't validate after 3 corrections — ask the user to clarify intent and start a fresh kickoff.
 
 **Bounds:** at most 4 round-trips per session (1 generate + 3 corrections). Each `brv curate` invocation in tool mode is short-lived — no `--detach`, no `-f` files. Session state lives in `.brv/sessions/curate-<id>/` and is cleaned up on terminal `done` or `failed`.

--- a/test/commands/curate.test.ts
+++ b/test/commands/curate.test.ts
@@ -143,6 +143,21 @@ describe('Curate Command', () => {
       expect(json.success).to.be.false
       expect(json.data).to.have.property('message').that.includes('Either a context argument')
     })
+
+    it('should reject --overwrite without --session (legacy path does not honour the flag)', async () => {
+      // --overwrite is a tool-mode-continuation-only flag. On a legacy
+      // curate (no --session) it would silently be ignored — fail fast
+      // so the user doesn't believe overwrite semantics took effect.
+      await createJsonCommand('some context', '--overwrite').run()
+
+      const json = parseJsonOutput()
+      expect(json.success).to.be.false
+      const data = json.data as {errors?: Array<{kind: string; message: string}>; status?: string}
+      expect(data.status).to.equal('failed')
+      const errors = data.errors ?? []
+      expect(errors.some((e) => e.kind === 'invalid-flag-combination')).to.equal(true)
+      expect(errors[0].message).to.include('--overwrite requires --session')
+    })
   })
 
   // ==================== Provider Validation ====================

--- a/test/unit/oclif/lib/curate-session.test.ts
+++ b/test/unit/oclif/lib/curate-session.test.ts
@@ -34,6 +34,27 @@ import {BRV_DIR} from '../../../../src/server/constants.js'
 
 const UUID_RE = /^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/i
 
+/**
+ * Type-narrowing guard for optional envelope fields. Replaces
+ * `value!.field` (non-null assertion) with a clear runtime error when
+ * the field is missing, while also narrowing the TS type so the
+ * subsequent access is statically safe.
+ */
+function assertDefined<T>(value: T | undefined, label: string): asserts value is T {
+  if (value === undefined) throw new Error(`expected ${label} to be defined`)
+}
+
+/**
+ * Seed an existing topic at `security/auth.html` for overwrite-guard
+ * tests. Runs a full kickoff → valid-response cycle so the file lands
+ * via the production code path.
+ */
+async function seedExistingTopic(projectRoot: string): Promise<void> {
+  const kickoff = await kickoffSession({content: 'remember JWT', projectRoot})
+  const done = await continueSession({projectRoot, response: VALID_TOPIC_HTML, sessionId: kickoff.sessionId!})
+  expect(done.status).to.equal('done')
+}
+
 describe('curate-session placeholder', () => {
   let projectRoot: string
 
@@ -404,6 +425,138 @@ describe('curate-session placeholder', () => {
       expect(envelope.ok).to.equal(false)
       expect(envelope.status).to.equal('failed')
       expect(envelope.errors).to.be.an('array').with.length.greaterThan(0)
+    })
+  })
+
+  describe('continueSession — overwrite guard', () => {
+    // Background: a second tool-mode curate that targets a path already
+    // present in the context-tree must NOT silently overwrite. The
+    // writer surfaces `path-exists`; the orchestrator maps it onto a
+    // `correct-html` step carrying the existing content so the calling
+    // agent can merge. An explicit `confirmOverwrite: true` on the
+    // continuation bypasses the guard.
+
+    it('blocks a second valid response on the same path; emits correct-html with path-exists', async () => {
+      await seedExistingTopic(projectRoot)
+
+      const kickoff2 = await kickoffSession({content: 'remember JWT again', projectRoot})
+      const envelope = await continueSession({
+        projectRoot,
+        response: VALID_TOPIC_HTML,
+        sessionId: kickoff2.sessionId!,
+      })
+
+      expect(envelope.ok).to.equal(false)
+      expect(envelope.status).to.equal('needs-llm-step')
+      expect(envelope.step).to.equal('correct-html')
+      expect(envelope.sessionId).to.equal(kickoff2.sessionId)
+      assertDefined(envelope.errors, 'envelope.errors')
+      expect(envelope.errors.some((e) => e.kind === 'path-exists')).to.equal(true)
+    })
+
+    it('carries existingContent on the path-exists envelope error', async () => {
+      await seedExistingTopic(projectRoot)
+      const onDiskPath = join(projectRoot, BRV_DIR, 'context-tree', 'security', 'auth.html')
+      const original = await readFile(onDiskPath, 'utf8')
+
+      const kickoff2 = await kickoffSession({content: 'x', projectRoot})
+      const envelope = await continueSession({
+        projectRoot,
+        response: VALID_TOPIC_HTML,
+        sessionId: kickoff2.sessionId!,
+      })
+
+      assertDefined(envelope.errors, 'envelope.errors')
+      const pathExists = envelope.errors.find((e) => e.kind === 'path-exists')
+      assertDefined(pathExists, 'path-exists error')
+      expect(pathExists.existingContent).to.equal(original)
+    })
+
+    it('correction prompt embeds the existing topic for merge context', async () => {
+      await seedExistingTopic(projectRoot)
+
+      const kickoff2 = await kickoffSession({content: 'x', projectRoot})
+      const envelope = await continueSession({
+        projectRoot,
+        response: VALID_TOPIC_HTML,
+        sessionId: kickoff2.sessionId!,
+      })
+
+      // The previously written file's body content should be inlined into
+      // the correction prompt so the calling LLM can merge without parsing
+      // structured JSON.
+      assertDefined(envelope.prompt, 'envelope.prompt')
+      expect(envelope.prompt).to.include('<bv-reason>x</bv-reason>')
+    })
+
+    it('path-exists block counts toward retry cap (state.attempts increments)', async () => {
+      await seedExistingTopic(projectRoot)
+
+      const kickoff2 = await kickoffSession({content: 'x', projectRoot})
+      const sessionId = kickoff2.sessionId!
+      await continueSession({projectRoot, response: VALID_TOPIC_HTML, sessionId})
+
+      const statePath = join(
+        projectRoot,
+        BRV_DIR,
+        CURATE_SESSIONS_DIR,
+        `${CURATE_SESSION_PREFIX}${sessionId}`,
+        'state.json',
+      )
+      const state = JSON.parse(await readFile(statePath, 'utf8'))
+      expect(state.attempts).to.equal(1)
+      expect(state.step).to.equal('awaiting-correct')
+    })
+
+    it('confirmOverwrite=true on continuation bypasses the guard and writes through', async () => {
+      await seedExistingTopic(projectRoot)
+
+      const kickoff2 = await kickoffSession({content: 'overwrite', projectRoot})
+      const envelope = await continueSession({
+        confirmOverwrite: true,
+        projectRoot,
+        response: VALID_TOPIC_HTML,
+        sessionId: kickoff2.sessionId!,
+      })
+
+      expect(envelope.status).to.equal('done')
+      expect(envelope.filePath).to.equal('security/auth.html')
+
+      const stateDir = join(projectRoot, BRV_DIR, CURATE_SESSIONS_DIR, `${CURATE_SESSION_PREFIX}${kickoff2.sessionId!}`)
+      expect(existsSync(stateDir), 'session cleared on overwrite success').to.equal(false)
+    })
+
+    it('after a path-exists block, a follow-up confirmOverwrite continuation writes through', async () => {
+      // Real-world flow: agent sees path-exists, decides to clobber,
+      // re-emits with --overwrite on the SAME session.
+      await seedExistingTopic(projectRoot)
+
+      const kickoff2 = await kickoffSession({content: 'x', projectRoot})
+      const sessionId = kickoff2.sessionId!
+
+      const blocked = await continueSession({projectRoot, response: VALID_TOPIC_HTML, sessionId})
+      assertDefined(blocked.errors, 'blocked.errors')
+      expect(blocked.errors.some((e) => e.kind === 'path-exists')).to.equal(true)
+
+      const written = await continueSession({
+        confirmOverwrite: true,
+        projectRoot,
+        response: VALID_TOPIC_HTML,
+        sessionId,
+      })
+      expect(written.status).to.equal('done')
+    })
+
+    it('confirmOverwrite=true is a no-op on a path that does not yet exist', async () => {
+      // A fresh kickoff using --overwrite shouldn't block or break.
+      const kickoff = await kickoffSession({content: 'x', projectRoot})
+      const envelope = await continueSession({
+        confirmOverwrite: true,
+        projectRoot,
+        response: VALID_TOPIC_HTML,
+        sessionId: kickoff.sessionId!,
+      })
+      expect(envelope.status).to.equal('done')
     })
   })
 })

--- a/test/unit/server/core/domain/render/curate-prompt-builder.test.ts
+++ b/test/unit/server/core/domain/render/curate-prompt-builder.test.ts
@@ -270,6 +270,27 @@ describe('curate-prompt-builder', () => {
       expect(prompt).to.not.include('<existing-topic')
     })
 
+    it('omits the <existing-topic> block when path-exists carries undefined existingContent (unreadable)', () => {
+      // If the existing file was unreadable, the writer surfaces
+      // existingContent: undefined. The prompt MUST NOT render an empty
+      // <existing-topic> block — that would lead the LLM to conclude
+      // the prior topic was empty and produce a merge with no carry-over.
+      const errors = [
+        {
+          existingContent: undefined,
+          kind: 'path-exists' as const,
+          message: 'A topic already exists at "x/y" but its content could not be read.',
+          topicPath: 'x/y',
+        },
+      ]
+      const prompt = buildCorrectionPrompt({errors, previousHtml, userIntent})
+
+      expect(prompt).to.not.include('# Existing topic on disk')
+      expect(prompt).to.not.include('<existing-topic')
+      // The fix hint still appears so the agent knows to use --overwrite or pick a different path.
+      expect(prompt).to.include('merge your new content')
+    })
+
     it('falls back to a generic instruction when given zero errors', () => {
       const prompt = buildCorrectionPrompt({errors: [], previousHtml, userIntent})
       expect(prompt).to.include('No structured errors')

--- a/test/unit/server/core/domain/render/curate-prompt-builder.test.ts
+++ b/test/unit/server/core/domain/render/curate-prompt-builder.test.ts
@@ -231,6 +231,7 @@ describe('curate-prompt-builder', () => {
         {kind: 'unknown-bv-element' as const, message: 'm', tag: 'bv-foo'},
         {kind: 'unsafe-path' as const, message: 'm'},
         {field: 'severity', kind: 'attribute-validation' as const, message: 'm', tag: 'bv-rule' as const},
+        {existingContent: '<bv-topic path="x/y" title="t"/>', kind: 'path-exists' as const, message: 'm', topicPath: 'x/y'},
       ]
       const prompt = buildCorrectionPrompt({errors, previousHtml, userIntent})
 
@@ -241,6 +242,32 @@ describe('curate-prompt-builder', () => {
       expect(prompt).to.include('Remove `<bv-foo>`')           // unknown-bv-element
       expect(prompt).to.include('no `..` or `.` parts')        // unsafe-path
       expect(prompt).to.include('value of `severity`')         // attribute-validation
+      expect(prompt).to.include('merge your new content')      // path-exists
+    })
+
+    it('renders an <existing-topic> block when path-exists is present so the LLM can merge', () => {
+      const errors = [
+        {
+          existingContent: '<bv-topic path="security/auth" title="JWT auth">prior body</bv-topic>',
+          kind: 'path-exists' as const,
+          message: 'A topic already exists at "security/auth".',
+          topicPath: 'security/auth',
+        },
+      ]
+      const prompt = buildCorrectionPrompt({errors, previousHtml, userIntent})
+
+      expect(prompt).to.include('# Existing topic on disk')
+      expect(prompt).to.include('<existing-topic path="security/auth">')
+      expect(prompt).to.include('prior body')
+      expect(prompt).to.include('</existing-topic>')
+    })
+
+    it('omits the <existing-topic> block when no path-exists error is present', () => {
+      const errors = [{kind: 'missing-path-attribute' as const, message: 'm'}]
+      const prompt = buildCorrectionPrompt({errors, previousHtml, userIntent})
+
+      expect(prompt).to.not.include('# Existing topic on disk')
+      expect(prompt).to.not.include('<existing-topic')
     })
 
     it('falls back to a generic instruction when given zero errors', () => {

--- a/test/unit/server/infra/render/writer/html-writer.test.ts
+++ b/test/unit/server/infra/render/writer/html-writer.test.ts
@@ -249,7 +249,11 @@ describe('html-writer', () => {
         }
       })
 
-      it('preserves createdat across re-writes; updatedat advances', async () => {
+      it('preserves createdat across confirmed re-writes; updatedat advances', async () => {
+        // Re-writes to a path that already has a topic require explicit
+        // `confirmOverwrite: true` after the path-exists guard landed.
+        // The timestamp semantics under that consent flag are unchanged:
+        // createdat is preserved from the prior file, updatedat advances.
         const first = await writeHtmlTopic({contextTreeRoot: tmpRoot, rawHtml: VALID_TOPIC})
         expect(first.ok).to.equal(true)
         if (!first.ok) return
@@ -266,7 +270,7 @@ describe('html-writer', () => {
           setTimeout(resolve, 5)
         })
 
-        const second = await writeHtmlTopic({contextTreeRoot: tmpRoot, rawHtml: VALID_TOPIC})
+        const second = await writeHtmlTopic({confirmOverwrite: true, contextTreeRoot: tmpRoot, rawHtml: VALID_TOPIC})
         expect(second.ok).to.equal(true)
         if (!second.ok) return
 
@@ -297,6 +301,106 @@ describe('html-writer', () => {
         expect(updatedAt).to.not.equal('1999-01-01T00:00:00.000Z')
         expect(createdAt! >= before, `createdat (${createdAt!}) should be >= before (${before})`).to.equal(true)
         expect(updatedAt! >= before, `updatedat (${updatedAt!}) should be >= before (${before})`).to.equal(true)
+      })
+    })
+
+    describe('overwrite guard', () => {
+      // Background: tool-mode curate can route the calling agent to author
+      // a topic whose `path` collides with an existing file. The writer's
+      // default policy is "refuse to clobber" — surface a structured
+      // `path-exists` error with the existing content so the calling
+      // agent can merge instead of silently losing prior facts. An
+      // explicit `confirmOverwrite: true` is the only way to clobber.
+      const ALT_TOPIC = `<bv-topic path="security/auth" title="JWT auth — replaced">
+  <bv-reason>Replacement reason after intentional overwrite.</bv-reason>
+</bv-topic>`
+
+      it('returns a path-exists error when writing to an existing topic without confirmOverwrite', async () => {
+        const first = await writeHtmlTopic({contextTreeRoot: tmpRoot, rawHtml: VALID_TOPIC})
+        expect(first.ok).to.equal(true)
+
+        const second = await writeHtmlTopic({contextTreeRoot: tmpRoot, rawHtml: VALID_TOPIC})
+        expect(second.ok).to.equal(false)
+        if (!second.ok) {
+          const pathExists = second.errors.find((e) => e.kind === 'path-exists')
+          expect(pathExists, 'expected path-exists error').to.not.equal(undefined)
+        }
+      })
+
+      it('carries the existing file content + topicPath on the path-exists error', async () => {
+        const first = await writeHtmlTopic({contextTreeRoot: tmpRoot, rawHtml: VALID_TOPIC})
+        expect(first.ok).to.equal(true)
+        if (!first.ok) return
+        const onDisk = readFileSync(first.filePath, 'utf8')
+
+        const second = await writeHtmlTopic({contextTreeRoot: tmpRoot, rawHtml: ALT_TOPIC})
+        expect(second.ok).to.equal(false)
+        if (!second.ok) {
+          const pathExists = second.errors.find((e) => e.kind === 'path-exists')
+          expect(pathExists, 'expected path-exists error').to.not.equal(undefined)
+          if (pathExists && pathExists.kind === 'path-exists') {
+            expect(pathExists.existingContent).to.equal(onDisk)
+            expect(pathExists.topicPath).to.equal('security/auth')
+          }
+        }
+      })
+
+      it('does not modify the existing file when path-exists blocks the write', async () => {
+        const first = await writeHtmlTopic({contextTreeRoot: tmpRoot, rawHtml: VALID_TOPIC})
+        expect(first.ok).to.equal(true)
+        if (!first.ok) return
+        const originalBytes = readFileSync(first.filePath, 'utf8')
+
+        // Distinct ISO millisecond — if the writer mistakenly went
+        // through, `updatedat` would shift.
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 5)
+        })
+
+        const second = await writeHtmlTopic({contextTreeRoot: tmpRoot, rawHtml: ALT_TOPIC})
+        expect(second.ok).to.equal(false)
+
+        const afterBytes = readFileSync(first.filePath, 'utf8')
+        expect(afterBytes, 'existing file must be untouched on path-exists block').to.equal(originalBytes)
+      })
+
+      it('writes through when confirmOverwrite=true; preserves createdat, advances updatedat', async () => {
+        const first = await writeHtmlTopic({contextTreeRoot: tmpRoot, rawHtml: VALID_TOPIC})
+        expect(first.ok).to.equal(true)
+        if (!first.ok) return
+        const firstCreatedAt = extractAttribute(readFileSync(first.filePath, 'utf8'), 'createdat')
+        const firstUpdatedAt = extractAttribute(readFileSync(first.filePath, 'utf8'), 'updatedat')
+
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 5)
+        })
+
+        const second = await writeHtmlTopic({confirmOverwrite: true, contextTreeRoot: tmpRoot, rawHtml: ALT_TOPIC})
+        expect(second.ok).to.equal(true)
+        if (!second.ok) return
+
+        const written = readFileSync(second.filePath, 'utf8')
+        expect(written).to.include('Replacement reason after intentional overwrite.')
+        expect(extractAttribute(written, 'createdat'), 'createdat preserved').to.equal(firstCreatedAt)
+        const newUpdatedAt = extractAttribute(written, 'updatedat')
+        expect(newUpdatedAt, 'updatedat advanced').to.not.equal(firstUpdatedAt)
+      })
+
+      it('first write to a new path with confirmOverwrite=true succeeds (no false positive)', async () => {
+        // confirmOverwrite is a no-op when nothing is on disk to clobber.
+        const result = await writeHtmlTopic({confirmOverwrite: true, contextTreeRoot: tmpRoot, rawHtml: VALID_TOPIC})
+        expect(result.ok).to.equal(true)
+      })
+
+      it('does not affect writes to a different path (collision is exact-path scoped)', async () => {
+        const first = await writeHtmlTopic({contextTreeRoot: tmpRoot, rawHtml: VALID_TOPIC})
+        expect(first.ok).to.equal(true)
+
+        const otherTopic = `<bv-topic path="security/oauth" title="OAuth">
+  <bv-reason>Different topic.</bv-reason>
+</bv-topic>`
+        const second = await writeHtmlTopic({contextTreeRoot: tmpRoot, rawHtml: otherTopic})
+        expect(second.ok).to.equal(true)
       })
     })
   })

--- a/test/unit/server/infra/render/writer/html-writer.test.ts
+++ b/test/unit/server/infra/render/writer/html-writer.test.ts
@@ -402,6 +402,37 @@ describe('html-writer', () => {
         const second = await writeHtmlTopic({contextTreeRoot: tmpRoot, rawHtml: otherTopic})
         expect(second.ok).to.equal(true)
       })
+
+      it('surfaces existingContent as undefined when the prior file exists but is unreadable', async () => {
+        // Edge case raised in PR review: if existsSync succeeds but
+        // readFileSync throws (perms change, concurrent unlink, broken
+        // symlink), the guard MUST NOT emit `existingContent: ''` —
+        // that would lead a downstream merge-then-overwrite path to
+        // produce new-only HTML and silently clobber the prior file
+        // (the same data-loss class this guard prevents, through a
+        // different door). Verify by chmod-ing the file unreadable
+        // before triggering the guard.
+        const first = await writeHtmlTopic({contextTreeRoot: tmpRoot, rawHtml: VALID_TOPIC})
+        expect(first.ok).to.equal(true)
+        if (!first.ok) return
+
+        const {chmodSync} = await import('node:fs')
+        chmodSync(first.filePath, 0)
+        try {
+          const second = await writeHtmlTopic({contextTreeRoot: tmpRoot, rawHtml: VALID_TOPIC})
+          expect(second.ok).to.equal(false)
+          if (!second.ok) {
+            const pathExists = second.errors.find((e) => e.kind === 'path-exists')
+            expect(pathExists, 'expected path-exists error').to.not.equal(undefined)
+            if (pathExists && pathExists.kind === 'path-exists') {
+              expect(pathExists.existingContent, 'existingContent must be undefined for unreadable prior file').to.equal(undefined)
+              expect(pathExists.message).to.include('could not be read')
+            }
+          }
+        } finally {
+          chmodSync(first.filePath, 0o644)
+        }
+      })
     })
   })
 })


### PR DESCRIPTION
## Summary

- **Problem:** Tool-mode \`brv curate\` silently overwrites an existing topic file when the calling agent's \`<bv-topic path="…">\` matches a file already on disk. No merge, no warning, no audit trail. Detection latency is "next query".
- **Why it matters:** The only protection today is the SKILL.md instruction telling the calling agent to \`search → read → author merged HTML\` before submitting. That is a probabilistic check on a text instruction — strong models comply, smaller ones drift, long contexts dilute compliance. The user reports a live reproduction where curating two facts at the same path loses the first one.
- **What changed:** The writer now refuses to clobber an existing topic. When \`writeHtmlTopic\` resolves a target path that already exists and \`confirmOverwrite: true\` was not passed, it returns a structured \`path-exists\` error carrying the existing file's bytes. The orchestrator maps this to a \`correct-html\` step; the existing content is also inlined into the correction prompt inside an \`<existing-topic path="…">…</existing-topic>\` block so the calling LLM can merge without parsing JSON. The calling agent expresses overwrite intent via a new \`--overwrite\` flag on \`brv curate\` continuation. Three paths through the guard: (1) merge \`existingContent\` with the new content and re-emit with \`--overwrite\` (default — preserves prior facts), (2) pick a different \`<bv-topic path>\` (no \`--overwrite\` needed), (3) re-emit with \`--overwrite\` carrying only new content (data-destructive; reserved for explicit user-driven replacement).
- **What did NOT change (scope boundary):** No changes to the kickoff prompt, the bv-* element vocabulary, the validation pipeline, the legacy agent-driven curate path, or the retry-cap semantics. The guard is additive on the write step only. Daemon-side search-first orchestration (\"Option 2\" from the source analysis) is intentionally out of scope.

## Type of change

- [x] Bug fix

## Scope (select all touched areas)

- [x] Agent / Tools
- [x] Server / Daemon
- [x] CLI Commands (oclif)

## Linked issues

- Closes #
- Related #

## Root cause

- **Root cause:** \`writeHtmlTopic\` called \`DirectoryManager.writeFileAtomic(filePath, stamped)\` unconditionally after validation. The writer already touched the existing file via \`readExistingTopicAttribute(filePath, 'createdat')\` to preserve \`createdat\`, but treated the existence of the prior file purely as a timestamp-inheritance signal. Nothing along the curate path consulted the search index or asked the calling agent to confirm the clobber, and the legacy \`pendingReview\` machinery is engaged only on the in-daemon agent path.
- **Why this was not caught earlier:** The first tool-mode milestone shipped an INSERT-only contract — there was no test covering "second curate at the same path." The end-to-end harness exercised happy-path single curates only.

## Test plan

- Coverage added:
  - [x] Unit test
  - [x] Manual verification only (also)
- Test file(s):
  - \`test/unit/server/infra/render/writer/html-writer.test.ts\` — 6 new tests for the writer's guard + 1 updated test (\`preserves createdat across confirmed re-writes\` now passes \`confirmOverwrite: true\` since silent re-write is the bug being fixed)
  - \`test/unit/oclif/lib/curate-session.test.ts\` — 7 new tests for the orchestrator surface (block, existingContent propagation, prompt embedding, retry-cap interaction, bypass, after-block recovery, no-false-positive on fresh paths)
  - \`test/unit/server/core/domain/render/curate-prompt-builder.test.ts\` — 3 new tests (fix-hint for the new kind, \`<existing-topic>\` block renders when present, omitted when absent)
- Key scenario(s) covered (also exercised end-to-end against a linked \`brv\` binary):
  1. Fresh kickoff + valid HTML to a new path → \`done\`, file written.
  2. Same-path collision without \`--overwrite\` → \`status: needs-llm-step\`, \`step: correct-html\`, \`errors: [{kind: 'path-exists', existingContent: '<bv-topic …>…</bv-topic>'}]\`. Existing file byte-identical after the call.
  3. Same session retry with merged HTML + \`--overwrite\` → \`done\`. \`createdat\` preserved, \`updatedat\` advanced, every prior fact still present alongside the merged-in addition.
  4. Fresh kickoff with \`--overwrite\` on the first continuation → \`done\`, prior content replaced. \`createdat\` STILL preserved from the original write.
  5. Retry with merged content but no \`--overwrite\` → still blocked (the merge alone does not bypass the guard).
  6. Retry-cap interaction: 3 \`path-exists\` corrections followed by a 4th attempt → terminal \`status: failed\` with \`kind: retry-cap-exceeded\`, session cleared.

## User-visible changes

- New CLI flag: \`brv curate --session <id> --response <html> --overwrite\` (continuation only).
- New error \`kind: 'path-exists'\` in the curate-protocol envelope errors table, carrying \`existingContent\` on the envelope error.
- Default tool-mode curate now refuses to clobber an existing topic; calling agents see \`correct-html\` instead of a silent overwrite.

## Evidence

End-to-end trace across all 6 scenarios above ran clean against the linked binary on the source-analysis test project. Full suite: 8010 passing. Touched-file lint clean, typecheck clean, build clean. Trace artefacts (\`t1-cont.json\` through \`t6-att4.json\`, plus the resulting context-tree file) retained in the analysis directory referenced by the source report.

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

## Checklist

- [x] Tests added or updated and passing (\`npm test\`) — 8010 passing
- [x] Lint passes (\`npm run lint\`) on the changed files (repo-wide \`npm run lint\` has a pre-existing failure in \`packages/byterover-packages/ui/\` submodule unrelated to this branch)
- [x] Type check passes (\`npm run typecheck\`)
- [x] Build succeeds (\`npm run build\`)
- [x] Commits follow Conventional Commits format
- [x] Documentation updated (\`docs/curate-protocol.md\` + \`SKILL.md\`)
- [x] No breaking changes — default behavior of \`brv curate\` is unchanged for first-time writes; the new guard only fires on re-writes that prior to this PR were silent overwrites.
- [x] Branch is up to date with the project branch (cut from \`proj/byterover-tool-mode\` HEAD)

## Risks and mitigations

- **Risk:** A calling agent that doesn't know about the new \`--overwrite\` flag will hit the retry cap on legitimate re-curates of the same topic.
  - **Mitigation:** \`SKILL.md\` is updated to document the three paths through the guard (merge + overwrite, different path, replace). Agents reading the skill from the kickoff prompt's framing will see the correction-step prompt explicitly call out \`--overwrite\` plus inline the existing topic for merging.
- **Risk:** The \`existingContent\` field on the envelope error increases response size for the collision path.
  - **Mitigation:** This response is on the unhappy path only; it is also exactly the data the calling agent needs to merge — adding it inline removes a separate \`brv read\` round-trip the agent would otherwise need.