### PR TITLE
feat: [ENG-2700] dedupe duplicate models from openai-compatible upstream

### DIFF
--- a/src/server/infra/http/provider-model-fetchers.ts
+++ b/src/server/infra/http/provider-model-fetchers.ts
@@ -426,18 +426,21 @@ export class OpenAICompatibleModelFetcher implements IProviderModelFetcher {
       ? responseData
       : (responseData.data ?? responseData.models ?? [])
 
-    const models: ProviderModelInfo[] = modelList.map((model) => {
+    const uniqueModels = new Map<string, ProviderModelInfo>()
+    for (const model of modelList) {
       const id = String(model.id ?? model.name ?? '')
-
-      return {
+      if (uniqueModels.has(id)) continue
+      uniqueModels.set(id, {
         contextLength: typeof model.context_length === 'number' ? model.context_length : 128_000,
         id,
         isFree: false,
         name: id,
         pricing: {inputPerM: 0, outputPerM: 0},
         provider: this.providerName,
-      }
-    })
+      })
+    }
+
+    const models: ProviderModelInfo[] = [...uniqueModels.values()]
 
     // Sort by ID
     models.sort((a, b) => a.id.localeCompare(b.id))

--- a/src/server/infra/http/provider-model-fetchers.ts
+++ b/src/server/infra/http/provider-model-fetchers.ts
@@ -429,6 +429,7 @@ export class OpenAICompatibleModelFetcher implements IProviderModelFetcher {
     const uniqueModels = new Map<string, ProviderModelInfo>()
     for (const model of modelList) {
       const id = String(model.id ?? model.name ?? '')
+      if (!id) continue
       if (uniqueModels.has(id)) continue
       uniqueModels.set(id, {
         contextLength: typeof model.context_length === 'number' ? model.context_length : 128_000,

--- a/test/unit/infra/http/provider-model-fetchers.test.ts
+++ b/test/unit/infra/http/provider-model-fetchers.test.ts
@@ -301,6 +301,25 @@ describe('OpenAIModelFetcher', () => {
       expect(models[0].contextLength).to.equal(128_000)
     })
 
+    it('skips entries with neither id nor name', async () => {
+      stub(axios, 'get').resolves({
+        data: {
+          data: [
+            {id: 'a-model'},
+            {description: 'orphan with no id or name'},
+            {id: '', name: ''},
+            {id: 'b-model'},
+          ],
+        },
+        status: 200,
+      })
+      const fetcher = new OpenAICompatibleModelFetcher('https://example.test/v1', 'OpenAI Compatible')
+
+      const models = await fetcher.fetchModels('sk-test')
+
+      expect(models.map((m) => m.id)).to.deep.equal(['a-model', 'b-model'])
+    })
+
     it('passes through unique ids unchanged', async () => {
       stub(axios, 'get').resolves({
         data: {

--- a/test/unit/infra/http/provider-model-fetchers.test.ts
+++ b/test/unit/infra/http/provider-model-fetchers.test.ts
@@ -5,7 +5,7 @@ import {restore, type SinonStub, stub} from 'sinon'
 import type {ProviderModelInfo} from '../../../../src/server/core/interfaces/i-provider-model-fetcher.js'
 import type {ModelsDevClient} from '../../../../src/server/infra/http/models-dev-client.js'
 
-import {ChatBasedModelFetcher, CODEX_FALLBACK_MODELS, OpenAIModelFetcher} from '../../../../src/server/infra/http/provider-model-fetchers.js'
+import {ChatBasedModelFetcher, CODEX_FALLBACK_MODELS, OpenAICompatibleModelFetcher, OpenAIModelFetcher} from '../../../../src/server/infra/http/provider-model-fetchers.js'
 
 function makeAxiosErr(status: number): Error {
   const err = new Error(`HTTP ${status}`)
@@ -255,4 +255,68 @@ describe('OpenAIModelFetcher', () => {
       expect(body.model).to.equal('default')
     })
     })
+
+  describe('OpenAICompatibleModelFetcher.fetchModels dedup', () => {
+    afterEach(() => {
+      restore()
+    })
+
+    it('dedupes by id when upstream returns duplicate entries', async () => {
+      stub(axios, 'get').resolves({
+        data: {
+          data: [
+            {id: 'openai/gpt-oss-120b'},
+            {id: 'openai/gpt-oss-120b'},
+            {id: 'openai/gpt-oss-20b'},
+            {id: 'openai/gpt-oss-20b'},
+          ],
+        },
+        status: 200,
+      })
+      const fetcher = new OpenAICompatibleModelFetcher('https://example.test/v1', 'OpenAI Compatible')
+
+      const models = await fetcher.fetchModels('sk-test')
+      const ids = models.map((m) => m.id)
+
+      expect(ids).to.deep.equal(['openai/gpt-oss-120b', 'openai/gpt-oss-20b'])
+    })
+
+    it('keeps the first occurrence when ids collide', async () => {
+      /* eslint-disable camelcase */
+      stub(axios, 'get').resolves({
+        data: {
+          data: [
+            {context_length: 128_000, id: 'mistral-large', name: 'mistral-large'},
+            {context_length: 999_999, id: 'mistral-large', name: 'mistral-large'},
+          ],
+        },
+        status: 200,
+      })
+      /* eslint-enable camelcase */
+      const fetcher = new OpenAICompatibleModelFetcher('https://example.test/v1', 'OpenAI Compatible')
+
+      const models = await fetcher.fetchModels('sk-test')
+
+      expect(models).to.have.lengthOf(1)
+      expect(models[0].contextLength).to.equal(128_000)
+    })
+
+    it('passes through unique ids unchanged', async () => {
+      stub(axios, 'get').resolves({
+        data: {
+          data: [
+            {id: 'b-model'},
+            {id: 'a-model'},
+            {id: 'c-model'},
+          ],
+        },
+        status: 200,
+      })
+      const fetcher = new OpenAICompatibleModelFetcher('https://example.test/v1', 'OpenAI Compatible')
+
+      const models = await fetcher.fetchModels('sk-test')
+
+      expect(models.map((m) => m.id)).to.deep.equal(['a-model', 'b-model', 'c-model'])
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- Fixes #620 — duplicate model rows in `/model` TUI dialog when configured against nVidia NIM (or any OpenAI-compat aggregator that violates the spec).
- Root cause: NIM's `integrate.api.nvidia.com/v1/models` returns byte-identical duplicates for `openai/gpt-oss-120b`, `openai/gpt-oss-20b`, and `nvidia/nemotron-3-super-120b-a12b`. Confirmed in [NVIDIA dev forum](https://forums.developer.nvidia.com/t/nim-api-duplicate-model-issue/365698). `OpenAICompatibleModelFetcher` previously mapped the upstream list 1:1, leaking the duplicates straight into the dialog.
- Fix: dedupe by `id` (first occurrence wins) inside the fetcher, before sort. Localized to `openai-compatible` because it's the only fetcher whose upstream is user-configured and therefore exposed to malformed aggregator responses.

## Test plan

- [x] `npx mocha "test/unit/infra/http/provider-model-fetchers.test.ts"` — 19 pass (3 new for dedup: duplicate-input, first-occurrence preservation, unique pass-through)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] Manual: connect `openai-compatible` against NIM (`https://integrate.api.nvidia.com/v1`) → `/model` shows each id exactly once
- [ ] Reporter (Dario) re-tests on Windows Terminal and confirms duplicates are gone