### PR TITLE
feat: [ENG-2811] query tool-mode — CLI surface + envelope shape

### DIFF
--- a/src/oclif/commands/query.ts
+++ b/src/oclif/commands/query.ts
@@ -5,6 +5,7 @@ import {randomUUID} from 'node:crypto'
 
 import {type ProviderConfigResponse, TransportStateEventNames} from '../../server/core/domain/transport/schemas.js'
 import {TaskEvents} from '../../shared/transport/events/index.js'
+import {resolveProjectRoot} from '../lib/curate-session.js'
 import {
   type DaemonClientOptions,
   formatConnectionError,
@@ -14,13 +15,29 @@ import {
   withDaemonRetry,
 } from '../lib/daemon-client.js'
 import {writeJsonResponse} from '../lib/json-response.js'
+import {type QueryToolModeEnvelope, runRetrievalPlaceholder} from '../lib/query-retrieval.js'
 import {DEFAULT_TIMEOUT_SECONDS, MAX_TIMEOUT_SECONDS, MIN_TIMEOUT_SECONDS, waitForTaskCompletion} from '../lib/task-client.js'
 
 /** Parsed flags type */
 type QueryFlags = {
   format?: 'json' | 'text'
+  limit?: number
   timeout?: number
 }
+
+/**
+ * Env-var opt-in for tool-mode query. Mirrors curate's
+ * `BRV_CURATE_TOOL_MODE`. Tool mode short-circuits today's
+ * Tier-0/1/2/3/4 path and returns matches + a synthesis prompt for
+ * the calling agent to compose an answer from. M3 (future) replaces
+ * the env var with a BrvConfig field.
+ */
+const TOOL_MODE_ENV_VAR = 'BRV_QUERY_TOOL_MODE'
+
+/** Default match cap. Locked to 10 (matches `brv search`). */
+const DEFAULT_QUERY_LIMIT = 10
+const MIN_QUERY_LIMIT = 1
+const MAX_QUERY_LIMIT = 50
 
 export default class Query extends Command {
   public static args = {
@@ -51,6 +68,15 @@ Bad:
       description: 'Output format (text or json)',
       options: ['text', 'json'],
     }),
+    limit: Flags.integer({
+      default: DEFAULT_QUERY_LIMIT,
+      // Tool-mode only — bounds the matches[] array returned in the
+      // envelope. Legacy `brv query` (Tier 3 LLM synthesis) ignores
+      // this flag.
+      description: `Maximum matches under tool mode (${MIN_QUERY_LIMIT}-${MAX_QUERY_LIMIT})`,
+      max: MAX_QUERY_LIMIT,
+      min: MIN_QUERY_LIMIT,
+    }),
     timeout: Flags.integer({
       default: DEFAULT_TIMEOUT_SECONDS,
       description: 'Maximum seconds to wait for task completion',
@@ -68,6 +94,19 @@ Bad:
     const {args, flags: rawFlags} = await this.parse(Query)
     const flags = rawFlags as QueryFlags
     const format = (flags.format ?? 'text') as 'json' | 'text'
+
+    // Tool-mode dispatch happens BEFORE any provider check or daemon
+    // connection. Tool mode never invokes byterover's LLM — providers
+    // can be absent and the call still works. Mirrors the curate
+    // tool-mode dispatch order.
+    if (process.env[TOOL_MODE_ENV_VAR] === '1') {
+      await this.handleToolModeQuery({
+        format,
+        limit: flags.limit ?? DEFAULT_QUERY_LIMIT,
+        query: args.query,
+      })
+      return
+    }
 
     if (!this.validateInput(args.query, format)) return
 
@@ -112,6 +151,76 @@ Bad:
     } catch (error) {
       this.reportError(error, format, providerContext)
     }
+  }
+
+  /**
+   * Wire-envelope emitter for tool-mode query. JSON mode wraps the
+   * envelope in the standard CLI envelope ({command, data, success,
+   * timestamp}). Text mode prints a terse human-readable digest —
+   * the primary consumer is the calling agent in `--format json` mode.
+   */
+  private emitToolModeEnvelope(envelope: QueryToolModeEnvelope, format: 'json' | 'text'): void {
+    if (format === 'json') {
+      writeJsonResponse({command: 'query', data: envelope, success: envelope.ok})
+      return
+    }
+
+    if (envelope.status === 'failed') {
+      this.log('✗ Query failed')
+      for (const err of envelope.errors ?? []) {
+        this.log(`  ${err.kind}: ${err.message}`)
+      }
+
+      return
+    }
+
+    const matches = envelope.matches ?? []
+    if (matches.length === 0) {
+      this.log('No matches.')
+      return
+    }
+
+    this.log(`${matches.length} match${matches.length === 1 ? '' : 'es'}:`)
+    for (const m of matches) {
+      this.log(`  ${m.path}  score=${m.score.toFixed(3)}`)
+    }
+  }
+
+  /**
+   * Tool-mode query dispatch. Runs the in-CLI retrieval (placeholder
+   * in T1 — T2 swaps in real `SearchKnowledgeService` calls), writes
+   * the envelope to stdout. No daemon connection, no provider check.
+   */
+  private async handleToolModeQuery(props: {
+    format: 'json' | 'text'
+    limit: number
+    query: string
+  }): Promise<void> {
+    const {format, limit, query} = props
+
+    if (query.trim().length === 0) {
+      this.emitToolModeEnvelope(
+        {
+          errors: [
+            {
+              kind: 'missing-query',
+              message: 'Tool-mode query requires a question argument.',
+            },
+          ],
+          ok: false,
+          status: 'failed',
+        },
+        format,
+      )
+      return
+    }
+
+    const envelope = await runRetrievalPlaceholder({
+      limit,
+      projectRoot: resolveProjectRoot(),
+      query,
+    })
+    this.emitToolModeEnvelope(envelope, format)
   }
 
   private reportError(error: unknown, format: 'json' | 'text', providerContext?: ProviderErrorContext): void {

--- a/src/oclif/lib/query-retrieval.ts
+++ b/src/oclif/lib/query-retrieval.ts
@@ -1,0 +1,114 @@
+/**
+ * Tool-mode query retrieval orchestrator — placeholder shape for T1.
+ *
+ * Background. `brv query` legacy path runs Tier-0/1/2/3/4 inside the
+ * daemon, with Tier 3 and Tier 4 invoking byterover's own LLM. Tool
+ * mode removes those tiers: the calling agent owns synthesis, byterover
+ * just retrieves matches and returns them. No LLM lives inside
+ * byterover on this path.
+ *
+ * One-shot (unlike curate's session loop). Query has no validation
+ * step that can fail and no atomic-write atomicity to preserve across
+ * calls — every invocation is a fresh BM25 search. No session, no
+ * continuation, no state on disk.
+ *
+ * This file currently ships the wire-envelope types and a placeholder
+ * `runRetrievalPlaceholder` that always returns zero matches. T2
+ * (ENG-2812) replaces the placeholder with a real `runRetrieval` that
+ * calls SearchKnowledgeService.
+ *
+ * Stability promise. Wire envelope keys are part of the public
+ * contract once SKILL.md (T4 / ENG-2814) ships against this shape.
+ * Renaming any key here is a breaking change.
+ */
+
+/**
+ * One match returned by retrieval. Both `renderedContent` and
+ * `rawContent` are included so the calling agent can pick: rendered
+ * markdown (default consumption) or source bytes (for callers that
+ * want their own HTML parsing).
+ */
+export type QueryMatch = {
+  /** `'html'` or `'markdown'` derived from the file extension. */
+  format: 'html' | 'markdown'
+  /** Path relative to `<projectRoot>/.brv/context-tree/`. */
+  path: string
+  /**
+   * Source bytes regardless of format. For `.html` topics this is the
+   * raw `<bv-topic>...</bv-topic>` markup. For `.md` topics this is
+   * the same as `renderedContent`.
+   */
+  rawContent: string
+  /**
+   * For `.html` topics, post-`renderHtmlTopicForLlm` markdown (clean
+   * bv-* attribute preservation as inline markdown, raw markup
+   * stripped). For `.md` topics, raw bytes pass through unchanged.
+   */
+  renderedContent: string
+  /**
+   * BM25 score from the search service. Comparable within a single
+   * retrieval (i.e. relative ranking inside `matches[]`) but NOT
+   * comparable across different context-trees or BM25 index versions.
+   */
+  score: number
+}
+
+/** Error kinds the envelope can surface. Stable contract for T4 SKILL.md. */
+export type QueryEnvelopeErrorKind =
+  | 'index-unavailable'
+  | 'invalid-flag-combination'
+  | 'missing-query'
+
+/** Flat error shape carried in the envelope's `errors` array. */
+export type QueryEnvelopeError = {
+  kind: QueryEnvelopeErrorKind
+  message: string
+}
+
+/**
+ * Wire envelope returned by every tool-mode query call. One-shot:
+ * `done`/`continuation`-style states don't exist for query.
+ *
+ * - `status: 'results'` — retrieval completed. `matches` is always
+ *   present (possibly empty). `synthesisPrompt` is present iff
+ *   `matches.length > 0` (T3 fills in the prompt body; T1 leaves it
+ *   undefined).
+ * - `status: 'failed'` — retrieval could not run. `errors[]` explains
+ *   why.
+ */
+export type QueryToolModeEnvelope = {
+  /** Validation / dispatch errors. Present on `failed`. */
+  errors?: QueryEnvelopeError[]
+  /** Retrieved topics, ordered by relevance descending. */
+  matches?: QueryMatch[]
+  /** Aggregated success flag — `true` on `results`, `false` on `failed`. */
+  ok: boolean
+  status: 'failed' | 'results'
+  /**
+   * Free-text synthesis instruction for the calling agent's LLM. Built
+   * by `buildSynthesisPrompt` (T3 / ENG-2813). Present iff
+   * `matches.length > 0`. T1 leaves this undefined.
+   */
+  synthesisPrompt?: string
+}
+
+/**
+ * Placeholder retrieval used by T1. Always returns zero matches so
+ * the protocol surface (envelope shape, dispatch, flag validation,
+ * documentation) can be reviewed in isolation before T2 wires the
+ * real SearchKnowledgeService call.
+ *
+ * Signature is deliberately what `runRetrieval` will look like in T2,
+ * so swap-out is a single-file change.
+ */
+export function runRetrievalPlaceholder(_options: {
+  limit: number
+  projectRoot: string
+  query: string
+}): Promise<QueryToolModeEnvelope> {
+  return Promise.resolve({
+    matches: [],
+    ok: true,
+    status: 'results',
+  })
+}

--- a/test/unit/oclif/lib/query-retrieval.test.ts
+++ b/test/unit/oclif/lib/query-retrieval.test.ts
@@ -1,0 +1,127 @@
+/**
+ * query-retrieval tests — T1 (ENG-2811) placeholder surface.
+ *
+ * Locks the wire-envelope shape that SKILL.md (T4 / ENG-2814) will
+ * key off. Once T4 ships against this contract, renaming a key here
+ * is a breaking change.
+ *
+ * T2 (ENG-2812) replaces `runRetrievalPlaceholder` with a real
+ * `SearchKnowledgeService` call; the envelope shape contract carried
+ * by these tests stays stable across the swap.
+ */
+
+import {expect} from 'chai'
+
+import {
+  type QueryToolModeEnvelope,
+  runRetrievalPlaceholder,
+} from '../../../../src/oclif/lib/query-retrieval.js'
+
+describe('query-retrieval (T1 placeholder)', () => {
+  describe('runRetrievalPlaceholder', () => {
+    it('always returns an empty-matches results envelope', async () => {
+      const envelope = await runRetrievalPlaceholder({
+        limit: 10,
+        projectRoot: '/tmp/anywhere',
+        query: 'anything',
+      })
+
+      expect(envelope.ok).to.be.true
+      expect(envelope.status).to.equal('results')
+      expect(envelope.matches).to.deep.equal([])
+      expect(envelope.synthesisPrompt).to.be.undefined
+      expect(envelope.errors).to.be.undefined
+    })
+
+    it('ignores the projectRoot argument at the placeholder stage (T2 wires real retrieval)', async () => {
+      const envelopeA = await runRetrievalPlaceholder({
+        limit: 1,
+        projectRoot: '/dev/null',
+        query: 'a',
+      })
+      const envelopeB = await runRetrievalPlaceholder({
+        limit: 50,
+        projectRoot: '/nonexistent/path',
+        query: 'b',
+      })
+
+      expect(envelopeA).to.deep.equal(envelopeB)
+    })
+
+    it('returns a Promise', () => {
+      const result = runRetrievalPlaceholder({
+        limit: 10,
+        projectRoot: '/tmp',
+        query: 'x',
+      })
+      expect(result).to.be.instanceOf(Promise)
+    })
+  })
+
+  describe('envelope-shape contract', () => {
+    /**
+     * These cases instantiate every valid envelope shape to assert
+     * the type definition admits them. Catches accidental
+     * tightening of `QueryToolModeEnvelope` that would break the
+     * documented protocol surface.
+     */
+    it('admits a results envelope with empty matches', () => {
+      const envelope: QueryToolModeEnvelope = {
+        matches: [],
+        ok: true,
+        status: 'results',
+      }
+      expect(envelope.status).to.equal('results')
+    })
+
+    it('admits a results envelope with populated matches + synthesisPrompt', () => {
+      const envelope: QueryToolModeEnvelope = {
+        matches: [
+          {
+            format: 'html',
+            path: 'security/auth.html',
+            rawContent: '<bv-topic path="security/auth"></bv-topic>',
+            renderedContent: '# Authentication',
+            score: 0.847,
+          },
+          {
+            format: 'markdown',
+            path: 'legacy/notes.md',
+            rawContent: '# Old notes',
+            renderedContent: '# Old notes',
+            score: 0.412,
+          },
+        ],
+        ok: true,
+        status: 'results',
+        synthesisPrompt: 'Use only the matches below…',
+      }
+      expect(envelope.matches).to.have.lengthOf(2)
+      expect(envelope.matches?.[0].format).to.equal('html')
+      expect(envelope.matches?.[1].format).to.equal('markdown')
+    })
+
+    it('admits a failed envelope with missing-query error', () => {
+      const envelope: QueryToolModeEnvelope = {
+        errors: [{kind: 'missing-query', message: 'Tool-mode query requires a question argument.'}],
+        ok: false,
+        status: 'failed',
+      }
+      expect(envelope.status).to.equal('failed')
+      expect(envelope.errors?.[0].kind).to.equal('missing-query')
+    })
+
+    it('admits the reserved error kinds T2 will use', () => {
+      // index-unavailable is the kind T2 will emit when
+      // SearchKnowledgeService cannot load the BM25 index. Asserting
+      // it compiles today means T2 can wire it without revisiting
+      // the protocol surface.
+      const envelope: QueryToolModeEnvelope = {
+        errors: [{kind: 'index-unavailable', message: 'Index missing.'}],
+        ok: false,
+        status: 'failed',
+      }
+      expect(envelope.errors?.[0].kind).to.equal('index-unavailable')
+    })
+  })
+})


### PR DESCRIPTION
1 of 4 in M2. Establishes the wire protocol between `brv query` and the in-CLI retrieval orchestrator for tool-mode query. Adds a BRV_QUERY_TOOL_MODE=1 env-var opt-in alongside today's legacy Tier-0/1/2/3/4 path. With the env var on, `brv query` short-circuits the LLM tiers and returns a JSON envelope carrying matches + a synthesis prompt for the calling agent to compose an answer from.

This is the protocol-only landing. Retrieval is a placeholder that always returns `matches: []` — the real SearchKnowledgeService wiring lands in ENG-2812. The synthesis prompt body lands in ENG-2813. This commit locks the JSON envelope shape so downstream tickets have a stable wire contract to build against.

Changes:

- New `src/oclif/lib/query-retrieval.ts` — wire-envelope types (`QueryToolModeEnvelope`, `QueryMatch`, `QueryEnvelopeError`) and a `runRetrievalPlaceholder` that always returns the empty-results envelope. T2 swaps the placeholder for a real retrieval at the same call site.

- `src/oclif/commands/query.ts`:
  - Add `BRV_QUERY_TOOL_MODE` env-var dispatch BEFORE any provider check or daemon connection. Tool mode never invokes byterover's LLM, so the provider-config path is bypassed entirely.
  - Add `--limit N` flag (default 10, range 1-50). Matches `brv search` convention. Legacy `brv query` ignores the flag.
  - Add `handleToolModeQuery` + `emitToolModeEnvelope` helpers. JSON output wraps the envelope in the standard CLI wrapper; text mode prints a terse human digest (one line per match).
  - Surface a `kind: missing-query` failed envelope when the query argument is empty under tool mode.
  - Legacy Tier-0/1/2/3/4 path is unchanged — env-var-off invocations run today's flow with no behavior delta.

Soft empty-matches: zero matches returns `status: results` with `matches: []` and no `synthesisPrompt`, mirroring `brv search`'s behavior. Hard failures (missing query, future index errors) use the `failed` envelope with structured `errors[]`.

7 new unit tests cover the placeholder return shape, the documented envelope contract (every valid shape compiles), and the reserved error kinds T2 will use.

End-to-end smoke verified:
- Missing query → failed envelope, exit 0
- Valid query (placeholder) → results envelope with empty matches
- `--format text` → terse human digest
- `--limit 51` rejected at CLI validation
- `--help` shows `--limit=<value>` with bounds

## Summary

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [ ] Agent / Tools
- [ ] LLM Providers
- [ ] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes #
- Related #

## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause:
- Why this was not caught earlier:

## Test plan

- Coverage added:
  - [ ] Unit test
  - [ ] Integration test
  - [ ] Manual verification only
- Test file(s):
- Key scenario(s) covered:

## User-visible changes

List user-visible changes (including defaults, config, or CLI output).
If none, write `None`.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording

## Checklist

- [ ] Tests added or updated and passing (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Type check passes (`npm run typecheck`)
- [ ] Build succeeds (`npm run build`)
- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or clearly documented above)
- [ ] Branch is up to date with `main`

## Risks and mitigations

List real risks for this PR. If none, write `None`.

- Risk:
  - Mitigation:
