### PR TITLE
feat: [ENG-2840] Update SKILL.md to force "brv swarm query" to run si…

### DIFF
--- a/src/server/templates/skill/SKILL.md
+++ b/src/server/templates/skill/SKILL.md
@@ -9,10 +9,10 @@ Use the `brv` CLI to manage your project's long-term memory.
 Install: `npm install -g byterover-cli`
 Knowledge is stored in `.brv/context-tree/` as human-readable Markdown files.
 
-**No authentication needed.** `brv query`, `brv curate`, and `brv vc` (local version control) work out of the box. Login is only required for remote sync (`brv vc push`/`brv vc pull`).
+**No authentication needed.** `brv query`, `brv swarm query`, `brv curate`, and `brv vc` (local version control) work out of the box. Login is only required for remote sync (`brv vc push`/`brv vc pull`).
 
 ## Workflow
-1.  **Before Thinking:** Run `brv query` to understand existing patterns.
+1.  **Before Thinking:** Run `brv query` and `brv swarm query` to understand existing patterns.
 2.  **After Implementing:** Run `brv curate` to save new patterns/decisions.
 
 ## Commands
@@ -321,7 +321,7 @@ brv vc clone https://byterover.dev/<team>/<space>.git
 ```
 
 ### 8. Swarm Query
-**Overview:** Search across all active memory providers simultaneously — ByteRover context tree, Obsidian vault, Local Markdown folders, GBrain, and Memory Wiki. Results are fused via Reciprocal Rank Fusion (RRF) and ranked by provider weight and relevance. No LLM call — pure algorithmic search.
+**Overview:** Search across all active memory providers simultaneously — ByteRover context tree, Obsidian vault, Local Markdown folders, GBrain, and Memory Wiki. Results are fused via Reciprocal Rank Fusion (RRF) and ranked by provider weight and relevance. No LLM call — pure algorithmic search. Always use `brv swarm query` alongside `brv query` to get the best results.
 
 **Use this skill when:**
 - You need to search across multiple knowledge sources at once

--- a/src/server/templates/skill/SKILL.md
+++ b/src/server/templates/skill/SKILL.md
@@ -12,7 +12,7 @@ Knowledge is stored in `.brv/context-tree/` as human-readable Markdown files.
 **No authentication needed.** `brv query`, `brv swarm query`, `brv curate`, and `brv vc` (local version control) work out of the box. Login is only required for remote sync (`brv vc push`/`brv vc pull`).
 
 ## Workflow
-1.  **Before Thinking:** Run `brv query` and `brv swarm query` to understand existing patterns.
+1.  **Before Thinking:** Run `brv query` and `brv swarm query` in parallel to understand existing patterns.
 2.  **After Implementing:** Run `brv curate` to save new patterns/decisions.
 
 ## Commands
@@ -321,7 +321,7 @@ brv vc clone https://byterover.dev/<team>/<space>.git
 ```
 
 ### 8. Swarm Query
-**Overview:** Search across all active memory providers simultaneously — ByteRover context tree, Obsidian vault, Local Markdown folders, GBrain, and Memory Wiki. Results are fused via Reciprocal Rank Fusion (RRF) and ranked by provider weight and relevance. No LLM call — pure algorithmic search. Always use `brv swarm query` alongside `brv query` to get the best results.
+**Overview:** Search across all active memory providers simultaneously — ByteRover context tree, Obsidian vault, Local Markdown folders, GBrain, and Memory Wiki. Results are fused via Reciprocal Rank Fusion (RRF) and ranked by provider weight and relevance. No LLM call — pure algorithmic search. When multiple memory providers are configured, run `brv swarm query` alongside `brv query` to broaden recall at near-zero token cost.
 
 **Use this skill when:**
 - You need to search across multiple knowledge sources at once


### PR DESCRIPTION
## Summary

- Problem: The in-daemon agent only ran `brv query` during its "Before Thinking" step, ignoring `brv swarm query` even when users had configured additional memory providers (Obsidian, GBrain, Memory Wiki, Local Markdown). Recall was limited to whatever the ByteRover context tree contained.
- Why it matters: `brv swarm query` is a pure RRF-fused search across all active providers with no LLM call — running it alongside `brv query` adds breadth at near-zero token cost. Skipping it meant relevant knowledge in other providers was being missed during recall.
- What changed: Updated `src/server/templates/skill/SKILL.md` (the runtime behavioral contract loaded by the in-daemon agent) so the workflow now instructs the agent to run `brv query` and `brv swarm query` simultaneously, and the Swarm Query section explicitly recommends pairing them.
- What did NOT change (scope boundary): No source code, no command implementations, no transport schemas, no provider registry, no tests. The `brv swarm query` command and its underlying federation logic are unchanged — only the agent's default invocation pattern is.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [x] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

> Note: this is a documentation-format change to a markdown file, but because `SKILL.md` is runtime-loaded by the in-daemon agent, the practical effect is a behavior change in the agent's default workflow.

## Scope (select all touched areas)

- [ ] TUI / REPL
- [x] Agent / Tools
- [ ] LLM Providers
- [x] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes ENG-2840
- Related #

## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause: N/A
- Why this was not caught earlier: N/A

## Test plan

- Coverage added:
  - [ ] Unit test
  - [ ] Integration test
  - [x] Manual verification only
- Test file(s): N/A — change is to a runtime-loaded skill template, not application logic
- Key scenario(s) covered:
  - Start a fresh agent session and confirm both `brv query` and `brv swarm query` are invoked during the "Before Thinking" phase
  - With at least one non-ByteRover provider configured (e.g. Obsidian or Local Markdown), confirm swarm results appear alongside the synthesized `brv query` answer
  - With no extra providers configured, confirm `brv swarm query` degrades gracefully (returns ByteRover-only results) without breaking the workflow

## User-visible changes

- The in-daemon agent now runs `brv swarm query` in parallel with `brv query` at the start of every task, so users with Obsidian/GBrain/Memory Wiki/Local Markdown providers configured will see broader recall results during recall.
- The "No authentication needed" line in `SKILL.md` now lists `brv swarm query` alongside `brv query`, `brv curate`, and `brv vc`.
- No CLI flags, defaults, or config changed.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording

> Attach a trace or screenshot showing the agent running both `brv query` and `brv swarm query` during a real task (before this PR: only `brv query` appears; after: both appear).

## Checklist

- [x] Tests added or updated and passing (`npm test`) — N/A, no code logic changed
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format — `feat: [ENG-2840] ...`
- [x] Documentation updated (if applicable) — this PR IS the documentation update
- [x] No breaking changes (or clearly documented above)
- [x] Branch is up to date with `main` — 1 commit ahead, 0 behind

## Risks and mitigations

- Risk: Users without any non-ByteRover swarm provider configured see `brv swarm query` invocations that effectively duplicate `brv query`'s scope, adding latency.
  - Mitigation: `brv swarm query` is non-LLM (pure BM25/RRF), so the added latency is small (tens of ms). The two queries run simultaneously, so wall-clock time is bounded by the slower of the two — `brv query` (LLM call) typically dominates anyway.
- Risk: Agents on older skill caches keep the old prompt and ignore the new instruction.
  - Mitigation: `SKILL.md` is read at runtime from `src/server/templates/`, so the next daemon restart picks up the change. No migration needed.
- Risk: Swarm misconfiguration (e.g., an Obsidian vault path that no longer exists) could surface as a noisy error in every recall.
  - Mitigation: `brv swarm status` pre-flight remains the documented way to validate provider health; the swarm command already degrades gracefully when a single provider fails, so the workflow keeps working.