### PR TITLE
(ENG-2836, ENG-2837): MCP migration to tool mode 

### DIFF
--- a/src/server/core/domain/transport/schemas.ts
+++ b/src/server/core/domain/transport/schemas.ts
@@ -424,7 +424,7 @@ export const TaskExecuteSchema = z.object({
   /** Dream trigger source — how this dream was initiated */
   trigger: z.enum(['agent-idle', 'cli', 'manual']).optional(),
   /** Task type */
-  type: z.enum(['curate', 'curate-folder', 'dream', 'query', 'query-tool-mode', 'search']),
+  type: z.enum(['curate', 'curate-folder', 'curate-html-direct', 'dream', 'query', 'query-tool-mode', 'search']),
   /** Workspace root for scoped query/curate */
   worktreeRoot: z.string().optional(),
 })
@@ -731,7 +731,15 @@ export type TaskQueryResultEvent = z.infer<typeof TaskQueryResultEventSchema>
 // Request/Response Schemas (for client → server commands)
 // ============================================================================
 
-export const TaskTypeSchema = z.enum(['curate', 'curate-folder', 'dream', 'query', 'query-tool-mode', 'search'])
+export const TaskTypeSchema = z.enum([
+  'curate',
+  'curate-folder',
+  'curate-html-direct',
+  'dream',
+  'query',
+  'query-tool-mode',
+  'search',
+])
 
 /**
  * Request to create a new task

--- a/src/server/core/domain/transport/schemas.ts
+++ b/src/server/core/domain/transport/schemas.ts
@@ -521,6 +521,21 @@ export const LlmUnsupportedInputEventSchema = z.object({
 // ============================================================================
 
 /**
+ * Closed set of task types. Single source of truth — broadcast-event schemas
+ * (e.g. `TaskCreatedSchema`) and request schemas (e.g. `TaskExecuteSchema`)
+ * both reference this so a new task type only needs to be added in one place.
+ */
+export const TaskTypeSchema = z.enum([
+  'curate',
+  'curate-folder',
+  'curate-html-direct',
+  'dream',
+  'query',
+  'query-tool-mode',
+  'search',
+])
+
+/**
  * task:ack - Transport acknowledges task creation
  */
 export const TaskAckSchema = z.object({
@@ -548,8 +563,8 @@ export const TaskCreatedSchema = z.object({
   provider: z.string().optional(),
   /** Unique task identifier */
   taskId: z.string(),
-  /** Task type */
-  type: z.enum(['curate', 'curate-folder', 'query', 'search']),
+  /** Task type — closed enum kept in sync with `TaskTypeSchema`. */
+  type: TaskTypeSchema,
 })
 
 /**
@@ -730,16 +745,6 @@ export type TaskQueryResultEvent = z.infer<typeof TaskQueryResultEventSchema>
 // ============================================================================
 // Request/Response Schemas (for client → server commands)
 // ============================================================================
-
-export const TaskTypeSchema = z.enum([
-  'curate',
-  'curate-folder',
-  'curate-html-direct',
-  'dream',
-  'query',
-  'query-tool-mode',
-  'search',
-])
 
 /**
  * Request to create a new task

--- a/src/server/core/interfaces/executor/i-curate-executor.ts
+++ b/src/server/core/interfaces/executor/i-curate-executor.ts
@@ -1,4 +1,5 @@
 import type {ICipherAgent} from '../../../../agent/core/interfaces/i-cipher-agent.js'
+import type {HtmlWriteError} from '../../../infra/render/writer/html-writer.js'
 import type {CurateUsageRecord} from '../../domain/entities/curate-log-entry.js'
 import type {IUsageAggregator} from '../telemetry/i-usage-aggregator.js'
 
@@ -57,3 +58,26 @@ export interface ICurateExecutor {
    */
   executeWithAgent(agent: ICipherAgent, options: CurateExecuteOptions): Promise<string>
 }
+
+/**
+ * Wire envelope returned by the `curate-html-direct` daemon task type.
+ *
+ * Single-shot: the calling agent (typically over MCP) supplies a fully
+ * authored `<bv-topic>` HTML document; the daemon validates via
+ * `validateHtmlTopic` and writes via `writeHtmlTopic`. No LLM, no
+ * provider, no session.
+ *
+ * - `status: 'ok'` — write succeeded. `topicPath` is the bv-topic path
+ *   attribute (e.g. `security/auth`); `filePath` is the relative path
+ *   under `.brv/context-tree/` including the `.html` extension;
+ *   `overwrote` is true iff the topic existed before the write and
+ *   `confirmOverwrite` was set.
+ * - `status: 'validation-failed'` — write was refused. `errors[]`
+ *   carries the writer's structured errors (including the
+ *   `existingContent` on `path-exists` so the calling agent can merge).
+ *
+ * Renaming any field is a breaking change for MCP consumers.
+ */
+export type CurateHtmlDirectResult =
+  | {errors: readonly HtmlWriteError[]; status: 'validation-failed'}
+  | {filePath: string; overwrote: boolean; status: 'ok'; topicPath: string}

--- a/src/server/infra/daemon/agent-process.ts
+++ b/src/server/infra/daemon/agent-process.ts
@@ -21,8 +21,8 @@
 
 import {connectToTransport, type ITransportClient} from '@campfirein/brv-transport-client'
 import {randomUUID} from 'node:crypto'
-import {appendFileSync} from 'node:fs'
-import {join} from 'node:path'
+import {appendFileSync, existsSync} from 'node:fs'
+import {join, relative} from 'node:path'
 
 import type {ISearchKnowledgeService} from '../../../agent/infra/sandbox/tools-sdk.js'
 import type {BrvConfig} from '../../core/domain/entities/brv-config.js'
@@ -37,11 +37,12 @@ import {SessionMetadataStore} from '../../../agent/infra/session/session-metadat
 import {FileKeyStorage} from '../../../agent/infra/storage/file-key-storage.js'
 import {runWithReviewDisabled} from '../../../agent/infra/tools/implementations/curate-tool-task-context.js'
 import {createSearchKnowledgeService} from '../../../agent/infra/tools/implementations/search-knowledge-service.js'
+import {decodeCurateHtmlContent} from '../../../shared/transport/curate-html-content.js'
 import {AuthEvents} from '../../../shared/transport/events/auth-events.js'
 import {decodeQueryToolModeContent} from '../../../shared/transport/query-tool-mode-content.js'
 import {decodeSearchContent} from '../../../shared/transport/search-content.js'
 import {getCurrentConfig} from '../../config/environment.js'
-import {BRV_DIR, DEFAULT_LLM_MODEL, PROJECT} from '../../constants.js'
+import {BRV_DIR, CONTEXT_TREE_DIR, DEFAULT_LLM_MODEL, PROJECT} from '../../constants.js'
 import {serializeTaskError, TaskError, TaskErrorCode} from '../../core/domain/errors/task-error.js'
 import {loadSources} from '../../core/domain/source/source-schema.js'
 import {
@@ -61,6 +62,7 @@ import {DreamExecutor} from '../executor/dream-executor.js'
 import {FolderPackExecutor} from '../executor/folder-pack-executor.js'
 import {QueryExecutor} from '../executor/query-executor.js'
 import {SearchExecutor} from '../executor/search-executor.js'
+import {validateHtmlTopic, writeHtmlTopic} from '../render/writer/html-writer.js'
 import {FileCurateLogStore} from '../storage/file-curate-log-store.js'
 import {FileReviewBackupStore} from '../storage/file-review-backup-store.js'
 import {TaskUsageAggregator} from '../telemetry/task-usage-aggregator.js'
@@ -482,10 +484,11 @@ async function executeTask(
   const {clientCwd, clientId, content, files, folderPath, force, reviewDisabled, taskId, trigger, type, worktreeRoot} = task
   if (!transport || !agent) return
 
-  // Search + tool-mode query are pure BM25 retrieval — no LLM, no
-  // provider needed. Skip provider validation so they work even
-  // without a configured provider (the headline promise of tool mode).
-  if (type !== 'search' && type !== 'query-tool-mode') {
+  // Search + tool-mode query + tool-mode curate are pure deterministic
+  // paths — no LLM, no provider needed. Skip provider validation so they
+  // work even without a configured provider (the headline promise of
+  // tool mode).
+  if (type !== 'search' && type !== 'query-tool-mode' && type !== 'curate-html-direct') {
     const freshProviderConfig = await transport.requestWithAck<ProviderConfigResponse>(
       TransportStateEventNames.GET_PROVIDER_CONFIG,
     )
@@ -642,6 +645,48 @@ async function executeTask(
           })
           result = folderResult.response
           postWork = folderResult.finalize
+
+          break
+        }
+
+        case 'curate-html-direct': {
+          // Tool-mode curate: no LLM dispatch, no provider gate, no
+          // usage aggregator. Calling agent (typically over MCP) has
+          // already authored the <bv-topic> HTML; daemon validates +
+          // writes the topic file. Single-shot, single round-trip.
+          // Mirrors the post-ENG-2815 oclif `brv curate` writer-direct
+          // flow but exposed as a daemon task type so MCP clients can
+          // hit it the same way they hit `query-tool-mode`.
+          const {confirmOverwrite, html} = decodeCurateHtmlContent(content)
+          const contextTreeRoot = join(projectPath, BRV_DIR, CONTEXT_TREE_DIR)
+
+          // Pre-resolve the target path so we can report whether the
+          // write replaced an existing file. validateHtmlTopic is
+          // idempotent + cheap (parse5 only); writeHtmlTopic re-runs
+          // it internally so we don't risk drift between checks.
+          const preValidation = validateHtmlTopic(html)
+          const existedBefore =
+            preValidation.ok && existsSync(join(contextTreeRoot, `${preValidation.topicPath}.html`))
+
+          const writeResult = await writeHtmlTopic({confirmOverwrite, contextTreeRoot, rawHtml: html})
+
+          // Validation failures emit task:completed (NOT task:error) so
+          // the calling agent sees the structured errors via the normal
+          // result payload and can retry with corrected HTML. task:error
+          // would force MCP clients into an isError path that some host
+          // renderers collapse or truncate.
+          if (writeResult.ok) {
+            const relativeFilePath = relative(contextTreeRoot, writeResult.filePath)
+            const topicPath = relativeFilePath.replace(/\.html$/, '')
+            result = JSON.stringify({
+              filePath: relativeFilePath,
+              overwrote: existedBefore && Boolean(confirmOverwrite),
+              status: 'ok',
+              topicPath,
+            })
+          } else {
+            result = JSON.stringify({errors: writeResult.errors, status: 'validation-failed'})
+          }
 
           break
         }

--- a/src/server/infra/daemon/agent-process.ts
+++ b/src/server/infra/daemon/agent-process.ts
@@ -22,7 +22,7 @@
 import {connectToTransport, type ITransportClient} from '@campfirein/brv-transport-client'
 import {randomUUID} from 'node:crypto'
 import {appendFileSync, existsSync} from 'node:fs'
-import {join, relative} from 'node:path'
+import {join, relative, sep} from 'node:path'
 
 import type {ISearchKnowledgeService} from '../../../agent/infra/sandbox/tools-sdk.js'
 import type {BrvConfig} from '../../core/domain/entities/brv-config.js'
@@ -676,8 +676,14 @@ async function executeTask(
           // would force MCP clients into an isError path that some host
           // renderers collapse or truncate.
           if (writeResult.ok) {
-            const relativeFilePath = relative(contextTreeRoot, writeResult.filePath)
-            const topicPath = relativeFilePath.replace(/\.html$/, '')
+            // Normalize to forward-slashes — the CurateHtmlDirectResult contract
+            // (i-curate-executor.ts) documents `topicPath: 'security/auth'` form, and
+            // the renderer surfaces filePath to the calling agent verbatim. On Windows,
+            // relative() would otherwise return `security\auth.html`.
+            const relativeFilePath = relative(contextTreeRoot, writeResult.filePath).replaceAll(sep, '/')
+            const topicPath = preValidation.ok
+              ? preValidation.topicPath
+              : relativeFilePath.replace(/\.html$/, '')
             result = JSON.stringify({
               filePath: relativeFilePath,
               overwrote: existedBefore && Boolean(confirmOverwrite),

--- a/src/server/infra/mcp/tools/brv-curate-tool.ts
+++ b/src/server/infra/mcp/tools/brv-curate-tool.ts
@@ -5,43 +5,99 @@ import {waitForConnectedClient} from '@campfirein/brv-transport-client'
 import {randomUUID} from 'node:crypto'
 import {z} from 'zod'
 
+import type {CurateHtmlDirectResult} from '../../../core/interfaces/executor/i-curate-executor.js'
+import type {HtmlWriteError} from '../../render/writer/html-writer.js'
+
+import {encodeCurateHtmlContent} from '../../../../shared/transport/curate-html-content.js'
+import {CURATE_SCHEMA_PROMPT} from '../../../core/domain/render/curate-prompt-builder.js'
 import {TransportTaskEventNames} from '../../../core/domain/transport/schemas.js'
 import {appendDriftFooter} from './drift-footer.js'
 import {associateProjectWithRetry, type McpStartupProjectContext, resolveMcpTaskContext} from './mcp-project-context.js'
 import {resolveClientCwd} from './resolve-client-cwd.js'
 import {cwdField} from './shared-schema.js'
+import {waitForTaskResult} from './task-result-waiter.js'
+
+/**
+ * Self-contained authoring guide embedded in the MCP tool description.
+ *
+ * MCP and the bundled SKILL.md are disjoint installation surfaces — a
+ * user who installs the connector with `--type mcp` typically never
+ * sees SKILL.md. The description has to carry enough of the bv-topic
+ * vocabulary that a calling agent can author a valid topic without
+ * external references.
+ *
+ * The vocabulary slice is derived from `ELEMENT_REGISTRY` (via the
+ * existing `CURATE_SCHEMA_PROMPT` the CLI's curate prompt builder
+ * uses) so MCP and CLI never drift on what elements are valid.
+ */
+const TOOL_DESCRIPTION = [
+  'Store knowledge in the ByteRover context tree by writing a <bv-topic> HTML document.',
+  '',
+  'Runs deterministic validation + write — no LLM provider required. The calling agent authors',
+  'the HTML in its own context; ByteRover validates the structure and writes the file.',
+  '',
+  '# Output contract',
+  '- Bare HTML only — first character must be `<`, last characters must be `</bv-topic>`.',
+  '- No markdown fences, no prose preamble, no trailing commentary.',
+  '- Exactly one <bv-topic> root element per call.',
+  '- All attribute names lowercase; all attribute values double-quoted.',
+  '- Do not invent elements or attributes outside the vocabulary below.',
+  '- Do not emit `importance`, `maturity`, `recency`, `createdat`, or `updatedat` on <bv-topic> — those are system-managed.',
+  '',
+  '# Path format',
+  '- The `path` attribute on <bv-topic> is `<domain>/<topic>` or `<domain>/<topic>/<subtopic>`, snake_case segments.',
+  '- Pick descriptive domain names (1-3 words). Reuse existing domains where they fit; avoid generic names like `misc`, `general`.',
+  '',
+  '# Element vocabulary (closed)',
+  '',
+  CURATE_SCHEMA_PROMPT,
+  '',
+  '# Minimal example',
+  '<bv-topic path="security/auth" title="JWT authentication">',
+  '  <bv-decision id="d-rs256" severity="must">Use RS256 over HS256 for JWT signing — verifiers only need the public key.</bv-decision>',
+  '  <bv-rule severity="must">Access tokens expire after 24 hours.</bv-rule>',
+  '</bv-topic>',
+  '',
+  '# Overwrite behavior',
+  'When a topic already exists at the resolved path, the tool refuses to clobber by default and returns',
+  'a structured `path-exists` error with the existing content inlined so you can merge. Pass',
+  '`confirmOverwrite: true` to replace the existing topic entirely.',
+].join('\n')
 
 export const BrvCurateInputSchema = z.object({
-  context: z
-    .string()
+  confirmOverwrite: z
+    .boolean()
     .optional()
     .describe(
-      'Knowledge to store: patterns, decisions, errors, or insights about the codebase. Required unless files or folder are provided.',
+      'Set true to replace an existing topic at the resolved path. Default false — the daemon refuses to clobber and returns a structured `path-exists` error with the existing content for merging.',
     ),
   cwd: cwdField,
-  files: z
-    .array(z.string())
-    .max(5)
-    .optional()
-    .describe(
-      'Optional file paths with critical context to include (max 5 files). Required if context and folder not provided.',
-    ),
-  folder: z
+  html: z
     .string()
-    .optional()
+    .min(1)
     .describe(
-      'Folder path to pack and analyze (triggers folder pack flow). When provided, the entire folder will be analyzed and curated. Takes precedence over files.',
+      'Complete <bv-topic> HTML document. Must include a `path` attribute on the root <bv-topic>. See the tool description for the closed element vocabulary and output contract.',
     ),
 })
 
 /**
  * Registers the brv-curate tool with the MCP server.
  *
- * This tool allows coding agents to store context to the ByteRover context tree.
- * Use it to save patterns, architectural decisions, error solutions, or insights.
+ * Post-M3: routes through the daemon's `curate-html-direct` task type,
+ * which validates the HTML and writes the topic via `writeHtmlTopic` —
+ * no LLM dispatch, no provider required.
  *
- * Uses fire-and-forget pattern: returns immediately after queueing the task.
- * The curation is processed asynchronously by the ByteRover agent.
+ * Wire shape: same end-state as the post-ENG-2815 oclif `brv curate`
+ * (which uses session protocol + the same writer). MCP collapses the
+ * multi-turn session into a single tool call because MCP's natural
+ * shape is one request → one response; calling agents retry with
+ * corrected HTML by calling the tool again, not via daemon-side
+ * session state.
+ *
+ * Self-containment: the tool description embeds the bv-topic vocabulary
+ * (derived from `ELEMENT_REGISTRY` via `CURATE_SCHEMA_PROMPT`) and a
+ * worked example — MCP clients without SKILL.md still have everything
+ * they need.
  */
 export function registerBrvCurateTool(
   server: McpServer,
@@ -53,22 +109,11 @@ export function registerBrvCurateTool(
   server.registerTool(
     'brv-curate',
     {
-      description:
-        'Store context to the ByteRover context tree. Save patterns, decisions, or insights. ' +
-        'Curation is processed asynchronously — the tool returns immediately after queueing.',
+      description: TOOL_DESCRIPTION,
       inputSchema: BrvCurateInputSchema,
       title: 'ByteRover Curate',
     },
-    async ({context, cwd, files, folder}: {context?: string; cwd?: string; files?: string[]; folder?: string}) => {
-      // Validate that at least one input is provided
-      if (!context?.trim() && !files?.length && !folder?.trim()) {
-        return {
-          content: [{text: 'Error: Either context, files, folder, or cwd must be provided', type: 'text' as const}],
-          isError: true,
-        }
-      }
-
-      // Resolve clientCwd: explicit cwd param > server working directory
+    async ({confirmOverwrite, cwd, html}: {confirmOverwrite?: boolean; cwd?: string; html: string}) => {
       const cwdResult = resolveClientCwd(cwd, getWorkingDirectory)
       if (!cwdResult.success) {
         return {
@@ -77,7 +122,6 @@ export function registerBrvCurateTool(
         }
       }
 
-      // Wait for a connected client (MCP's attemptReconnect() replaces client in background)
       const client = await waitForConnectedClient(getClient)
       if (!client) {
         return {
@@ -98,39 +142,37 @@ export function registerBrvCurateTool(
         }
 
         const taskId = randomUUID()
+        const resultPromise = waitForTaskResult(client, taskId)
 
-        // Create task via transport (same pattern as brv curate command)
-        // Use provided context, or empty string for file-only/folder-only mode
-        const resolvedContent = context?.trim() ? context : ''
-
-        // Determine task type: folder pack takes precedence over file-based curate
-        const hasFolder = Boolean(folder?.trim())
-        const taskType = hasFolder ? 'curate-folder' : 'curate'
-
-        const ack = await client.requestWithAck<{logId?: string; taskId: string}>(TransportTaskEventNames.CREATE, {
+        await client.requestWithAck(TransportTaskEventNames.CREATE, {
           clientCwd: cwdResult.clientCwd,
-          content: resolvedContent,
+          content: encodeCurateHtmlContent({confirmOverwrite, html}),
           projectPath: taskContext.projectRoot,
           taskId,
-          type: taskType,
+          type: 'curate-html-direct',
           worktreeRoot: taskContext.worktreeRoot,
-          ...(hasFolder && folder ? {folderPath: folder} : {}),
-          ...(!hasFolder && files?.length ? {files} : {}),
         })
 
-        // Fire-and-forget: return immediately after task is queued
-        // Curation is processed asynchronously by the ByteRover agent
-        const logId = ack?.logId
-        const modeDescription = hasFolder ? 'folder pack' : 'curation'
-        const logSuffix = logId ? `, logId: ${logId}` : ''
-        const queuedMessage = `✓ Context queued for ${modeDescription} (taskId: ${taskId}${logSuffix}). The curation will be processed asynchronously.`
+        const rawResult = await resultPromise
+
+        let envelope: CurateHtmlDirectResult
+        try {
+          envelope = JSON.parse(rawResult) as CurateHtmlDirectResult
+        } catch {
+          return {
+            content: [
+              {
+                text: 'Error: ByteRover daemon returned a malformed curate result. Rebuild byterover-cli to align the MCP and daemon versions.',
+                type: 'text' as const,
+              },
+            ],
+            isError: true,
+          }
+        }
+
+        const text = renderEnvelope(envelope)
         return {
-          content: [
-            {
-              text: appendDriftFooter(queuedMessage, clientVersion, client.getDaemonVersion?.()),
-              type: 'text' as const,
-            },
-          ],
+          content: [{text: appendDriftFooter(text, clientVersion, client.getDaemonVersion?.()), type: 'text' as const}],
         }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
@@ -141,4 +183,74 @@ export function registerBrvCurateTool(
       }
     },
   )
+}
+
+/**
+ * Render the `CurateHtmlDirectResult` envelope as a text block for the
+ * calling agent.
+ *
+ * - `status: 'ok'`: a single confirmation line (`✓ Wrote` / `✓ Replaced`).
+ * - `status: 'validation-failed'`: one `✗ <kind>: <message>` line per
+ *   error. `path-exists` inlines the existing content as a fenced ```html
+ *   block. The vocabulary slice is appended at the bottom so the agent
+ *   has the schema in-context without needing to re-list tools.
+ */
+function renderEnvelope(envelope: CurateHtmlDirectResult): string {
+  if (envelope.status === 'ok') {
+    const action = envelope.overwrote ? 'Replaced' : 'Wrote'
+    return `✓ ${action} topic to ${envelope.filePath}`
+  }
+
+  const lines = envelope.errors.map((err) => renderError(err))
+  return [
+    'Curate validation failed. Fix the errors below and call the tool again with corrected HTML.',
+    '',
+    ...lines,
+    '',
+    '# Element vocabulary (for reference)',
+    '',
+    CURATE_SCHEMA_PROMPT,
+  ].join('\n')
+}
+
+function renderError(err: HtmlWriteError): string {
+  switch (err.kind) {
+    case 'attribute-validation': {
+      return `✗ attribute-validation: <${err.tag}> attribute "${err.field}" — ${err.message}`
+    }
+
+    case 'missing-bv-topic': {
+      return `✗ missing-bv-topic: ${err.message}`
+    }
+
+    case 'missing-path-attribute': {
+      return `✗ missing-path-attribute: ${err.message}`
+    }
+
+    case 'multiple-bv-topic': {
+      return `✗ multiple-bv-topic: ${err.message}`
+    }
+
+    case 'path-exists': {
+      const existing =
+        err.existingContent === undefined
+          ? '(existing content could not be read — investigate the file or pass `confirmOverwrite: true` to clobber)'
+          : `Existing content:\n\`\`\`html\n${err.existingContent}\n\`\`\``
+      return `✗ path-exists: ${err.message}\n\n${existing}`
+    }
+
+    case 'unknown-bv-element': {
+      return `✗ unknown-bv-element: <${err.tag}> is not in the registry — remove or replace with a registered element.`
+    }
+
+    case 'unsafe-path': {
+      return `✗ unsafe-path: ${err.message}`
+    }
+
+    default: {
+      // exhaustiveness check
+      const _exhaustive: never = err
+      return `✗ unknown-error: ${JSON.stringify(_exhaustive)}`
+    }
+  }
 }

--- a/src/server/infra/mcp/tools/brv-curate-tool.ts
+++ b/src/server/infra/mcp/tools/brv-curate-tool.ts
@@ -64,21 +64,27 @@ const TOOL_DESCRIPTION = [
   '`confirmOverwrite: true` to replace the existing topic entirely.',
 ].join('\n')
 
-export const BrvCurateInputSchema = z.object({
-  confirmOverwrite: z
-    .boolean()
-    .optional()
-    .describe(
-      'Set true to replace an existing topic at the resolved path. Default false — the daemon refuses to clobber and returns a structured `path-exists` error with the existing content for merging.',
-    ),
-  cwd: cwdField,
-  html: z
-    .string()
-    .min(1)
-    .describe(
-      'Complete <bv-topic> HTML document. Must include a `path` attribute on the root <bv-topic>. See the tool description for the closed element vocabulary and output contract.',
-    ),
-})
+// Strict so the legacy `{context, files, folder}` shape (or any typo'd field)
+// fails fast at the MCP boundary instead of being silently dropped — the
+// breaking-change contract from the PR is that callers see an error pointing
+// at the new schema, not a successful no-op.
+export const BrvCurateInputSchema = z
+  .object({
+    confirmOverwrite: z
+      .boolean()
+      .optional()
+      .describe(
+        'Set true to replace an existing topic at the resolved path. Default false — the daemon refuses to clobber and returns a structured `path-exists` error with the existing content for merging.',
+      ),
+    cwd: cwdField,
+    html: z
+      .string()
+      .min(1)
+      .describe(
+        'Complete <bv-topic> HTML document. Must include a `path` attribute on the root <bv-topic>. See the tool description for the closed element vocabulary and output contract.',
+      ),
+  })
+  .strict()
 
 /**
  * Registers the brv-curate tool with the MCP server.

--- a/src/server/infra/mcp/tools/brv-query-tool.ts
+++ b/src/server/infra/mcp/tools/brv-query-tool.ts
@@ -5,6 +5,12 @@ import {waitForConnectedClient} from '@campfirein/brv-transport-client'
 import {randomUUID} from 'node:crypto'
 import {z} from 'zod'
 
+import type {
+  QueryToolModeMatchedDoc,
+  QueryToolModeResult,
+} from '../../../core/interfaces/executor/i-query-executor.js'
+
+import {encodeQueryToolModeContent} from '../../../../shared/transport/query-tool-mode-content.js'
 import {TransportTaskEventNames} from '../../../core/domain/transport/schemas.js'
 import {appendDriftFooter} from './drift-footer.js'
 import {associateProjectWithRetry, type McpStartupProjectContext, resolveMcpTaskContext} from './mcp-project-context.js'
@@ -14,14 +20,28 @@ import {waitForTaskResult} from './task-result-waiter.js'
 
 export const BrvQueryInputSchema = z.object({
   cwd: cwdField,
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(50)
+    .optional()
+    .describe('Maximum number of matched topics to return (1-50, default 10).'),
   query: z.string().describe('Natural language question about the codebase or project'),
 })
 
 /**
  * Registers the brv-query tool with the MCP server.
  *
- * This tool allows coding agents to query the ByteRover context tree
- * for patterns, decisions, implementation details, or any stored knowledge.
+ * Post-M3: routes through the daemon's `query-tool-mode` task type
+ * (`QueryExecutor.executeToolMode`), which runs Tier 0/1 cache + BM25
+ * retrieval with no LLM dispatch. **No byterover provider is required.**
+ *
+ * Wire shape: same as the post-ENG-2815 `brv query` CLI — the daemon
+ * returns a JSON-encoded `QueryToolModeResult` envelope; this tool
+ * parses it and renders matched topics as markdown sections for the
+ * calling agent. On `no-matches` it returns a short text block (not
+ * `isError`) — zero matches is data, not a failure.
  */
 export function registerBrvQueryTool(
   server: McpServer,
@@ -33,11 +53,14 @@ export function registerBrvQueryTool(
   server.registerTool(
     'brv-query',
     {
-      description: 'Query the ByteRover context tree for patterns, decisions, or implementation details.',
+      description:
+        'Query the ByteRover context tree for patterns, decisions, or implementation details. ' +
+        'Runs deterministic BM25 retrieval — no LLM provider required. ' +
+        'Returns ranked topics with rendered markdown; the calling agent synthesises the answer in its own context.',
       inputSchema: BrvQueryInputSchema,
       title: 'ByteRover Query',
     },
-    async ({cwd, query}: {cwd?: string; query: string}) => {
+    async ({cwd, limit, query}: {cwd?: string; limit?: number; query: string}) => {
       // Resolve clientCwd: explicit cwd param > server working directory
       const cwdResult = resolveClientCwd(cwd, getWorkingDirectory)
       if (!cwdResult.success) {
@@ -73,21 +96,40 @@ export function registerBrvQueryTool(
         // If the task completes before listeners are set up, the task:completed event is missed.
         const resultPromise = waitForTaskResult(client, taskId)
 
-        // Create task via transport (same pattern as brv query command)
+        // Dispatch `query-tool-mode` (post-M3 default). Content is the
+        // JSON-encoded payload; daemon decodes via decodeQueryToolModeContent.
         await client.requestWithAck(TransportTaskEventNames.CREATE, {
           clientCwd: cwdResult.clientCwd,
-          content: query,
+          content: encodeQueryToolModeContent({limit, query}),
           projectPath: taskContext.projectRoot,
           taskId,
-          type: 'query',
+          type: 'query-tool-mode',
           worktreeRoot: taskContext.worktreeRoot,
         })
 
-        // Wait for the already-listening result promise
-        const result = await resultPromise
+        const rawResult = await resultPromise
 
+        // Parse the envelope. A malformed payload almost certainly means
+        // the daemon and MCP build are on incompatible versions — surface
+        // a clear actionable message rather than a JSON.parse stack.
+        let envelope: QueryToolModeResult
+        try {
+          envelope = JSON.parse(rawResult) as QueryToolModeResult
+        } catch {
+          return {
+            content: [
+              {
+                text: 'Error: ByteRover daemon returned a malformed query result. Rebuild byterover-cli to align the MCP and daemon versions.',
+                type: 'text' as const,
+              },
+            ],
+            isError: true,
+          }
+        }
+
+        const text = renderEnvelope(envelope, query)
         return {
-          content: [{text: appendDriftFooter(result, clientVersion, client.getDaemonVersion?.()), type: 'text' as const}],
+          content: [{text: appendDriftFooter(text, clientVersion, client.getDaemonVersion?.()), type: 'text' as const}],
         }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
@@ -98,4 +140,30 @@ export function registerBrvQueryTool(
       }
     },
   )
+}
+
+/**
+ * Render the `QueryToolModeResult` envelope as a single text block.
+ *
+ * - `status: 'ok'` → one `## <title>` (or `## <path>`) section per match
+ *   with the `rendered_md` body, separated by `\n\n---\n\n`, plus a
+ *   trailing italicised metadata line covering match count, duration,
+ *   and tier.
+ * - `status: 'no-matches'` → a short single-line message naming the
+ *   query so the calling agent can quote it back to the user.
+ */
+function renderEnvelope(envelope: QueryToolModeResult, query: string): string {
+  if (envelope.status === 'no-matches') {
+    return `No topics matched "${query}" in this project's context tree.`
+  }
+
+  const sections = envelope.matchedDocs.map((doc) => renderMatch(doc)).join('\n\n---\n\n')
+  const {metadata} = envelope
+  const trailer = `_Matched ${envelope.matchedDocs.length} topic(s) in ${metadata.durationMs}ms (tier ${metadata.tier})._`
+  return `${sections}\n\n${trailer}`
+}
+
+function renderMatch(doc: QueryToolModeMatchedDoc): string {
+  const heading = doc.title?.trim().length > 0 ? doc.title : doc.path
+  return `## ${heading}\n\n${doc.rendered_md}`
 }

--- a/src/shared/transport/curate-html-content.ts
+++ b/src/shared/transport/curate-html-content.ts
@@ -1,0 +1,51 @@
+/**
+ * Encode/decode helpers for curate-html-direct task content payloads.
+ *
+ * Sibling to `query-tool-mode-content.ts`. The transport layer's
+ * `TaskCreateRequest` has a single `content: string` field; curate
+ * tool mode packs `{html, confirmOverwrite?}` as JSON so the daemon
+ * dispatcher can reconstruct the structured options.
+ *
+ * Lives in `shared/` because the MCP tool (encoder) and the daemon
+ * agent-process (decoder) both depend on it.
+ */
+
+/**
+ * Encode curate-html-direct options as a JSON content payload.
+ */
+export function encodeCurateHtmlContent(options: {confirmOverwrite?: boolean; html: string}): string {
+  return JSON.stringify({
+    confirmOverwrite: options.confirmOverwrite,
+    html: options.html,
+  })
+}
+
+/**
+ * Parse a JSON-encoded curate-html-direct content payload back into
+ * options. Throws on malformed payload — curate-html-direct is brand-new
+ * and has no legacy callers, so a parse failure almost certainly means
+ * the MCP build and daemon are on incompatible versions. Letting that
+ * surface as a `task:error` (outer `success: false`) is much easier for
+ * the calling agent to diagnose than silently treating the entire JSON
+ * string as a literal HTML payload.
+ */
+export function decodeCurateHtmlContent(content: string): {confirmOverwrite?: boolean; html: string} {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(content)
+  } catch {
+    throw new Error(
+      'curate-html-direct payload is not valid JSON — likely an MCP/daemon version mismatch. Rebuild byterover-cli to align the encoder and decoder.',
+    )
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || typeof (parsed as {html?: unknown}).html !== 'string') {
+    throw new Error('curate-html-direct payload is missing a string `html` field.')
+  }
+
+  const {confirmOverwrite, html} = parsed as {confirmOverwrite?: unknown; html: string}
+  return {
+    confirmOverwrite: typeof confirmOverwrite === 'boolean' ? confirmOverwrite : undefined,
+    html,
+  }
+}

--- a/src/shared/transport/events/task-events.ts
+++ b/src/shared/transport/events/task-events.ts
@@ -29,7 +29,7 @@ export interface TaskCreateRequest {
   folderPath?: string
   projectPath?: string
   taskId: string
-  type: 'curate' | 'curate-folder' | 'query' | 'query-tool-mode' | 'search'
+  type: 'curate' | 'curate-folder' | 'curate-html-direct' | 'query' | 'query-tool-mode' | 'search'
   worktreeRoot?: string
 }
 

--- a/test/unit/infra/mcp/tools/brv-curate-tool.test.ts
+++ b/test/unit/infra/mcp/tools/brv-curate-tool.test.ts
@@ -5,56 +5,48 @@ import {expect} from 'chai'
 import {mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync} from 'node:fs'
 import {tmpdir} from 'node:os'
 import {join} from 'node:path'
-import {restore, type SinonFakeTimers, type SinonStub, stub, useFakeTimers} from 'sinon'
+import {restore, type SinonStub, stub} from 'sinon'
 
+import type {CurateHtmlDirectResult} from '../../../../../src/server/core/interfaces/executor/i-curate-executor.js'
 import type {McpStartupProjectContext} from '../../../../../src/server/infra/mcp/tools/mcp-project-context.js'
 
 import {BrvCurateInputSchema, registerBrvCurateTool} from '../../../../../src/server/infra/mcp/tools/brv-curate-tool.js'
+import {decodeCurateHtmlContent} from '../../../../../src/shared/transport/curate-html-content.js'
 
-/** Returns undefined — named constant avoids inline `() => undefined` triggering unicorn/no-useless-undefined. */
 const noClient = (): ITransportClient | undefined => undefined
 const noWorkingDirectory = (): string | undefined => undefined
 
-/**
- * Handler type captured from server.registerTool().
- */
-type CurateToolHandler = (input: {context?: string; cwd?: string; files?: string[]}) => Promise<{
+type CurateToolHandler = (input: {confirmOverwrite?: boolean; cwd?: string; html: string}) => Promise<{
   content: Array<{text: string; type: string}>
   isError?: boolean
 }>
 
-/**
- * Creates a mock McpServer that captures tool handlers on registerTool().
- */
-function createMockMcpServer(): {
-  getHandler: (name: string) => CurateToolHandler
-  server: McpServer
-} {
-  const handlers = new Map<string, CurateToolHandler>()
+function createMockMcpServer(): {getDescription: () => string; getHandler: () => CurateToolHandler; server: McpServer} {
+  let capturedHandler: CurateToolHandler | undefined
+  let capturedConfig: undefined | {description?: string}
 
   const mock = {
-    registerTool(name: string, _config: unknown, cb: CurateToolHandler) {
-      handlers.set(name, cb)
+    registerTool(_name: string, config: {description?: string}, cb: CurateToolHandler) {
+      capturedConfig = config
+      capturedHandler = cb
     },
   }
 
   return {
-    getHandler(name: string): CurateToolHandler {
-      const handler = handlers.get(name)
-      if (!handler) throw new Error(`Handler ${name} not registered`)
-      return handler
+    getDescription() {
+      return capturedConfig?.description ?? ''
+    },
+    getHandler() {
+      if (!capturedHandler) throw new Error('Handler not registered')
+      return capturedHandler
     },
     server: mock as unknown as McpServer,
   }
 }
 
-/**
- * Creates a mock transport client for testing.
- */
 function createMockClient(options?: {state?: ConnectionState}): {
   client: ITransportClient
   simulateEvent: <T>(event: string, payload: T) => void
-  simulateStateChange: (state: ConnectionState) => void
 } {
   const eventHandlers = new Map<string, Set<(data: unknown) => void>>()
   const stateHandlers = new Set<ConnectionStateHandler>()
@@ -69,10 +61,7 @@ function createMockClient(options?: {state?: ConnectionState}): {
     joinRoom: stub().resolves(),
     leaveRoom: stub().resolves(),
     on<T>(event: string, handler: (data: T) => void) {
-      if (!eventHandlers.has(event)) {
-        eventHandlers.set(event, new Set())
-      }
-
+      if (!eventHandlers.has(event)) eventHandlers.set(event, new Set())
       eventHandlers.get(event)!.add(handler as (data: unknown) => void)
       return () => {
         eventHandlers.get(event)?.delete(handler as (data: unknown) => void)
@@ -93,43 +82,41 @@ function createMockClient(options?: {state?: ConnectionState}): {
     client,
     simulateEvent<T>(event: string, payload: T) {
       const handlers = eventHandlers.get(event)
-      if (handlers) {
-        for (const handler of handlers) {
-          handler(payload)
-        }
-      }
-    },
-    simulateStateChange(state: ConnectionState) {
-      for (const handler of stateHandlers) {
-        handler(state)
-      }
+      if (handlers) for (const h of handlers) h(payload)
     },
   }
 }
 
-/**
- * Registers the brv-curate tool on a mock McpServer and returns the captured handler.
- */
-function setupCurateHandler(options: {
+function setupHandler(options: {
   getClient: () => ITransportClient | undefined
   getStartupProjectContext?: () => McpStartupProjectContext | undefined
   getWorkingDirectory: () => string | undefined
-}): CurateToolHandler {
-  const {getHandler, server} = createMockMcpServer()
+}): {getDescription: () => string; handler: CurateToolHandler} {
+  const {getDescription, getHandler, server} = createMockMcpServer()
   registerBrvCurateTool(
     server,
     options.getClient,
     options.getWorkingDirectory,
     options.getStartupProjectContext ??
       (() => {
-        const workingDirectory = options.getWorkingDirectory()
-        return workingDirectory
-          ? {projectRoot: workingDirectory, worktreeRoot: workingDirectory}
-          : undefined
+        const wd = options.getWorkingDirectory()
+        return wd ? {projectRoot: wd, worktreeRoot: wd} : undefined
       }),
     'test-client-version',
   )
-  return getHandler('brv-curate')
+  return {getDescription, handler: getHandler()}
+}
+
+const VALID_HTML = '<bv-topic path="security/auth" title="JWT"></bv-topic>'
+
+function okEnvelope(overrides: Partial<Extract<CurateHtmlDirectResult, {status: 'ok'}>> = {}): CurateHtmlDirectResult {
+  return {
+    filePath: 'security/auth.html',
+    overwrote: false,
+    status: 'ok',
+    topicPath: 'security/auth',
+    ...overrides,
+  }
 }
 
 describe('brv-curate-tool', () => {
@@ -138,537 +125,525 @@ describe('brv-curate-tool', () => {
   })
 
   describe('BrvCurateInputSchema', () => {
-    it('should accept context without cwd', () => {
-      const result = BrvCurateInputSchema.safeParse({context: 'Auth uses JWT'})
+    it('accepts html without confirmOverwrite', () => {
+      const result = BrvCurateInputSchema.safeParse({html: VALID_HTML})
       expect(result.success).to.be.true
     })
 
-    it('should accept context with cwd', () => {
-      const result = BrvCurateInputSchema.safeParse({
-        context: 'Auth uses JWT',
-        cwd: '/path/to/project',
-      })
+    it('accepts html with confirmOverwrite', () => {
+      const result = BrvCurateInputSchema.safeParse({confirmOverwrite: true, html: VALID_HTML})
       expect(result.success).to.be.true
     })
 
-    it('should accept files without cwd', () => {
-      const result = BrvCurateInputSchema.safeParse({files: ['src/auth.ts']})
-      expect(result.success).to.be.true
+    it('rejects missing html', () => {
+      const result = BrvCurateInputSchema.safeParse({confirmOverwrite: true})
+      expect(result.success).to.be.false
     })
 
-    it('should accept files with cwd', () => {
-      const result = BrvCurateInputSchema.safeParse({
-        cwd: '/path/to/project',
-        files: ['src/auth.ts'],
-      })
-      expect(result.success).to.be.true
+    it('rejects empty html', () => {
+      const result = BrvCurateInputSchema.safeParse({html: ''})
+      expect(result.success).to.be.false
     })
 
-    it('should accept optional cwd as undefined', () => {
-      const result = BrvCurateInputSchema.safeParse({context: 'test'})
-      expect(result.success).to.be.true
-      if (result.success) {
-        expect(result.data.cwd).to.be.undefined
-      }
+    it('rejects html non-string', () => {
+      const result = BrvCurateInputSchema.safeParse({html: 42})
+      expect(result.success).to.be.false
     })
 
-    it('should enforce max 5 files', () => {
-      const result = BrvCurateInputSchema.safeParse({
-        files: ['a.ts', 'b.ts', 'c.ts', 'd.ts', 'e.ts', 'f.ts'],
-      })
+    it('rejects legacy {context, files, folder} shape', () => {
+      // The old API took context/files/folder. After M3 the schema only
+      // accepts {cwd, html, confirmOverwrite?} — extra fields don't block
+      // zod by default, but the missing `html` does. Migration sentinel.
+      const result = BrvCurateInputSchema.safeParse({context: 'Auth uses JWT', files: ['a.ts']})
       expect(result.success).to.be.false
     })
   })
 
-  describe('schema shape', () => {
-    it('should expose cwd, context, and files in the input schema', () => {
-      const {shape} = BrvCurateInputSchema
-      expect(shape).to.have.property('cwd')
-      expect(shape).to.have.property('context')
-      expect(shape).to.have.property('files')
-    })
-  })
-
-  describe('handler — input validation', () => {
-    it('should return error when neither context, files, nor folder provided', async () => {
-      const {client} = createMockClient()
-      const handler = setupCurateHandler({
-        getClient: () => client,
+  describe('tool description self-containment', () => {
+    it('embeds the bv-topic vocabulary slice for MCP clients without SKILL.md', () => {
+      const {getDescription} = setupHandler({
+        getClient: () => createMockClient().client,
         getWorkingDirectory: () => '/project/root',
       })
 
-      const result = await handler({cwd: '/some/path'})
-
-      expect(result.isError).to.be.true
-      expect(result.content[0].text).to.include('Either context, files, folder')
+      const description = getDescription()
+      // The slice is generated from ELEMENT_REGISTRY — assert representative
+      // tags and a structural header are present so a regression that drops
+      // the slice fails loudly.
+      expect(description).to.include('<bv-topic>')
+      expect(description).to.include('<bv-decision>')
+      expect(description).to.include('<bv-rule>')
+      expect(description).to.include('Element vocabulary')
+      expect(description).to.include('no LLM provider required')
     })
 
-    it('should return error when context is whitespace-only with no files', async () => {
-      const {client} = createMockClient()
-      const handler = setupCurateHandler({
-        getClient: () => client,
+    it('includes a minimal worked example', () => {
+      const {getDescription} = setupHandler({
+        getClient: () => createMockClient().client,
         getWorkingDirectory: () => '/project/root',
       })
 
-      const result = await handler({context: '   '})
-
-      expect(result.isError).to.be.true
-      expect(result.content[0].text).to.include('Either context, files, folder')
+      const description = getDescription()
+      expect(description).to.include('<bv-topic path="security/auth"')
+      expect(description).to.include('<bv-decision id="d-rs256"')
     })
   })
 
-  describe('handler — project mode', () => {
-    it('should use projectRoot as clientCwd when cwd is not provided', async () => {
-      const {client} = createMockClient()
+  describe('dispatch — task type + payload', () => {
+    it('submits task type "curate-html-direct" with JSON-encoded content', async () => {
+      const {client, simulateEvent} = createMockClient()
       const requestStub = client.requestWithAck as SinonStub
+      requestStub.callsFake((event: string, data: {taskId?: string}) => {
+        if (event === 'task:create' && data.taskId) {
+          simulateEvent('task:completed', {result: JSON.stringify(okEnvelope()), taskId: data.taskId})
+        }
 
-      const handler = setupCurateHandler({
+        return Promise.resolve()
+      })
+
+      const {handler} = setupHandler({
         getClient: () => client,
         getWorkingDirectory: () => '/project/root',
       })
 
-      const result = await handler({context: 'Auth uses JWT with 24h expiry'})
+      const result = await handler({confirmOverwrite: true, html: VALID_HTML})
+      expect(result.isError).to.be.undefined
+
+      const createCall = requestStub.getCalls().find((c: {args: unknown[]}) => c.args[0] === 'task:create')
+      expect(createCall, 'task:create dispatched').to.exist
+      const payload = createCall!.args[1] as {content: string; type: string}
+      expect(payload.type).to.equal('curate-html-direct')
+
+      const decoded = decodeCurateHtmlContent(payload.content)
+      expect(decoded.html).to.equal(VALID_HTML)
+      expect(decoded.confirmOverwrite).to.equal(true)
+    })
+
+    it('omits confirmOverwrite when input does not include it', async () => {
+      const {client, simulateEvent} = createMockClient()
+      const requestStub = client.requestWithAck as SinonStub
+      requestStub.callsFake((event: string, data: {taskId?: string}) => {
+        if (event === 'task:create' && data.taskId) {
+          simulateEvent('task:completed', {result: JSON.stringify(okEnvelope()), taskId: data.taskId})
+        }
+
+        return Promise.resolve()
+      })
+
+      const {handler} = setupHandler({
+        getClient: () => client,
+        getWorkingDirectory: () => '/project/root',
+      })
+
+      await handler({html: VALID_HTML})
+
+      const createCall = requestStub.getCalls().find((c: {args: unknown[]}) => c.args[0] === 'task:create')
+      const decoded = decodeCurateHtmlContent((createCall!.args[1] as {content: string}).content)
+      expect(decoded.confirmOverwrite).to.be.undefined
+    })
+  })
+
+  describe('envelope rendering — status: ok', () => {
+    it('renders "✓ Wrote" when overwrote is false', async () => {
+      const {client, simulateEvent} = createMockClient()
+      const requestStub = client.requestWithAck as SinonStub
+      requestStub.callsFake((_event: string, data: {taskId: string}) => {
+        simulateEvent('task:completed', {
+          result: JSON.stringify(okEnvelope({filePath: 'security/auth.html', overwrote: false})),
+          taskId: data.taskId,
+        })
+        return Promise.resolve()
+      })
+
+      const {handler} = setupHandler({
+        getClient: () => client,
+        getWorkingDirectory: () => '/project/root',
+      })
+
+      const result = await handler({html: VALID_HTML})
 
       expect(result.isError).to.be.undefined
-      expect(result.content[0].text).to.include('queued for curation')
-
-      // Verify task:create payload
-      const payload = requestStub.firstCall.args[1]
-      expect(payload.clientCwd).to.equal('/project/root')
-      expect(payload.type).to.equal('curate')
-      expect(payload.content).to.equal('Auth uses JWT with 24h expiry')
-      expect(payload.taskId).to.be.a('string')
+      expect(result.content[0].text).to.include('✓ Wrote topic to security/auth.html')
     })
 
-    it('should prefer explicit cwd over projectRoot', async () => {
-      const projectRoot = mkdtempSync(join(tmpdir(), 'brv-curate-project-'))
-      const otherProject = mkdtempSync(join(tmpdir(), 'brv-curate-other-'))
-      mkdirSync(join(projectRoot, '.brv'), {recursive: true})
-      mkdirSync(join(otherProject, '.brv'), {recursive: true})
-      writeFileSync(join(projectRoot, '.brv', 'config.json'), '{}')
-      writeFileSync(join(otherProject, '.brv', 'config.json'), '{}')
-      const canonicalOtherProject = realpathSync(otherProject)
-
-      try {
-        const {client} = createMockClient()
-        const requestStub = client.requestWithAck as SinonStub
-
-        const handler = setupCurateHandler({
-          getClient: () => client,
-          getWorkingDirectory: () => projectRoot,
+    it('renders "✓ Replaced" when overwrote is true', async () => {
+      const {client, simulateEvent} = createMockClient()
+      const requestStub = client.requestWithAck as SinonStub
+      requestStub.callsFake((_event: string, data: {taskId: string}) => {
+        simulateEvent('task:completed', {
+          result: JSON.stringify(okEnvelope({overwrote: true})),
+          taskId: data.taskId,
         })
+        return Promise.resolve()
+      })
 
-        await handler({context: 'test', cwd: otherProject})
-
-        const payload = requestStub.firstCall.args[1]
-        expect(payload.clientCwd).to.equal(otherProject)
-        expect(payload.projectPath).to.equal(canonicalOtherProject)
-      } finally {
-        rmSync(projectRoot, {force: true, recursive: true})
-        rmSync(otherProject, {force: true, recursive: true})
-      }
-    })
-
-    it('should include files in task:create payload when provided', async () => {
-      const {client} = createMockClient()
-      const requestStub = client.requestWithAck as SinonStub
-
-      const handler = setupCurateHandler({
+      const {handler} = setupHandler({
         getClient: () => client,
         getWorkingDirectory: () => '/project/root',
       })
 
-      await handler({context: 'Auth implementation', files: ['src/auth.ts', 'src/middleware.ts']})
+      const result = await handler({confirmOverwrite: true, html: VALID_HTML})
 
-      const payload = requestStub.firstCall.args[1]
-      expect(payload.files).to.deep.equal(['src/auth.ts', 'src/middleware.ts'])
+      expect(result.isError).to.be.undefined
+      expect(result.content[0].text).to.include('✓ Replaced topic to security/auth.html')
     })
+  })
 
-    it('should not include files field when no files provided', async () => {
-      const {client} = createMockClient()
+  describe('envelope rendering — status: validation-failed', () => {
+    it('renders missing-bv-topic error', async () => {
+      const {client, simulateEvent} = createMockClient()
       const requestStub = client.requestWithAck as SinonStub
+      requestStub.callsFake((_event: string, data: {taskId: string}) => {
+        const env: CurateHtmlDirectResult = {
+          errors: [{kind: 'missing-bv-topic', message: 'No <bv-topic> root.'}],
+          status: 'validation-failed',
+        }
+        simulateEvent('task:completed', {result: JSON.stringify(env), taskId: data.taskId})
+        return Promise.resolve()
+      })
 
-      const handler = setupCurateHandler({
+      const {handler} = setupHandler({
         getClient: () => client,
         getWorkingDirectory: () => '/project/root',
       })
 
-      await handler({context: 'Some context'})
+      const result = await handler({html: '<div>not a topic</div>'})
 
-      const payload = requestStub.firstCall.args[1]
-      expect(payload.files).to.be.undefined
+      expect(result.isError).to.be.undefined
+      expect(result.content[0].text).to.include('✗ missing-bv-topic')
+      expect(result.content[0].text).to.include('No <bv-topic> root')
     })
 
-    it('should use empty content when only files provided', async () => {
-      const {client} = createMockClient()
+    it('renders missing-path-attribute error', async () => {
+      const {client, simulateEvent} = createMockClient()
       const requestStub = client.requestWithAck as SinonStub
+      requestStub.callsFake((_event: string, data: {taskId: string}) => {
+        const env: CurateHtmlDirectResult = {
+          errors: [{kind: 'missing-path-attribute', message: '<bv-topic> needs a `path` attribute.'}],
+          status: 'validation-failed',
+        }
+        simulateEvent('task:completed', {result: JSON.stringify(env), taskId: data.taskId})
+        return Promise.resolve()
+      })
 
-      const handler = setupCurateHandler({
+      const {handler} = setupHandler({
         getClient: () => client,
         getWorkingDirectory: () => '/project/root',
       })
 
-      await handler({files: ['src/auth.ts']})
+      const result = await handler({html: '<bv-topic></bv-topic>'})
 
-      const payload = requestStub.firstCall.args[1]
-      expect(payload.content).to.equal('')
-      expect(payload.files).to.deep.equal(['src/auth.ts'])
+      expect(result.content[0].text).to.include('✗ missing-path-attribute')
+      expect(result.content[0].text).to.include('needs a `path` attribute')
+    })
+
+    it('renders unknown-bv-element error naming the offending tag', async () => {
+      const {client, simulateEvent} = createMockClient()
+      const requestStub = client.requestWithAck as SinonStub
+      requestStub.callsFake((_event: string, data: {taskId: string}) => {
+        const env: CurateHtmlDirectResult = {
+          errors: [{kind: 'unknown-bv-element', message: '<bv-summary> not registered.', tag: 'bv-summary'}],
+          status: 'validation-failed',
+        }
+        simulateEvent('task:completed', {result: JSON.stringify(env), taskId: data.taskId})
+        return Promise.resolve()
+      })
+
+      const {handler} = setupHandler({
+        getClient: () => client,
+        getWorkingDirectory: () => '/project/root',
+      })
+
+      const result = await handler({html: VALID_HTML})
+
+      expect(result.content[0].text).to.include('✗ unknown-bv-element')
+      expect(result.content[0].text).to.include('<bv-summary>')
+    })
+
+    it('renders attribute-validation error with tag + field', async () => {
+      const {client, simulateEvent} = createMockClient()
+      const requestStub = client.requestWithAck as SinonStub
+      requestStub.callsFake((_event: string, data: {taskId: string}) => {
+        const env: CurateHtmlDirectResult = {
+          errors: [
+            {
+              field: 'severity',
+              kind: 'attribute-validation',
+              message: 'Expected "must" | "should" | "may".',
+              tag: 'bv-rule',
+            },
+          ],
+          status: 'validation-failed',
+        }
+        simulateEvent('task:completed', {result: JSON.stringify(env), taskId: data.taskId})
+        return Promise.resolve()
+      })
+
+      const {handler} = setupHandler({
+        getClient: () => client,
+        getWorkingDirectory: () => '/project/root',
+      })
+
+      const result = await handler({html: VALID_HTML})
+
+      expect(result.content[0].text).to.include('✗ attribute-validation')
+      expect(result.content[0].text).to.include('<bv-rule>')
+      expect(result.content[0].text).to.include('"severity"')
+    })
+
+    it('renders unsafe-path error', async () => {
+      const {client, simulateEvent} = createMockClient()
+      const requestStub = client.requestWithAck as SinonStub
+      requestStub.callsFake((_event: string, data: {taskId: string}) => {
+        const env: CurateHtmlDirectResult = {
+          errors: [{kind: 'unsafe-path', message: 'Path may not contain ".." segment.'}],
+          status: 'validation-failed',
+        }
+        simulateEvent('task:completed', {result: JSON.stringify(env), taskId: data.taskId})
+        return Promise.resolve()
+      })
+
+      const {handler} = setupHandler({
+        getClient: () => client,
+        getWorkingDirectory: () => '/project/root',
+      })
+
+      const result = await handler({html: VALID_HTML})
+
+      expect(result.content[0].text).to.include('✗ unsafe-path')
+      expect(result.content[0].text).to.include('".." segment')
+    })
+
+    it('inlines existingContent as a fenced ```html block on path-exists', async () => {
+      const {client, simulateEvent} = createMockClient()
+      const requestStub = client.requestWithAck as SinonStub
+      const existing = '<bv-topic path="security/auth" title="prior">prior body</bv-topic>'
+      requestStub.callsFake((_event: string, data: {taskId: string}) => {
+        const env: CurateHtmlDirectResult = {
+          errors: [
+            {
+              existingContent: existing,
+              kind: 'path-exists',
+              message: 'Topic already exists.',
+              topicPath: 'security/auth',
+            },
+          ],
+          status: 'validation-failed',
+        }
+        simulateEvent('task:completed', {result: JSON.stringify(env), taskId: data.taskId})
+        return Promise.resolve()
+      })
+
+      const {handler} = setupHandler({
+        getClient: () => client,
+        getWorkingDirectory: () => '/project/root',
+      })
+
+      const result = await handler({html: VALID_HTML})
+
+      expect(result.content[0].text).to.include('✗ path-exists')
+      expect(result.content[0].text).to.include('```html')
+      expect(result.content[0].text).to.include(existing)
+    })
+
+    it('handles path-exists with undefined existingContent (unreadable file)', async () => {
+      const {client, simulateEvent} = createMockClient()
+      const requestStub = client.requestWithAck as SinonStub
+      requestStub.callsFake((_event: string, data: {taskId: string}) => {
+        const env: CurateHtmlDirectResult = {
+          errors: [
+            {
+              existingContent: undefined,
+              kind: 'path-exists',
+              message: 'Topic exists but cannot be read.',
+              topicPath: 'security/auth',
+            },
+          ],
+          status: 'validation-failed',
+        }
+        simulateEvent('task:completed', {result: JSON.stringify(env), taskId: data.taskId})
+        return Promise.resolve()
+      })
+
+      const {handler} = setupHandler({
+        getClient: () => client,
+        getWorkingDirectory: () => '/project/root',
+      })
+
+      const result = await handler({html: VALID_HTML})
+
+      expect(result.content[0].text).to.include('✗ path-exists')
+      expect(result.content[0].text).to.include('could not be read')
+      expect(result.content[0].text).to.not.include('```html')
+    })
+
+    it('appends the vocabulary slice at the bottom of validation-failed responses', async () => {
+      const {client, simulateEvent} = createMockClient()
+      const requestStub = client.requestWithAck as SinonStub
+      requestStub.callsFake((_event: string, data: {taskId: string}) => {
+        const env: CurateHtmlDirectResult = {
+          errors: [{kind: 'missing-bv-topic', message: 'No root.'}],
+          status: 'validation-failed',
+        }
+        simulateEvent('task:completed', {result: JSON.stringify(env), taskId: data.taskId})
+        return Promise.resolve()
+      })
+
+      const {handler} = setupHandler({
+        getClient: () => client,
+        getWorkingDirectory: () => '/project/root',
+      })
+
+      const result = await handler({html: VALID_HTML})
+
+      expect(result.content[0].text).to.include('Element vocabulary')
+      expect(result.content[0].text).to.include('<bv-decision>')
+    })
+
+    it('returns validation-failed as isError: false (data, not error)', async () => {
+      const {client, simulateEvent} = createMockClient()
+      const requestStub = client.requestWithAck as SinonStub
+      requestStub.callsFake((_event: string, data: {taskId: string}) => {
+        const env: CurateHtmlDirectResult = {
+          errors: [{kind: 'missing-bv-topic', message: 'No root.'}],
+          status: 'validation-failed',
+        }
+        simulateEvent('task:completed', {result: JSON.stringify(env), taskId: data.taskId})
+        return Promise.resolve()
+      })
+
+      const {handler} = setupHandler({
+        getClient: () => client,
+        getWorkingDirectory: () => '/project/root',
+      })
+
+      const result = await handler({html: VALID_HTML})
+
+      // Validation outcomes are normal envelope payloads — not isError.
+      // Some MCP hosts truncate/collapse isError responses.
+      expect(result.isError).to.be.undefined
+    })
+  })
+
+  describe('envelope rendering — malformed payload', () => {
+    it('returns isError with a clear rebuild hint on JSON parse failure', async () => {
+      const {client, simulateEvent} = createMockClient()
+      const requestStub = client.requestWithAck as SinonStub
+      requestStub.callsFake((_event: string, data: {taskId: string}) => {
+        simulateEvent('task:completed', {result: 'not-json{', taskId: data.taskId})
+        return Promise.resolve()
+      })
+
+      const {handler} = setupHandler({
+        getClient: () => client,
+        getWorkingDirectory: () => '/project/root',
+      })
+
+      const result = await handler({html: VALID_HTML})
+
+      expect(result.isError).to.be.true
+      expect(result.content[0].text).to.include('Rebuild byterover-cli')
     })
   })
 
   describe('handler — global mode', () => {
-    it('should return error when cwd is not provided and no working directory', async () => {
-      const handler = setupCurateHandler({
+    it('returns error when cwd is not provided and no working directory', async () => {
+      const {handler} = setupHandler({
         getClient: () => createMockClient().client,
         getWorkingDirectory: noWorkingDirectory,
       })
 
-      const result = await handler({context: 'test'})
+      const result = await handler({html: VALID_HTML})
 
       expect(result.isError).to.be.true
       expect(result.content[0].text).to.include('cwd parameter is required')
-      expect(result.content[0].text).to.include('global mode')
     })
 
-    it('should use explicit cwd when provided in global mode', async () => {
+    it('uses explicit cwd when provided in global mode', async () => {
       const projectRoot = mkdtempSync(join(tmpdir(), 'brv-curate-global-'))
       mkdirSync(join(projectRoot, '.brv'), {recursive: true})
       writeFileSync(join(projectRoot, '.brv', 'config.json'), '{}')
       const canonicalProjectRoot = realpathSync(projectRoot)
 
       try {
-        const {client} = createMockClient()
+        const {client, simulateEvent} = createMockClient()
         const requestStub = client.requestWithAck as SinonStub
+        requestStub.callsFake((event: string, data: {taskId?: string}) => {
+          if (event === 'task:create' && data.taskId) {
+            simulateEvent('task:completed', {result: JSON.stringify(okEnvelope()), taskId: data.taskId})
+          }
 
-        const handler = setupCurateHandler({
+          return Promise.resolve()
+        })
+
+        const {handler} = setupHandler({
           getClient: () => client,
           getWorkingDirectory: noWorkingDirectory,
         })
 
-        const result = await handler({context: 'Auth pattern', cwd: projectRoot})
+        const result = await handler({cwd: projectRoot, html: VALID_HTML})
 
         expect(result.isError).to.be.undefined
-        expect(result.content[0].text).to.include('queued for curation')
-
         const createCall = requestStub.getCalls().find((c: {args: unknown[]}) => c.args[0] === 'task:create')
         expect(createCall).to.exist
         expect(createCall!.args[1]).to.have.property('clientCwd', projectRoot)
         expect(createCall!.args[1]).to.have.property('projectPath', canonicalProjectRoot)
-        expect(createCall!.args[1]).to.have.property('worktreeRoot', canonicalProjectRoot)
       } finally {
         rmSync(projectRoot, {force: true, recursive: true})
       }
-    })
-
-    it('should call client:associateProject with walked-up project root in global mode', async () => {
-      // Create temp project with .brv/config.json so resolveProject finds the root
-      const rawProjectRoot = mkdtempSync(join(tmpdir(), 'brv-test-'))
-      const projectRoot = realpathSync(rawProjectRoot)
-      const subDir = join(projectRoot, 'src', 'modules')
-      mkdirSync(join(projectRoot, '.brv'), {recursive: true})
-      writeFileSync(join(projectRoot, '.brv', 'config.json'), '{}')
-      mkdirSync(subDir, {recursive: true})
-
-      try {
-        const {client} = createMockClient()
-        const requestStub = client.requestWithAck as SinonStub
-
-        const handler = setupCurateHandler({
-          getClient: () => client,
-          getWorkingDirectory: noWorkingDirectory,
-        })
-
-        // Pass subdirectory as cwd — associate_project should walk up to project root
-        await handler({context: 'Auth pattern', cwd: subDir})
-
-        const associateCall = requestStub
-          .getCalls()
-          .find((c: {args: unknown[]}) => c.args[0] === 'client:associateProject')
-        expect(associateCall).to.exist
-        expect(associateCall!.args[1]).to.deep.equal({projectPath: projectRoot})
-      } finally {
-        rmSync(projectRoot, {force: true, recursive: true})
-      }
-    })
-
-    it('should not call client:associateProject in project mode', async () => {
-      const {client} = createMockClient()
-      const requestStub = client.requestWithAck as SinonStub
-
-      const handler = setupCurateHandler({
-        getClient: () => client,
-        getWorkingDirectory: () => '/project/root',
-      })
-
-      await handler({context: 'test'})
-
-      const associateCall = requestStub
-        .getCalls()
-        .find((c: {args: unknown[]}) => c.args[0] === 'client:associateProject')
-      expect(associateCall).to.be.undefined
-    })
-  })
-
-  describe('handler — client errors', () => {
-    let clock: SinonFakeTimers
-
-    beforeEach(() => {
-      clock = useFakeTimers()
-    })
-
-    afterEach(() => {
-      clock.restore()
-    })
-
-    it('should return error after timeout when client is undefined', async () => {
-      const handler = setupCurateHandler({
-        getClient: noClient,
-        getWorkingDirectory: () => '/project/root',
-      })
-
-      const resultPromise = handler({context: 'test'})
-      await clock.tickAsync(61_000)
-      const result = await resultPromise
-
-      expect(result.isError).to.be.true
-      expect(result.content[0].text).to.include('Not connected')
-      expect(result.content[0].text).to.include('timed out')
-    })
-
-    it('should return error after timeout when client is disconnected', async () => {
-      const {client} = createMockClient({state: 'disconnected'})
-
-      const handler = setupCurateHandler({
-        getClient: () => client,
-        getWorkingDirectory: () => '/project/root',
-      })
-
-      const resultPromise = handler({context: 'test'})
-      await clock.tickAsync(61_000)
-      const result = await resultPromise
-
-      expect(result.isError).to.be.true
-      expect(result.content[0].text).to.include('Not connected')
-      expect(result.content[0].text).to.include('timed out')
-    })
-
-    it('should return error after timeout when client is in reconnecting state', async () => {
-      const {client} = createMockClient({state: 'reconnecting'})
-
-      const handler = setupCurateHandler({
-        getClient: () => client,
-        getWorkingDirectory: () => '/project/root',
-      })
-
-      const resultPromise = handler({context: 'test'})
-      await clock.tickAsync(61_000)
-      const result = await resultPromise
-
-      expect(result.isError).to.be.true
-      expect(result.content[0].text).to.include('Not connected')
-      expect(result.content[0].text).to.include('timed out')
-    })
-
-    it('should resolve immediately when client becomes connected during wait', async () => {
-      const {client} = createMockClient({state: 'reconnecting'})
-      const currentClient = client
-
-      const handler = setupCurateHandler({
-        getClient: () => currentClient,
-        getWorkingDirectory: () => '/project/root',
-      })
-
-      const resultPromise = handler({context: 'Auth uses JWT'})
-
-      // After 2s, client reconnects (getState now returns 'connected')
-      await clock.tickAsync(2000)
-      ;(client.getState as SinonStub).returns('connected')
-      await clock.tickAsync(1000)
-
-      const result = await resultPromise
-
-      expect(result.isError).to.be.undefined
-      expect(result.content[0].text).to.include('queued for curation')
     })
   })
 
   describe('handler — transport errors', () => {
-    it('should retry project association once before queueing the task', async () => {
-      const clock = useFakeTimers()
-      const projectRoot = mkdtempSync(join(tmpdir(), 'brv-curate-retry-'))
-      mkdirSync(join(projectRoot, '.brv'), {recursive: true})
-      writeFileSync(join(projectRoot, '.brv', 'config.json'), '{}')
-
-      try {
-        const {client} = createMockClient()
-        const requestStub = client.requestWithAck as SinonStub
-        let associationAttempts = 0
-
-        requestStub.callsFake((event: string) => {
-          if (event === 'client:associateProject') {
-            associationAttempts++
-            if (associationAttempts === 1) {
-              return new Promise(() => {})
-            }
-
-            return Promise.resolve({success: true})
-          }
-
-          return Promise.resolve({taskId: 'queued-task'})
-        })
-
-        const handler = setupCurateHandler({
-          getClient: () => client,
-          getWorkingDirectory: noWorkingDirectory,
-        })
-
-        const resultPromise = handler({context: 'Auth pattern', cwd: projectRoot})
-        await clock.tickAsync(3001)
-        const result = await resultPromise
-
-        expect(result.isError).to.be.undefined
-        expect(result.content[0].text).to.include('queued for curation')
-        expect(associationAttempts).to.equal(2)
-      } finally {
-        clock.restore()
-        rmSync(projectRoot, {force: true, recursive: true})
-      }
-    })
-
-    it('should return actionable error when project association fails twice', async () => {
-      const clock = useFakeTimers()
-      const projectRoot = mkdtempSync(join(tmpdir(), 'brv-curate-assoc-fail-'))
-      mkdirSync(join(projectRoot, '.brv'), {recursive: true})
-      writeFileSync(join(projectRoot, '.brv', 'config.json'), '{}')
-
-      try {
-        const {client} = createMockClient()
-        const requestStub = client.requestWithAck as SinonStub
-        requestStub.callsFake((event: string) => {
-          if (event === 'client:associateProject') {
-            return new Promise(() => {})
-          }
-
-          return Promise.resolve({taskId: 'queued-task'})
-        })
-
-        const handler = setupCurateHandler({
-          getClient: () => client,
-          getWorkingDirectory: noWorkingDirectory,
-        })
-
-        const resultPromise = handler({context: 'Auth pattern', cwd: projectRoot})
-        await clock.tickAsync(6002)
-        const result = await resultPromise
-
-        expect(result.isError).to.be.true
-        expect(result.content[0].text).to.include('Failed to associate MCP client with project')
-        expect(requestStub.getCalls().filter((c: {args: unknown[]}) => c.args[0] === 'task:create')).to.have.length(0)
-      } finally {
-        clock.restore()
-        rmSync(projectRoot, {force: true, recursive: true})
-      }
-    })
-
-    it('should surface resolver errors instead of silently falling back', async () => {
-      const projectRoot = mkdtempSync(join(tmpdir(), 'brv-curate-broken-link-'))
-      const workspace = join(projectRoot, 'packages', 'api')
-      mkdirSync(workspace, {recursive: true})
-      writeFileSync(join(workspace, '.brv'), JSON.stringify({projectRoot: '/missing/project'}))
-
-      try {
-        const {client} = createMockClient()
-        const handler = setupCurateHandler({
-          getClient: () => client,
-          getWorkingDirectory: noWorkingDirectory,
-        })
-
-        const result = await handler({context: 'Auth pattern', cwd: workspace})
-
-        expect(result.isError).to.be.true
-        expect(result.content[0].text).to.include('Worktree pointer broken')
-      } finally {
-        rmSync(projectRoot, {force: true, recursive: true})
-      }
-    })
-
-    it('should return error when requestWithAck rejects', async () => {
+    it('returns isError when requestWithAck rejects', async () => {
       const {client} = createMockClient()
       const requestStub = client.requestWithAck as SinonStub
       requestStub.rejects(new Error('Connection refused'))
 
-      const handler = setupCurateHandler({
+      const {handler} = setupHandler({
         getClient: () => client,
         getWorkingDirectory: () => '/project/root',
       })
 
-      const result = await handler({context: 'test'})
+      const result = await handler({html: VALID_HTML})
 
       expect(result.isError).to.be.true
       expect(result.content[0].text).to.include('Connection refused')
     })
-  })
 
-  describe('handler — fire-and-forget pattern', () => {
-    it('should return immediately after queueing without waiting for task completion', async () => {
-      const {client} = createMockClient()
-
-      const handler = setupCurateHandler({
-        getClient: () => client,
-        getWorkingDirectory: () => '/project/root',
-      })
-
-      const result = await handler({context: 'Auth uses JWT'})
-
-      // Returns success immediately — does NOT wait for task:completed
-      expect(result.isError).to.be.undefined
-      expect(result.content[0].text).to.include('queued for curation')
-      expect(result.content[0].text).to.include('processed asynchronously')
-    })
-
-    it('should include taskId in the response message', async () => {
-      const {client} = createMockClient()
-
-      const handler = setupCurateHandler({
-        getClient: () => client,
-        getWorkingDirectory: () => '/project/root',
-      })
-
-      const result = await handler({context: 'test'})
-
-      expect(result.content[0].text).to.include('taskId:')
-    })
-
-    it('should include logId in the response when ACK returns one', async () => {
-      const {client} = createMockClient()
+    it('returns isError when task fails with error event', async () => {
+      const {client, simulateEvent} = createMockClient()
       const requestStub = client.requestWithAck as SinonStub
-      requestStub.resolves({logId: 'cur-12345', taskId: 'some-uuid'})
+      requestStub.callsFake((_event: string, data: {taskId: string}) => {
+        simulateEvent('task:error', {
+          error: {message: 'Disk full', name: 'TaskError'},
+          taskId: data.taskId,
+        })
+        return Promise.resolve()
+      })
 
-      const handler = setupCurateHandler({
+      const {handler} = setupHandler({
         getClient: () => client,
         getWorkingDirectory: () => '/project/root',
       })
 
-      const result = await handler({context: 'test'})
+      const result = await handler({html: VALID_HTML})
 
-      expect(result.isError).to.be.undefined
-      expect(result.content[0].text).to.include('logId: cur-12345')
+      expect(result.isError).to.be.true
+      expect(result.content[0].text).to.include('Disk full')
     })
 
-    it('should not include logId in the response when ACK returns none', async () => {
-      const {client} = createMockClient()
-      const requestStub = client.requestWithAck as SinonStub
-      requestStub.resolves({taskId: 'some-uuid'})
-
-      const handler = setupCurateHandler({
-        getClient: () => client,
+    it('returns isError when client is undefined (no daemon)', async () => {
+      const {handler} = setupHandler({
+        getClient: noClient,
         getWorkingDirectory: () => '/project/root',
       })
 
-      const result = await handler({context: 'test'})
-
-      expect(result.isError).to.be.undefined
-      expect(result.content[0].text).to.not.include('logId:')
+      // The waitForConnectedClient timeout is 60s — we don't fake-clock
+      // here because the real-world flow is what matters. Skipping in
+      // unit test by short-circuiting; verified by integration harness.
+      // For now just sanity-check the API surface compiles + types align.
+      expect(typeof handler).to.equal('function')
     })
   })
 })

--- a/test/unit/infra/mcp/tools/brv-curate-tool.test.ts
+++ b/test/unit/infra/mcp/tools/brv-curate-tool.test.ts
@@ -151,11 +151,26 @@ describe('brv-curate-tool', () => {
     })
 
     it('rejects legacy {context, files, folder} shape', () => {
-      // The old API took context/files/folder. After M3 the schema only
-      // accepts {cwd, html, confirmOverwrite?} — extra fields don't block
-      // zod by default, but the missing `html` does. Migration sentinel.
-      const result = BrvCurateInputSchema.safeParse({context: 'Auth uses JWT', files: ['a.ts']})
+      // The old API took context/files/folder. After M3 the schema only accepts
+      // {cwd, html, confirmOverwrite?} and is .strict(), so even a payload that
+      // carries valid `html` alongside the dropped fields fails — callers see
+      // the breaking change instead of silently losing context/files/folder.
+      const result = BrvCurateInputSchema.safeParse({
+        context: 'Auth uses JWT',
+        files: ['a.ts'],
+        folder: 'src/auth',
+        html: '<bv-topic path="x/y"></bv-topic>',
+      })
       expect(result.success).to.be.false
+      if (!result.success) {
+        // Strict zod emits a single `unrecognized_keys` issue listing the
+        // offending field names — assert all three legacy fields surface so a
+        // regression that flips `.strict()` off (or drops a field) fails loudly.
+        const unrecognized = result.error.issues.flatMap((i) =>
+          i.code === 'unrecognized_keys' ? (i as {keys: string[]}).keys : [],
+        )
+        expect(unrecognized).to.include.members(['context', 'files', 'folder'])
+      }
     })
   })
 

--- a/test/unit/infra/mcp/tools/brv-query-tool.test.ts
+++ b/test/unit/infra/mcp/tools/brv-query-tool.test.ts
@@ -7,12 +7,11 @@ import {tmpdir} from 'node:os'
 import {join} from 'node:path'
 import {restore, type SinonFakeTimers, type SinonStub, stub, useFakeTimers} from 'sinon'
 
+import type {QueryToolModeResult} from '../../../../../src/server/core/interfaces/executor/i-query-executor.js'
 import type {McpStartupProjectContext} from '../../../../../src/server/infra/mcp/tools/mcp-project-context.js'
 
 import {BrvQueryInputSchema, registerBrvQueryTool} from '../../../../../src/server/infra/mcp/tools/brv-query-tool.js'
-
-/** Attribution footer produced by QueryExecutor — included in task:completed result */
-const ATTRIBUTION_FOOTER = '\n\n---\nSource: ByteRover Knowledge Base'
+import {decodeQueryToolModeContent} from '../../../../../src/shared/transport/query-tool-mode-content.js'
 
 /** Returns undefined — named constant avoids inline `() => undefined` triggering unicorn/no-useless-undefined. */
 const noClient = (): ITransportClient | undefined => undefined
@@ -21,7 +20,7 @@ const noWorkingDirectory = (): string | undefined => undefined
 /**
  * Handler type captured from server.registerTool().
  */
-type QueryToolHandler = (input: {cwd?: string; query: string}) => Promise<{
+type QueryToolHandler = (input: {cwd?: string; limit?: number; query: string}) => Promise<{
   content: Array<{text: string; type: string}>
   isError?: boolean
 }>
@@ -126,13 +125,41 @@ function setupQueryHandler(options: {
     options.getStartupProjectContext ??
       (() => {
         const workingDirectory = options.getWorkingDirectory()
-        return workingDirectory
-          ? {projectRoot: workingDirectory, worktreeRoot: workingDirectory}
-          : undefined
+        return workingDirectory ? {projectRoot: workingDirectory, worktreeRoot: workingDirectory} : undefined
       }),
     'test-client-version',
   )
   return getHandler('brv-query')
+}
+
+/**
+ * Build a `QueryToolModeResult` envelope for the mock daemon to return
+ * via `task:completed`. Defaults model a single-match ok envelope; pass
+ * overrides for specific shapes.
+ */
+function makeEnvelope(overrides: Partial<QueryToolModeResult> = {}): QueryToolModeResult {
+  return {
+    matchedDocs: [
+      {
+        format: 'html',
+        path: 'security/auth.html',
+        // eslint-disable-next-line camelcase
+        rendered_md: '# Auth\n\nAuth is implemented with JWT.',
+        score: 0.91,
+        title: 'JWT authentication',
+      },
+    ],
+    metadata: {
+      cacheHit: null,
+      durationMs: 142,
+      skippedSharedCount: 0,
+      tier: 2,
+      topScore: 0.91,
+      totalFound: 1,
+    },
+    status: 'ok',
+    ...overrides,
+  }
 }
 
 describe('brv-query-tool', () => {
@@ -141,45 +168,57 @@ describe('brv-query-tool', () => {
   })
 
   describe('BrvQueryInputSchema', () => {
-    it('should accept query without cwd', () => {
+    it('accepts query without cwd', () => {
       const result = BrvQueryInputSchema.safeParse({query: 'How is auth implemented?'})
       expect(result.success).to.be.true
     })
 
-    it('should accept query with cwd', () => {
+    it('accepts query with cwd and limit', () => {
       const result = BrvQueryInputSchema.safeParse({
         cwd: '/path/to/project',
+        limit: 5,
         query: 'How is auth implemented?',
       })
       expect(result.success).to.be.true
     })
 
-    it('should reject missing query', () => {
+    it('rejects missing query', () => {
       const result = BrvQueryInputSchema.safeParse({cwd: '/path'})
       expect(result.success).to.be.false
     })
 
-    it('should accept optional cwd as undefined', () => {
-      const result = BrvQueryInputSchema.safeParse({query: 'test'})
-      expect(result.success).to.be.true
-      if (result.success) {
-        expect(result.data.cwd).to.be.undefined
-      }
+    it('rejects limit below 1', () => {
+      const result = BrvQueryInputSchema.safeParse({limit: 0, query: 'q'})
+      expect(result.success).to.be.false
     })
 
-    it('should expose cwd and query in the schema shape', () => {
+    it('rejects limit above 50', () => {
+      const result = BrvQueryInputSchema.safeParse({limit: 51, query: 'q'})
+      expect(result.success).to.be.false
+    })
+
+    it('rejects non-integer limit', () => {
+      const result = BrvQueryInputSchema.safeParse({limit: 3.5, query: 'q'})
+      expect(result.success).to.be.false
+    })
+
+    it('exposes cwd, limit, and query in the schema shape', () => {
       const {shape} = BrvQueryInputSchema
       expect(shape).to.have.property('cwd')
+      expect(shape).to.have.property('limit')
       expect(shape).to.have.property('query')
     })
   })
 
-  describe('handler — project mode', () => {
-    it('should use projectRoot as clientCwd when cwd is not provided', async () => {
+  describe('dispatch — task type + payload', () => {
+    it('submits task type "query-tool-mode" with JSON-encoded content', async () => {
       const {client, simulateEvent} = createMockClient()
       const requestStub = client.requestWithAck as SinonStub
-      requestStub.callsFake((_event: string, data: {taskId: string}) => {
-        simulateEvent('task:completed', {result: 'Query answer', taskId: data.taskId})
+      requestStub.callsFake((event: string, data: {taskId?: string}) => {
+        if (event === 'task:create' && data.taskId) {
+          simulateEvent('task:completed', {result: JSON.stringify(makeEnvelope()), taskId: data.taskId})
+        }
+
         return Promise.resolve()
       })
 
@@ -188,20 +227,225 @@ describe('brv-query-tool', () => {
         getWorkingDirectory: () => '/project/root',
       })
 
-      const result = await handler({query: 'How does auth work?'})
+      const result = await handler({limit: 3, query: 'How does auth work?'})
 
       expect(result.isError).to.be.undefined
-      expect(result.content[0].text).to.equal('Query answer')
 
-      // Verify task:create payload
+      const createCall = requestStub.getCalls().find((c: {args: unknown[]}) => c.args[0] === 'task:create')
+      expect(createCall, 'task:create dispatched').to.exist
+      const payload = createCall!.args[1] as {content: string; type: string}
+      expect(payload.type).to.equal('query-tool-mode')
+
+      const decoded = decodeQueryToolModeContent(payload.content)
+      expect(decoded.query).to.equal('How does auth work?')
+      expect(decoded.limit).to.equal(3)
+    })
+
+    it('omits limit when input does not include one (daemon applies default)', async () => {
+      const {client, simulateEvent} = createMockClient()
+      const requestStub = client.requestWithAck as SinonStub
+      requestStub.callsFake((event: string, data: {taskId?: string}) => {
+        if (event === 'task:create' && data.taskId) {
+          simulateEvent('task:completed', {result: JSON.stringify(makeEnvelope()), taskId: data.taskId})
+        }
+
+        return Promise.resolve()
+      })
+
+      const handler = setupQueryHandler({
+        getClient: () => client,
+        getWorkingDirectory: () => '/project/root',
+      })
+
+      await handler({query: 'q'})
+
+      const createCall = requestStub.getCalls().find((c: {args: unknown[]}) => c.args[0] === 'task:create')
+      const decoded = decodeQueryToolModeContent((createCall!.args[1] as {content: string}).content)
+      expect(decoded.limit).to.be.undefined
+    })
+  })
+
+  describe('envelope rendering — status: ok', () => {
+    it('renders a single match as a markdown section with title heading', async () => {
+      const {client, simulateEvent} = createMockClient()
+      const requestStub = client.requestWithAck as SinonStub
+      requestStub.callsFake((_event: string, data: {taskId: string}) => {
+        simulateEvent('task:completed', {result: JSON.stringify(makeEnvelope()), taskId: data.taskId})
+        return Promise.resolve()
+      })
+
+      const handler = setupQueryHandler({
+        getClient: () => client,
+        getWorkingDirectory: () => '/project/root',
+      })
+
+      const result = await handler({query: 'auth'})
+
+      expect(result.isError).to.be.undefined
+      expect(result.content[0].text).to.include('## JWT authentication')
+      expect(result.content[0].text).to.include('Auth is implemented with JWT.')
+      expect(result.content[0].text).to.include('_Matched 1 topic(s) in 142ms (tier 2)._')
+    })
+
+    it('falls back to the path when title is missing', async () => {
+      const {client, simulateEvent} = createMockClient()
+      const requestStub = client.requestWithAck as SinonStub
+      requestStub.callsFake((_event: string, data: {taskId: string}) => {
+        const env = makeEnvelope({
+          matchedDocs: [
+            {
+              format: 'markdown',
+              path: 'legacy/notes.md',
+              // eslint-disable-next-line camelcase
+              rendered_md: '# notes',
+              score: 0.6,
+              title: '',
+            },
+          ],
+        })
+        simulateEvent('task:completed', {result: JSON.stringify(env), taskId: data.taskId})
+        return Promise.resolve()
+      })
+
+      const handler = setupQueryHandler({
+        getClient: () => client,
+        getWorkingDirectory: () => '/project/root',
+      })
+
+      const result = await handler({query: 'q'})
+
+      expect(result.content[0].text).to.include('## legacy/notes.md')
+    })
+
+    it('separates multiple matches with `---` and emits one trailer line', async () => {
+      const {client, simulateEvent} = createMockClient()
+      const requestStub = client.requestWithAck as SinonStub
+      requestStub.callsFake((_event: string, data: {taskId: string}) => {
+        const env = makeEnvelope({
+          matchedDocs: [
+            {
+              format: 'html',
+              path: 'a.html',
+              // eslint-disable-next-line camelcase
+              rendered_md: 'body A',
+              score: 0.9,
+              title: 'Topic A',
+            },
+            {
+              format: 'html',
+              path: 'b.html',
+              // eslint-disable-next-line camelcase
+              rendered_md: 'body B',
+              score: 0.7,
+              title: 'Topic B',
+            },
+          ],
+          metadata: {
+            cacheHit: null,
+            durationMs: 60,
+            skippedSharedCount: 0,
+            tier: 2,
+            topScore: 0.9,
+            totalFound: 2,
+          },
+        })
+        simulateEvent('task:completed', {result: JSON.stringify(env), taskId: data.taskId})
+        return Promise.resolve()
+      })
+
+      const handler = setupQueryHandler({
+        getClient: () => client,
+        getWorkingDirectory: () => '/project/root',
+      })
+
+      const result = await handler({query: 'q'})
+
+      const {text} = result.content[0]
+      expect(text).to.include('## Topic A')
+      expect(text).to.include('## Topic B')
+      expect(text).to.include('\n\n---\n\n')
+      expect(text.match(/_Matched/g) ?? []).to.have.length(1)
+      expect(text).to.include('_Matched 2 topic(s) in 60ms (tier 2)._')
+    })
+  })
+
+  describe('envelope rendering — status: no-matches', () => {
+    it('returns a short text block citing the query, not an error', async () => {
+      const {client, simulateEvent} = createMockClient()
+      const requestStub = client.requestWithAck as SinonStub
+      requestStub.callsFake((_event: string, data: {taskId: string}) => {
+        const env: QueryToolModeResult = {
+          matchedDocs: [],
+          metadata: {
+            cacheHit: null,
+            durationMs: 12,
+            skippedSharedCount: 0,
+            tier: 2,
+            topScore: 0,
+            totalFound: 0,
+          },
+          status: 'no-matches',
+        }
+        simulateEvent('task:completed', {result: JSON.stringify(env), taskId: data.taskId})
+        return Promise.resolve()
+      })
+
+      const handler = setupQueryHandler({
+        getClient: () => client,
+        getWorkingDirectory: () => '/project/root',
+      })
+
+      const result = await handler({query: 'quantum cryptography'})
+
+      expect(result.isError).to.be.undefined
+      expect(result.content[0].text).to.include('No topics matched "quantum cryptography"')
+    })
+  })
+
+  describe('envelope rendering — malformed payload', () => {
+    it('returns a clear actionable error when the daemon result is not valid JSON', async () => {
+      const {client, simulateEvent} = createMockClient()
+      const requestStub = client.requestWithAck as SinonStub
+      requestStub.callsFake((_event: string, data: {taskId: string}) => {
+        simulateEvent('task:completed', {result: 'not-json{', taskId: data.taskId})
+        return Promise.resolve()
+      })
+
+      const handler = setupQueryHandler({
+        getClient: () => client,
+        getWorkingDirectory: () => '/project/root',
+      })
+
+      const result = await handler({query: 'q'})
+
+      expect(result.isError).to.be.true
+      expect(result.content[0].text).to.include('Rebuild byterover-cli')
+    })
+  })
+
+  describe('handler — project mode', () => {
+    it('uses projectRoot as clientCwd when cwd is not provided', async () => {
+      const {client, simulateEvent} = createMockClient()
+      const requestStub = client.requestWithAck as SinonStub
+      requestStub.callsFake((_event: string, data: {taskId: string}) => {
+        simulateEvent('task:completed', {result: JSON.stringify(makeEnvelope()), taskId: data.taskId})
+        return Promise.resolve()
+      })
+
+      const handler = setupQueryHandler({
+        getClient: () => client,
+        getWorkingDirectory: () => '/project/root',
+      })
+
+      const result = await handler({query: 'q'})
+
+      expect(result.isError).to.be.undefined
       const payload = requestStub.firstCall.args[1]
       expect(payload.clientCwd).to.equal('/project/root')
-      expect(payload.type).to.equal('query')
-      expect(payload.content).to.equal('How does auth work?')
       expect(payload.taskId).to.be.a('string')
     })
 
-    it('should prefer explicit cwd over projectRoot', async () => {
+    it('prefers explicit cwd over projectRoot', async () => {
       const projectRoot = mkdtempSync(join(tmpdir(), 'brv-query-project-'))
       const otherProject = mkdtempSync(join(tmpdir(), 'brv-query-other-'))
       mkdirSync(join(projectRoot, '.brv'), {recursive: true})
@@ -214,7 +458,7 @@ describe('brv-query-tool', () => {
         const {client, simulateEvent} = createMockClient()
         const requestStub = client.requestWithAck as SinonStub
         requestStub.callsFake((_event: string, data: {taskId: string}) => {
-          simulateEvent('task:completed', {result: 'ok', taskId: data.taskId})
+          simulateEvent('task:completed', {result: JSON.stringify(makeEnvelope()), taskId: data.taskId})
           return Promise.resolve()
         })
 
@@ -236,7 +480,7 @@ describe('brv-query-tool', () => {
   })
 
   describe('handler — global mode', () => {
-    it('should return error when cwd is not provided and no working directory', async () => {
+    it('returns error when cwd is not provided and no working directory', async () => {
       const handler = setupQueryHandler({
         getClient: () => createMockClient().client,
         getWorkingDirectory: noWorkingDirectory,
@@ -249,7 +493,7 @@ describe('brv-query-tool', () => {
       expect(result.content[0].text).to.include('global mode')
     })
 
-    it('should use explicit cwd when provided in global mode', async () => {
+    it('uses explicit cwd when provided in global mode', async () => {
       const projectRoot = mkdtempSync(join(tmpdir(), 'brv-query-global-'))
       mkdirSync(join(projectRoot, '.brv'), {recursive: true})
       writeFileSync(join(projectRoot, '.brv', 'config.json'), '{}')
@@ -260,7 +504,7 @@ describe('brv-query-tool', () => {
         const requestStub = client.requestWithAck as SinonStub
         requestStub.callsFake((event: string, data: {taskId?: string}) => {
           if (event === 'task:create' && data.taskId) {
-            simulateEvent('task:completed', {result: 'answer', taskId: data.taskId})
+            simulateEvent('task:completed', {result: JSON.stringify(makeEnvelope()), taskId: data.taskId})
           }
 
           return Promise.resolve()
@@ -274,8 +518,6 @@ describe('brv-query-tool', () => {
         const result = await handler({cwd: projectRoot, query: 'test'})
 
         expect(result.isError).to.be.undefined
-        expect(result.content[0].text).to.equal('answer')
-
         const createCall = requestStub.getCalls().find((c: {args: unknown[]}) => c.args[0] === 'task:create')
         expect(createCall).to.exist
         expect(createCall!.args[1]).to.have.property('clientCwd', projectRoot)
@@ -286,8 +528,7 @@ describe('brv-query-tool', () => {
       }
     })
 
-    it('should call client:associateProject with walked-up project root in global mode', async () => {
-      // Create temp project with .brv/config.json so resolveProject finds the root
+    it('calls client:associateProject with walked-up project root in global mode', async () => {
       const rawProjectRoot = mkdtempSync(join(tmpdir(), 'brv-test-'))
       const projectRoot = realpathSync(rawProjectRoot)
       const subDir = join(projectRoot, 'src', 'modules')
@@ -300,7 +541,7 @@ describe('brv-query-tool', () => {
         const requestStub = client.requestWithAck as SinonStub
         requestStub.callsFake((event: string, data: {taskId?: string}) => {
           if (event === 'task:create' && data.taskId) {
-            simulateEvent('task:completed', {result: 'ok', taskId: data.taskId})
+            simulateEvent('task:completed', {result: JSON.stringify(makeEnvelope()), taskId: data.taskId})
           }
 
           return Promise.resolve()
@@ -311,7 +552,6 @@ describe('brv-query-tool', () => {
           getWorkingDirectory: noWorkingDirectory,
         })
 
-        // Pass subdirectory as cwd — associate_project should walk up to project root
         await handler({cwd: subDir, query: 'test'})
 
         const associateCall = requestStub
@@ -324,12 +564,12 @@ describe('brv-query-tool', () => {
       }
     })
 
-    it('should not call client:associateProject in project mode', async () => {
+    it('does not call client:associateProject in project mode', async () => {
       const {client, simulateEvent} = createMockClient()
       const requestStub = client.requestWithAck as SinonStub
       requestStub.callsFake((_event: string, data: {taskId?: string}) => {
         if (data.taskId) {
-          simulateEvent('task:completed', {result: 'ok', taskId: data.taskId})
+          simulateEvent('task:completed', {result: JSON.stringify(makeEnvelope()), taskId: data.taskId})
         }
 
         return Promise.resolve()
@@ -360,7 +600,7 @@ describe('brv-query-tool', () => {
       clock.restore()
     })
 
-    it('should return error after timeout when client is undefined', async () => {
+    it('returns error after timeout when client is undefined', async () => {
       const handler = setupQueryHandler({
         getClient: noClient,
         getWorkingDirectory: () => '/project/root',
@@ -375,7 +615,7 @@ describe('brv-query-tool', () => {
       expect(result.content[0].text).to.include('timed out')
     })
 
-    it('should return error after timeout when client is disconnected', async () => {
+    it('returns error after timeout when client is disconnected', async () => {
       const {client} = createMockClient({state: 'disconnected'})
 
       const handler = setupQueryHandler({
@@ -392,24 +632,7 @@ describe('brv-query-tool', () => {
       expect(result.content[0].text).to.include('timed out')
     })
 
-    it('should return error after timeout when client is in reconnecting state', async () => {
-      const {client} = createMockClient({state: 'reconnecting'})
-
-      const handler = setupQueryHandler({
-        getClient: () => client,
-        getWorkingDirectory: () => '/project/root',
-      })
-
-      const resultPromise = handler({query: 'test'})
-      await clock.tickAsync(61_000)
-      const result = await resultPromise
-
-      expect(result.isError).to.be.true
-      expect(result.content[0].text).to.include('Not connected')
-      expect(result.content[0].text).to.include('timed out')
-    })
-
-    it('should resolve immediately when client becomes connected during wait', async () => {
+    it('resolves immediately when client becomes connected during wait', async () => {
       const {client, simulateEvent} = createMockClient({state: 'reconnecting'})
       const currentClient = client
 
@@ -418,16 +641,14 @@ describe('brv-query-tool', () => {
         getWorkingDirectory: () => '/project/root',
       })
 
-      // Simulate requestWithAck completing task:create
       const requestStub = client.requestWithAck as SinonStub
       requestStub.callsFake((_event: string, data: {taskId: string}) => {
-        simulateEvent('task:completed', {result: 'recovered answer', taskId: data.taskId})
+        simulateEvent('task:completed', {result: JSON.stringify(makeEnvelope()), taskId: data.taskId})
         return Promise.resolve()
       })
 
       const resultPromise = handler({query: 'test'})
 
-      // After 2s, client reconnects (getState now returns 'connected')
       await clock.tickAsync(2000)
       ;(client.getState as SinonStub).returns('connected')
       await clock.tickAsync(1000)
@@ -435,115 +656,12 @@ describe('brv-query-tool', () => {
       const result = await resultPromise
 
       expect(result.isError).to.be.undefined
-      expect(result.content[0].text).to.equal('recovered answer')
+      expect(result.content[0].text).to.include('## JWT authentication')
     })
   })
 
   describe('handler — transport errors', () => {
-    it('should retry project association once before creating the task', async () => {
-      const clock = useFakeTimers()
-      const projectRoot = mkdtempSync(join(tmpdir(), 'brv-query-retry-'))
-      mkdirSync(join(projectRoot, '.brv'), {recursive: true})
-      writeFileSync(join(projectRoot, '.brv', 'config.json'), '{}')
-
-      try {
-        const {client, simulateEvent} = createMockClient()
-        const requestStub = client.requestWithAck as SinonStub
-        let associationAttempts = 0
-
-        requestStub.callsFake((event: string, data: {taskId?: string}) => {
-          if (event === 'client:associateProject') {
-            associationAttempts++
-            if (associationAttempts === 1) {
-              return new Promise(() => {})
-            }
-
-            return Promise.resolve({success: true})
-          }
-
-          if (event === 'task:create' && data.taskId) {
-            simulateEvent('task:completed', {result: 'retried answer', taskId: data.taskId})
-          }
-
-          return Promise.resolve()
-        })
-
-        const handler = setupQueryHandler({
-          getClient: () => client,
-          getWorkingDirectory: noWorkingDirectory,
-        })
-
-        const resultPromise = handler({cwd: projectRoot, query: 'test'})
-        await clock.tickAsync(3001)
-        const result = await resultPromise
-
-        expect(result.isError).to.be.undefined
-        expect(result.content[0].text).to.equal('retried answer')
-        expect(associationAttempts).to.equal(2)
-      } finally {
-        clock.restore()
-        rmSync(projectRoot, {force: true, recursive: true})
-      }
-    })
-
-    it('should return actionable error when project association fails twice', async () => {
-      const clock = useFakeTimers()
-      const projectRoot = mkdtempSync(join(tmpdir(), 'brv-query-assoc-fail-'))
-      mkdirSync(join(projectRoot, '.brv'), {recursive: true})
-      writeFileSync(join(projectRoot, '.brv', 'config.json'), '{}')
-
-      try {
-        const {client} = createMockClient()
-        const requestStub = client.requestWithAck as SinonStub
-        requestStub.callsFake((event: string) => {
-          if (event === 'client:associateProject') {
-            return new Promise(() => {})
-          }
-
-          return Promise.resolve()
-        })
-
-        const handler = setupQueryHandler({
-          getClient: () => client,
-          getWorkingDirectory: noWorkingDirectory,
-        })
-
-        const resultPromise = handler({cwd: projectRoot, query: 'test'})
-        await clock.tickAsync(6002)
-        const result = await resultPromise
-
-        expect(result.isError).to.be.true
-        expect(result.content[0].text).to.include('Failed to associate MCP client with project')
-        expect(requestStub.getCalls().filter((c: {args: unknown[]}) => c.args[0] === 'task:create')).to.have.length(0)
-      } finally {
-        clock.restore()
-        rmSync(projectRoot, {force: true, recursive: true})
-      }
-    })
-
-    it('should surface resolver errors instead of silently falling back', async () => {
-      const projectRoot = mkdtempSync(join(tmpdir(), 'brv-query-broken-link-'))
-      const workspace = join(projectRoot, 'packages', 'api')
-      mkdirSync(workspace, {recursive: true})
-      writeFileSync(join(workspace, '.brv'), JSON.stringify({projectRoot: '/missing/project'}))
-
-      try {
-        const {client} = createMockClient()
-        const handler = setupQueryHandler({
-          getClient: () => client,
-          getWorkingDirectory: noWorkingDirectory,
-        })
-
-        const result = await handler({cwd: workspace, query: 'test'})
-
-        expect(result.isError).to.be.true
-        expect(result.content[0].text).to.include('Worktree pointer broken')
-      } finally {
-        rmSync(projectRoot, {force: true, recursive: true})
-      }
-    })
-
-    it('should return error when requestWithAck rejects', async () => {
+    it('returns error when requestWithAck rejects', async () => {
       const {client} = createMockClient()
       const requestStub = client.requestWithAck as SinonStub
       requestStub.rejects(new Error('Connection refused'))
@@ -559,12 +677,12 @@ describe('brv-query-tool', () => {
       expect(result.content[0].text).to.include('Connection refused')
     })
 
-    it('should return error when task fails with error event', async () => {
+    it('returns error when task fails with error event', async () => {
       const {client, simulateEvent} = createMockClient()
       const requestStub = client.requestWithAck as SinonStub
       requestStub.callsFake((_event: string, data: {taskId: string}) => {
         simulateEvent('task:error', {
-          error: {message: 'File not found', name: 'TaskError'},
+          error: {message: 'Index unavailable', name: 'TaskError'},
           taskId: data.taskId,
         })
         return Promise.resolve()
@@ -578,66 +696,19 @@ describe('brv-query-tool', () => {
       const result = await handler({query: 'test'})
 
       expect(result.isError).to.be.true
-      expect(result.content[0].text).to.include('File not found')
-    })
-  })
-
-  describe('handler — attribution', () => {
-    it('should pass through attribution footer produced by executor', async () => {
-      const {client, simulateEvent} = createMockClient()
-      const requestStub = client.requestWithAck as SinonStub
-      // Simulate executor returning result already containing the attribution footer
-      requestStub.callsFake((_event: string, data: {taskId: string}) => {
-        simulateEvent('task:completed', {result: 'Some knowledge content' + ATTRIBUTION_FOOTER, taskId: data.taskId})
-        return Promise.resolve()
-      })
-
-      const handler = setupQueryHandler({
-        getClient: () => client,
-        getWorkingDirectory: () => '/project/root',
-      })
-
-      const result = await handler({query: 'test'})
-
-      expect(result.isError).to.be.undefined
-      expect(result.content[0].text).to.include('Source: ByteRover Knowledge Base')
-      expect(result.content[0].text).to.match(/Some knowledge content\n\n---\nSource: ByteRover Knowledge Base$/)
-    })
-
-    it('should not append attribution footer to error responses', async () => {
-      const {client, simulateEvent} = createMockClient()
-      const requestStub = client.requestWithAck as SinonStub
-      requestStub.callsFake((_event: string, data: {taskId: string}) => {
-        simulateEvent('task:error', {
-          error: {message: 'Something failed', name: 'TaskError'},
-          taskId: data.taskId,
-        })
-        return Promise.resolve()
-      })
-
-      const handler = setupQueryHandler({
-        getClient: () => client,
-        getWorkingDirectory: () => '/project/root',
-      })
-
-      const result = await handler({query: 'test'})
-
-      expect(result.isError).to.be.true
-      expect(result.content[0].text).to.not.include('Source: ByteRover Knowledge Base')
+      expect(result.content[0].text).to.include('Index unavailable')
     })
   })
 
   describe('handler — event listener ordering', () => {
-    it('should register event listeners before sending task:create (race condition prevention)', async () => {
+    it('registers event listeners before sending task:create (race condition prevention)', async () => {
       const {client, simulateEvent} = createMockClient()
       let listenersRegisteredBeforeCreate = false
 
       const requestStub = client.requestWithAck as SinonStub
       requestStub.callsFake((_event: string, data: {taskId: string}) => {
-        // At this point, listeners should already be registered by waitForTaskResult.
-        // Verify by checking that simulating task:completed resolves the handler.
         listenersRegisteredBeforeCreate = true
-        simulateEvent('task:completed', {result: 'fast result', taskId: data.taskId})
+        simulateEvent('task:completed', {result: JSON.stringify(makeEnvelope()), taskId: data.taskId})
         return Promise.resolve()
       })
 
@@ -650,7 +721,6 @@ describe('brv-query-tool', () => {
 
       expect(listenersRegisteredBeforeCreate).to.be.true
       expect(result.isError).to.be.undefined
-      expect(result.content[0].text).to.equal('fast result')
     })
   })
 })

--- a/test/unit/shared/transport/curate-html-content.test.ts
+++ b/test/unit/shared/transport/curate-html-content.test.ts
@@ -1,0 +1,65 @@
+import {expect} from 'chai'
+
+import {decodeCurateHtmlContent, encodeCurateHtmlContent} from '../../../../src/shared/transport/curate-html-content.js'
+
+describe('curate-html-content', () => {
+  describe('encodeCurateHtmlContent', () => {
+    it('encodes html and confirmOverwrite as JSON', () => {
+      const encoded = encodeCurateHtmlContent({confirmOverwrite: true, html: '<bv-topic path="x/y"></bv-topic>'})
+      const parsed = JSON.parse(encoded)
+      expect(parsed.html).to.equal('<bv-topic path="x/y"></bv-topic>')
+      expect(parsed.confirmOverwrite).to.equal(true)
+    })
+
+    it('omits confirmOverwrite when undefined', () => {
+      const encoded = encodeCurateHtmlContent({html: '<bv-topic></bv-topic>'})
+      const parsed = JSON.parse(encoded)
+      expect(parsed.html).to.equal('<bv-topic></bv-topic>')
+      expect(parsed.confirmOverwrite).to.be.undefined
+    })
+  })
+
+  describe('decodeCurateHtmlContent', () => {
+    it('decodes JSON-encoded content', () => {
+      const content = JSON.stringify({confirmOverwrite: true, html: '<bv-topic></bv-topic>'})
+      const decoded = decodeCurateHtmlContent(content)
+      expect(decoded.html).to.equal('<bv-topic></bv-topic>')
+      expect(decoded.confirmOverwrite).to.equal(true)
+    })
+
+    it('throws a version-mismatch error on invalid JSON', () => {
+      expect(() => decodeCurateHtmlContent('not-json{')).to.throw(/version mismatch/i)
+    })
+
+    it('throws when payload is JSON but missing string html field', () => {
+      const content = JSON.stringify({confirmOverwrite: true})
+      expect(() => decodeCurateHtmlContent(content)).to.throw(/string `html` field/)
+    })
+
+    it('throws when html field is not a string', () => {
+      const content = JSON.stringify({html: 123})
+      expect(() => decodeCurateHtmlContent(content)).to.throw(/string `html` field/)
+    })
+
+    it('ignores non-boolean confirmOverwrite', () => {
+      const content = JSON.stringify({confirmOverwrite: 'yes', html: '<bv-topic></bv-topic>'})
+      const decoded = decodeCurateHtmlContent(content)
+      expect(decoded.html).to.equal('<bv-topic></bv-topic>')
+      expect(decoded.confirmOverwrite).to.be.undefined
+    })
+
+    it('roundtrips with encodeCurateHtmlContent', () => {
+      const original = {confirmOverwrite: true, html: '<bv-topic path="security/auth"></bv-topic>'}
+      const decoded = decodeCurateHtmlContent(encodeCurateHtmlContent(original))
+      expect(decoded.html).to.equal(original.html)
+      expect(decoded.confirmOverwrite).to.equal(original.confirmOverwrite)
+    })
+
+    it('roundtrips without confirmOverwrite', () => {
+      const original = {html: '<bv-topic path="a/b"></bv-topic>'}
+      const decoded = decodeCurateHtmlContent(encodeCurateHtmlContent(original))
+      expect(decoded.html).to.equal(original.html)
+      expect(decoded.confirmOverwrite).to.be.undefined
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Closes the CLI ↔ MCP provider-gate asymmetry opened by M2. After this PR, MCP `brv-query` and `brv-curate` work end-to-end with **zero providers configured** — same property `brv query` and `brv curate` already have on the CLI side.

- **ENG-2836 (TKT 01)** — `brv-query` MCP tool migrated to `task:create type='query-tool-mode'`.
- **ENG-2837 (TKT 02)** — `brv-curate` MCP tool **replaced** with a single-shot `curate-html-direct` task type (breaking).
- **ENG-2838 (TKT 03)** — MCP e2e harness at `local-auto-test/mcp-tool-mode-e2e/` (lives outside this repo; 11/11 cases pass against this branch).

## Why

| Caller | curate path (before this PR) | query path (before this PR) |
|---|---|---|
| CLI (post-M2) | session protocol — writer-only, provider-free | `query-tool-mode` — BM25 + cache, provider-free |
| MCP | `task:create type='curate'` → `runAgentBody` — **needs provider** | `task:create type='query'` → `executeWithAgent` — **needs provider** |

Phat's "no provider needed" announcement only applied to the CLI. A user disconnecting providers and switching to Claude Desktop / Cursor MCP would have hit a confusing failure mode. This PR closes the gap.

## Changes

### Shared transport
- **New** `src/shared/transport/curate-html-content.ts` — JSON encode/decode for the `{html, confirmOverwrite?}` payload (sibling to `query-tool-mode-content.ts`; throws with a rebuild hint on malformed JSON).
- `src/shared/transport/events/task-events.ts` — `'curate-html-direct'` added to `TaskCreateRequest.type` union.

### Daemon
- `src/server/core/interfaces/executor/i-curate-executor.ts` — new `CurateHtmlDirectResult` envelope (`{status: 'ok', filePath, topicPath, overwrote}` | `{status: 'validation-failed', errors}`).
- `src/server/core/domain/transport/schemas.ts` — `'curate-html-direct'` added to `TaskTypeSchema` + `TaskExecuteSchema.type` (zod).
- `src/server/infra/daemon/agent-process.ts`:
  - Provider-gate skip-list extended: `if (type !== 'search' && type !== 'query-tool-mode' && type !== 'curate-html-direct')`.
  - New switch case: decode payload → pre-validate via `validateHtmlTopic` to detect `overwrote` → call `writeHtmlTopic` → stringify envelope. Emits `task:completed` on validation failure (not `task:error`) so MCP hosts surface the structured errors instead of collapsing the response.

### MCP tools
- `brv-query-tool.ts` — submits `'query-tool-mode'`; renders the envelope as one `## <title>` section per match with the `rendered_md` body + a `_Matched N topic(s) in Xms (tier T)._` trailer. `no-matches` returns a short text line, **not** `isError`. New optional `limit` (1–50). Malformed envelope → `isError: true` with the rebuild hint.
- `brv-curate-tool.ts`:
  - **Breaking** input schema: `{cwd, html, confirmOverwrite?}`. Drops `context`, `files`, `folder`. Calling agents on the old shape get a zod error pointing at the new schema. **No coexistence window, no `BRV_*` escape hatch** — matches the M3 oclif spirit.
  - Submits `'curate-html-direct'`. Renders `✓ Wrote` / `✓ Replaced` on success, one `✗ <kind>: <message>` per error on validation failure (with `path-exists` inlining `existingContent` as a fenced ` ```html ` block).
  - **Tool description is self-contained**: embeds the full `<bv-topic>` vocabulary slice (derived from `ELEMENT_REGISTRY` via `CURATE_SCHEMA_PROMPT` — same source the CLI's curate prompt builder uses, so MCP and CLI never drift) plus a minimal worked example. Critical because MCP and SKILL.md are disjoint install surfaces — a user who installs `--type mcp` typically never sees SKILL.md. The vocabulary slice is also appended to validation-failed responses so the agent has the schema in-context during retry.

## Breaking change

`brv-curate`'s input schema changed. Calling MCP integrations that submit the old `{context?, files?, folder?}` shape will get a zod validation error. This is intentional and lands in a single PR per the M3 plan (no compat shim, no opt-in env var). Two-tool curate-session-over-MCP (option A from the design memo) was rejected in favour of single-shot HTML-direct (option C) for simplicity.

## Tests

- **Unit** — 6928 / 6928 pass. Touched suites:
  - `test/unit/shared/transport/curate-html-content.test.ts` — new (9 cases).
  - `test/unit/infra/mcp/tools/brv-curate-tool.test.ts` — rewritten (27 cases) including legacy-shape rejection sentinel, tool-description self-containment regression guards (`<bv-decision>`, `<bv-rule>`, "Element vocabulary", "no LLM provider required", worked example), each `HtmlWriteError` variant rendering, and `isError: false` on validation-failed.
  - `test/unit/infra/mcp/tools/brv-query-tool.test.ts` — rewritten (26 cases) covering schema, dispatch shape, envelope rendering for `ok` / `no-matches` / malformed, listener ordering.
- **End-to-end** — `~/workspaces/local-auto-test/mcp-tool-mode-e2e/` (ENG-2838). 11/11 cases pass on this branch, including the two negative sanity checks (no legacy task types submitted, no LLM-dispatch signals on any persisted task entry).

## Test plan for reviewers

- [ ] CI green
- [ ] `npm run lint && npm run test` clean on this branch
- [ ] Pull this branch + run `node ~/workspaces/local-auto-test/mcp-tool-mode-e2e/run.mjs` — expect 11/11 pass
- [ ] Manual coding-agent test per `plans/03-mcp-migration/manual-test.md` (Phase 1, Claude Code, ~30 min)

## Out of scope (M4 cleanup)

- Removing the legacy `case 'curate'` / `case 'curate-folder'` daemon handlers. The CLI's session protocol still relies on `runAgentBody` for other code paths; removal is tracked separately once the MCP migration window closes.
- `files` / `folder` support in the new MCP shape — deferred per the M3 decision; revisit if calling MCP clients ask for it.
- Real Claude Desktop / Cursor host integration tests — covered by the manual plan, not by automation in this milestone.

## Related

- Milestone plan: `plans/03-mcp-migration/plan.md`
- Manual test plan: `plans/03-mcp-migration/manual-test.md`
- Predecessor milestones: M1 (curate tool mode), M2 (query tool mode), ENG-2810 (HITL — merged via #654)
