### PR TITLE
feat: [ENG-2621] add analytics settings panel to webui Configuration page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "@ai-sdk/xai": "^2.0.57",
         "@anthropic-ai/sdk": "^0.70.1",
         "@campfirein/brv-transport-client": "github:campfirein/brv-transport-client#1.1.0",
-        "@campfirein/byterover-packages": "github:campfirein/byterover-packages#1.0.2",
+        "@campfirein/byterover-packages": "github:campfirein/byterover-packages#1.0.4",
         "@google/genai": "^1.29.0",
         "@inkjs/ui": "^2.0.0",
         "@inquirer/prompts": "^7.9.0",
@@ -3355,7 +3355,7 @@
     },
     "node_modules/@campfirein/byterover-packages": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/campfirein/byterover-packages.git#bbd9b8854cd951d47a9e26d8a0b1ad7119307f25",
+      "resolved": "git+ssh://git@github.com/campfirein/byterover-packages.git#58ef81f48b5ebc6cf2138a9b07ad874dd2c52a3c",
       "inBundle": true,
       "dependencies": {
         "@base-ui/react": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@ai-sdk/xai": "^2.0.57",
     "@anthropic-ai/sdk": "^0.70.1",
     "@campfirein/brv-transport-client": "github:campfirein/brv-transport-client#1.1.0",
-    "@campfirein/byterover-packages": "github:campfirein/byterover-packages#1.0.2",
+    "@campfirein/byterover-packages": "github:campfirein/byterover-packages#1.0.4",
     "@google/genai": "^1.29.0",
     "@inkjs/ui": "^2.0.0",
     "@inquirer/prompts": "^7.9.0",

--- a/src/webui/features/analytics/api/get-global-config.ts
+++ b/src/webui/features/analytics/api/get-global-config.ts
@@ -1,0 +1,32 @@
+import {queryOptions, useQuery} from '@tanstack/react-query'
+
+import type {QueryConfig} from '../../../lib/react-query'
+
+import {
+  GlobalConfigEvents,
+  type GlobalConfigGetResponse,
+} from '../../../../shared/transport/events/global-config-events.js'
+import {useTransportStore} from '../../../stores/transport-store'
+
+export const getGlobalConfig = async (): Promise<GlobalConfigGetResponse> => {
+  const {apiClient} = useTransportStore.getState()
+  if (!apiClient) throw new Error('Not connected')
+  return apiClient.request<GlobalConfigGetResponse, void>(GlobalConfigEvents.GET)
+}
+
+export const getGlobalConfigQueryOptions = () =>
+  queryOptions({
+    queryFn: getGlobalConfig,
+    queryKey: ['globalConfig'],
+    staleTime: 5000,
+  })
+
+type UseGetGlobalConfigOptions = {
+  queryConfig?: QueryConfig<typeof getGlobalConfigQueryOptions>
+}
+
+export const useGetGlobalConfig = ({queryConfig}: UseGetGlobalConfigOptions = {}) =>
+  useQuery({
+    ...getGlobalConfigQueryOptions(),
+    ...queryConfig,
+  })

--- a/src/webui/features/analytics/api/get-global-config.ts
+++ b/src/webui/features/analytics/api/get-global-config.ts
@@ -19,7 +19,6 @@ export const getGlobalConfigQueryOptions = () =>
     queryFn: getGlobalConfig,
     queryKey: ['globalConfig'],
     refetchOnWindowFocus: true,
-    staleTime: 5000,
   })
 
 type UseGetGlobalConfigOptions = {

--- a/src/webui/features/analytics/api/get-global-config.ts
+++ b/src/webui/features/analytics/api/get-global-config.ts
@@ -8,9 +8,9 @@ import {
 } from '../../../../shared/transport/events/global-config-events.js'
 import {useTransportStore} from '../../../stores/transport-store'
 
-export const getGlobalConfig = async (): Promise<GlobalConfigGetResponse> => {
+export const getGlobalConfig = (): Promise<GlobalConfigGetResponse> => {
   const {apiClient} = useTransportStore.getState()
-  if (!apiClient) throw new Error('Not connected')
+  if (!apiClient) return Promise.reject(new Error('Not connected'))
   return apiClient.request<GlobalConfigGetResponse, void>(GlobalConfigEvents.GET)
 }
 
@@ -18,6 +18,7 @@ export const getGlobalConfigQueryOptions = () =>
   queryOptions({
     queryFn: getGlobalConfig,
     queryKey: ['globalConfig'],
+    refetchOnWindowFocus: true,
     staleTime: 5000,
   })
 

--- a/src/webui/features/analytics/api/set-analytics.ts
+++ b/src/webui/features/analytics/api/set-analytics.ts
@@ -1,0 +1,40 @@
+import {useMutation, useQueryClient} from '@tanstack/react-query'
+
+import type {MutationConfig} from '../../../lib/react-query'
+
+import {
+  GlobalConfigEvents,
+  type GlobalConfigSetAnalyticsRequest,
+  type GlobalConfigSetAnalyticsResponse,
+} from '../../../../shared/transport/events/global-config-events.js'
+import {useTransportStore} from '../../../stores/transport-store'
+import {getGlobalConfigQueryOptions} from './get-global-config'
+
+export const setAnalytics = (
+  request: GlobalConfigSetAnalyticsRequest,
+): Promise<GlobalConfigSetAnalyticsResponse> => {
+  const {apiClient} = useTransportStore.getState()
+  if (!apiClient) return Promise.reject(new Error('Not connected'))
+  return apiClient.request<GlobalConfigSetAnalyticsResponse, GlobalConfigSetAnalyticsRequest>(
+    GlobalConfigEvents.SET_ANALYTICS,
+    request,
+  )
+}
+
+type UseSetAnalyticsOptions = {
+  mutationConfig?: MutationConfig<typeof setAnalytics>
+}
+
+export const useSetAnalytics = ({mutationConfig}: UseSetAnalyticsOptions = {}) => {
+  const queryClient = useQueryClient()
+  const {onSuccess, ...rest} = mutationConfig ?? {}
+
+  return useMutation({
+    onSuccess(...args) {
+      queryClient.invalidateQueries({queryKey: getGlobalConfigQueryOptions().queryKey})
+      onSuccess?.(...args)
+    },
+    ...rest,
+    mutationFn: setAnalytics,
+  })
+}

--- a/src/webui/features/analytics/components/analytics-panel.tsx
+++ b/src/webui/features/analytics/components/analytics-panel.tsx
@@ -32,11 +32,10 @@ export function AnalyticsPanel() {
     try {
       await setAnalytics.mutateAsync({analytics: next})
       toast.success(next ? 'Analytics enabled.' : 'Analytics disabled.')
-      setPendingIntent(undefined)
     } catch (error_) {
       toast.error(formatError(error_, 'Failed to update analytics setting.'))
+    } finally {
       setPendingIntent(undefined)
-      throw error_
     }
   }
 
@@ -69,7 +68,9 @@ export function AnalyticsPanel() {
         <div className="bg-card flex flex-col rounded-xl border">
           <div className="flex items-start justify-between gap-4 px-5 py-4">
             <div className="flex min-w-0 flex-col">
-              <span className="text-foreground text-sm font-medium">Share usage analytics</span>
+              <span className="text-foreground text-sm font-medium" id="analytics-switch-label">
+                Share usage analytics
+              </span>
               <span className="text-muted-foreground mt-0.5 text-[0.8125rem] leading-snug">
                 Help us build a better Byterover by sharing your usage insights securely.
               </span>
@@ -78,6 +79,7 @@ export function AnalyticsPanel() {
               <Skeleton className="h-[18.4px] w-8 rounded-full" />
             ) : (
               <Switch
+                aria-labelledby="analytics-switch-label"
                 checked={analytics}
                 disabled={setAnalytics.isPending}
                 onCheckedChange={requestToggle}
@@ -105,8 +107,8 @@ export function AnalyticsPanel() {
             rel="noopener noreferrer"
             target="_blank"
           >
-            <ExternalLink className="size-3.5 text-primary-foreground" />
-            <span className="text-primary-foreground">docs.byterover.dev/privacy</span>
+            <ExternalLink className="size-3.5 text-primary" />
+            <span className="text-primary">docs.byterover.dev/privacy</span>
           </a>
         </div>
       )}

--- a/src/webui/features/analytics/components/analytics-panel.tsx
+++ b/src/webui/features/analytics/components/analytics-panel.tsx
@@ -1,0 +1,128 @@
+import {Collapsible, CollapsibleContent, CollapsibleTrigger} from '@campfirein/byterover-packages/components/collapsible'
+import {Skeleton} from '@campfirein/byterover-packages/components/skeleton'
+import {Switch} from '@campfirein/byterover-packages/components/switch'
+import {ChevronDown, ExternalLink, ShieldCheck} from 'lucide-react'
+import {useState} from 'react'
+import {toast} from 'sonner'
+
+import {formatError} from '../../../lib/error-messages'
+import {noop} from '../../../lib/noop'
+import {useGetGlobalConfig} from '../api/get-global-config'
+import {useSetAnalytics} from '../api/set-analytics'
+import {ANALYTICS_PRIVACY_URL} from '../constants'
+import {DisableConfirmDialog} from './disable-confirm-dialog'
+import {DisclosureDetails} from './disclosure-details'
+import {EnableConfirmDialog} from './enable-confirm-dialog'
+
+export function AnalyticsPanel() {
+  const {data, error, isError, isLoading, refetch} = useGetGlobalConfig()
+  const setAnalytics = useSetAnalytics()
+  const [pendingIntent, setPendingIntent] = useState<'disable' | 'enable' | undefined>()
+  const [detailsOpen, setDetailsOpen] = useState(false)
+
+  const analytics = data?.analytics ?? false
+
+  function requestToggle(next: boolean) {
+    if (setAnalytics.isPending) return
+    if (analytics === next) return
+    setPendingIntent(next ? 'enable' : 'disable')
+  }
+
+  async function applyChange(next: boolean) {
+    try {
+      await setAnalytics.mutateAsync({analytics: next})
+      toast.success(next ? 'Analytics enabled.' : 'Analytics disabled.')
+      setPendingIntent(undefined)
+    } catch (error_) {
+      toast.error(formatError(error_, 'Failed to update analytics setting.'))
+      setPendingIntent(undefined)
+      throw error_
+    }
+  }
+
+  function handleDialogOpenChange(open: boolean) {
+    if (!open && !setAnalytics.isPending) setPendingIntent(undefined)
+  }
+
+  return (
+    <div className="flex w-full flex-col gap-3.5">
+      <div className="flex flex-col">
+        <h2 className="text-foreground text-[0.95rem] font-semibold leading-tight">Analytics</h2>
+        <p className="text-muted-foreground mt-0.5 text-[0.8125rem] leading-snug">
+          Control how usage data is collected to improve Byterover.
+        </p>
+      </div>
+
+      {isError ? (
+        <p className="text-destructive text-sm">
+          ✗ {formatError(error, 'Failed to load analytics state')}
+          {' · '}
+          <button
+            className="underline underline-offset-2"
+            onClick={() => refetch().catch(noop)}
+            type="button"
+          >
+            retry
+          </button>
+        </p>
+      ) : (
+        <div className="bg-card flex flex-col rounded-xl border">
+          <div className="flex items-start justify-between gap-4 px-5 py-4">
+            <div className="flex min-w-0 flex-col">
+              <span className="text-foreground text-sm font-medium">Share usage analytics</span>
+              <span className="text-muted-foreground mt-0.5 text-[0.8125rem] leading-snug">
+                Help us build a better Byterover by sharing your usage insights securely.
+              </span>
+            </div>
+            {isLoading ? (
+              <Skeleton className="h-[18.4px] w-8 rounded-full" />
+            ) : (
+              <Switch
+                checked={analytics}
+                disabled={setAnalytics.isPending}
+                onCheckedChange={requestToggle}
+              />
+            )}
+          </div>
+
+          <Collapsible onOpenChange={setDetailsOpen} open={detailsOpen}>
+            <CollapsibleTrigger className="text-foreground hover:bg-muted/40 group flex w-full cursor-pointer items-center gap-2.5 border-t px-5 py-3 text-left text-sm transition-colors">
+              <ShieldCheck className="text-muted-foreground size-4" strokeWidth={1.75} />
+              <span className="flex-1">What data will be collected?</span>
+              <span className="text-muted-foreground flex items-center gap-1 text-xs">
+                {detailsOpen ? 'Hide details' : 'Show details'}
+                <ChevronDown className="size-3.5 transition-transform group-data-[panel-open]:rotate-180" />
+              </span>
+            </CollapsibleTrigger>
+            <CollapsibleContent className="border-t px-5 py-5">
+              <DisclosureDetails />
+            </CollapsibleContent>
+          </Collapsible>
+
+          <a
+            className="text-foreground/80 hover:text-foreground inline-flex items-center gap-2 border-t px-5 py-3 text-sm transition-colors"
+            href={ANALYTICS_PRIVACY_URL}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <ExternalLink className="size-3.5 text-primary-foreground" />
+            <span className="text-primary-foreground">docs.byterover.dev/privacy</span>
+          </a>
+        </div>
+      )}
+
+      <EnableConfirmDialog
+        isPending={setAnalytics.isPending}
+        onConfirm={() => applyChange(true)}
+        onOpenChange={handleDialogOpenChange}
+        open={pendingIntent === 'enable'}
+      />
+      <DisableConfirmDialog
+        isPending={setAnalytics.isPending}
+        onConfirm={() => applyChange(false)}
+        onOpenChange={handleDialogOpenChange}
+        open={pendingIntent === 'disable'}
+      />
+    </div>
+  )
+}

--- a/src/webui/features/analytics/components/disable-confirm-dialog.tsx
+++ b/src/webui/features/analytics/components/disable-confirm-dialog.tsx
@@ -1,0 +1,43 @@
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@campfirein/byterover-packages/components/alert-dialog'
+import {Button} from '@campfirein/byterover-packages/components/button'
+
+import {noop} from '../../../lib/noop'
+
+type Props = {
+  isPending: boolean
+  onConfirm: () => Promise<void>
+  onOpenChange: (open: boolean) => void
+  open: boolean
+}
+
+export function DisableConfirmDialog({isPending, onConfirm, onOpenChange, open}: Props) {
+  function fire() {
+    onConfirm().catch(noop)
+  }
+
+  return (
+    <AlertDialog onOpenChange={onOpenChange} open={open}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Stop sharing usage analytics?</AlertDialogTitle>
+          <AlertDialogDescription>You can re-enable this at any time from this page.</AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+          <Button disabled={isPending} onClick={fire} variant="destructive">
+            {isPending ? 'Disabling…' : 'Disable analytics'}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/src/webui/features/analytics/components/disclosure-details.tsx
+++ b/src/webui/features/analytics/components/disclosure-details.tsx
@@ -1,0 +1,22 @@
+import {ANALYTICS_DISCLOSURE_SECTIONS} from '../constants'
+
+export function DisclosureDetails() {
+  return (
+    <div className="grid grid-cols-1 gap-x-6 gap-y-5 md:grid-cols-2">
+      {ANALYTICS_DISCLOSURE_SECTIONS.map((section) => {
+        const Icon = section.icon
+        return (
+          <div className="flex flex-col gap-2" key={section.label}>
+            <Icon className="size-4 text-muted-foreground" strokeWidth={1.75} />
+            <div className="flex flex-col gap-1">
+              <span className="text-foreground text-[0.6875rem] font-semibold tracking-wider">
+                {section.label}
+              </span>
+              <p className="text-muted-foreground text-[0.8125rem] leading-relaxed">{section.body}</p>
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/webui/features/analytics/components/enable-confirm-dialog.tsx
+++ b/src/webui/features/analytics/components/enable-confirm-dialog.tsx
@@ -1,0 +1,50 @@
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@campfirein/byterover-packages/components/alert-dialog'
+import {Button} from '@campfirein/byterover-packages/components/button'
+
+import {noop} from '../../../lib/noop'
+import {DisclosureDetails} from './disclosure-details'
+
+type Props = {
+  isPending: boolean
+  onConfirm: () => Promise<void>
+  onOpenChange: (open: boolean) => void
+  open: boolean
+}
+
+export function EnableConfirmDialog({isPending, onConfirm, onOpenChange, open}: Props) {
+  function fire() {
+    onConfirm().catch(noop)
+  }
+
+  return (
+    <AlertDialog onOpenChange={onOpenChange} open={open}>
+      <AlertDialogContent className="max-w-2xl">
+        <AlertDialogHeader>
+          <AlertDialogTitle>Share usage analytics with Byterover?</AlertDialogTitle>
+          <AlertDialogDescription>
+            Review what is collected before enabling. You can turn this off at any time.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <div className="py-2">
+          <DisclosureDetails />
+        </div>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+          <Button disabled={isPending} onClick={fire}>
+            {isPending ? 'Enabling…' : 'Enable analytics'}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/src/webui/features/analytics/constants.ts
+++ b/src/webui/features/analytics/constants.ts
@@ -1,0 +1,39 @@
+import type {LucideIcon} from 'lucide-react'
+
+import {Database, Eye, Link2, PowerOff, Server} from 'lucide-react'
+
+export type AnalyticsDisclosureSection = {
+  body: string
+  icon: LucideIcon
+  label: string
+}
+
+export const ANALYTICS_PRIVACY_URL = 'https://docs.byterover.dev/privacy'
+
+export const ANALYTICS_DISCLOSURE_SECTIONS: readonly AnalyticsDisclosureSection[] = [
+  {
+    body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore.',
+    icon: Database,
+    label: 'WHAT IS COLLECTED',
+  },
+  {
+    body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore.',
+    icon: Eye,
+    label: 'WHICH SURFACES ARE TRACKED',
+  },
+  {
+    body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore.',
+    icon: Server,
+    label: 'WHERE IT GOES',
+  },
+  {
+    body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore.',
+    icon: Link2,
+    label: 'CROSS-DEVICE ALIAS',
+  },
+  {
+    body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore.',
+    icon: PowerOff,
+    label: 'HOW TO DISABLE',
+  },
+] as const

--- a/src/webui/pages/configuration-page.tsx
+++ b/src/webui/pages/configuration-page.tsx
@@ -1,3 +1,4 @@
+import {AnalyticsPanel} from '../features/analytics/components/analytics-panel'
 import {ConnectorsPanel} from '../features/connectors/components/connectors-panel'
 import {IdentityPanel} from '../features/vc/components/identity-panel'
 import {RemotesPanel} from '../features/vc/components/remotes-panel'
@@ -9,6 +10,7 @@ export function ConfigurationPage() {
         <IdentityPanel />
         <RemotesPanel />
         <ConnectorsPanel />
+        <AnalyticsPanel />
       </div>
     </div>
   )

--- a/test/unit/webui/features/analytics/api/get-global-config.test.ts
+++ b/test/unit/webui/features/analytics/api/get-global-config.test.ts
@@ -1,0 +1,48 @@
+import {expect} from 'chai'
+import {createSandbox, type SinonSandbox, type SinonStub} from 'sinon'
+
+import type {BrvApiClient} from '../../../../../../src/webui/lib/api-client.js'
+
+import {GlobalConfigEvents} from '../../../../../../src/shared/transport/events/global-config-events.js'
+import {getGlobalConfig} from '../../../../../../src/webui/features/analytics/api/get-global-config.js'
+import {useTransportStore} from '../../../../../../src/webui/stores/transport-store.js'
+
+describe('getGlobalConfig', () => {
+  let sandbox: SinonSandbox
+  let request: SinonStub
+
+  beforeEach(() => {
+    sandbox = createSandbox()
+    request = sandbox.stub()
+    useTransportStore.setState({
+      apiClient: {on: sandbox.stub(), request} as unknown as BrvApiClient,
+    })
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+    useTransportStore.setState({apiClient: null})
+  })
+
+  it('emits globalConfig:get with no payload', async () => {
+    request.resolves({analytics: false, deviceId: 'dev-1', version: '1'})
+    await getGlobalConfig()
+    expect(request.firstCall.args[0]).to.equal(GlobalConfigEvents.GET)
+  })
+
+  it('returns the analytics, deviceId, and version from the daemon response', async () => {
+    request.resolves({analytics: true, deviceId: 'dev-2', version: '2'})
+    const result = await getGlobalConfig()
+    expect(result).to.deep.equal({analytics: true, deviceId: 'dev-2', version: '2'})
+  })
+
+  it('rejects when the transport is not connected', async () => {
+    useTransportStore.setState({apiClient: null})
+    try {
+      await getGlobalConfig()
+      expect.fail('expected promise to reject')
+    } catch (error) {
+      expect((error as Error).message).to.equal('Not connected')
+    }
+  })
+})

--- a/test/unit/webui/features/analytics/api/get-global-config.test.ts
+++ b/test/unit/webui/features/analytics/api/get-global-config.test.ts
@@ -38,11 +38,9 @@ describe('getGlobalConfig', () => {
 
   it('rejects when the transport is not connected', async () => {
     useTransportStore.setState({apiClient: null})
-    try {
-      await getGlobalConfig()
-      expect.fail('expected promise to reject')
-    } catch (error) {
-      expect((error as Error).message).to.equal('Not connected')
-    }
+    await getGlobalConfig().then(
+      () => expect.fail('expected promise to reject'),
+      (error: Error) => expect(error.message).to.equal('Not connected'),
+    )
   })
 })

--- a/test/unit/webui/features/analytics/api/set-analytics.test.ts
+++ b/test/unit/webui/features/analytics/api/set-analytics.test.ts
@@ -1,0 +1,55 @@
+import {expect} from 'chai'
+import {createSandbox, type SinonSandbox, type SinonStub} from 'sinon'
+
+import type {BrvApiClient} from '../../../../../../src/webui/lib/api-client.js'
+
+import {GlobalConfigEvents} from '../../../../../../src/shared/transport/events/global-config-events.js'
+import {setAnalytics} from '../../../../../../src/webui/features/analytics/api/set-analytics.js'
+import {useTransportStore} from '../../../../../../src/webui/stores/transport-store.js'
+
+describe('setAnalytics', () => {
+  let sandbox: SinonSandbox
+  let request: SinonStub
+
+  beforeEach(() => {
+    sandbox = createSandbox()
+    request = sandbox.stub()
+    useTransportStore.setState({
+      apiClient: {on: sandbox.stub(), request} as unknown as BrvApiClient,
+    })
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+    useTransportStore.setState({apiClient: null})
+  })
+
+  it('emits globalConfig:setAnalytics with the analytics payload', async () => {
+    request.resolves({current: true, previous: false})
+    await setAnalytics({analytics: true})
+    expect(request.firstCall.args[0]).to.equal(GlobalConfigEvents.SET_ANALYTICS)
+    expect(request.firstCall.args[1]).to.deep.equal({analytics: true})
+  })
+
+  it('forwards false to disable analytics', async () => {
+    request.resolves({current: false, previous: true})
+    await setAnalytics({analytics: false})
+    expect(request.firstCall.args[1]).to.deep.equal({analytics: false})
+  })
+
+  it('resolves with the daemon response on success', async () => {
+    request.resolves({current: true, previous: false})
+    const result = await setAnalytics({analytics: true})
+    expect(result).to.deep.equal({current: true, previous: false})
+  })
+
+  it('rejects when the transport is not connected', async () => {
+    useTransportStore.setState({apiClient: null})
+    try {
+      await setAnalytics({analytics: true})
+      expect.fail('expected promise to reject')
+    } catch (error) {
+      expect((error as Error).message).to.equal('Not connected')
+    }
+  })
+})

--- a/test/unit/webui/features/analytics/constants.test.ts
+++ b/test/unit/webui/features/analytics/constants.test.ts
@@ -1,0 +1,44 @@
+import {expect} from 'chai'
+
+import {
+  ANALYTICS_DISCLOSURE_SECTIONS,
+  ANALYTICS_PRIVACY_URL,
+} from '../../../../../src/webui/features/analytics/constants.js'
+
+describe('analytics constants', () => {
+  describe('ANALYTICS_DISCLOSURE_SECTIONS', () => {
+    it('contains the five required sections in ticket-spec order', () => {
+      const labels = ANALYTICS_DISCLOSURE_SECTIONS.map((s) => s.label)
+      expect(labels).to.deep.equal([
+        'WHAT IS COLLECTED',
+        'WHICH SURFACES ARE TRACKED',
+        'WHERE IT GOES',
+        'CROSS-DEVICE ALIAS',
+        'HOW TO DISABLE',
+      ])
+    })
+
+    it('every section has a non-empty body', () => {
+      for (const section of ANALYTICS_DISCLOSURE_SECTIONS) {
+        expect(section.body.length).to.be.greaterThan(0)
+      }
+    })
+
+    it('every section has an icon component reference', () => {
+      for (const section of ANALYTICS_DISCLOSURE_SECTIONS) {
+        expect(section.icon).to.exist
+        expect(['function', 'object']).to.include(typeof section.icon)
+      }
+    })
+  })
+
+  describe('ANALYTICS_PRIVACY_URL', () => {
+    it('is a https URL', () => {
+      expect(ANALYTICS_PRIVACY_URL).to.match(/^https:\/\//)
+    })
+
+    it('points at the byterover privacy docs', () => {
+      expect(ANALYTICS_PRIVACY_URL).to.include('byterover.dev/privacy')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- New `AnalyticsPanel` on the webui Configuration page reads/writes the `analytics: boolean` global config flag via existing `globalConfig:get` / `globalConfig:setAnalytics` transport events (no new daemon surface).
- Toggle-on opens an explicit-confirmation `AlertDialog` showing the 5-section inline disclosure; toggle-off opens a lighter "Stop sharing analytics?" confirmation. Matches M1.7 spec.
- Inline "What data will be collected?" `Collapsible` shares the same 5-section `DisclosureDetails` component. Section bodies are intentionally Lorem ipsum — final PM/legal copy comes from M1.4 (the markdown template is also still placeholder).
- Bumps `@campfirein/byterover-packages` 1.0.2 → 1.0.4 to pull in the new `Collapsible` component required by the disclosure expander.
- Cross-surface coherence with the CLI relies on TanStack Query's default `refetchOnWindowFocus: true` — the panel reflects `brv analytics enable/disable` changes on tab refocus.

## Test plan

- [ ] `npm run dev:ui` → open `brv webui` → Configuration page → toggle on/off in both directions; observe enable disclosure and disable confirm flows
- [ ] `./bin/dev.js analytics status` after each toggle reflects the new state
- [ ] CLI toggle (`./bin/dev.js analytics enable` / `disable`) → switch back to the webui tab → panel observes the new state on refocus
- [ ] Verify toast on success and error paths (disconnect transport mid-toggle)
- [ ] `npm test -- --grep "analytics"` — 12 unit tests pass (constants + get-global-config + set-analytics)
- [ ] `npm run lint`, `npm run typecheck`, `npm run build:ui:submodule` green