### PR TITLE
feat: [ENG-2512] split useBillingDisplay + honor pinned free team for top-up URL

### DIFF
--- a/src/webui/features/provider/components/provider-flow/provider-select-step.tsx
+++ b/src/webui/features/provider/components/provider-flow/provider-select-step.tsx
@@ -67,14 +67,14 @@ export function ProviderSelectStep({onSelect, providers}: ProviderSelectStepProp
     () => providers.find((p) => p.id === BYTEROVER_PROVIDER_ID && p.isCurrent),
     [providers],
   )
-  const {billingSource: usage, billingTone, paidOrg} = useBillingDisplay({
+  const {billedOrgId, billingSource: usage, billingTone} = useBillingDisplay({
     preferredOrgId: pinnedData?.teamId,
   })
   const isExhausted = byteRoverActive !== undefined && billingTone === 'danger' && usage !== undefined
 
   const {data: envConfig} = useGetEnvironmentConfig()
   const {data: teamsData} = useListTeams()
-  const teamSlug = teamsData?.teams?.find((t) => t.id === paidOrg?.organizationId)?.slug
+  const teamSlug = teamsData?.teams?.find((t) => t.id === billedOrgId)?.slug
   const topUpUrl = buildTopUpUrl({teamSlug, webAppUrl: envConfig?.webAppUrl})
 
   const filtered = useMemo(() => {

--- a/src/webui/features/provider/hooks/use-billing-display.ts
+++ b/src/webui/features/provider/hooks/use-billing-display.ts
@@ -20,13 +20,13 @@ export function useBillingDisplay({preferredOrgId}: {preferredOrgId?: string} = 
   const {hasPaidTeam, isLoaded, paidOrganizationIds, usagesByOrg} = useBillingUsages()
   const freeMonthly = useFreeMonthlyCredits({enabled: isLoaded && !hasPaidTeam})
 
-  const resolvedTeam = resolveBilledTeam({hasPaidTeam, paidOrganizationIds, preferredOrgId, usagesByOrg})
+  const resolvedTeam = resolveBilledTeam({paidOrganizationIds, preferredOrgId, usagesByOrg})
   const isPaidOrg = resolvedTeam !== undefined && resolvedTeam.tier !== 'FREE'
   const billingSource: BillingToneInput | undefined = resolvedTeam ?? freeMonthly
   const paidOrg = isPaidOrg ? resolvedTeam : undefined
 
   return {
-    billedOrgId: preferredOrgId ?? paidOrg?.organizationId,
+    billedOrgId: resolvedTeam?.organizationId ?? preferredOrgId,
     billingSource,
     billingTone: getBillingTone(billingSource),
     hasPaidTeam,

--- a/src/webui/features/provider/hooks/use-billing-display.ts
+++ b/src/webui/features/provider/hooks/use-billing-display.ts
@@ -1,12 +1,12 @@
 import type {BillingUsageDTO} from '../../../../shared/transport/types/dto'
 
-import {useAuthStore} from '../../auth/stores/auth-store'
-import {useGetFreeUserLimit} from '../api/get-free-user-limit'
-import {useListBillingUsage} from '../api/list-billing-usage'
 import {type BillingTone, type BillingToneInput, getBillingTone} from '../utils/get-billing-tone'
-import {getPaidOrganizationIds} from '../utils/has-paid-team'
+import {resolveBilledTeam} from '../utils/resolve-billed-team'
+import {useBillingUsages} from './use-billing-usages'
+import {useFreeMonthlyCredits} from './use-free-monthly-credits'
 
 export interface BillingDisplay {
+  billedOrgId?: string
   billingSource?: BillingToneInput
   billingTone: BillingTone
   hasPaidTeam: boolean
@@ -17,32 +17,21 @@ export interface BillingDisplay {
 }
 
 export function useBillingDisplay({preferredOrgId}: {preferredOrgId?: string} = {}): BillingDisplay {
-  const isAuthorized = useAuthStore((s) => s.isAuthorized)
+  const {hasPaidTeam, isLoaded, paidOrganizationIds, usagesByOrg} = useBillingUsages()
+  const freeMonthly = useFreeMonthlyCredits({enabled: isLoaded && !hasPaidTeam})
 
-  const {data: usagesData} = useListBillingUsage({enabled: isAuthorized})
-  const usagesByOrg = usagesData?.usage ?? {}
-  const paidOrganizationIds = getPaidOrganizationIds(usagesByOrg)
-  const hasPaidTeam = paidOrganizationIds.length > 0
-
-  const {data: freeData} = useGetFreeUserLimit({
-    enabled: isAuthorized && usagesData !== undefined && !hasPaidTeam,
-  })
-  const freeMonthly = freeData?.limit?.monthly
-
-  const pinUsage = preferredOrgId ? usagesByOrg[preferredOrgId] : undefined
-  const autoPickUsage = paidOrganizationIds.length === 1 ? usagesByOrg[paidOrganizationIds[0]] : undefined
-  const resolvedTeam = hasPaidTeam ? (pinUsage ?? autoPickUsage) : undefined
+  const resolvedTeam = resolveBilledTeam({hasPaidTeam, paidOrganizationIds, preferredOrgId, usagesByOrg})
   const isPaidOrg = resolvedTeam !== undefined && resolvedTeam.tier !== 'FREE'
   const billingSource: BillingToneInput | undefined = resolvedTeam ?? freeMonthly
-  const billingTone = getBillingTone(billingSource)
-  const needsPickPrompt = paidOrganizationIds.length > 1 && resolvedTeam === undefined
+  const paidOrg = isPaidOrg ? resolvedTeam : undefined
 
   return {
+    billedOrgId: preferredOrgId ?? paidOrg?.organizationId,
     billingSource,
-    billingTone,
+    billingTone: getBillingTone(billingSource),
     hasPaidTeam,
-    needsPickPrompt,
-    paidOrg: isPaidOrg ? resolvedTeam : undefined,
+    needsPickPrompt: paidOrganizationIds.length > 1 && resolvedTeam === undefined,
+    paidOrg,
     showCreditPill: billingSource !== undefined,
     usagesByOrg,
   }

--- a/src/webui/features/provider/hooks/use-billing-usages.ts
+++ b/src/webui/features/provider/hooks/use-billing-usages.ts
@@ -1,0 +1,25 @@
+import type {BillingUsageDTO} from '../../../../shared/transport/types/dto'
+
+import {useAuthStore} from '../../auth/stores/auth-store'
+import {useListBillingUsage} from '../api/list-billing-usage'
+import {getPaidOrganizationIds} from '../utils/has-paid-team'
+
+export interface BillingUsagesState {
+  hasPaidTeam: boolean
+  isLoaded: boolean
+  paidOrganizationIds: string[]
+  usagesByOrg: Record<string, BillingUsageDTO>
+}
+
+export function useBillingUsages(): BillingUsagesState {
+  const isAuthorized = useAuthStore((s) => s.isAuthorized)
+  const {data} = useListBillingUsage({enabled: isAuthorized})
+  const usagesByOrg = data?.usage ?? {}
+  const paidOrganizationIds = getPaidOrganizationIds(usagesByOrg)
+  return {
+    hasPaidTeam: paidOrganizationIds.length > 0,
+    isLoaded: data !== undefined,
+    paidOrganizationIds,
+    usagesByOrg,
+  }
+}

--- a/src/webui/features/provider/hooks/use-free-monthly-credits.ts
+++ b/src/webui/features/provider/hooks/use-free-monthly-credits.ts
@@ -1,10 +1,8 @@
 import type {BillingFreeUserLimitDTO} from '../../../../shared/transport/types/dto'
 
-import {useAuthStore} from '../../auth/stores/auth-store'
 import {useGetFreeUserLimit} from '../api/get-free-user-limit'
 
 export function useFreeMonthlyCredits({enabled}: {enabled: boolean}): BillingFreeUserLimitDTO['monthly'] | undefined {
-  const isAuthorized = useAuthStore((s) => s.isAuthorized)
-  const {data} = useGetFreeUserLimit({enabled: isAuthorized && enabled})
+  const {data} = useGetFreeUserLimit({enabled})
   return data?.limit?.monthly
 }

--- a/src/webui/features/provider/hooks/use-free-monthly-credits.ts
+++ b/src/webui/features/provider/hooks/use-free-monthly-credits.ts
@@ -1,0 +1,10 @@
+import type {BillingFreeUserLimitDTO} from '../../../../shared/transport/types/dto'
+
+import {useAuthStore} from '../../auth/stores/auth-store'
+import {useGetFreeUserLimit} from '../api/get-free-user-limit'
+
+export function useFreeMonthlyCredits({enabled}: {enabled: boolean}): BillingFreeUserLimitDTO['monthly'] | undefined {
+  const isAuthorized = useAuthStore((s) => s.isAuthorized)
+  const {data} = useGetFreeUserLimit({enabled: isAuthorized && enabled})
+  return data?.limit?.monthly
+}

--- a/src/webui/features/provider/utils/resolve-billed-team.ts
+++ b/src/webui/features/provider/utils/resolve-billed-team.ts
@@ -1,13 +1,12 @@
 import type {BillingUsageDTO} from '../../../../shared/transport/types/dto'
 
 export function resolveBilledTeam(args: {
-  hasPaidTeam: boolean
   paidOrganizationIds: readonly string[]
   preferredOrgId?: string
   usagesByOrg: Record<string, BillingUsageDTO>
 }): BillingUsageDTO | undefined {
-  const {hasPaidTeam, paidOrganizationIds, preferredOrgId, usagesByOrg} = args
-  if (!hasPaidTeam) return undefined
+  const {paidOrganizationIds, preferredOrgId, usagesByOrg} = args
+  if (paidOrganizationIds.length === 0) return undefined
   const pinUsage = preferredOrgId ? usagesByOrg[preferredOrgId] : undefined
   const autoPickUsage = paidOrganizationIds.length === 1 ? usagesByOrg[paidOrganizationIds[0]] : undefined
   return pinUsage ?? autoPickUsage

--- a/src/webui/features/provider/utils/resolve-billed-team.ts
+++ b/src/webui/features/provider/utils/resolve-billed-team.ts
@@ -1,0 +1,14 @@
+import type {BillingUsageDTO} from '../../../../shared/transport/types/dto'
+
+export function resolveBilledTeam(args: {
+  hasPaidTeam: boolean
+  paidOrganizationIds: readonly string[]
+  preferredOrgId?: string
+  usagesByOrg: Record<string, BillingUsageDTO>
+}): BillingUsageDTO | undefined {
+  const {hasPaidTeam, paidOrganizationIds, preferredOrgId, usagesByOrg} = args
+  if (!hasPaidTeam) return undefined
+  const pinUsage = preferredOrgId ? usagesByOrg[preferredOrgId] : undefined
+  const autoPickUsage = paidOrganizationIds.length === 1 ? usagesByOrg[paidOrganizationIds[0]] : undefined
+  return pinUsage ?? autoPickUsage
+}

--- a/src/webui/layouts/header.tsx
+++ b/src/webui/layouts/header.tsx
@@ -67,13 +67,13 @@ export function Header() {
 
   const {data: teamsData} = useListTeams()
 
-  const {billingSource, billingTone, needsPickPrompt, paidOrg, showCreditPill: hasBillingData} = useBillingDisplay({
+  const {billedOrgId, billingSource, billingTone, needsPickPrompt, showCreditPill: hasBillingData} = useBillingDisplay({
     preferredOrgId: pinnedData?.teamId,
   })
   const showCreditPill = isByteRoverActive && hasBillingData
 
   const {data: envConfig} = useGetEnvironmentConfig()
-  const teamSlug = teamsData?.teams?.find((t) => t.id === paidOrg?.organizationId)?.slug
+  const teamSlug = teamsData?.teams?.find((t) => t.id === billedOrgId)?.slug
   const topUpUrl = buildTopUpUrl({teamSlug, webAppUrl: envConfig?.webAppUrl})
 
   const needsAttention = !activeProvider || (isByteRoverActive && needsPickPrompt)

--- a/test/unit/webui/features/provider/utils/resolve-billed-team.test.ts
+++ b/test/unit/webui/features/provider/utils/resolve-billed-team.test.ts
@@ -1,0 +1,91 @@
+import {expect} from 'chai'
+
+import type {BillingUsageDTO} from '../../../../../../src/shared/transport/types/dto'
+
+import {resolveBilledTeam} from '../../../../../../src/webui/features/provider/utils/resolve-billed-team'
+
+function makeUsage(id: string, tier: 'FREE' | 'PRO' | 'TEAM' = 'TEAM'): BillingUsageDTO {
+  return {
+    addOnRemaining: 0,
+    isTrialing: false,
+    limit: 100_000,
+    limitExceeded: false,
+    organizationId: id,
+    organizationName: id,
+    organizationStatus: 'ACTIVE',
+    percentUsed: 0,
+    remaining: 100_000,
+    tier,
+    totalLimit: 100_000,
+    used: 0,
+  }
+}
+
+describe('resolveBilledTeam', () => {
+  it('returns undefined when there are no paid teams', () => {
+    const result = resolveBilledTeam({
+      paidOrganizationIds: [],
+      preferredOrgId: 'any-id',
+      usagesByOrg: {'any-id': makeUsage('any-id', 'FREE')},
+    })
+    expect(result).to.equal(undefined)
+  })
+
+  it('auto-picks the single paid team when no pin is provided', () => {
+    const usage = makeUsage('A')
+    const result = resolveBilledTeam({
+      paidOrganizationIds: ['A'],
+      usagesByOrg: {A: usage},
+    })
+    expect(result).to.equal(usage)
+  })
+
+  it('honors a valid pin to a paid team', () => {
+    const a = makeUsage('A')
+    const b = makeUsage('B')
+    const result = resolveBilledTeam({
+      paidOrganizationIds: ['A', 'B'],
+      preferredOrgId: 'B',
+      usagesByOrg: {A: a, B: b},
+    })
+    expect(result).to.equal(b)
+  })
+
+  it('honors a pin to a free-tier team when paid teams exist (visual pin)', () => {
+    const a = makeUsage('A')
+    const free = makeUsage('free', 'FREE')
+    const result = resolveBilledTeam({
+      paidOrganizationIds: ['A'],
+      preferredOrgId: 'free',
+      usagesByOrg: {A: a, free},
+    })
+    expect(result).to.equal(free)
+  })
+
+  it('falls through to auto-pick when pin is stale and there is exactly one paid team', () => {
+    const a = makeUsage('A')
+    const result = resolveBilledTeam({
+      paidOrganizationIds: ['A'],
+      preferredOrgId: 'stale-id',
+      usagesByOrg: {A: a},
+    })
+    expect(result).to.equal(a)
+  })
+
+  it('returns undefined when there are 2+ paid teams and no valid pin', () => {
+    const result = resolveBilledTeam({
+      paidOrganizationIds: ['A', 'B'],
+      usagesByOrg: {A: makeUsage('A'), B: makeUsage('B')},
+    })
+    expect(result).to.equal(undefined)
+  })
+
+  it('returns undefined when pin is stale and there are 2+ paid teams (no auto-pick)', () => {
+    const result = resolveBilledTeam({
+      paidOrganizationIds: ['A', 'B'],
+      preferredOrgId: 'stale-id',
+      usagesByOrg: {A: makeUsage('A'), B: makeUsage('B')},
+    })
+    expect(result).to.equal(undefined)
+  })
+})


### PR DESCRIPTION
## Summary
- Refactor \`useBillingDisplay\` into three focused pieces:
  - \`useBillingUsages\` — data hook for the org list + derived \`paidOrganizationIds\` / \`hasPaidTeam\`.
  - \`useFreeMonthlyCredits\` — data hook for free monthly with the conditional fetch gate.
  - \`resolveBilledTeam\` — pure helper for the pin → auto-pick → undefined resolution (unit-testable in isolation).
- \`useBillingDisplay\` is now a thin composer; gains a derived \`billedOrgId\` field so callers don't re-derive \`pin ?? paidOrg\`.
- Fix: header + provider-select-step now look up the top-up team slug by \`billedOrgId\` (pin first, paid auto-pick fallback) so a user who explicitly pinned a free team still gets a working Top up button — previously the slug lookup used only \`paidOrg.organizationId\`, which is undefined for free pins.

## Test plan
- [ ] Pin a paid team → header shows paid team's credits; top-up link in tooltip points to that team
- [ ] No pin + 1 paid team → header auto-picks; top-up still points to that team
- [ ] Pin a free team → header reflects pin (0 credits, danger tone); Top up tooltip now shows clickable link pointing to that free team
- [ ] No pin + 2+ paid teams → amber "Select a team" tooltip; no top-up link (server can't disambiguate)
- [ ] 0 paid teams → free monthly credits shown; no top-up link