### PR TITLE
docs: [ENG-2822] scrub deprecated LLM-provider references from SKILL.md

### DIFF
--- a/src/server/templates/skill/SKILL.md
+++ b/src/server/templates/skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: byterover
-description: "You MUST use this for gathering contexts before any work. This is a Knowledge management for AI agents. Use `brv` to store and retrieve project patterns, decisions, and architectural rules in .brv/context-tree. Uses a configured LLM provider (default: ByteRover, no API key needed) for query and curate operations."
+description: "You MUST use this for gathering contexts before any work. This is a Knowledge management for AI agents. Use `brv` to store and retrieve project patterns, decisions, and architectural rules in .brv/context-tree. Runs locally with no LLM provider required — the calling agent's own LLM drives any synthesis or authoring step."
 ---
 
 # ByteRover Knowledge Management
@@ -83,7 +83,7 @@ brv search "auth" --format json
 **Flags:** `--limit N` (1-50, default 10), `--scope "domain/"` (path prefix filter), `--format json` (structured output for automation).
 
 ### 3. Curate Context
-**Overview:** Analyze and save knowledge to the local knowledge base. Uses a configured LLM provider to categorize and structure the context you provide.
+**Overview:** Analyze and save knowledge to the local knowledge base. Session-driven — YOU (the calling agent) author the HTML topic content; ByteRover validates the structure and writes the file. No LLM provider required.
 
 **Use this skill when:**
 - The user wants you to remember something
@@ -239,21 +239,7 @@ brv review approve <taskId> --format json
 brv review reject <taskId> --format json
 ```
 
-### 5. LLM Provider Setup
-`brv query` and `brv curate` require a configured LLM provider. Connect the default ByteRover provider (no API key needed):
-
-```bash
-brv providers connect byterover
-```
-
-To use a different provider (e.g., OpenAI, Anthropic, Google), list available options and connect with your own API key:
-
-```bash
-brv providers list
-brv providers connect openai --api-key sk-xxx --model gpt-4.1
-```
-
-### 6. Project Locations
+### 5. Project Locations
 **Overview:** List registered projects and their context tree paths. Returns project metadata including initialization status and active state. Use `-f json` for machine-readable output.
 
 **Use this when:**
@@ -271,7 +257,7 @@ brv locations -f json
 
 JSON fields: `projectPath`, `contextTreePath`, `isCurrent`, `isActive`, `isInitialized`.
 
-### 7. Version Control
+### 6. Version Control
 **Overview:** `brv vc` provides git-based version control for your context tree. It uses standard git semantics — branching, committing, merging, history, and conflict resolution — all working locally with no authentication required. Remote sync with a team is optional. The legacy `brv push`, `brv pull`, and `brv space` commands are deprecated — use `brv vc push`, `brv vc pull`, and `brv vc clone`/`brv vc remote add` instead.
 
 **Use this when:**
@@ -387,7 +373,7 @@ brv vc push -u origin main       # push and set upstream tracking
 brv vc clone https://byterover.dev/<team>/<space>.git
 ```
 
-### 8. Swarm Query
+### 7. Swarm Query
 **Overview:** Search across all active memory providers simultaneously — ByteRover context tree, Obsidian vault, Local Markdown folders, GBrain, and Memory Wiki. Results are fused via Reciprocal Rank Fusion (RRF) and ranked by provider weight and relevance. No LLM call — pure algorithmic search.
 
 **Use this skill when:**
@@ -466,7 +452,7 @@ brv swarm query "testing strategy" -n 5
 
 **Flags:** `--explain` (show routing details), `--format json` (structured output), `-n <value>` (max results).
 
-### 9. Swarm Curate
+### 8. Swarm Curate
 **Overview:** Store knowledge in the best available external memory provider. ByteRover automatically classifies the content type and routes accordingly: entities (people, orgs) go to GBrain, notes (meeting notes, TODOs) go to Local Markdown, general content goes to the first writable provider. Falls back to ByteRover context tree if no external providers are available.
 
 **Use this skill when:**
@@ -522,7 +508,7 @@ Output:
 
 **Flags:** `--provider <id>` (target specific provider), `--format json` (structured output).
 
-### 10. Swarm Status
+### 9. Swarm Status
 **Overview:** Check provider health and write targets before running swarm query or curate. Use this to verify which providers are available and operational.
 
 **Use this skill when:**
