### PR TITLE
fix: file-context-file-reader extracts metadata from HTML topics (was MD-only)

### DIFF
--- a/src/server/infra/context-tree/file-context-file-reader.ts
+++ b/src/server/infra/context-tree/file-context-file-reader.ts
@@ -51,15 +51,20 @@ export class FileContextFileReader implements IContextFileReader {
 
     try {
       const content = await readFile(fullPath, 'utf8')
-      const fallbackTitle = extractTitle(content, relativePath)
 
       // Extension-based dispatch: HTML topics go through the bv-* extractor,
       // markdown goes through the existing parser. Same return shape from
-      // either path.
+      // either path. Fallback-title strategy diverges per format:
+      //   - MD: `extractTitle` reads the first `# H1` line (markdown idiom).
+      //   - HTML: use the relative path directly — running the H1 regex on
+      //     HTML body content could pick up a stray `# ` inside, e.g., a
+      //     `<bv-examples>` markdown snippet and surface it as the file's
+      //     title.
       if (isHtmlTopic(relativePath)) {
-        return parseHtmlContextContent(content, fallbackTitle, relativePath)
+        return parseHtmlContextContent(content, relativePath, relativePath)
       }
 
+      const fallbackTitle = extractTitle(content, relativePath)
       const parsedContent = MarkdownWriter.parseContent(content, fallbackTitle)
       // Frontmatter title takes precedence, then H1 heading, then path fallback
       const title = parsedContent.name || fallbackTitle

--- a/src/server/infra/context-tree/file-context-file-reader.ts
+++ b/src/server/infra/context-tree/file-context-file-reader.ts
@@ -5,6 +5,7 @@ import type {ContextFileContent, IContextFileReader} from '../../core/interfaces
 
 import {BRV_DIR, CONTEXT_TREE_DIR} from '../../constants.js'
 import {MarkdownWriter} from '../../core/domain/knowledge/markdown-writer.js'
+import {parseHtmlContextContent} from './html-context-file-extractor.js'
 
 export type FileContextFileReaderConfig = {
   baseDirectory?: string
@@ -12,6 +13,9 @@ export type FileContextFileReaderConfig = {
 
 /**
  * Extracts the title from the first markdown heading in the content.
+ * Used as a fallback when neither the MD frontmatter `title` nor the
+ * HTML `<bv-topic title="…">` attribute is present.
+ *
  * @param content - The file content
  * @param fallbackTitle - The title to use if no heading is found
  * @returns The extracted title or fallback
@@ -24,7 +28,15 @@ const extractTitle = (content: string, fallbackTitle: string): string => {
 
 /**
  * File-based implementation of IContextFileReader.
- * Reads context.md files from the context tree and extracts their metadata.
+ *
+ * Reads topic files from `.brv/context-tree/` and extracts structured
+ * metadata. Format-aware: branches on file extension so HTML topics
+ * route through `parseHtmlContextContent` (walks `<bv-topic>` attributes
+ * + typed `<bv-*>` elements), markdown topics route through the
+ * existing `MarkdownWriter.parseContent` (YAML frontmatter + `##`
+ * sections). Same `ContextFileContent` return shape from either path
+ * so downstream consumers (`push-handler`, `context-tree-handler`)
+ * don't need to know which format they got.
  */
 export class FileContextFileReader implements IContextFileReader {
   private readonly config: FileContextFileReaderConfig
@@ -40,6 +52,13 @@ export class FileContextFileReader implements IContextFileReader {
     try {
       const content = await readFile(fullPath, 'utf8')
       const fallbackTitle = extractTitle(content, relativePath)
+
+      // Extension-based dispatch: HTML topics go through the bv-* extractor,
+      // markdown goes through the existing parser. Same return shape from
+      // either path.
+      if (isHtmlTopic(relativePath)) {
+        return parseHtmlContextContent(content, fallbackTitle, relativePath)
+      }
 
       const parsedContent = MarkdownWriter.parseContent(content, fallbackTitle)
       // Frontmatter title takes precedence, then H1 heading, then path fallback
@@ -66,4 +85,8 @@ export class FileContextFileReader implements IContextFileReader {
     // Filter out undefined results (files that couldn't be read)
     return results.filter((result): result is ContextFileContent => result !== undefined)
   }
+}
+
+function isHtmlTopic(relativePath: string): boolean {
+  return relativePath.toLowerCase().endsWith('.html')
 }

--- a/src/server/infra/context-tree/html-context-file-extractor.ts
+++ b/src/server/infra/context-tree/html-context-file-extractor.ts
@@ -1,0 +1,229 @@
+import type {Narrative, RawConcept} from '../../core/domain/knowledge/markdown-writer.js'
+import type {ElementNode} from '../../core/domain/render/element-types.js'
+import type {ContextFileContent} from '../../core/interfaces/context-tree/i-context-file-reader.js'
+
+import {getInnerText, parseHtml, walkElements} from '../render/reader/html-parser.js'
+
+/**
+ * Extract a `ContextFileContent` from an HTML topic file.
+ *
+ * Format-aware counterpart to `MarkdownWriter.parseContent`: produces the
+ * same return shape, but sources fields from `<bv-topic>` attributes +
+ * typed `<bv-*>` child elements instead of YAML frontmatter + markdown
+ * sections. Used by `FileContextFileReader` when the input is `.html`.
+ *
+ * Field mapping (HTML → ContextFileContent):
+ *   <bv-topic title>             → title  (falls back to fallbackTitle)
+ *   <bv-topic tags>              → tags   (comma-split, trimmed)
+ *   <bv-topic keywords>          → keywords  (comma-split, trimmed)
+ *   <bv-task>                    → rawConcept.task
+ *   <bv-changes> > <li>          → rawConcept.changes[]
+ *   <bv-files> > <li>            → rawConcept.files[]
+ *   <bv-flow>                    → rawConcept.flow
+ *   <bv-timestamp>               → rawConcept.timestamp
+ *   <bv-author>                  → rawConcept.author
+ *   <bv-pattern>                 → rawConcept.patterns[]  (with flags + description attrs)
+ *   <bv-structure>               → narrative.structure
+ *   <bv-dependencies>            → narrative.dependencies
+ *   <bv-highlights>              → narrative.highlights
+ *   <bv-rule>                    → narrative.rules  (siblings serialised as bullet list)
+ *   <bv-examples>                → narrative.examples
+ *   <bv-diagram>                 → narrative.diagrams[]  (with type + title attrs)
+ *
+ * Not yet exposed (interface gap on ContextFileContent — follow-up):
+ *   <bv-topic summary>, <bv-topic related>, <bv-fact>, <bv-decision>,
+ *   <bv-bug>, <bv-fix>.
+ */
+export function parseHtmlContextContent(
+  content: string,
+  fallbackTitle: string,
+  relativePath: string,
+): ContextFileContent {
+  const document = parseHtml(content)
+  const elements = walkElements(document)
+
+  const topic = elements.find((e) => e.tagName === 'bv-topic')
+  const attrs = topic?.attributes ?? {}
+
+  const title = attrs.title?.trim() ? attrs.title.trim() : fallbackTitle
+  const tags = parseCsvAttribute(attrs.tags)
+  const keywords = parseCsvAttribute(attrs.keywords)
+
+  const rawConcept = extractRawConcept(elements)
+  const narrative = extractNarrative(elements)
+
+  return {
+    content,
+    keywords,
+    ...(narrative !== undefined && {narrative}),
+    path: relativePath,
+    ...(rawConcept !== undefined && {rawConcept}),
+    tags,
+    title,
+  }
+}
+
+// ── Internal helpers ──────────────────────────────────────────────
+
+function parseCsvAttribute(value: string | undefined): string[] {
+  if (!value) return []
+  return value
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+}
+
+function extractRawConcept(elements: readonly ElementNode[]): RawConcept | undefined {
+  const rawConcept: RawConcept = {}
+
+  const taskNode = elements.find((e) => e.tagName === 'bv-task')
+  if (taskNode) {
+    const text = getInnerText(taskNode).trim()
+    if (text) rawConcept.task = text
+  }
+
+  const changesNode = elements.find((e) => e.tagName === 'bv-changes')
+  if (changesNode) {
+    const items = extractListItems(changesNode)
+    if (items.length > 0) rawConcept.changes = items
+  }
+
+  const filesNode = elements.find((e) => e.tagName === 'bv-files')
+  if (filesNode) {
+    const items = extractListItems(filesNode)
+    if (items.length > 0) rawConcept.files = items
+  }
+
+  const flowNode = elements.find((e) => e.tagName === 'bv-flow')
+  if (flowNode) {
+    const text = getInnerText(flowNode).trim()
+    if (text) rawConcept.flow = text
+  }
+
+  const timestampNode = elements.find((e) => e.tagName === 'bv-timestamp')
+  if (timestampNode) {
+    const text = getInnerText(timestampNode).trim()
+    if (text) rawConcept.timestamp = text
+  }
+
+  const authorNode = elements.find((e) => e.tagName === 'bv-author')
+  if (authorNode) {
+    const text = getInnerText(authorNode).trim()
+    if (text) rawConcept.author = text
+  }
+
+  const patternNodes = elements.filter((e) => e.tagName === 'bv-pattern')
+  if (patternNodes.length > 0) {
+    const patterns: Array<{description: string; flags?: string; pattern: string}> = []
+    for (const node of patternNodes) {
+      const pattern = getInnerText(node).trim()
+      if (!pattern) continue
+      const description = node.attributes.description?.trim() ?? ''
+      const flags = node.attributes.flags?.trim()
+      patterns.push({
+        description,
+        pattern,
+        ...(flags && {flags}),
+      })
+    }
+
+    if (patterns.length > 0) rawConcept.patterns = patterns
+  }
+
+  return Object.keys(rawConcept).length === 0 ? undefined : rawConcept
+}
+
+function extractNarrative(elements: readonly ElementNode[]): Narrative | undefined {
+  const narrative: Narrative = {}
+
+  const structureNode = elements.find((e) => e.tagName === 'bv-structure')
+  if (structureNode) {
+    const text = getInnerText(structureNode).trim()
+    if (text) narrative.structure = text
+  }
+
+  const dependenciesNode = elements.find((e) => e.tagName === 'bv-dependencies')
+  if (dependenciesNode) {
+    const text = getInnerText(dependenciesNode).trim()
+    if (text) narrative.dependencies = text
+  }
+
+  const highlightsNode = elements.find((e) => e.tagName === 'bv-highlights')
+  if (highlightsNode) {
+    const text = getInnerText(highlightsNode).trim()
+    if (text) narrative.highlights = text
+  }
+
+  const examplesNode = elements.find((e) => e.tagName === 'bv-examples')
+  if (examplesNode) {
+    const text = getInnerText(examplesNode).trim()
+    if (text) narrative.examples = text
+  }
+
+  // Multiple `<bv-rule>` siblings are aggregated into a single bullet list
+  // matching the markdown-writer's `### Rules` render format. The MD shape
+  // for narrative.rules is freeform string; we serialise structured HTML
+  // rules deterministically so the cogit push / webui consumers see the
+  // same shape they used to.
+  const ruleNodes = elements.filter((e) => e.tagName === 'bv-rule')
+  if (ruleNodes.length > 0) {
+    const lines: string[] = []
+    for (const node of ruleNodes) {
+      const text = getInnerText(node).trim()
+      if (!text) continue
+      const severity = node.attributes.severity?.trim()
+      const id = node.attributes.id?.trim()
+      const severityPart = severity ? `[${severity}]` : ''
+      const idPart = id ? ` (${id})` : ''
+      lines.push(`- ${severityPart}${idPart}${severity || id ? ': ' : ''}${text}`.replace(/^- : /, '- '))
+    }
+
+    if (lines.length > 0) narrative.rules = lines.join('\n')
+  }
+
+  // Multiple `<bv-diagram>` siblings → structured list. Type defaults to
+  // 'other' when the attribute is absent (mirrors the MD writer's behaviour).
+  const diagramNodes = elements.filter((e) => e.tagName === 'bv-diagram')
+  if (diagramNodes.length > 0) {
+    const diagrams: Array<{content: string; title?: string; type: string}> = []
+    for (const node of diagramNodes) {
+      const text = getInnerText(node).trim()
+      if (!text) continue
+      const type = node.attributes.type?.trim() ?? 'other'
+      const title = node.attributes.title?.trim()
+      diagrams.push({
+        content: text,
+        type,
+        ...(title && {title}),
+      })
+    }
+
+    if (diagrams.length > 0) narrative.diagrams = diagrams
+  }
+
+  return Object.keys(narrative).length === 0 ? undefined : narrative
+}
+
+/**
+ * Extract `<li>` items from a container element (e.g. `<bv-changes>` or
+ * `<bv-files>` with a nested `<ul>` or `<ol>`). Falls back to splitting
+ * the element's inner text by newlines if no `<li>` children are present
+ * — mirrors the MD writer's tolerance for either shape.
+ */
+function extractListItems(container: ElementNode): string[] {
+  const lis = walkElements(container).filter((e) => e.tagName === 'li')
+  if (lis.length > 0) {
+    return lis
+      .map((li) => getInnerText(li).trim())
+      .filter((s) => s.length > 0)
+  }
+
+  // Fallback: split inner text by newlines (handles authors that wrote
+  // plain text instead of <li>).
+  const text = getInnerText(container).trim()
+  if (!text) return []
+  return text
+    .split('\n')
+    .map((s) => s.replace(/^\s*[-*]\s+/, '').trim())
+    .filter((s) => s.length > 0)
+}

--- a/src/server/infra/context-tree/html-context-file-extractor.ts
+++ b/src/server/infra/context-tree/html-context-file-extractor.ts
@@ -40,17 +40,23 @@ export function parseHtmlContextContent(
   relativePath: string,
 ): ContextFileContent {
   const document = parseHtml(content)
-  const elements = walkElements(document)
+  const topic = walkElements(document).find((e) => e.tagName === 'bv-topic')
 
-  const topic = elements.find((e) => e.tagName === 'bv-topic')
+  // Scope all subsequent element extraction to the `<bv-topic>` subtree.
+  // Stray sibling bv-* elements outside the topic (malformed input, or
+  // a future format with multiple roots) are intentionally ignored —
+  // matches the "fields are sourced from <bv-topic> children" contract.
+  // If no topic root was found, fall through with an empty scope so the
+  // result has all-empty fields rather than crashing.
+  const scope: readonly ElementNode[] = topic ? walkElements(topic) : []
   const attrs = topic?.attributes ?? {}
 
   const title = attrs.title?.trim() ? attrs.title.trim() : fallbackTitle
   const tags = parseCsvAttribute(attrs.tags)
   const keywords = parseCsvAttribute(attrs.keywords)
 
-  const rawConcept = extractRawConcept(elements)
-  const narrative = extractNarrative(elements)
+  const rawConcept = extractRawConcept(scope)
+  const narrative = extractNarrative(scope)
 
   return {
     content,
@@ -164,7 +170,8 @@ function extractNarrative(elements: readonly ElementNode[]): Narrative | undefin
   // matching the markdown-writer's `### Rules` render format. The MD shape
   // for narrative.rules is freeform string; we serialise structured HTML
   // rules deterministically so the cogit push / webui consumers see the
-  // same shape they used to.
+  // same shape they used to. Prefix is built from parts so spacing is
+  // correct in every combination (severity-only, id-only, both, neither).
   const ruleNodes = elements.filter((e) => e.tagName === 'bv-rule')
   if (ruleNodes.length > 0) {
     const lines: string[] = []
@@ -173,9 +180,11 @@ function extractNarrative(elements: readonly ElementNode[]): Narrative | undefin
       if (!text) continue
       const severity = node.attributes.severity?.trim()
       const id = node.attributes.id?.trim()
-      const severityPart = severity ? `[${severity}]` : ''
-      const idPart = id ? ` (${id})` : ''
-      lines.push(`- ${severityPart}${idPart}${severity || id ? ': ' : ''}${text}`.replace(/^- : /, '- '))
+      const prefixParts: string[] = []
+      if (severity) prefixParts.push(`[${severity}]`)
+      if (id) prefixParts.push(`(${id})`)
+      const prefix = prefixParts.length > 0 ? `${prefixParts.join(' ')}: ` : ''
+      lines.push(`- ${prefix}${text}`)
     }
 
     if (lines.length > 0) narrative.rules = lines.join('\n')
@@ -206,24 +215,16 @@ function extractNarrative(elements: readonly ElementNode[]): Narrative | undefin
 
 /**
  * Extract `<li>` items from a container element (e.g. `<bv-changes>` or
- * `<bv-files>` with a nested `<ul>` or `<ol>`). Falls back to splitting
- * the element's inner text by newlines if no `<li>` children are present
- * — mirrors the MD writer's tolerance for either shape.
+ * `<bv-files>` with a nested `<ul>` or `<ol>`). Returns an empty array
+ * when no `<li>` children are present — the schema documents `<li>`
+ * children as the expected shape, and `getInnerText` collapses
+ * whitespace (so a newline-based fallback wouldn't be reachable in
+ * practice). Matches the markdown writer's strictness: MD-side bullets
+ * that don't start with `- ` are also dropped.
  */
 function extractListItems(container: ElementNode): string[] {
-  const lis = walkElements(container).filter((e) => e.tagName === 'li')
-  if (lis.length > 0) {
-    return lis
-      .map((li) => getInnerText(li).trim())
-      .filter((s) => s.length > 0)
-  }
-
-  // Fallback: split inner text by newlines (handles authors that wrote
-  // plain text instead of <li>).
-  const text = getInnerText(container).trim()
-  if (!text) return []
-  return text
-    .split('\n')
-    .map((s) => s.replace(/^\s*[-*]\s+/, '').trim())
+  return walkElements(container)
+    .filter((e) => e.tagName === 'li')
+    .map((li) => getInnerText(li).trim())
     .filter((s) => s.length > 0)
 }

--- a/test/integration/infra/context-tree/file-context-file-reader.test.ts
+++ b/test/integration/infra/context-tree/file-context-file-reader.test.ts
@@ -411,6 +411,106 @@ describe('FileContextFileReader', () => {
         expect(result!.keywords).to.deep.equal([])
       })
 
+      // AC (review #1): id-only <bv-rule> renders without a double space.
+      it('renders <bv-rule> with id but no severity correctly (no double space)', async () => {
+        const html = `<bv-topic path="x/y" title="t">
+  <bv-rule id="r-foo">id only.</bv-rule>
+</bv-topic>`
+        await mkdir(join(contextTreeDir, 'x'), {recursive: true})
+        await writeFile(join(contextTreeDir, 'x/y.html'), html)
+
+        const result = await reader.read('x/y.html')
+
+        // Exactly one space after the dash; no double space.
+        expect(result!.narrative?.rules).to.equal('- (r-foo): id only.')
+        expect(result!.narrative?.rules).to.not.match(/^- {2}/)
+      })
+
+      // AC (review #1): severity-only <bv-rule> formats cleanly.
+      it('renders <bv-rule> with severity but no id correctly', async () => {
+        const html = `<bv-topic path="x/y" title="t">
+  <bv-rule severity="info">severity only.</bv-rule>
+</bv-topic>`
+        await mkdir(join(contextTreeDir, 'x'), {recursive: true})
+        await writeFile(join(contextTreeDir, 'x/y.html'), html)
+
+        const result = await reader.read('x/y.html')
+
+        expect(result!.narrative?.rules).to.equal('- [info]: severity only.')
+      })
+
+      // AC (review #1): <bv-rule> with neither severity nor id — no prefix.
+      it('renders <bv-rule> with no attributes as a plain bullet (no prefix)', async () => {
+        const html = `<bv-topic path="x/y" title="t">
+  <bv-rule>bare rule text.</bv-rule>
+</bv-topic>`
+        await mkdir(join(contextTreeDir, 'x'), {recursive: true})
+        await writeFile(join(contextTreeDir, 'x/y.html'), html)
+
+        const result = await reader.read('x/y.html')
+
+        expect(result!.narrative?.rules).to.equal('- bare rule text.')
+      })
+
+      // AC (review): <bv-diagram> without `type` defaults to 'other'.
+      it('defaults <bv-diagram type> to "other" when the attribute is absent', async () => {
+        const html = `<bv-topic path="x/y" title="t">
+  <bv-diagram>no type attr</bv-diagram>
+</bv-topic>`
+        await mkdir(join(contextTreeDir, 'x'), {recursive: true})
+        await writeFile(join(contextTreeDir, 'x/y.html'), html)
+
+        const result = await reader.read('x/y.html')
+
+        expect(result!.narrative?.diagrams).to.deep.equal([
+          {content: 'no type attr', type: 'other'},
+        ])
+      })
+
+      // AC (review #3): bv-* elements outside <bv-topic> must NOT be pulled in.
+      it('ignores bv-* elements outside the <bv-topic> root (scope guard)', async () => {
+        const html = `<bv-task>stray task outside</bv-task>
+<bv-topic path="x/y" title="t">
+  <bv-task>real task inside</bv-task>
+</bv-topic>
+<bv-rule>stray rule outside</bv-rule>`
+        await mkdir(join(contextTreeDir, 'x'), {recursive: true})
+        await writeFile(join(contextTreeDir, 'x/y.html'), html)
+
+        const result = await reader.read('x/y.html')
+
+        expect(result!.rawConcept?.task).to.equal('real task inside')
+        expect(result!.narrative?.rules).to.equal(undefined)
+      })
+
+      // AC (review #5): HTML branch ignores `# H1` lines inside the body.
+      // A markdown-styled heading inside <bv-examples> must NOT leak into
+      // the title (was a fallback path before this fix).
+      it('does not use a stray "# heading" inside HTML body as fallback title', async () => {
+        const html = `<bv-topic path="security/auth" title="Real title">
+  <bv-examples># Looks like a markdown heading inside an example</bv-examples>
+</bv-topic>`
+        await mkdir(join(contextTreeDir, 'security'), {recursive: true})
+        await writeFile(join(contextTreeDir, 'security/leak.html'), html)
+
+        const result = await reader.read('security/leak.html')
+
+        expect(result!.title).to.equal('Real title')
+      })
+
+      // AC (review #5 — companion): missing-title HTML uses relative path, NOT a body H1.
+      it('uses relativePath as fallback title when <bv-topic title> is absent (not body H1)', async () => {
+        const html = `<bv-topic path="x/y">
+  <bv-examples># H1 in body</bv-examples>
+</bv-topic>`
+        await mkdir(join(contextTreeDir, 'x'), {recursive: true})
+        await writeFile(join(contextTreeDir, 'x/no-title.html'), html)
+
+        const result = await reader.read('x/no-title.html')
+
+        expect(result!.title).to.equal('x/no-title.html')
+      })
+
       // AC: HTML routing is extension-based — doesn't interfere with the MD path.
       it('does not affect .md topics — markdown path still runs', async () => {
         const mdContent = '---\ntitle: MD topic\ntags: [legacy]\nkeywords: [old]\n---\n\n# MD topic'

--- a/test/integration/infra/context-tree/file-context-file-reader.test.ts
+++ b/test/integration/infra/context-tree/file-context-file-reader.test.ts
@@ -214,6 +214,216 @@ describe('FileContextFileReader', () => {
         }
       })
     })
+
+    describe('HTML topic extraction (bv-* vocabulary)', () => {
+      // Reference fixture covering every field documented in the
+      // ContextFileContent contract — keeps the per-test setup tight.
+      const FULL_HTML_TOPIC = `<bv-topic path="security/auth" title="JWT authentication" summary="JWT design and refresh flow" tags="security,authentication" keywords="jwt,refresh,token" related="@security/oauth">
+  <bv-reason>Document JWT design.</bv-reason>
+  <bv-task>Capture JWT design decisions.</bv-task>
+  <bv-changes><ul><li>Migrated from HS256 to RS256.</li><li>Added JWKS endpoint.</li></ul></bv-changes>
+  <bv-files><ul><li>src/middleware/auth.ts</li><li>docs/auth-design.md</li></ul></bv-files>
+  <bv-flow>request → middleware → validate signature → attach user</bv-flow>
+  <bv-timestamp>2026-04-01</bv-timestamp>
+  <bv-author>Andy</bv-author>
+  <bv-pattern flags="g" description="email">[\\w.+-]+@[\\w.-]+</bv-pattern>
+  <bv-pattern description="Bearer header">Bearer (\\S+)</bv-pattern>
+  <bv-structure>Auth module in src/auth/.</bv-structure>
+  <bv-dependencies>Requires @anthropic-ai/sdk ^0.27.</bv-dependencies>
+  <bv-highlights>Sub-100ms validation.</bv-highlights>
+  <bv-rule severity="must" id="r-validate">Always validate JWT signatures.</bv-rule>
+  <bv-rule severity="should" id="r-rotate">Rotate signing keys every 30 days.</bv-rule>
+  <bv-examples>jwt.verify(token, key)</bv-examples>
+  <bv-diagram type="mermaid" title="lifecycle">sequenceDiagram\nClient->>API: Bearer</bv-diagram>
+  <bv-fact subject="signing_algorithm" category="convention" value="RS256">All service-to-service JWTs are signed with RS256.</bv-fact>
+</bv-topic>`
+
+      // AC: <bv-topic title> overrides the filename fallback.
+      it('extracts title from <bv-topic title="…"> attribute', async () => {
+        await mkdir(join(contextTreeDir, 'security'), {recursive: true})
+        await writeFile(join(contextTreeDir, 'security/auth.html'), FULL_HTML_TOPIC)
+
+        const result = await reader.read('security/auth.html')
+
+        expect(result).to.not.be.undefined
+        expect(result!.title).to.equal('JWT authentication')
+      })
+
+      // AC: tags is comma-split + trimmed.
+      it('parses tags from <bv-topic tags="…"> as comma-split array', async () => {
+        await mkdir(join(contextTreeDir, 'security'), {recursive: true})
+        await writeFile(join(contextTreeDir, 'security/auth.html'), FULL_HTML_TOPIC)
+
+        const result = await reader.read('security/auth.html')
+
+        expect(result!.tags).to.deep.equal(['security', 'authentication'])
+      })
+
+      // AC: keywords is comma-split + trimmed.
+      it('parses keywords from <bv-topic keywords="…"> as comma-split array', async () => {
+        await mkdir(join(contextTreeDir, 'security'), {recursive: true})
+        await writeFile(join(contextTreeDir, 'security/auth.html'), FULL_HTML_TOPIC)
+
+        const result = await reader.read('security/auth.html')
+
+        expect(result!.keywords).to.deep.equal(['jwt', 'refresh', 'token'])
+      })
+
+      // AC: rawConcept.task is the <bv-task> inner text.
+      it('extracts rawConcept.task from <bv-task>', async () => {
+        await mkdir(join(contextTreeDir, 'security'), {recursive: true})
+        await writeFile(join(contextTreeDir, 'security/auth.html'), FULL_HTML_TOPIC)
+
+        const result = await reader.read('security/auth.html')
+
+        expect(result!.rawConcept?.task).to.equal('Capture JWT design decisions.')
+      })
+
+      // AC: rawConcept.changes is the <li> list inside <bv-changes>.
+      it('extracts rawConcept.changes as <li> items from <bv-changes>', async () => {
+        await mkdir(join(contextTreeDir, 'security'), {recursive: true})
+        await writeFile(join(contextTreeDir, 'security/auth.html'), FULL_HTML_TOPIC)
+
+        const result = await reader.read('security/auth.html')
+
+        expect(result!.rawConcept?.changes).to.deep.equal([
+          'Migrated from HS256 to RS256.',
+          'Added JWKS endpoint.',
+        ])
+      })
+
+      // AC: rawConcept.files is the <li> list inside <bv-files>.
+      it('extracts rawConcept.files as <li> items from <bv-files>', async () => {
+        await mkdir(join(contextTreeDir, 'security'), {recursive: true})
+        await writeFile(join(contextTreeDir, 'security/auth.html'), FULL_HTML_TOPIC)
+
+        const result = await reader.read('security/auth.html')
+
+        expect(result!.rawConcept?.files).to.deep.equal([
+          'src/middleware/auth.ts',
+          'docs/auth-design.md',
+        ])
+      })
+
+      // AC: rawConcept.flow / timestamp / author come from their respective elements.
+      it('extracts rawConcept.flow, .timestamp, .author from their respective bv-* elements', async () => {
+        await mkdir(join(contextTreeDir, 'security'), {recursive: true})
+        await writeFile(join(contextTreeDir, 'security/auth.html'), FULL_HTML_TOPIC)
+
+        const result = await reader.read('security/auth.html')
+
+        expect(result!.rawConcept?.flow).to.equal('request → middleware → validate signature → attach user')
+        expect(result!.rawConcept?.timestamp).to.equal('2026-04-01')
+        expect(result!.rawConcept?.author).to.equal('Andy')
+      })
+
+      // AC: rawConcept.patterns carries pattern + flags + description per <bv-pattern> sibling.
+      it('extracts rawConcept.patterns with flags + description from <bv-pattern> siblings', async () => {
+        await mkdir(join(contextTreeDir, 'security'), {recursive: true})
+        await writeFile(join(contextTreeDir, 'security/auth.html'), FULL_HTML_TOPIC)
+
+        const result = await reader.read('security/auth.html')
+
+        expect(result!.rawConcept?.patterns).to.deep.equal([
+          {description: 'email', flags: 'g', pattern: String.raw`[\w.+-]+@[\w.-]+`},
+          {description: 'Bearer header', pattern: String.raw`Bearer (\S+)`},
+        ])
+      })
+
+      // AC: narrative.structure / dependencies / highlights / examples from their elements.
+      it('extracts narrative.structure, .dependencies, .highlights, .examples', async () => {
+        await mkdir(join(contextTreeDir, 'security'), {recursive: true})
+        await writeFile(join(contextTreeDir, 'security/auth.html'), FULL_HTML_TOPIC)
+
+        const result = await reader.read('security/auth.html')
+
+        expect(result!.narrative?.structure).to.equal('Auth module in src/auth/.')
+        expect(result!.narrative?.dependencies).to.equal('Requires @anthropic-ai/sdk ^0.27.')
+        expect(result!.narrative?.highlights).to.equal('Sub-100ms validation.')
+        expect(result!.narrative?.examples).to.equal('jwt.verify(token, key)')
+      })
+
+      // AC: narrative.rules aggregates <bv-rule> siblings into a bullet list
+      // mirroring the markdown-writer's `### Rules` render.
+      it('aggregates <bv-rule> siblings into narrative.rules bullet list with severity + id', async () => {
+        await mkdir(join(contextTreeDir, 'security'), {recursive: true})
+        await writeFile(join(contextTreeDir, 'security/auth.html'), FULL_HTML_TOPIC)
+
+        const result = await reader.read('security/auth.html')
+
+        const rules = result!.narrative?.rules ?? ''
+        expect(rules).to.include('[must] (r-validate): Always validate JWT signatures.')
+        expect(rules).to.include('[should] (r-rotate): Rotate signing keys every 30 days.')
+      })
+
+      // AC: narrative.diagrams gets a structured array.
+      it('extracts narrative.diagrams as a list with type + title + content', async () => {
+        await mkdir(join(contextTreeDir, 'security'), {recursive: true})
+        await writeFile(join(contextTreeDir, 'security/auth.html'), FULL_HTML_TOPIC)
+
+        const result = await reader.read('security/auth.html')
+
+        expect(result!.narrative?.diagrams).to.have.lengthOf(1)
+        const diagram = result!.narrative!.diagrams![0]
+        expect(diagram.type).to.equal('mermaid')
+        expect(diagram.title).to.equal('lifecycle')
+        expect(diagram.content).to.include('Client')
+      })
+
+      // AC: raw content survives intact regardless of extraction.
+      it('returns the source HTML bytes in content unchanged', async () => {
+        await mkdir(join(contextTreeDir, 'security'), {recursive: true})
+        await writeFile(join(contextTreeDir, 'security/auth.html'), FULL_HTML_TOPIC)
+
+        const result = await reader.read('security/auth.html')
+
+        expect(result!.content).to.equal(FULL_HTML_TOPIC)
+      })
+
+      // AC: minimal topic produces sensible defaults.
+      it('handles a minimal <bv-topic> with only path + title — empty tags/keywords, no rawConcept/narrative', async () => {
+        await mkdir(join(contextTreeDir, 'misc'), {recursive: true})
+        await writeFile(
+          join(contextTreeDir, 'misc/x.html'),
+          '<bv-topic path="misc/x" title="Empty topic"></bv-topic>',
+        )
+
+        const result = await reader.read('misc/x.html')
+
+        expect(result!.title).to.equal('Empty topic')
+        expect(result!.tags).to.deep.equal([])
+        expect(result!.keywords).to.deep.equal([])
+        expect(result!.rawConcept).to.equal(undefined)
+        expect(result!.narrative).to.equal(undefined)
+      })
+
+      // AC: malformed HTML (no bv-topic root) — falls back to filename title,
+      //      empty fields. Doesn't throw.
+      it('falls back gracefully when there is no <bv-topic> root', async () => {
+        await mkdir(join(contextTreeDir, 'broken'), {recursive: true})
+        await writeFile(join(contextTreeDir, 'broken/y.html'), '<p>just html, no bv-topic</p>')
+
+        const result = await reader.read('broken/y.html')
+
+        expect(result).to.not.be.undefined
+        expect(result!.title).to.equal('broken/y.html') // falls back to path
+        expect(result!.tags).to.deep.equal([])
+        expect(result!.keywords).to.deep.equal([])
+      })
+
+      // AC: HTML routing is extension-based — doesn't interfere with the MD path.
+      it('does not affect .md topics — markdown path still runs', async () => {
+        const mdContent = '---\ntitle: MD topic\ntags: [legacy]\nkeywords: [old]\n---\n\n# MD topic'
+        await mkdir(join(contextTreeDir, 'legacy'), {recursive: true})
+        await writeFile(join(contextTreeDir, 'legacy/old.md'), mdContent)
+
+        const result = await reader.read('legacy/old.md')
+
+        expect(result!.title).to.equal('MD topic')
+        expect(result!.tags).to.deep.equal(['legacy'])
+        expect(result!.keywords).to.deep.equal(['old'])
+      })
+    })
   })
 
   describe('readMany', () => {


### PR DESCRIPTION
## Summary

Unblocks FE topic-browser integration. `FileContextFileReader` (consumed by the webui `GET_FILE` RPC + cogit `push-handler`) called `MarkdownWriter.parseContent` unconditionally — so HTML topics came back with empty \`tags\` / \`keywords\` and \`title\` falling back to the filename, even though the raw content on disk was correct.

Fix: branch on file extension in \`FileContextFileReader.read\`. \`.html\` files route through a new \`parseHtmlContextContent\` extractor that walks the \`<bv-topic>\` attributes + typed \`<bv-*>\` child elements. Same \`ContextFileContent\` return shape — downstream consumers (\`push-handler\`, \`context-tree-handler\`) don't need to know which format produced it.

## Type
fix (FE-integration blocker)

## Field mapping (HTML → ContextFileContent)

| ContextFileContent field | HTML source | Extraction |
|---|---|---|
| \`title\` | \`<bv-topic title="…">\` | attribute value, trimmed; falls back to filename if empty |
| \`tags\` | \`<bv-topic tags="…">\` | comma-split, trimmed, empty entries dropped |
| \`keywords\` | \`<bv-topic keywords="…">\` | comma-split, trimmed |
| \`rawConcept.task\` | \`<bv-task>\` | inner text |
| \`rawConcept.changes\` | \`<bv-changes> > <li>\` | each \`<li>\` inner text; falls back to newline-split if no \`<li>\` |
| \`rawConcept.files\` | \`<bv-files> > <li>\` | same as changes |
| \`rawConcept.flow\` | \`<bv-flow>\` | inner text |
| \`rawConcept.timestamp\` | \`<bv-timestamp>\` | inner text |
| \`rawConcept.author\` | \`<bv-author>\` | inner text |
| \`rawConcept.patterns\` | \`<bv-pattern>\` siblings | element text + \`flags\` / \`description\` attrs |
| \`narrative.structure\` | \`<bv-structure>\` | inner text |
| \`narrative.dependencies\` | \`<bv-dependencies>\` | inner text |
| \`narrative.highlights\` | \`<bv-highlights>\` | inner text |
| \`narrative.rules\` | \`<bv-rule>\` siblings | aggregated bullet list with \`[severity] (id): text\` per rule (mirrors MD writer's render) |
| \`narrative.examples\` | \`<bv-examples>\` | inner text |
| \`narrative.diagrams\` | \`<bv-diagram>\` siblings | structured \`{type, title, content}\` per element; \`type\` defaults to \`'other'\` |

\`.md\` path unchanged — extension-based dispatch is purely additive.

## Before / after

Live probe on the same HTML fixture:

\`\`\`
BEFORE:
{
  "title": "security/auth.html",   ← filename fallback (bug)
  "tags": [],                       ← empty (bug)
  "keywords": [],                   ← empty (bug)
  "rawConcept": null,               ← undefined (bug)
  "narrative": null,                ← undefined (bug)
  "content": "<bv-topic ...>"       ← raw HTML (correct)
}

AFTER:
{
  "title": "JWT authentication",
  "tags": ["security","authentication"],
  "keywords": ["jwt","refresh","token"],
  "rawConcept": {
    "task": "Capture JWT design decisions.",
    "changes": ["Migrated from HS256 to RS256."],
    "files": ["src/middleware/auth.ts"],
    "flow": "request → middleware → validate signature → attach user"
  },
  "narrative": {
    "rules": "- [must] (r-validate): Always validate JWT signatures."
  },
  "content": "<bv-topic ...>"
}
\`\`\`

## Out of scope (known interface gap, follow-up)

\`ContextFileContent\` doesn't yet have fields for HTML-native data that has no MD analog: \`summary\`, \`related\`, \`facts\`, \`decisions\`, \`bugs\`, \`fixes\`. These are exposed on the topic file but the existing interface drops them. Extending the interface ripples into transport-handler response shapes — that's a separate ticket once we know which consumers want the new fields.

For FE consumers that want the richer data NOW: parse the raw \`content\` field client-side per \`bv-element-reference.md\` (DOMParser + read \`<bv-topic>\` attributes). The raw HTML is in the response and complete.

## Test plan

- [x] 15 new integration tests in \`test/integration/infra/context-tree/file-context-file-reader.test.ts\`, one per AC field on the table above, plus minimal-topic / malformed-html / MD-regression cases
- [x] All existing reader tests pass unchanged (MD path is untouched)
- [x] Full suite: 7992 pass (+15)
- [x] Typecheck, lint, build clean
- [x] Live verified via probe against the same fixture used in the bug report

## Scope

| File | Change |
|---|---|
| \`src/server/infra/context-tree/html-context-file-extractor.ts\` (new) | HTML → \`ContextFileContent\` walker |
| \`src/server/infra/context-tree/file-context-file-reader.ts\` | Extension-based dispatch; delegates HTML to new extractor; MD path unchanged |
| \`test/integration/infra/context-tree/file-context-file-reader.test.ts\` | +15 HTML test cases + 1 MD regression case at the end of the \`read\` describe |

No transport-handler changes, no interface changes, no consumer changes.