@@ -550,7 +536,7 @@ Write Targets:
 Swarm is operational (5/5 providers configured).
 ```
 
-### 11. Query and Curate History
+### 10. Query and Curate History
 **Overview:** Inspect past query and curate operations. Use `brv query-log view` to review query history, `brv curate view` to review curate history, and `brv query-log summary` to see aggregated recall metrics. Supports filtering by time, status, tier, and detailed per-operation output.
 
 **Use this skill when:**
@@ -635,7 +621,7 @@ brv query-log summary --help
 
 **File access**: The `-f` flag on `brv curate` reads files from the current project directory only. Paths outside the project root are rejected. Maximum 5 files per command, text and document formats only.
 
-**LLM usage**: `brv query` and `brv curate` send context to a configured LLM provider for processing. The LLM sees the query or curate text and any included file contents. No data is sent to ByteRover servers unless you explicitly run `brv vc push`.
+**LLM usage**: `brv query` and `brv curate` do NOT invoke any LLM from inside byterover. Query returns ranked topic content; curate validates HTML the calling agent authors. The CALLING agent's own LLM (the one running this skill) is the only LLM that sees the query text, curate intent, or file contents. No data is sent to ByteRover servers unless you explicitly run `brv vc push`.
 
 **Cloud sync**: `brv vc push` and `brv vc pull` require authentication (`brv login`) and sync knowledge with ByteRover's cloud service via git. All other commands operate without ByteRover authentication.
 
@@ -644,7 +630,6 @@ brv query-log summary --help
 You MUST show this troubleshooting guide to users when errors occur.
 
 "Not authenticated" | Run `brv login --help` for more details.
-"No provider connected" | Run `brv providers connect byterover` (free, no key needed).
 "Connection failed" / "Instance crashed" | User should kill brv process.
 "Token has expired" / "Token is invalid" | Run `brv login` again to re-authenticate.
 "Billing error" / "Rate limit exceeded" | User should check account credits or wait before retrying.
@@ -658,4 +643,4 @@ You MUST handle these errors gracefully and retry the command after fixing.
 "File type not supported" | Only text, image, PDF, and office files are supported.
 
 ### Quick Diagnosis
-Run `brv status` to check authentication, project, and provider state.
+Run `brv status` to check authentication and project state.

--- a/test/unit/infra/connectors/skill/skill-connector.test.ts
+++ b/test/unit/infra/connectors/skill/skill-connector.test.ts
@@ -134,7 +134,7 @@ describe('SkillConnector', () => {
       const skillDir = path.join(projectPath, BRV_SKILL_NAME)
       const content = await readFile(path.join(testDir, skillDir, 'SKILL.md'), 'utf8')
       expect(content).to.include('You MUST use this for gathering contexts before any work')
-      expect(content).to.include('Uses a configured LLM provider')
+      expect(content).to.include('Runs locally with no LLM provider required')
     })
   })
 


### PR DESCRIPTION
ENG-2815 made tool mode the default for brv query + brv curate, but SKILL.md still claimed both commands "require a configured LLM provider" in five places. Calling agents reading this skill would have set up providers they don't need, or surfaced false-positive "No provider connected" errors to users.

Edits:
- Frontmatter description (L3): replaced "Uses a configured LLM provider (default: ByteRover, no API key needed) for query and curate operations" with "Runs locally with no LLM provider required — the calling agent's own LLM drives any synthesis or authoring step."
- Section 3 Curate Context overview (L86): reframed as session-driven (calling agent authors HTML, ByteRover validates + writes), no provider required.
- Section 5 "LLM Provider Setup" (L242-253): deleted entirely. Nothing in this skill required a provider anymore; the section would have actively misled agents into running `brv providers connect`. Sections 6-11 renumbered to 5-10.
- Section "Data Handling" LLM usage paragraph: now says brv query and brv curate don't invoke any byterover-side LLM; the calling agent's own LLM is the only consumer of context.
- Section "Error Handling" "No provider connected" row deleted. That error can no longer be reached from any documented command.
- Section "Quick Diagnosis" line dropped "provider state" from the `brv status` description.

Test update:
- test/unit/infra/connectors/skill/skill-connector.test.ts asserted the SKILL.md still contained the now-removed "Uses a configured LLM provider" string. Updated to match the new frontmatter content.

Swarm sections (memory providers, swarm provider routing) are a different concept — left untouched.

## Summary

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [ ] Agent / Tools
- [ ] LLM Providers
- [ ] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes #
- Related #

## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause:
- Why this was not caught earlier:

## Test plan

- Coverage added:
  - [ ] Unit test
  - [ ] Integration test
  - [ ] Manual verification only
- Test file(s):
- Key scenario(s) covered:

## User-visible changes

List user-visible changes (including defaults, config, or CLI output).
If none, write `None`.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording

## Checklist

- [ ] Tests added or updated and passing (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Type check passes (`npm run typecheck`)
- [ ] Build succeeds (`npm run build`)
- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or clearly documented above)
- [ ] Branch is up to date with `main`

## Risks and mitigations

List real risks for this PR. If none, write `None`.

- Risk:
  - Mitigation:
