### PR TITLE
Curate response envelope — restore HITL review surface for tool-mode curate

### DIFF
--- a/src/oclif/lib/curate-session.ts
+++ b/src/oclif/lib/curate-session.ts
@@ -9,9 +9,10 @@ import type {CurateMeta} from '../../shared/curate-meta.js'
 import {BRV_DIR, CONTEXT_TREE_DIR} from '../../server/constants.js'
 import {buildCorrectionPrompt, buildGeneratePrompt} from '../../server/core/domain/render/curate-prompt-builder.js'
 import {ProjectConfigStore} from '../../server/infra/config/file-config-store.js'
-import {buildCurateHtmlLogEntry} from '../../server/infra/process/curate-html-log.js'
+import {backupContextTreeFile, buildCurateHtmlLogEntry} from '../../server/infra/process/curate-html-log.js'
 import {type HtmlWriteError, validateHtmlTopic, writeHtmlTopic} from '../../server/infra/render/writer/html-writer.js'
 import {FileCurateLogStore} from '../../server/infra/storage/file-curate-log-store.js'
+import {FileReviewBackupStore} from '../../server/infra/storage/file-review-backup-store.js'
 import {getProjectDataDir} from '../../server/utils/path-utils.js'
 import {CurateMetaSchema} from '../../shared/curate-meta.js'
 
@@ -327,7 +328,31 @@ export async function continueSession(options: ContinueOptions): Promise<CurateS
   // and the log entry uses the sentinel path.
   const preValidation = validateHtmlTopic(html)
   const topicPath = preValidation.ok ? preValidation.topicPath : undefined
-  const existedBefore = topicPath !== undefined && existsSync(join(contextTreeRoot, `${topicPath}.html`))
+  const absoluteTopicPath = topicPath === undefined ? undefined : join(contextTreeRoot, `${topicPath}.html`)
+  const existedBefore = absoluteTopicPath !== undefined && existsSync(absoluteTopicPath)
+
+  // Snapshot the project's reviewDisabled state once for this continuation.
+  // Reading it twice (here + in persistCurateLog) could race a mid-task
+  // `brv review --enable/--disable` toggle and produce inconsistent semantics
+  // between the backup decision and the log-entry decision.
+  const reviewDisabled = await resolveProjectReviewDisabled(projectRoot)
+
+  // Seed the review-backup BEFORE the destructive write. Without this, an
+  // UPDATE-shaped continuation (confirmOverwrite=true over an existing topic)
+  // creates a `reviewStatus: pending` log entry but leaves nothing for
+  // `brv review reject` to restore from — review-handler.ts:152 then treats
+  // the missing backup as ADD and `unlink`s the file, destroying the user's
+  // prior knowledge. backupContextTreeFile honors reviewDisabled and ENOENT
+  // gracefully, so it's safe to call on every continuation regardless of
+  // whether the file existed.
+  if (absoluteTopicPath !== undefined && existedBefore) {
+    await backupContextTreeFile({
+      absoluteFilePath: absoluteTopicPath,
+      contextTreeRoot,
+      reviewBackupStore: new FileReviewBackupStore(join(projectRoot, BRV_DIR)),
+      reviewDisabled,
+    })
+  }
 
   const startedAt = Date.now()
   const writeResult = await writeHtmlTopic({confirmOverwrite, contextTreeRoot, rawHtml: html})
@@ -344,6 +369,7 @@ export async function continueSession(options: ContinueOptions): Promise<CurateS
     intent: state.userIntent,
     meta,
     projectRoot,
+    reviewDisabled,
     startedAt,
     taskId: sessionId,
     topicPath,
@@ -461,13 +487,19 @@ async function persistCurateLog(input: {
   intent: string
   meta?: CurateMeta
   projectRoot: string
+  /**
+   * Snapshot of the project's `reviewDisabled` flag at the start of the
+   * continuation. Threaded in (rather than re-read here) so the backup
+   * decision and the log-entry decision observe the same value even if
+   * the user toggles `brv review --enable/--disable` mid-task.
+   */
+  reviewDisabled: boolean
   startedAt: number
   taskId: string
   topicPath?: string
   writeResult: Awaited<ReturnType<typeof writeHtmlTopic>>
 }): Promise<void> {
   try {
-    const reviewDisabled = await resolveProjectReviewDisabled(input.projectRoot)
     const store = new FileCurateLogStore({baseDir: getProjectDataDir(input.projectRoot)})
     const id = await store.getNextId()
     const entry = buildCurateHtmlLogEntry({
@@ -478,15 +510,21 @@ async function persistCurateLog(input: {
       id,
       intent: input.intent,
       meta: input.meta,
-      reviewDisabled,
+      reviewDisabled: input.reviewDisabled,
       startedAt: input.startedAt,
       taskId: input.taskId,
       topicPath: input.topicPath,
       writeResult: input.writeResult,
     })
     await store.save(entry)
-  } catch {
-    // Best-effort: log persistence must never fail the curate.
+  } catch (error) {
+    // Best-effort: log persistence must never fail the curate. Surface a
+    // single-line stderr signal so a user diagnosing "my curate ran but
+    // `brv review pending` is empty" has something to grep — paralleling
+    // the daemon-side agentLog at `agent-process.ts > curate-html-direct`.
+    process.stderr.write(
+      `brv curate: failed to persist review log entry: ${error instanceof Error ? error.message : String(error)}\n`,
+    )
   }
 }
 

--- a/src/oclif/lib/curate-session.ts
+++ b/src/oclif/lib/curate-session.ts
@@ -2,10 +2,18 @@ import {randomUUID} from 'node:crypto'
 import {existsSync} from 'node:fs'
 import {mkdir, readFile, rm, writeFile} from 'node:fs/promises'
 import {dirname, join, relative} from 'node:path'
+import {z} from 'zod'
+
+import type {CurateMeta} from '../../shared/curate-meta.js'
 
 import {BRV_DIR, CONTEXT_TREE_DIR} from '../../server/constants.js'
 import {buildCorrectionPrompt, buildGeneratePrompt} from '../../server/core/domain/render/curate-prompt-builder.js'
-import {type HtmlWriteError, writeHtmlTopic} from '../../server/infra/render/writer/html-writer.js'
+import {ProjectConfigStore} from '../../server/infra/config/file-config-store.js'
+import {buildCurateHtmlLogEntry} from '../../server/infra/process/curate-html-log.js'
+import {type HtmlWriteError, validateHtmlTopic, writeHtmlTopic} from '../../server/infra/render/writer/html-writer.js'
+import {FileCurateLogStore} from '../../server/infra/storage/file-curate-log-store.js'
+import {getProjectDataDir} from '../../server/utils/path-utils.js'
+import {CurateMetaSchema} from '../../shared/curate-meta.js'
 
 /**
  * Curate session protocol — CLI-side orchestrator for the multi-step
@@ -199,6 +207,63 @@ export async function kickoffSession(options: KickoffOptions): Promise<CurateSes
 }
 
 /**
+ * Parsed CLI envelope response. Mirrors the MCP tool's typed input but
+ * arrives as a JSON string on the `--response` flag, so we have to
+ * parse + validate here. `meta` is optional — agents that don't supply
+ * it still curate successfully (just no review surfacing for that entry).
+ */
+const CurateResponseEnvelopeSchema = z.object({
+  html: z.string().min(1),
+  meta: CurateMetaSchema.optional(),
+})
+
+/**
+ * Custom error thrown by `parseCurateResponse` when the agent's response
+ * is not a well-formed envelope. Carries `kind: 'invalid-response-format'`
+ * so the orchestrator can map it to the envelope's structured `errors[]`
+ * shape without coupling parsing to envelope construction.
+ */
+class InvalidResponseFormatError extends Error {
+  readonly kind = 'invalid-response-format'
+}
+
+/**
+ * Parse the agent's `--response` payload as a JSON envelope `{html, meta?}`.
+ *
+ * The CLI session protocol used to accept raw HTML on `--response`; M4
+ * switches to a structured envelope so the calling agent's LLM can
+ * supply operation metadata (impact, type, reason) alongside the HTML
+ * for the HITL review pipeline.
+ *
+ * Throws `InvalidResponseFormatError` with `kind: 'invalid-response-format'`
+ * on malformed JSON, missing/empty `html`, or invalid `meta`. The caller
+ * (continueSession) catches and maps to a structured envelope error so
+ * the calling agent sees a clear "your response shape was wrong" signal
+ * pointing at the envelope contract.
+ */
+export function parseCurateResponse(raw: string): {html: string; meta?: CurateMeta} {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    throw new InvalidResponseFormatError(
+      '--response must be a JSON envelope `{"html": "<bv-topic>...</bv-topic>", "meta": {...}}`. Got non-JSON input.',
+    )
+  }
+
+  const result = CurateResponseEnvelopeSchema.safeParse(parsed)
+  if (!result.success) {
+    const issue = result.error.issues[0]
+    const field = issue?.path.join('.') || '<root>'
+    throw new InvalidResponseFormatError(
+      `--response envelope failed validation at \`${field}\`: ${issue?.message ?? 'unknown error'}. Expected \`{"html": "<bv-topic>...</bv-topic>", "meta": {...}}\`.`,
+    )
+  }
+
+  return {html: result.data.html, meta: result.data.meta}
+}
+
+/**
  * Continue an existing session. Validates the response, writes the
  * topic file on success, advances the retry loop on failure, terminates
  * with `failed` once the retry cap is exhausted.
@@ -228,11 +293,62 @@ export async function continueSession(options: ContinueOptions): Promise<CurateS
     }
   }
 
+  // Parse the JSON envelope before touching the writer. A malformed
+  // envelope is a protocol-level failure (agent didn't follow the
+  // contract) — distinct from HTML validation failure (agent followed
+  // the contract but the HTML inside is wrong). The session stays
+  // alive so the caller can retry with a corrected envelope.
+  let parsed: {html: string; meta?: CurateMeta}
+  try {
+    parsed = parseCurateResponse(response)
+  } catch (error) {
+    if (error instanceof InvalidResponseFormatError) {
+      return {
+        errors: [{kind: error.kind, message: error.message}],
+        ok: false,
+        sessionId,
+        status: 'failed',
+      }
+    }
+
+    throw error
+  }
+
+  const {html, meta} = parsed
+
   // Run the writer end-to-end: parse, validate against the registry,
   // and atomically write to `.brv/context-tree/<topic.path>.html`. On
   // validation failure no file lands on disk.
   const contextTreeRoot = join(projectRoot, BRV_DIR, CONTEXT_TREE_DIR)
-  const writeResult = await writeHtmlTopic({confirmOverwrite, contextTreeRoot, rawHtml: response})
+
+  // Pre-resolve topicPath + existedBefore for the log entry. parse5 is
+  // cheap (validateHtmlTopic re-runs internally inside writeHtmlTopic
+  // so we don't risk drift). On parse failure topicPath is undefined
+  // and the log entry uses the sentinel path.
+  const preValidation = validateHtmlTopic(html)
+  const topicPath = preValidation.ok ? preValidation.topicPath : undefined
+  const existedBefore = topicPath !== undefined && existsSync(join(contextTreeRoot, `${topicPath}.html`))
+
+  const startedAt = Date.now()
+  const writeResult = await writeHtmlTopic({confirmOverwrite, contextTreeRoot, rawHtml: html})
+  const completedAt = Date.now()
+
+  await persistCurateLog({
+    completedAt,
+    confirmOverwrite,
+    existedBefore,
+    // Absolute path — review-handler treats `op.filePath` as absolute and
+    // calls `relative(contextTreeDir, ...)` to derive its display key.
+    // Mirrors dream-executor's convention.
+    filePath: writeResult.ok ? writeResult.filePath : undefined,
+    intent: state.userIntent,
+    meta,
+    projectRoot,
+    startedAt,
+    taskId: sessionId,
+    topicPath,
+    writeResult,
+  })
 
   state.attempts += 1
   state.lastResponse = response
@@ -322,6 +438,70 @@ function mapWriterError(err: HtmlWriteError): CurateSessionError {
       // missing-bv-topic, missing-path-attribute, multiple-bv-topic, unsafe-path
       return {kind: err.kind, message: err.message}
     }
+  }
+}
+
+/**
+ * Build + persist a CurateLogEntry for an in-process CLI continuation.
+ *
+ * The CLI session runs in-process (no daemon round-trip for the write),
+ * so the log entry is written directly here. `FileCurateLogStore` uses
+ * atomic tmp+rename writes — safe to interleave with daemon writes from
+ * the same project.
+ *
+ * Logging is best-effort: errors are swallowed (just like daemon-side
+ * `curate-log-handler`) so a transient FS error doesn't fail an
+ * otherwise-successful curate. The user can still recover via re-run.
+ */
+async function persistCurateLog(input: {
+  completedAt: number
+  confirmOverwrite: boolean
+  existedBefore: boolean
+  filePath?: string
+  intent: string
+  meta?: CurateMeta
+  projectRoot: string
+  startedAt: number
+  taskId: string
+  topicPath?: string
+  writeResult: Awaited<ReturnType<typeof writeHtmlTopic>>
+}): Promise<void> {
+  try {
+    const reviewDisabled = await resolveProjectReviewDisabled(input.projectRoot)
+    const store = new FileCurateLogStore({baseDir: getProjectDataDir(input.projectRoot)})
+    const id = await store.getNextId()
+    const entry = buildCurateHtmlLogEntry({
+      completedAt: input.completedAt,
+      confirmOverwrite: input.confirmOverwrite,
+      existedBefore: input.existedBefore,
+      filePath: input.filePath,
+      id,
+      intent: input.intent,
+      meta: input.meta,
+      reviewDisabled,
+      startedAt: input.startedAt,
+      taskId: input.taskId,
+      topicPath: input.topicPath,
+      writeResult: input.writeResult,
+    })
+    await store.save(entry)
+  } catch {
+    // Best-effort: log persistence must never fail the curate.
+  }
+}
+
+/**
+ * Read the project's `reviewDisabled` flag for the CLI's in-process
+ * session continuation. Equivalent of the daemon's `resolveReviewDisabled`
+ * in `brv-server.ts`. Returns `false` when the config file is absent
+ * (fail-open: review enabled by default).
+ */
+async function resolveProjectReviewDisabled(projectRoot: string): Promise<boolean> {
+  try {
+    const config = await new ProjectConfigStore().read(projectRoot)
+    return config?.reviewDisabled === true
+  } catch {
+    return false
   }
 }
 

--- a/src/server/core/domain/render/curate-prompt-builder.ts
+++ b/src/server/core/domain/render/curate-prompt-builder.ts
@@ -159,13 +159,23 @@ export function buildCorrectionPrompt(options: {
 // ── Private helpers ──────────────────────────────────────────────
 
 const OUTPUT_CONTRACT = [
-  '- Output is HTML, and only HTML.',
-  '- First character of your response must be `<`. Last characters must be `</bv-topic>`.',
-  '- DO NOT wrap the response in a code fence. No ``` html, no markdown formatting around the HTML.',
-  '- Exactly one `<bv-topic>` per output. It is the root container.',
-  '- All attribute names lowercase; all attribute values double-quoted.',
-  '- Do not invent elements or attributes outside the schema below.',
-  '- Do not emit `importance`, `maturity`, `recency`, `createdat`, or `updatedat` on `<bv-topic>` — those are system-managed sidecar signals.',
+  '- Emit a JSON envelope: `{"html": "...", "meta": {...}}`. First char `{`, last char `}`.',
+  '- DO NOT wrap the response in a code fence. No ``` json, no markdown around the envelope.',
+  '- The HTML inside `"html"`:',
+  '    - Exactly one `<bv-topic>` per output.',
+  '    - Lowercase attribute names, double-quoted values.',
+  '    - No elements/attributes outside the schema below.',
+  '    - Do not emit `importance`, `maturity`, `recency`, `createdat`, `updatedat` (system-managed).',
+  '',
+  'Optional `"meta"` (omit → curate succeeds but does NOT surface in `brv review pending`):',
+  '- `type`: "ADD" | "UPDATE" | "MERGE". Defaults from file-existed-before.',
+  '- `impact`: "high" (load-bearing decision / must-rule / architectural pattern / new domain knowledge) | "low" (refinement / clarification). Omit → no review surfacing.',
+  '- `reason`: one sentence shown to reviewers.',
+  '- `summary`: one-line summary after this operation.',
+  '- `previousSummary`: (UPDATE/MERGE) one-line summary before this operation.',
+  '- `confidence`: "high" | "low".',
+  '',
+  'Example: `{"html":"<bv-topic path=\\"security/auth\\" title=\\"JWT\\"><bv-decision severity=\\"must\\">RS256.</bv-decision></bv-topic>","meta":{"type":"ADD","impact":"high","reason":"Locks JWT alg.","summary":"JWT: RS256."}}`',
 ].join('\n')
 
 const PATH_FORMAT = [

--- a/src/server/infra/daemon/agent-process.ts
+++ b/src/server/infra/daemon/agent-process.ts
@@ -752,12 +752,14 @@ async function executeTask(
           // result payload and can retry with corrected HTML. task:error
           // would force MCP clients into an isError path that some host
           // renderers collapse or truncate.
-          result = writeResult.ok ? JSON.stringify({
-              filePath: relativeFilePath,
-              overwrote: existedBefore && Boolean(confirmOverwrite),
-              status: 'ok',
-              topicPath: topicPathResolved,
-            }) : JSON.stringify({errors: writeResult.errors, status: 'validation-failed'});
+          result = writeResult.ok
+            ? JSON.stringify({
+                filePath: relativeFilePath,
+                overwrote: existedBefore && Boolean(confirmOverwrite),
+                status: 'ok',
+                topicPath: topicPathResolved,
+              })
+            : JSON.stringify({errors: writeResult.errors, status: 'validation-failed'})
 
           break
         }

--- a/src/server/infra/daemon/agent-process.ts
+++ b/src/server/infra/daemon/agent-process.ts
@@ -67,7 +67,7 @@ import {DreamExecutor} from '../executor/dream-executor.js'
 import {FolderPackExecutor} from '../executor/folder-pack-executor.js'
 import {QueryExecutor} from '../executor/query-executor.js'
 import {SearchExecutor} from '../executor/search-executor.js'
-import {buildCurateHtmlLogEntry} from '../process/curate-html-log.js'
+import {backupContextTreeFile, buildCurateHtmlLogEntry} from '../process/curate-html-log.js'
 import {validateHtmlTopic, writeHtmlTopic} from '../render/writer/html-writer.js'
 import {FileCurateLogStore} from '../storage/file-curate-log-store.js'
 import {FileReviewBackupStore} from '../storage/file-review-backup-store.js'
@@ -675,8 +675,25 @@ async function executeTask(
           // idempotent + cheap (parse5 only); writeHtmlTopic re-runs
           // it internally so we don't risk drift between checks.
           const preValidation = validateHtmlTopic(html)
-          const existedBefore =
-            preValidation.ok && existsSync(join(contextTreeRoot, `${preValidation.topicPath}.html`))
+          const absoluteTopicFilePath = preValidation.ok
+            ? join(contextTreeRoot, `${preValidation.topicPath}.html`)
+            : undefined
+          const existedBefore = absoluteTopicFilePath !== undefined && existsSync(absoluteTopicFilePath)
+
+          // Seed the review-backup BEFORE the destructive write. Without this,
+          // a curate over an existing topic (confirmOverwrite=true, meta.impact=high)
+          // creates a `reviewStatus: pending` log entry but leaves nothing for
+          // `brv review reject` to restore from — review-handler.ts:152 treats
+          // a missing backup as ADD and unlinks the file, destroying the user's
+          // prior knowledge. Honors task.reviewDisabled and ENOENT gracefully.
+          if (existedBefore && absoluteTopicFilePath !== undefined) {
+            await backupContextTreeFile({
+              absoluteFilePath: absoluteTopicFilePath,
+              contextTreeRoot,
+              reviewBackupStore: new FileReviewBackupStore(join(projectPath, BRV_DIR)),
+              reviewDisabled: reviewDisabled ?? false,
+            })
+          }
 
           const startedAt = Date.now()
           const writeResult = await writeHtmlTopic({confirmOverwrite, contextTreeRoot, rawHtml: html})

--- a/src/server/infra/daemon/agent-process.ts
+++ b/src/server/infra/daemon/agent-process.ts
@@ -67,6 +67,7 @@ import {DreamExecutor} from '../executor/dream-executor.js'
 import {FolderPackExecutor} from '../executor/folder-pack-executor.js'
 import {QueryExecutor} from '../executor/query-executor.js'
 import {SearchExecutor} from '../executor/search-executor.js'
+import {buildCurateHtmlLogEntry} from '../process/curate-html-log.js'
 import {validateHtmlTopic, writeHtmlTopic} from '../render/writer/html-writer.js'
 import {FileCurateLogStore} from '../storage/file-curate-log-store.js'
 import {FileReviewBackupStore} from '../storage/file-review-backup-store.js'
@@ -666,7 +667,7 @@ async function executeTask(
           // Mirrors the post-ENG-2815 oclif `brv curate` writer-direct
           // flow but exposed as a daemon task type so MCP clients can
           // hit it the same way they hit `query-tool-mode`.
-          const {confirmOverwrite, html} = decodeCurateHtmlContent(content)
+          const {confirmOverwrite, html, meta} = decodeCurateHtmlContent(content)
           const contextTreeRoot = join(projectPath, BRV_DIR, CONTEXT_TREE_DIR)
 
           // Pre-resolve the target path so we can report whether the
@@ -677,31 +678,69 @@ async function executeTask(
           const existedBefore =
             preValidation.ok && existsSync(join(contextTreeRoot, `${preValidation.topicPath}.html`))
 
+          const startedAt = Date.now()
           const writeResult = await writeHtmlTopic({confirmOverwrite, contextTreeRoot, rawHtml: html})
+          const completedAt = Date.now()
+
+          // HITL log entry — restores `brv review pending` surfacing for
+          // tool-mode curates. Pre-allocate the id via getNextId() so it
+          // matches FileCurateLogStore's `cur-<timestamp>` ID_PATTERN; a
+          // random UUID would silently be invisible to list()/getById().
+          // Failed writes also get an entry (status: error) so the TUI
+          // doesn't lie about what was attempted.
+          let relativeFilePath: string | undefined
+          let topicPathResolved: string | undefined
+          if (writeResult.ok) {
+            relativeFilePath = relative(contextTreeRoot, writeResult.filePath).replaceAll(sep, '/')
+            topicPathResolved = preValidation.ok
+              ? preValidation.topicPath
+              : relativeFilePath.replace(/\.html$/, '')
+          } else if (preValidation.ok) {
+            topicPathResolved = preValidation.topicPath
+          }
+
+          try {
+            const curateLogStore = new FileCurateLogStore({baseDir: storagePath})
+            const entryId = await curateLogStore.getNextId()
+            const logEntry = buildCurateHtmlLogEntry({
+              completedAt,
+              confirmOverwrite: Boolean(confirmOverwrite),
+              existedBefore,
+              // Absolute path — the review-handler (and dream-executor) treat
+              // `op.filePath` as absolute and call `relative(contextTreeDir, ...)`
+              // to derive a display key. Storing a relative path here makes
+              // the entry unmatchable in `brv review approve`.
+              filePath: writeResult.ok ? writeResult.filePath : undefined,
+              id: entryId,
+              meta,
+              reviewDisabled: reviewDisabled ?? false,
+              startedAt,
+              taskId,
+              topicPath: topicPathResolved,
+              writeResult,
+            })
+            await curateLogStore.save(logEntry)
+            logId = entryId
+          } catch (error) {
+            // Logging must never block curate execution. Swallow + log
+            // so a transient FS error doesn't fail an otherwise-successful
+            // curate.
+            agentLog(
+              `curate-html-direct: failed to persist log entry for ${taskId}: ${error instanceof Error ? error.message : String(error)}`,
+            )
+          }
 
           // Validation failures emit task:completed (NOT task:error) so
           // the calling agent sees the structured errors via the normal
           // result payload and can retry with corrected HTML. task:error
           // would force MCP clients into an isError path that some host
           // renderers collapse or truncate.
-          if (writeResult.ok) {
-            // Normalize to forward-slashes — the CurateHtmlDirectResult contract
-            // (i-curate-executor.ts) documents `topicPath: 'security/auth'` form, and
-            // the renderer surfaces filePath to the calling agent verbatim. On Windows,
-            // relative() would otherwise return `security\auth.html`.
-            const relativeFilePath = relative(contextTreeRoot, writeResult.filePath).replaceAll(sep, '/')
-            const topicPath = preValidation.ok
-              ? preValidation.topicPath
-              : relativeFilePath.replace(/\.html$/, '')
-            result = JSON.stringify({
+          result = writeResult.ok ? JSON.stringify({
               filePath: relativeFilePath,
               overwrote: existedBefore && Boolean(confirmOverwrite),
               status: 'ok',
-              topicPath,
-            })
-          } else {
-            result = JSON.stringify({errors: writeResult.errors, status: 'validation-failed'})
-          }
+              topicPath: topicPathResolved,
+            }) : JSON.stringify({errors: writeResult.errors, status: 'validation-failed'});
 
           break
         }

--- a/src/server/infra/mcp/tools/brv-curate-tool.ts
+++ b/src/server/infra/mcp/tools/brv-curate-tool.ts
@@ -5,9 +5,11 @@ import {waitForConnectedClient} from '@campfirein/brv-transport-client'
 import {randomUUID} from 'node:crypto'
 import {z} from 'zod'
 
+import type {CurateMeta} from '../../../../shared/curate-meta.js'
 import type {CurateHtmlDirectResult} from '../../../core/interfaces/executor/i-curate-executor.js'
 import type {HtmlWriteError} from '../../render/writer/html-writer.js'
 
+import {CurateMetaSchema} from '../../../../shared/curate-meta.js'
 import {encodeCurateHtmlContent} from '../../../../shared/transport/curate-html-content.js'
 import {CURATE_SCHEMA_PROMPT} from '../../../core/domain/render/curate-prompt-builder.js'
 import {TransportTaskEventNames} from '../../../core/domain/transport/schemas.js'
@@ -101,6 +103,20 @@ const TOOL_DESCRIPTION = [
   'When a topic already exists at the resolved path, the tool refuses to clobber by default and returns',
   'a structured `path-exists` error with the existing content inlined so you can merge. Pass',
   '`confirmOverwrite: true` to replace the existing topic entirely.',
+  '',
+  '# Operation metadata (optional `meta` field)',
+  'Supply `meta` alongside `html` so the curate operation surfaces in `brv review pending` for human',
+  'reviewers. Omitting `meta` still writes the topic — it just does not surface for review.',
+  '- `meta.type`: "ADD" for a fresh topic, "UPDATE" for replacing an existing one, "MERGE" when',
+  '  combining new content into an existing topic (typically after a path-exists correction).',
+  '  Optional — defaults to "ADD" when no file exists at the path, "UPDATE" otherwise.',
+  '- `meta.impact`: "high" for a load-bearing decision, must-rule, architectural pattern, or new',
+  '  domain knowledge a teammate should validate. "low" for refinements / additions / clarifications.',
+  '  Optional. Omitting it means "do not surface for review".',
+  '- `meta.reason`: one short sentence shown to human reviewers explaining why this curation matters.',
+  '- `meta.summary`: one-line semantic summary of the topic after this operation.',
+  '- `meta.previousSummary`: (UPDATE / MERGE only) one-line summary of what the topic said before.',
+  '- `meta.confidence`: "high" / "low". Optional.',
 ].join('\n')
 
 // Strict so the legacy `{context, files, folder}` shape (or any typo'd field)
@@ -122,6 +138,9 @@ export const BrvCurateInputSchema = z
       .describe(
         'Complete <bv-topic> HTML document. Must include a `path` attribute on the root <bv-topic>. See the tool description for the closed element vocabulary and output contract.',
       ),
+    meta: CurateMetaSchema.optional().describe(
+      'Operation metadata for the human-in-the-loop review pipeline. Supply when the curate is load-bearing enough to need review (impact: "high"). Omitting means the topic is written but does not surface in `brv review pending`. See the tool description for field semantics.',
+    ),
   })
   .strict()
 
@@ -158,7 +177,17 @@ export function registerBrvCurateTool(
       inputSchema: BrvCurateInputSchema,
       title: 'ByteRover Curate',
     },
-    async ({confirmOverwrite, cwd, html}: {confirmOverwrite?: boolean; cwd?: string; html: string}) => {
+    async ({
+      confirmOverwrite,
+      cwd,
+      html,
+      meta,
+    }: {
+      confirmOverwrite?: boolean
+      cwd?: string
+      html: string
+      meta?: CurateMeta
+    }) => {
       const cwdResult = resolveClientCwd(cwd, getWorkingDirectory)
       if (!cwdResult.success) {
         return {
@@ -191,7 +220,7 @@ export function registerBrvCurateTool(
 
         await client.requestWithAck(TransportTaskEventNames.CREATE, {
           clientCwd: cwdResult.clientCwd,
-          content: encodeCurateHtmlContent({confirmOverwrite, html}),
+          content: encodeCurateHtmlContent({confirmOverwrite, html, meta}),
           projectPath: taskContext.projectRoot,
           taskId,
           type: 'curate-html-direct',

--- a/src/server/infra/process/curate-html-log.ts
+++ b/src/server/infra/process/curate-html-log.ts
@@ -1,0 +1,168 @@
+import type {CurateMeta} from '../../../shared/curate-meta.js'
+import type {CurateLogEntry, CurateLogOperation} from '../../core/domain/entities/curate-log-entry.js'
+import type {HtmlWriteResult} from '../render/writer/html-writer.js'
+
+import {computeSummary} from './curate-log-handler.js'
+
+/**
+ * Default `input.context` sentinel for tool-mode curates that don't carry
+ * a user-intent string (MCP calls — the agent typed the HTML directly,
+ * there was no `brv curate "<text>"` kickoff). The TUI / `brv curate view`
+ * renders this so the log row isn't visually empty.
+ */
+const DEFAULT_TOOL_MODE_INTENT = '<curated via tool mode>'
+
+const FALLBACK_PATH = '<unknown>'
+
+type BuildInput = {
+  /** Wall-clock at write completion (write success OR validation failure). */
+  completedAt: number
+  /** Whether the caller passed --overwrite / `confirmOverwrite: true`. */
+  confirmOverwrite: boolean
+  /** Whether a file already existed at the resolved path BEFORE this write. Used to default `type`. */
+  existedBefore: boolean
+  /** Relative path of the written topic file (e.g. `security/auth.html`). May be undefined on validation failure. */
+  filePath?: string
+  /** Pre-allocated log id from `FileCurateLogStore.getNextId()` (`cur-<timestamp_ms>` format). */
+  id: string
+  /** User intent string (CLI kickoff text). MCP calls have no intent — leave undefined to use the sentinel. */
+  intent?: string
+  /** Agent-supplied operation metadata. Optional. */
+  meta?: CurateMeta
+  /** Snapshot of project's reviewDisabled flag at task-create time. */
+  reviewDisabled: boolean
+  /** Wall-clock at write start. */
+  startedAt: number
+  /** Task id correlating this log entry with its task. */
+  taskId: string
+  /** Topic path (`security/auth`, no `.html`). May be undefined on validation failure. */
+  topicPath?: string
+  /** Result from `writeHtmlTopic`. */
+  writeResult: HtmlWriteResult
+}
+
+/**
+ * Build a `CurateLogEntry` for a single tool-mode curate write.
+ *
+ * Pure — no I/O. The caller persists via `FileCurateLogStore.save()`.
+ * The log entry id MUST be pre-allocated via `store.getNextId()` so the
+ * resulting filename matches `FileCurateLogStore`'s `ID_PATTERN`
+ * (`cur-<timestamp_ms>`); a random UUID would silently produce an entry
+ * that `list()` and `getById()` cannot find.
+ *
+ * Both the daemon's `curate-html-direct` handler and the CLI's
+ * `continueSession` use this helper so the on-disk log shape stays
+ * identical regardless of which surface initiated the curate.
+ *
+ * Review semantics:
+ *   - `needsReview` is `meta.impact === 'high' && !reviewDisabled && status === 'success'`.
+ *   - `reviewStatus` is `'pending'` when `needsReview`, else undefined.
+ *   - On failure the entry is still written (with `status: 'error'`) for
+ *     telemetry, but no review surfacing — failed writes aren't actionable
+ *     and surfacing them would create noise in `brv review pending`.
+ */
+export function buildCurateHtmlLogEntry(input: BuildInput): CurateLogEntry {
+  const {
+    completedAt,
+    confirmOverwrite,
+    existedBefore,
+    filePath,
+    id,
+    intent,
+    meta,
+    reviewDisabled,
+    startedAt,
+    taskId,
+    topicPath,
+    writeResult,
+  } = input
+
+  const operation = writeResult.ok
+    ? buildSuccessOperation({confirmOverwrite, existedBefore, filePath, meta, reviewDisabled, topicPath})
+    : buildFailureOperation({filePath, meta, topicPath, writeResult})
+
+  const base = {
+    format: 'html' as const,
+    id,
+    input: {context: intent ?? DEFAULT_TOOL_MODE_INTENT},
+    operations: [operation],
+    startedAt,
+    summary: computeSummary([operation]),
+    taskId,
+  }
+
+  if (writeResult.ok) {
+    return {...base, completedAt, status: 'completed'}
+  }
+
+  return {
+    ...base,
+    completedAt,
+    error: writeResult.errors.map((e) => `${e.kind}: ${e.message}`).join('\n'),
+    status: 'error',
+  }
+}
+
+function buildSuccessOperation(args: {
+  confirmOverwrite: boolean
+  existedBefore: boolean
+  filePath?: string
+  meta?: CurateMeta
+  reviewDisabled: boolean
+  topicPath?: string
+}): CurateLogOperation {
+  const {confirmOverwrite, existedBefore, filePath, meta, reviewDisabled, topicPath} = args
+  const derivedType = existedBefore && confirmOverwrite ? 'UPDATE' : 'ADD'
+  const needsReview = meta?.impact === 'high' && !reviewDisabled
+
+  const op: CurateLogOperation = {
+    path: topicPath ?? FALLBACK_PATH,
+    status: 'success',
+    type: meta?.type ?? derivedType,
+  }
+
+  if (filePath !== undefined) op.filePath = filePath
+  if (meta?.impact !== undefined) op.impact = meta.impact
+  if (meta?.confidence !== undefined) op.confidence = meta.confidence
+  if (meta?.reason !== undefined) op.reason = meta.reason
+  if (meta?.summary !== undefined) op.summary = meta.summary
+  if (meta?.previousSummary !== undefined) op.previousSummary = meta.previousSummary
+
+  // Only emit needsReview when the agent asserted impact. No meta = no
+  // review-worthiness judgment, so the field stays undefined rather than
+  // an explicit `false` (which would conflate "agent said low" with
+  // "agent didn't say anything").
+  if (meta?.impact !== undefined) {
+    op.needsReview = needsReview
+    if (needsReview) op.reviewStatus = 'pending'
+  }
+
+  return op
+}
+
+function buildFailureOperation(args: {
+  filePath?: string
+  meta?: CurateMeta
+  topicPath?: string
+  writeResult: Extract<HtmlWriteResult, {ok: false}>
+}): CurateLogOperation {
+  const {filePath, meta, topicPath, writeResult} = args
+
+  const op: CurateLogOperation = {
+    needsReview: false,
+    path: topicPath ?? FALLBACK_PATH,
+    status: 'failed',
+    type: meta?.type ?? 'ADD',
+  }
+
+  if (filePath !== undefined) op.filePath = filePath
+  if (meta?.impact !== undefined) op.impact = meta.impact
+  if (meta?.confidence !== undefined) op.confidence = meta.confidence
+  if (meta?.reason !== undefined) op.reason = meta.reason
+  if (meta?.summary !== undefined) op.summary = meta.summary
+  if (meta?.previousSummary !== undefined) op.previousSummary = meta.previousSummary
+
+  op.message = writeResult.errors.map((e) => `${e.kind}: ${e.message}`).join('\n')
+
+  return op
+}

--- a/src/server/infra/process/curate-html-log.ts
+++ b/src/server/infra/process/curate-html-log.ts
@@ -1,5 +1,9 @@
+import {readFile} from 'node:fs/promises'
+import {relative, sep} from 'node:path'
+
 import type {CurateMeta} from '../../../shared/curate-meta.js'
 import type {CurateLogEntry, CurateLogOperation} from '../../core/domain/entities/curate-log-entry.js'
+import type {IReviewBackupStore} from '../../core/interfaces/storage/i-review-backup-store.js'
 import type {HtmlWriteResult} from '../render/writer/html-writer.js'
 
 import {computeSummary} from './curate-log-handler.js'
@@ -39,6 +43,57 @@ type BuildInput = {
   topicPath?: string
   /** Result from `writeHtmlTopic`. */
   writeResult: HtmlWriteResult
+}
+
+/**
+ * Capture the current bytes of a context-tree file into the review-backup
+ * store BEFORE a destructive write happens. This is the contract the
+ * review-handler reject path relies on (`review-handler.ts:148-167`): on
+ * reject, it reads `backupStore.read(relPath)`; `null` is treated as
+ * "ADD — unlink the file", any non-null content as "restore via writeFile".
+ *
+ * Without this call, an UPDATE-shaped tool-mode curate writes a
+ * `reviewStatus: 'pending'` log entry but no backup — and `brv review reject`
+ * deletes the user's prior knowledge instead of restoring it.
+ *
+ * Mirrors main's `backupBeforeWrite` (`src/agent/infra/tools/implementations/
+ * curate-tool.ts:480`) — same semantics:
+ *   - Honors `reviewDisabled`: backups exist solely to support reject-restore.
+ *     With reviews off they are dead state.
+ *   - First-write-wins (delegated to `FileReviewBackupStore.save`): the backup
+ *     always reflects the snapshot-at-last-push, never an intermediate state
+ *     between two curates that haven't been pushed.
+ *   - Best-effort: ENOENT (no prior file on disk = ADD case) is swallowed —
+ *     there's nothing to back up. Other I/O failures are also swallowed so a
+ *     transient store error doesn't fail an otherwise-successful curate.
+ *
+ * Call this immediately before `writeHtmlTopic` in both the daemon's
+ * `case 'curate-html-direct'` and the CLI's `continueSession`.
+ */
+export async function backupContextTreeFile(input: {
+  /** Absolute path to the file `writeHtmlTopic` will (over)write. */
+  absoluteFilePath: string
+  /** Absolute path to the project's context-tree root (`.brv/context-tree/`). */
+  contextTreeRoot: string
+  /** Project's review-backup store (instantiate with the project's `.brv/` dir). */
+  reviewBackupStore: IReviewBackupStore
+  /** Snapshot of the project's reviewDisabled flag for this task. */
+  reviewDisabled: boolean
+}): Promise<void> {
+  if (input.reviewDisabled) return
+  try {
+    const content = await readFile(input.absoluteFilePath, 'utf8')
+    // Normalize to forward-slashes — review-handler keys backups by the relative
+    // context-tree path it derived the same way (`relative()`); on Windows the
+    // separators would otherwise disagree across surfaces.
+    const relativePath = relative(input.contextTreeRoot, input.absoluteFilePath).replaceAll(sep, '/')
+    await input.reviewBackupStore.save(relativePath, content)
+  } catch {
+    // Best-effort. ENOENT is the ADD case (no prior file to back up) and is the
+    // most common path — leaving it implicit avoids tying this helper to fs error
+    // codes. Other failures (perms, disk full) also fall through so backup
+    // failure never blocks the user's curate.
+  }
 }
 
 /**
@@ -115,6 +170,14 @@ function buildSuccessOperation(args: {
   const derivedType = existedBefore && confirmOverwrite ? 'UPDATE' : 'ADD'
   const needsReview = meta?.impact === 'high' && !reviewDisabled
 
+  // Agent-asserted `meta.type` wins over `derivedType` unconditionally —
+  // even when on-disk truth contradicts it (e.g. agent says UPDATE but
+  // existedBefore=false, possibly because of a topic-path typo on a
+  // search-first-then-update flow). We honor the agent's intent because
+  // the agent had the user context the writer doesn't have; the on-disk
+  // signal is a sanity-check, not an override. The asymmetry is the same
+  // reason `impact` has no fallback at all — semantic judgments stay with
+  // the agent.
   const op: CurateLogOperation = {
     path: topicPath ?? FALLBACK_PATH,
     status: 'success',

--- a/src/shared/curate-meta.ts
+++ b/src/shared/curate-meta.ts
@@ -1,0 +1,71 @@
+import {z} from 'zod'
+
+/**
+ * Operation metadata the calling agent supplies alongside curate HTML.
+ *
+ * The legacy `case 'curate'` path used byterover's internal LLM to emit
+ * `type`/`impact`/`needsReview` via tool-call output, which surfaced
+ * curate operations for HITL review. Tool mode removed that LLM, leaving
+ * `case 'curate-html-direct'` and the CLI session protocol with no source
+ * of operation judgment — so `brv review pending` stayed empty for any
+ * user-initiated curate.
+ *
+ * `CurateMeta` is the calling agent's hook into the HITL pipeline: the
+ * agent that authored the HTML is also best-positioned to assert what
+ * kind of operation it is and whether it's load-bearing enough to need
+ * review. All fields are optional — agents that don't supply meta still
+ * curate successfully, just without review surfacing.
+ *
+ * Lives in `src/shared/` because the wire-payload encoder
+ * (`shared/transport/curate-html-content.ts`) must import it; placing
+ * the type under `src/server/` would force `shared → server` direction.
+ */
+export type CurateMeta = {
+  /** Agent's certainty in the curation. Optional — review pipeline does not gate on this in v1. */
+  confidence?: 'high' | 'low'
+  /**
+   * High = load-bearing decision, must-rule, architectural pattern,
+   * or new domain knowledge that the team needs to review before it
+   * propagates. Low = refinement, addition, or clarification.
+   *
+   * Has no fallback. `undefined` means "agent did not assert; don't
+   * surface for review" — silent omission is honest, defaulting to
+   * `'low'` would hide high-impact curates, defaulting to `'high'`
+   * would flood review.
+   */
+  impact?: 'high' | 'low'
+  /** Semantic summary of what existed before. Set on UPDATE / MERGE only. */
+  previousSummary?: string
+  /** One short sentence shown to human reviewers explaining why this curation matters. */
+  reason?: string
+  /** One-line semantic summary of the topic after this operation. */
+  summary?: string
+  /**
+   * Operation type, asserted by the agent. When absent, the log-entry
+   * builder falls back to `existedBefore ? 'UPDATE' : 'ADD'` based on
+   * what the writer observed on disk.
+   */
+  type?: 'ADD' | 'MERGE' | 'UPDATE'
+}
+
+/**
+ * Zod schema for `CurateMeta`. `.strict()` rejects unknown keys so typos
+ * (`importance` vs `impact`, `severity` vs `impact`) fail loudly at the
+ * MCP boundary instead of silently dropping into the void.
+ *
+ * Forward-incompatible payloads are graceful at the transport-decode
+ * layer: `decodeCurateHtmlContent` catches schema failures and returns
+ * `meta: undefined` so a future MCP client emitting newer fields against
+ * an older daemon downgrades to "no review surfacing" instead of failing
+ * the entire curate.
+ */
+export const CurateMetaSchema = z
+  .object({
+    confidence: z.enum(['high', 'low']).optional(),
+    impact: z.enum(['high', 'low']).optional(),
+    previousSummary: z.string().optional(),
+    reason: z.string().optional(),
+    summary: z.string().optional(),
+    type: z.enum(['ADD', 'MERGE', 'UPDATE']).optional(),
+  })
+  .strict()

--- a/src/shared/transport/curate-html-content.ts
+++ b/src/shared/transport/curate-html-content.ts
@@ -1,10 +1,14 @@
+import type {CurateMeta} from '../curate-meta.js'
+
+import {CurateMetaSchema} from '../curate-meta.js'
+
 /**
  * Encode/decode helpers for curate-html-direct task content payloads.
  *
  * Sibling to `query-tool-mode-content.ts`. The transport layer's
  * `TaskCreateRequest` has a single `content: string` field; curate
- * tool mode packs `{html, confirmOverwrite?}` as JSON so the daemon
- * dispatcher can reconstruct the structured options.
+ * tool mode packs `{html, meta?, confirmOverwrite?}` as JSON so the
+ * daemon dispatcher can reconstruct the structured options.
  *
  * Lives in `shared/` because the MCP tool (encoder) and the daemon
  * agent-process (decoder) both depend on it.
@@ -13,10 +17,15 @@
 /**
  * Encode curate-html-direct options as a JSON content payload.
  */
-export function encodeCurateHtmlContent(options: {confirmOverwrite?: boolean; html: string}): string {
+export function encodeCurateHtmlContent(options: {
+  confirmOverwrite?: boolean
+  html: string
+  meta?: CurateMeta
+}): string {
   return JSON.stringify({
     confirmOverwrite: options.confirmOverwrite,
     html: options.html,
+    meta: options.meta,
   })
 }
 
@@ -28,8 +37,19 @@ export function encodeCurateHtmlContent(options: {confirmOverwrite?: boolean; ht
  * surface as a `task:error` (outer `success: false`) is much easier for
  * the calling agent to diagnose than silently treating the entire JSON
  * string as a literal HTML payload.
+ *
+ * `meta` is best-effort: if present but invalid against `CurateMetaSchema`
+ * (typo'd field, wrong enum value), it downgrades to `undefined` so a
+ * forward-incompatible payload still curates — just without review
+ * surfacing for that entry. The trade-off: silently losing metadata is
+ * a small loss; failing the whole curate over a metadata typo would
+ * block users from saving knowledge over an HITL feature.
  */
-export function decodeCurateHtmlContent(content: string): {confirmOverwrite?: boolean; html: string} {
+export function decodeCurateHtmlContent(content: string): {
+  confirmOverwrite?: boolean
+  html: string
+  meta?: CurateMeta
+} {
   let parsed: unknown
   try {
     parsed = JSON.parse(content)
@@ -43,9 +63,14 @@ export function decodeCurateHtmlContent(content: string): {confirmOverwrite?: bo
     throw new Error('curate-html-direct payload is missing a string `html` field.')
   }
 
-  const {confirmOverwrite, html} = parsed as {confirmOverwrite?: unknown; html: string}
+  const {confirmOverwrite, html, meta} = parsed as {confirmOverwrite?: unknown; html: string; meta?: unknown}
+
+  const metaResult = meta === undefined ? undefined : CurateMetaSchema.safeParse(meta)
+  const validMeta = metaResult?.success ? metaResult.data : undefined
+
   return {
     confirmOverwrite: typeof confirmOverwrite === 'boolean' ? confirmOverwrite : undefined,
     html,
+    meta: validMeta,
   }
 }

--- a/src/shared/transport/curate-html-content.ts
+++ b/src/shared/transport/curate-html-content.ts
@@ -68,6 +68,19 @@ export function decodeCurateHtmlContent(content: string): {
   const metaResult = meta === undefined ? undefined : CurateMetaSchema.safeParse(meta)
   const validMeta = metaResult?.success ? metaResult.data : undefined
 
+  // Forward-compat downgrade safety net. The path is unreachable from MCP today
+  // (BrvCurateInputSchema is .strict() at the boundary), but it protects the
+  // wire layer against a newer client sending fields this daemon's schema doesn't
+  // know yet. Without observability, a forward-incompat field rename would look
+  // identical to a successful curate that just happens not to surface for review.
+  // shared/ can't take a logger; guard the signal on BRV_QUEUE_TRACE so production
+  // stays quiet and operators diagnosing the symptom can opt in.
+  if (meta !== undefined && metaResult && !metaResult.success && process.env.BRV_QUEUE_TRACE) {
+    process.stderr.write(
+      `decodeCurateHtmlContent: invalid meta downgraded to undefined (${metaResult.error.issues[0]?.message ?? 'unknown'})\n`,
+    )
+  }
+
   return {
     confirmOverwrite: typeof confirmOverwrite === 'boolean' ? confirmOverwrite : undefined,
     html,

--- a/test/unit/infra/mcp/tools/brv-curate-tool.test.ts
+++ b/test/unit/infra/mcp/tools/brv-curate-tool.test.ts
@@ -16,7 +16,14 @@ import {decodeCurateHtmlContent} from '../../../../../src/shared/transport/curat
 const noClient = (): ITransportClient | undefined => undefined
 const noWorkingDirectory = (): string | undefined => undefined
 
-type CurateToolHandler = (input: {confirmOverwrite?: boolean; cwd?: string; html: string}) => Promise<{
+import type {CurateMeta} from '../../../../../src/shared/curate-meta.js'
+
+type CurateToolHandler = (input: {
+  confirmOverwrite?: boolean
+  cwd?: string
+  html: string
+  meta?: CurateMeta
+}) => Promise<{
   content: Array<{text: string; type: string}>
   isError?: boolean
 }>
@@ -150,6 +157,38 @@ describe('brv-curate-tool', () => {
       expect(result.success).to.be.false
     })
 
+    it('accepts a well-formed meta object', () => {
+      const result = BrvCurateInputSchema.safeParse({
+        html: VALID_HTML,
+        meta: {impact: 'high', reason: 'Locks JWT alg.', summary: 'JWT RS256.', type: 'ADD'},
+      })
+      expect(result.success).to.be.true
+    })
+
+    it('accepts meta with only a subset of fields', () => {
+      const result = BrvCurateInputSchema.safeParse({
+        html: VALID_HTML,
+        meta: {impact: 'low'},
+      })
+      expect(result.success).to.be.true
+    })
+
+    it('rejects invalid meta.impact enum', () => {
+      const result = BrvCurateInputSchema.safeParse({
+        html: VALID_HTML,
+        meta: {impact: 'severe'},
+      })
+      expect(result.success).to.be.false
+    })
+
+    it('rejects unknown keys inside meta (.strict on the meta schema)', () => {
+      const result = BrvCurateInputSchema.safeParse({
+        html: VALID_HTML,
+        meta: {impact: 'high', importance: 'high'},
+      })
+      expect(result.success).to.be.false
+    })
+
     it('rejects legacy {context, files, folder} shape', () => {
       // The old API took context/files/folder. After M3 the schema only accepts
       // {cwd, html, confirmOverwrite?} and is .strict(), so even a payload that
@@ -228,6 +267,24 @@ describe('brv-curate-tool', () => {
       expect(inlineFlowMatch, 'sectioned example contains an inline <bv-flow> block').to.exist
     })
 
+    it('documents the optional meta field for review surfacing', () => {
+      const {getDescription} = setupHandler({
+        getClient: () => createMockClient().client,
+        getWorkingDirectory: () => '/project/root',
+      })
+
+      const description = getDescription()
+      // Calling agents must see how to opt in to HITL review surfacing —
+      // the meta section explains impact / type / reason semantics so the
+      // calling agent's LLM can make a judgment call on each curate.
+      expect(description).to.include('# Operation metadata')
+      expect(description).to.include('impact')
+      expect(description).to.include('high')
+      expect(description).to.include('reason')
+      // Optional — explicit so the agent doesn't think it's required.
+      expect(description.toLowerCase()).to.include('optional')
+    })
+
     it('includes the authoring-patterns guidance for sectioning', () => {
       const {getDescription} = setupHandler({
         getClient: () => createMockClient().client,
@@ -271,6 +328,60 @@ describe('brv-curate-tool', () => {
       const decoded = decodeCurateHtmlContent(payload.content)
       expect(decoded.html).to.equal(VALID_HTML)
       expect(decoded.confirmOverwrite).to.equal(true)
+    })
+
+    it('threads meta through to the encoded payload when supplied', async () => {
+      const {client, simulateEvent} = createMockClient()
+      const requestStub = client.requestWithAck as SinonStub
+      requestStub.callsFake((event: string, data: {taskId?: string}) => {
+        if (event === 'task:create' && data.taskId) {
+          simulateEvent('task:completed', {result: JSON.stringify(okEnvelope()), taskId: data.taskId})
+        }
+
+        return Promise.resolve()
+      })
+
+      const {handler} = setupHandler({
+        getClient: () => client,
+        getWorkingDirectory: () => '/project/root',
+      })
+
+      await handler({
+        html: VALID_HTML,
+        meta: {impact: 'high', reason: 'Locks alg.', summary: 'JWT.', type: 'ADD'},
+      })
+
+      const createCall = requestStub.getCalls().find((c: {args: unknown[]}) => c.args[0] === 'task:create')
+      const decoded = decodeCurateHtmlContent((createCall!.args[1] as {content: string}).content)
+      expect(decoded.meta).to.deep.equal({
+        impact: 'high',
+        reason: 'Locks alg.',
+        summary: 'JWT.',
+        type: 'ADD',
+      })
+    })
+
+    it('omits meta from the encoded payload when not supplied', async () => {
+      const {client, simulateEvent} = createMockClient()
+      const requestStub = client.requestWithAck as SinonStub
+      requestStub.callsFake((event: string, data: {taskId?: string}) => {
+        if (event === 'task:create' && data.taskId) {
+          simulateEvent('task:completed', {result: JSON.stringify(okEnvelope()), taskId: data.taskId})
+        }
+
+        return Promise.resolve()
+      })
+
+      const {handler} = setupHandler({
+        getClient: () => client,
+        getWorkingDirectory: () => '/project/root',
+      })
+
+      await handler({html: VALID_HTML})
+
+      const createCall = requestStub.getCalls().find((c: {args: unknown[]}) => c.args[0] === 'task:create')
+      const decoded = decodeCurateHtmlContent((createCall!.args[1] as {content: string}).content)
+      expect(decoded.meta).to.be.undefined
     })
 
     it('omits confirmOverwrite when input does not include it', async () => {

--- a/test/unit/infra/process/curate-html-log.test.ts
+++ b/test/unit/infra/process/curate-html-log.test.ts
@@ -1,8 +1,12 @@
 import {expect} from 'chai'
+import {mkdir, mkdtemp, readFile, rm, writeFile} from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join, relative} from 'node:path'
 
 import type {HtmlWriteResult} from '../../../../src/server/infra/render/writer/html-writer.js'
 
-import {buildCurateHtmlLogEntry} from '../../../../src/server/infra/process/curate-html-log.js'
+import {backupContextTreeFile, buildCurateHtmlLogEntry} from '../../../../src/server/infra/process/curate-html-log.js'
+import {FileReviewBackupStore} from '../../../../src/server/infra/storage/file-review-backup-store.js'
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -169,6 +173,111 @@ describe('buildCurateHtmlLogEntry', () => {
       expect(op.status).to.equal('failed')
       expect(op.needsReview).to.equal(false)
       expect(op.reviewStatus).to.be.undefined
+    })
+  })
+
+  describe('backupContextTreeFile (regression for `brv review reject` restoring prior content)', () => {
+    // Mirrors main's `backupBeforeWrite` contract: before any destructive
+    // write under the context-tree root, capture the existing bytes into
+    // `<brvDir>/review-backups/<relativePath>` via the store. Without this,
+    // `brv review reject` deletes the file (review-handler treats missing
+    // backup as ADD → unlink).
+
+    let projectRoot: string
+
+    beforeEach(async () => {
+      projectRoot = await mkdtemp(join(tmpdir(), 'backup-helper-'))
+    })
+
+    afterEach(async () => {
+      await rm(projectRoot, {force: true, recursive: true})
+    })
+
+    async function seedTopic(relativePath: string, content: string): Promise<string> {
+      const absolutePath = join(projectRoot, '.brv', 'context-tree', relativePath)
+      await mkdir(join(absolutePath, '..'), {recursive: true})
+      await writeFile(absolutePath, content, 'utf8')
+      return absolutePath
+    }
+
+    function backupStoreFor(): FileReviewBackupStore {
+      return new FileReviewBackupStore(join(projectRoot, '.brv'))
+    }
+
+    it('saves prior file bytes to the backup store when the file exists', async () => {
+      const absolutePath = await seedTopic('security/auth.html', '<bv-topic path="security/auth">prior</bv-topic>')
+      const store = backupStoreFor()
+      const contextTreeRoot = join(projectRoot, '.brv', 'context-tree')
+
+      await backupContextTreeFile({absoluteFilePath: absolutePath, contextTreeRoot, reviewBackupStore: store, reviewDisabled: false})
+
+      const backupContent = await store.read(relative(contextTreeRoot, absolutePath))
+      expect(backupContent).to.equal('<bv-topic path="security/auth">prior</bv-topic>')
+    })
+
+    it('no-ops when the file does not exist (ADD case — ENOENT swallowed)', async () => {
+      const store = backupStoreFor()
+      const contextTreeRoot = join(projectRoot, '.brv', 'context-tree')
+      const absent = join(contextTreeRoot, 'never/written.html')
+
+      // Should not throw.
+      await backupContextTreeFile({absoluteFilePath: absent, contextTreeRoot, reviewBackupStore: store, reviewDisabled: false})
+
+      const backupContent = await store.read('never/written.html')
+      expect(backupContent).to.equal(null)
+    })
+
+    it('skips backup creation when reviewDisabled = true', async () => {
+      const absolutePath = await seedTopic('x/y.html', 'prior')
+      const store = backupStoreFor()
+      const contextTreeRoot = join(projectRoot, '.brv', 'context-tree')
+
+      await backupContextTreeFile({absoluteFilePath: absolutePath, contextTreeRoot, reviewBackupStore: store, reviewDisabled: true})
+
+      const backupContent = await store.read('x/y.html')
+      expect(backupContent).to.equal(null)
+    })
+
+    it('first-write-wins (delegated to the store): second call does not overwrite the snapshot', async () => {
+      const absolutePath = await seedTopic('x/y.html', 'snapshot-at-last-push')
+      const store = backupStoreFor()
+      const contextTreeRoot = join(projectRoot, '.brv', 'context-tree')
+
+      // First backup captures the snapshot.
+      await backupContextTreeFile({absoluteFilePath: absolutePath, contextTreeRoot, reviewBackupStore: store, reviewDisabled: false})
+
+      // File evolves on disk, then a second curate triggers another backup attempt.
+      await writeFile(absolutePath, 'newer-content', 'utf8')
+      await backupContextTreeFile({absoluteFilePath: absolutePath, contextTreeRoot, reviewBackupStore: store, reviewDisabled: false})
+
+      // The backup must still hold the original snapshot — multiple curates between
+      // pushes must not erode the "state at last push" guarantee.
+      const backupContent = await store.read('x/y.html')
+      expect(backupContent).to.equal('snapshot-at-last-push')
+    })
+
+    it('I/O failure does not throw (best-effort; backup must never block curate)', async () => {
+      const store = backupStoreFor()
+      const contextTreeRoot = join(projectRoot, '.brv', 'context-tree')
+      // Path that doesn't resolve under context-tree-root and isn't readable.
+      const garbage = '/proc/this-cannot-be-read-or-resolved/xxx'
+
+      await backupContextTreeFile({absoluteFilePath: garbage, contextTreeRoot, reviewBackupStore: store, reviewDisabled: false})
+
+      // No exception, no backup.
+      expect(await store.list()).to.have.lengthOf(0)
+    })
+
+    // Sanity: this is the exact bytes-as-saved snapshot the rejected `brv review reject`
+    // reads. If this round-trip breaks, the restore path breaks silently.
+    it('backup content round-trips through the store byte-for-byte', async () => {
+      const absolutePath = await seedTopic('x/y.html', '<bv-topic>\n  <bv-rule>α β γ</bv-rule>\n</bv-topic>')
+      const store = backupStoreFor()
+      const contextTreeRoot = join(projectRoot, '.brv', 'context-tree')
+
+      await backupContextTreeFile({absoluteFilePath: absolutePath, contextTreeRoot, reviewBackupStore: store, reviewDisabled: false})
+      const backupContent = await readFile(join(projectRoot, '.brv', 'review-backups', 'x/y.html'), 'utf8')
+      expect(backupContent).to.equal('<bv-topic>\n  <bv-rule>α β γ</bv-rule>\n</bv-topic>')
     })
   })
 

--- a/test/unit/infra/process/curate-html-log.test.ts
+++ b/test/unit/infra/process/curate-html-log.test.ts
@@ -1,0 +1,224 @@
+import {expect} from 'chai'
+
+import type {HtmlWriteResult} from '../../../../src/server/infra/render/writer/html-writer.js'
+
+import {buildCurateHtmlLogEntry} from '../../../../src/server/infra/process/curate-html-log.js'
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const SUCCESS: HtmlWriteResult = {
+  filePath: '/project/.brv/context-tree/security/auth.html',
+  ok: true,
+  written: '<bv-topic path="security/auth"></bv-topic>',
+}
+
+const FAILURE: HtmlWriteResult = {
+  errors: [
+    {kind: 'missing-bv-topic', message: 'Curate output must contain exactly one <bv-topic> root.'},
+  ],
+  ok: false,
+}
+
+function baseInput() {
+  return {
+    completedAt: 1_700_000_010_000,
+    confirmOverwrite: false,
+    existedBefore: false,
+    // Absolute path — mirrors what writeHtmlTopic returns. Review-handler
+    // and dream-executor both treat `op.filePath` as absolute.
+    filePath: '/project/.brv/context-tree/security/auth.html',
+    id: 'cur-1700000000000',
+    reviewDisabled: false,
+    startedAt: 1_700_000_000_000,
+    taskId: 'task-abc',
+    topicPath: 'security/auth',
+    writeResult: SUCCESS,
+  }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('buildCurateHtmlLogEntry', () => {
+  describe('success with meta.impact = high', () => {
+    it('sets needsReview = true and reviewStatus = pending when reviewDisabled = false', () => {
+      const entry = buildCurateHtmlLogEntry({
+        ...baseInput(),
+        meta: {impact: 'high', reason: 'Locks JWT alg.', summary: 'JWT RS256.', type: 'ADD'},
+      })
+
+      expect(entry.status).to.equal('completed')
+      expect(entry.operations).to.have.lengthOf(1)
+      const op = entry.operations[0]
+      expect(op.needsReview).to.equal(true)
+      expect(op.reviewStatus).to.equal('pending')
+      expect(op.impact).to.equal('high')
+      expect(op.type).to.equal('ADD')
+      expect(op.reason).to.equal('Locks JWT alg.')
+      expect(op.summary).to.equal('JWT RS256.')
+      expect(op.status).to.equal('success')
+    })
+
+    it('suppresses needsReview when reviewDisabled = true', () => {
+      const entry = buildCurateHtmlLogEntry({
+        ...baseInput(),
+        meta: {impact: 'high', type: 'ADD'},
+        reviewDisabled: true,
+      })
+
+      const op = entry.operations[0]
+      expect(op.needsReview).to.equal(false)
+      expect(op.reviewStatus).to.be.undefined
+      expect(op.impact).to.equal('high')
+    })
+  })
+
+  describe('success with meta.impact = low', () => {
+    it('sets needsReview = false and omits reviewStatus', () => {
+      const entry = buildCurateHtmlLogEntry({
+        ...baseInput(),
+        meta: {impact: 'low', type: 'UPDATE'},
+      })
+
+      const op = entry.operations[0]
+      expect(op.needsReview).to.equal(false)
+      expect(op.reviewStatus).to.be.undefined
+      expect(op.impact).to.equal('low')
+    })
+  })
+
+  describe('success without meta', () => {
+    it('falls back to writer-derived type and omits impact / needsReview', () => {
+      const entry = buildCurateHtmlLogEntry({...baseInput()})
+
+      const op = entry.operations[0]
+      expect(op.type).to.equal('ADD') // existedBefore: false → ADD
+      expect(op.impact).to.be.undefined
+      expect(op.needsReview).to.be.undefined
+      expect(op.reviewStatus).to.be.undefined
+      expect(op.reason).to.be.undefined
+    })
+  })
+
+  describe('type derivation', () => {
+    it('defaults to UPDATE when existedBefore = true and confirmOverwrite = true, no meta.type', () => {
+      const entry = buildCurateHtmlLogEntry({...baseInput(), confirmOverwrite: true, existedBefore: true})
+      expect(entry.operations[0].type).to.equal('UPDATE')
+    })
+
+    it('defaults to ADD when existedBefore = true but confirmOverwrite = false', () => {
+      // existedBefore + confirmOverwrite=false is a writer "path-exists" failure scenario;
+      // type fallback only treats it as UPDATE when overwrite was confirmed.
+      const entry = buildCurateHtmlLogEntry({...baseInput(), confirmOverwrite: false, existedBefore: true})
+      expect(entry.operations[0].type).to.equal('ADD')
+    })
+
+    it('lets agent-asserted meta.type win over writer fallback (MERGE)', () => {
+      const entry = buildCurateHtmlLogEntry({
+        ...baseInput(),
+        confirmOverwrite: true,
+        existedBefore: true,
+        meta: {type: 'MERGE'},
+      })
+      expect(entry.operations[0].type).to.equal('MERGE')
+    })
+
+    it('lets agent-asserted meta.type win over writer fallback (ADD on UPDATE-ish state)', () => {
+      const entry = buildCurateHtmlLogEntry({
+        ...baseInput(),
+        confirmOverwrite: true,
+        existedBefore: true,
+        meta: {type: 'ADD'},
+      })
+      expect(entry.operations[0].type).to.equal('ADD')
+    })
+  })
+
+  describe('failure path', () => {
+    it('returns error entry with failed operation and preserves error message', () => {
+      const entry = buildCurateHtmlLogEntry({...baseInput(), writeResult: FAILURE})
+
+      expect(entry.status).to.equal('error')
+      if (entry.status !== 'error') throw new Error('unreachable')
+      expect(entry.error).to.contain('missing-bv-topic')
+
+      expect(entry.operations).to.have.lengthOf(1)
+      const op = entry.operations[0]
+      expect(op.status).to.equal('failed')
+      expect(op.needsReview).to.equal(false)
+      expect(op.reviewStatus).to.be.undefined
+      expect(op.message).to.contain('Curate output must contain exactly one')
+    })
+
+    it('uses sentinel path on failure when topicPath is unknown', () => {
+      const entry = buildCurateHtmlLogEntry({
+        ...baseInput(),
+        topicPath: undefined,
+        writeResult: FAILURE,
+      })
+      expect(entry.operations[0].path).to.equal('<unknown>')
+    })
+
+    it('failed entry still includes meta.impact when present (telemetry) but does not surface for review', () => {
+      const entry = buildCurateHtmlLogEntry({
+        ...baseInput(),
+        meta: {impact: 'high', type: 'ADD'},
+        writeResult: FAILURE,
+      })
+
+      const op = entry.operations[0]
+      expect(op.status).to.equal('failed')
+      expect(op.needsReview).to.equal(false)
+      expect(op.reviewStatus).to.be.undefined
+    })
+  })
+
+  describe('filePath convention (regression — see review-handler contract)', () => {
+    it('preserves the caller-supplied absolute filePath verbatim on the operation', () => {
+      // review-handler.ts:117 + dream-executor convention: op.filePath is
+      // absolute. The handler does `relative(contextTreeDir, op.filePath)`
+      // to derive its display key — passing a relative path produces a
+      // garbage key and `brv review approve <taskId>` silently no-ops.
+      const entry = buildCurateHtmlLogEntry({
+        ...baseInput(),
+        filePath: '/abs/.brv/context-tree/x/y.html',
+        meta: {impact: 'high', type: 'ADD'},
+      })
+      expect(entry.operations[0].filePath).to.equal('/abs/.brv/context-tree/x/y.html')
+    })
+  })
+
+  describe('entry shape', () => {
+    it('includes startedAt, completedAt, taskId, id, format = html', () => {
+      const entry = buildCurateHtmlLogEntry({...baseInput()})
+
+      expect(entry.id).to.equal('cur-1700000000000')
+      expect(entry.taskId).to.equal('task-abc')
+      expect(entry.startedAt).to.equal(1_700_000_000_000)
+      expect(entry.format).to.equal('html')
+      if (entry.status !== 'completed') throw new Error('expected completed')
+      expect(entry.completedAt).to.equal(1_700_000_010_000)
+    })
+
+    it('threads intent into input.context', () => {
+      const entry = buildCurateHtmlLogEntry({...baseInput(), intent: 'remember JWT decision'})
+      expect(entry.input.context).to.equal('remember JWT decision')
+    })
+
+    it('falls back to a sentinel intent when none supplied', () => {
+      const entry = buildCurateHtmlLogEntry({...baseInput()})
+      expect(entry.input.context).to.be.a('string').and.not.equal('')
+    })
+
+    it('computes summary from operations (success ADD increments added)', () => {
+      const entry = buildCurateHtmlLogEntry({...baseInput(), meta: {type: 'ADD'}})
+      expect(entry.summary.added).to.equal(1)
+      expect(entry.summary.failed).to.equal(0)
+    })
+
+    it('computes summary from operations (failure increments failed)', () => {
+      const entry = buildCurateHtmlLogEntry({...baseInput(), writeResult: FAILURE})
+      expect(entry.summary.failed).to.equal(1)
+      expect(entry.summary.added).to.equal(0)
+    })
+  })
+})

--- a/test/unit/infra/transport/handlers/review-handler-reject-restore.test.ts
+++ b/test/unit/infra/transport/handlers/review-handler-reject-restore.test.ts
@@ -1,0 +1,140 @@
+/**
+ * End-to-end "curate UPDATE → reject restores prior content" guardrail.
+ *
+ * The CLI/daemon backup-seeding helper has its own unit tests, but those only
+ * prove the *necessary* condition (backup file exists with the right bytes).
+ * This file proves the *sufficient* condition: that the seeded backup, keyed
+ * the way the curate side keys it, actually causes review-handler's reject
+ * path to RESTORE the file rather than `unlink` it (which is what happens when
+ * `backupStore.read()` returns null).
+ *
+ * If the curate side and the handler side ever drift on keying (Windows
+ * separators, a `relative()` rooted at a different dir, etc.), the unit tests
+ * stay green while production silently deletes the user's content. This test
+ * is the durable contract guard.
+ *
+ * Lives in its own file because mocha/max-top-level-suites caps one
+ * top-level `describe` per file.
+ */
+
+import type {SinonStub} from 'sinon'
+
+import {expect} from 'chai'
+import {existsSync} from 'node:fs'
+import {mkdtemp, readFile, rm} from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+import {restore, stub} from 'sinon'
+
+import type {IProjectConfigStore} from '../../../../../src/server/core/interfaces/storage/i-project-config-store.js'
+
+import {continueSession, kickoffSession} from '../../../../../src/oclif/lib/curate-session.js'
+import {BRV_DIR, CONTEXT_TREE_DIR} from '../../../../../src/server/constants.js'
+import {BrvConfig} from '../../../../../src/server/core/domain/entities/brv-config.js'
+import {FileCurateLogStore} from '../../../../../src/server/infra/storage/file-curate-log-store.js'
+import {FileReviewBackupStore} from '../../../../../src/server/infra/storage/file-review-backup-store.js'
+import {ReviewHandler} from '../../../../../src/server/infra/transport/handlers/review-handler.js'
+import {getProjectDataDir} from '../../../../../src/server/utils/path-utils.js'
+import {ReviewEvents} from '../../../../../src/shared/transport/events/review-events.js'
+import {createMockTransportServer, type MockTransportServer} from '../../../../helpers/mock-factories.js'
+
+function rejectEnvelope(html: string, metaType?: 'ADD' | 'UPDATE'): string {
+  const meta = metaType === undefined ? undefined : {impact: 'high' as const, type: metaType}
+  return JSON.stringify({html, meta})
+}
+
+describe('ReviewHandler — curate UPDATE → reject restores prior content (e2e contract)', () => {
+  let projectRoot: string
+  let transport: MockTransportServer
+  let projectConfigStore: Partial<IProjectConfigStore> & {read: SinonStub; write: SinonStub}
+
+  beforeEach(async () => {
+    projectRoot = await mkdtemp(join(tmpdir(), 'review-handler-e2e-'))
+    transport = createMockTransportServer()
+    projectConfigStore = {
+      read: stub().resolves(BrvConfig.createLocal({cwd: projectRoot})),
+      write: stub().resolves(),
+    }
+  })
+
+  afterEach(async () => {
+    restore()
+    await rm(projectRoot, {force: true, recursive: true})
+  })
+
+  function buildRealHandler(): ReviewHandler {
+    // Real stores rooted at the test's tmpdir — no stubs. The curate side wrote
+    // entries + backups via `FileCurateLogStore.save` / `FileReviewBackupStore.save`
+    // keyed by relative context-tree path. The handler reads via the SAME stores
+    // with paths derived the same way. Anything that drifts breaks this test.
+    const handler = new ReviewHandler({
+      curateLogStoreFactory: () => new FileCurateLogStore({baseDir: getProjectDataDir(projectRoot)}),
+      projectConfigStore: projectConfigStore as IProjectConfigStore,
+      resolveProjectPath: () => projectRoot,
+      reviewBackupStoreFactory: () => new FileReviewBackupStore(join(projectRoot, BRV_DIR)),
+      transport,
+    })
+    handler.setup()
+    return handler
+  }
+
+  async function callReject(taskId: string): Promise<unknown> {
+    const handler = transport._handlers.get(ReviewEvents.DECIDE_TASK)
+    expect(handler, 'review:decideTask handler should be registered').to.exist
+    return handler!({decision: 'rejected', taskId}, 'client-1')
+  }
+
+  it('rejecting an UPDATE-shaped curate restores the file to its prior content (not delete)', async () => {
+    const topicPath = 'security/auth.html'
+    const onDisk = join(projectRoot, BRV_DIR, CONTEXT_TREE_DIR, topicPath)
+    const originalHtml =
+      '<bv-topic path="security/auth" title="JWT auth"><bv-decision id="d-orig">ORIGINAL — must survive reject.</bv-decision></bv-topic>'
+    const updatedHtml =
+      '<bv-topic path="security/auth" title="JWT auth"><bv-decision id="d-bad">BAD UPDATE — should be reverted.</bv-decision></bv-topic>'
+
+    // 1. Seed the topic via an initial ADD.
+    const kAdd = await kickoffSession({content: 'add', projectRoot})
+    await continueSession({projectRoot, response: rejectEnvelope(originalHtml, 'ADD'), sessionId: kAdd.sessionId!})
+    const originalOnDisk = await readFile(onDisk, 'utf8')
+
+    // 2. Run an UPDATE that lands as `reviewStatus: 'pending'` (meta.impact:'high')
+    //    AND seeds the review-backup with the original bytes.
+    const kUpdate = await kickoffSession({content: 'update', projectRoot})
+    await continueSession({
+      confirmOverwrite: true,
+      projectRoot,
+      response: rejectEnvelope(updatedHtml, 'UPDATE'),
+      sessionId: kUpdate.sessionId!,
+    })
+
+    // 3. Drive the actual reject through the handler — same code path `brv review reject` runs.
+    buildRealHandler()
+    await callReject(kUpdate.sessionId!)
+
+    // 4. THE contract: file must be RESTORED to original bytes — not unlinked,
+    //    not left as the BAD UPDATE.
+    expect(existsSync(onDisk), 'file must still exist after reject (NOT unlinked)').to.equal(true)
+    const afterReject = await readFile(onDisk, 'utf8')
+    expect(afterReject, 'file must be restored to original content').to.equal(originalOnDisk)
+    expect(afterReject).to.include('ORIGINAL — must survive reject.')
+    expect(afterReject).to.not.include('BAD UPDATE')
+  })
+
+  it('rejecting an ADD-shaped curate unlinks the file (no backup, no restore — matches main)', async () => {
+    const topicPath = 'security/auth.html'
+    const onDisk = join(projectRoot, BRV_DIR, CONTEXT_TREE_DIR, topicPath)
+    const html =
+      '<bv-topic path="security/auth" title="JWT auth"><bv-decision id="d-new">New topic.</bv-decision></bv-topic>'
+
+    // ADD a high-impact topic — pending review, no prior file → no backup created.
+    const k = await kickoffSession({content: 'add', projectRoot})
+    await continueSession({projectRoot, response: rejectEnvelope(html, 'ADD'), sessionId: k.sessionId!})
+    expect(existsSync(onDisk)).to.equal(true)
+
+    buildRealHandler()
+    await callReject(k.sessionId!)
+
+    // ADD reject unlinks (there's nothing to restore to) — same as main's behaviour.
+    expect(existsSync(onDisk), 'file is unlinked on ADD reject').to.equal(false)
+  })
+})

--- a/test/unit/oclif/lib/curate-session.test.ts
+++ b/test/unit/oclif/lib/curate-session.test.ts
@@ -35,6 +35,7 @@ import {
 } from '../../../../src/oclif/lib/curate-session.js'
 import {BRV_DIR} from '../../../../src/server/constants.js'
 import {FileCurateLogStore} from '../../../../src/server/infra/storage/file-curate-log-store.js'
+import {FileReviewBackupStore} from '../../../../src/server/infra/storage/file-review-backup-store.js'
 import {getProjectDataDir} from '../../../../src/server/utils/path-utils.js'
 
 /** Build the M4 JSON envelope shape expected by the continuation protocol. */
@@ -48,6 +49,11 @@ const TOPIC_WITHOUT_PATH = envelope(TOPIC_WITHOUT_PATH_RAW)
 async function readLogEntries(root: string) {
   const store = new FileCurateLogStore({baseDir: getProjectDataDir(root)})
   return store.list()
+}
+
+async function readBackup(root: string, relativePath: string): Promise<null | string> {
+  const store = new FileReviewBackupStore(join(root, BRV_DIR))
+  return store.read(relativePath)
 }
 
 const UUID_RE = /^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/i
@@ -777,6 +783,117 @@ describe('curate-session placeholder', () => {
 
       const entries = await readLogEntries(projectRoot)
       expect(entries).to.have.lengthOf(0)
+    })
+  })
+
+  // ── M4: review-backup before destructive write (regression for `brv review reject` data loss) ──
+
+  describe('continueSession — review backups before overwrite', () => {
+    // Without seeding the backup store before `writeHtmlTopic` clobbers an existing
+    // topic, `brv review reject` reads `backupStore.read()` → null →
+    // review-handler.ts:152 treats null backup as ADD → `unlink(absolutePath)` →
+    // user's prior knowledge is destroyed instead of restored. This contract is
+    // identical to main's `backupBeforeWrite` in `curate-tool.ts`.
+
+    it('seeds the review-backup store with prior content on UPDATE (confirmOverwrite=true over existing topic)', async () => {
+      // Seed the topic via an initial ADD.
+      const k1 = await kickoffSession({content: 'remember JWT', projectRoot})
+      await continueSession({projectRoot, response: VALID_TOPIC_HTML, sessionId: k1.sessionId!})
+      const initialContent = await readFile(
+        join(projectRoot, BRV_DIR, 'context-tree', 'security', 'auth.html'),
+        'utf8',
+      )
+
+      // UPDATE with confirmOverwrite=true. After this, the backup MUST hold the prior bytes
+      // so a subsequent `brv review reject` can restore — not delete — the topic.
+      const k2 = await kickoffSession({content: 'tighten JWT spec', projectRoot})
+      await continueSession({
+        confirmOverwrite: true,
+        projectRoot,
+        response: envelope(
+          '<bv-topic path="security/auth" title="JWT auth"><bv-rule severity="must">Rotate keys every 90 days.</bv-rule><bv-reason>updated</bv-reason></bv-topic>',
+          {impact: 'high', previousSummary: 'prior', summary: 'new', type: 'UPDATE'},
+        ),
+        sessionId: k2.sessionId!,
+      })
+
+      const backupContent = await readBackup(projectRoot, 'security/auth.html')
+      expect(backupContent, 'backup must hold the prior bytes for restore-on-reject').to.equal(initialContent)
+    })
+
+    it('does NOT create a backup on ADD (no prior file at path)', async () => {
+      // Fresh ADD — there's nothing to back up. Backup store should stay empty.
+      const k = await kickoffSession({content: 'remember JWT', projectRoot})
+      await continueSession({projectRoot, response: VALID_TOPIC_HTML, sessionId: k.sessionId!})
+
+      const backupContent = await readBackup(projectRoot, 'security/auth.html')
+      expect(backupContent).to.equal(null)
+    })
+
+    it('does NOT create a backup when project has reviewDisabled = true', async () => {
+      // Seed the topic.
+      const k1 = await kickoffSession({content: 'x', projectRoot})
+      await continueSession({projectRoot, response: VALID_TOPIC_HTML, sessionId: k1.sessionId!})
+
+      // Now turn off reviews.
+      await mkdir(join(projectRoot, BRV_DIR), {recursive: true})
+      await writeFile(
+        join(projectRoot, BRV_DIR, 'config.json'),
+        JSON.stringify({createdAt: new Date().toISOString(), reviewDisabled: true, version: '1'}),
+        'utf8',
+      )
+
+      // UPDATE under reviewDisabled. No backup should appear (review-backups/ stays empty
+      // so rejected curates aren't restorable — consistent with main's behaviour).
+      const k2 = await kickoffSession({content: 'x', projectRoot})
+      await continueSession({
+        confirmOverwrite: true,
+        projectRoot,
+        response: envelope(VALID_TOPIC_HTML_RAW, {impact: 'high', type: 'UPDATE'}),
+        sessionId: k2.sessionId!,
+      })
+
+      const backupContent = await readBackup(projectRoot, 'security/auth.html')
+      expect(backupContent).to.equal(null)
+    })
+
+    it('first-write-wins: two consecutive UPDATEs between pushes preserve the snapshot-at-last-push', async () => {
+      // Seed.
+      const k1 = await kickoffSession({content: 'x', projectRoot})
+      await continueSession({projectRoot, response: VALID_TOPIC_HTML, sessionId: k1.sessionId!})
+      const originalSnapshot = await readFile(
+        join(projectRoot, BRV_DIR, 'context-tree', 'security', 'auth.html'),
+        'utf8',
+      )
+
+      // First UPDATE — backup captures the original snapshot.
+      const k2 = await kickoffSession({content: 'update 1', projectRoot})
+      await continueSession({
+        confirmOverwrite: true,
+        projectRoot,
+        response: envelope(
+          '<bv-topic path="security/auth" title="JWT auth"><bv-rule>v2</bv-rule><bv-reason>r</bv-reason></bv-topic>',
+          {impact: 'high', type: 'UPDATE'},
+        ),
+        sessionId: k2.sessionId!,
+      })
+
+      // Second UPDATE — first-write-wins means the backup must still hold the ORIGINAL
+      // snapshot, not the intermediate v2 content. Otherwise rejecting after multiple
+      // curates would restore to a state that was never committed.
+      const k3 = await kickoffSession({content: 'update 2', projectRoot})
+      await continueSession({
+        confirmOverwrite: true,
+        projectRoot,
+        response: envelope(
+          '<bv-topic path="security/auth" title="JWT auth"><bv-rule>v3</bv-rule><bv-reason>r</bv-reason></bv-topic>',
+          {impact: 'high', type: 'UPDATE'},
+        ),
+        sessionId: k3.sessionId!,
+      })
+
+      const backupContent = await readBackup(projectRoot, 'security/auth.html')
+      expect(backupContent).to.equal(originalSnapshot)
     })
   })
 })

--- a/test/unit/oclif/lib/curate-session.test.ts
+++ b/test/unit/oclif/lib/curate-session.test.ts
@@ -14,8 +14,8 @@
  * corrupted state handling, and the documented envelope-shape contract.
  */
 
-const VALID_TOPIC_HTML = '<bv-topic path="security/auth" title="JWT auth"><bv-reason>x</bv-reason></bv-topic>'
-const TOPIC_WITHOUT_PATH = '<bv-topic title="JWT auth"></bv-topic>'
+const VALID_TOPIC_HTML_RAW = '<bv-topic path="security/auth" title="JWT auth"><bv-reason>x</bv-reason></bv-topic>'
+const TOPIC_WITHOUT_PATH_RAW = '<bv-topic title="JWT auth"></bv-topic>'
 
 import {expect} from 'chai'
 import {existsSync} from 'node:fs'
@@ -23,14 +23,32 @@ import {mkdir, mkdtemp, readFile, rm, writeFile} from 'node:fs/promises'
 import {tmpdir} from 'node:os'
 import {join} from 'node:path'
 
+import type {CurateMeta} from '../../../../src/shared/curate-meta.js'
+
 import {
   continueSession,
   CURATE_SESSION_PREFIX,
   CURATE_SESSIONS_DIR,
   kickoffSession,
+  parseCurateResponse,
   resolveProjectRoot,
 } from '../../../../src/oclif/lib/curate-session.js'
 import {BRV_DIR} from '../../../../src/server/constants.js'
+import {FileCurateLogStore} from '../../../../src/server/infra/storage/file-curate-log-store.js'
+import {getProjectDataDir} from '../../../../src/server/utils/path-utils.js'
+
+/** Build the M4 JSON envelope shape expected by the continuation protocol. */
+function envelope(html: string, meta?: CurateMeta): string {
+  return meta === undefined ? JSON.stringify({html}) : JSON.stringify({html, meta})
+}
+
+const VALID_TOPIC_HTML = envelope(VALID_TOPIC_HTML_RAW)
+const TOPIC_WITHOUT_PATH = envelope(TOPIC_WITHOUT_PATH_RAW)
+
+async function readLogEntries(root: string) {
+  const store = new FileCurateLogStore({baseDir: getProjectDataDir(root)})
+  return store.list()
+}
 
 const UUID_RE = /^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/i
 
@@ -243,9 +261,9 @@ describe('curate-session placeholder', () => {
 
       // Trigger unknown-bv-element error: a tag that isn't in the registry
       const html = '<bv-topic path="x/y" title="t"><bv-not-a-real-tag/></bv-topic>'
-      const envelope = await continueSession({projectRoot, response: html, sessionId})
+      const envelopeResult = await continueSession({projectRoot, response: envelope(html), sessionId})
 
-      const unknown = envelope.errors!.find((e) => e.kind === 'unknown-element')
+      const unknown = envelopeResult.errors!.find((e) => e.kind === 'unknown-element')
       expect(unknown, 'expected unknown-element error in envelope').to.not.equal(undefined)
       expect(unknown!.tag).to.equal('bv-not-a-real-tag')
     })
@@ -557,6 +575,208 @@ describe('curate-session placeholder', () => {
         sessionId: kickoff.sessionId!,
       })
       expect(envelope.status).to.equal('done')
+    })
+  })
+
+  // ── M4: parseCurateResponse — JSON envelope parsing ─────────────────────────
+
+  describe('parseCurateResponse', () => {
+    it('parses a well-formed envelope with html only', () => {
+      const result = parseCurateResponse(envelope(VALID_TOPIC_HTML_RAW))
+      expect(result.html).to.equal(VALID_TOPIC_HTML_RAW)
+      expect(result.meta).to.be.undefined
+    })
+
+    it('parses a well-formed envelope with html and meta', () => {
+      const result = parseCurateResponse(envelope(VALID_TOPIC_HTML_RAW, {impact: 'high', type: 'ADD'}))
+      expect(result.html).to.equal(VALID_TOPIC_HTML_RAW)
+      expect(result.meta).to.deep.equal({impact: 'high', type: 'ADD'})
+    })
+
+    it('throws invalid-response-format on malformed JSON', () => {
+      let caught: unknown
+      try {
+        parseCurateResponse('not-json{')
+      } catch (error) {
+        caught = error
+      }
+
+      expect(caught).to.be.instanceOf(Error)
+      const err = caught as Error & {kind?: string}
+      expect(err.kind).to.equal('invalid-response-format')
+      expect(err.message).to.match(/json/i)
+    })
+
+    it('throws invalid-response-format when html field is missing', () => {
+      let caught: unknown
+      try {
+        parseCurateResponse(JSON.stringify({meta: {impact: 'high'}}))
+      } catch (error) {
+        caught = error
+      }
+
+      const err = caught as Error & {kind?: string}
+      expect(err.kind).to.equal('invalid-response-format')
+      expect(err.message).to.match(/html/i)
+    })
+
+    it('throws invalid-response-format when html is empty string', () => {
+      let caught: unknown
+      try {
+        parseCurateResponse(JSON.stringify({html: ''}))
+      } catch (error) {
+        caught = error
+      }
+
+      expect((caught as Error & {kind?: string}).kind).to.equal('invalid-response-format')
+    })
+
+    it('throws invalid-response-format when meta has invalid enum value', () => {
+      let caught: unknown
+      try {
+        parseCurateResponse(JSON.stringify({html: VALID_TOPIC_HTML_RAW, meta: {impact: 'severe'}}))
+      } catch (error) {
+        caught = error
+      }
+
+      expect((caught as Error & {kind?: string}).kind).to.equal('invalid-response-format')
+    })
+
+    it('throws invalid-response-format when meta has unknown keys (.strict)', () => {
+      let caught: unknown
+      try {
+        parseCurateResponse(JSON.stringify({html: VALID_TOPIC_HTML_RAW, meta: {importance: 'high'}}))
+      } catch (error) {
+        caught = error
+      }
+
+      expect((caught as Error & {kind?: string}).kind).to.equal('invalid-response-format')
+    })
+  })
+
+  // ── M4: continueSession with envelope — error path ──────────────────────────
+
+  describe('continueSession — envelope validation errors', () => {
+    it('returns invalid-response-format envelope when --response is not JSON', async () => {
+      const kickoff = await kickoffSession({content: 'x', projectRoot})
+      const result = await continueSession({
+        projectRoot,
+        response: '<bv-topic path="x/y"></bv-topic>', // raw HTML — was valid before M4
+        sessionId: kickoff.sessionId!,
+      })
+
+      expect(result.status).to.equal('failed')
+      expect(result.errors![0].kind).to.equal('invalid-response-format')
+    })
+
+    it('returns invalid-response-format when meta is invalid', async () => {
+      const kickoff = await kickoffSession({content: 'x', projectRoot})
+      const result = await continueSession({
+        projectRoot,
+        response: JSON.stringify({html: VALID_TOPIC_HTML_RAW, meta: {impact: 'severe'}}),
+        sessionId: kickoff.sessionId!,
+      })
+
+      expect(result.status).to.equal('failed')
+      expect(result.errors![0].kind).to.equal('invalid-response-format')
+    })
+  })
+
+  // ── M4: curate-log persistence ──────────────────────────────────────────────
+
+  describe('continueSession — curate-log persistence', () => {
+    it('writes a log entry with needsReview=true when meta.impact = high', async () => {
+      const kickoff = await kickoffSession({content: 'remember JWT', projectRoot})
+      const result = await continueSession({
+        projectRoot,
+        response: envelope(VALID_TOPIC_HTML_RAW, {
+          impact: 'high',
+          reason: 'Locks JWT alg.',
+          summary: 'JWT RS256.',
+          type: 'ADD',
+        }),
+        sessionId: kickoff.sessionId!,
+      })
+      expect(result.status).to.equal('done')
+
+      const entries = await readLogEntries(projectRoot)
+      expect(entries).to.have.lengthOf(1)
+      const entry = entries[0]
+      expect(entry.status).to.equal('completed')
+      expect(entry.operations).to.have.lengthOf(1)
+      const op = entry.operations[0]
+      expect(op.needsReview).to.equal(true)
+      expect(op.reviewStatus).to.equal('pending')
+      expect(op.impact).to.equal('high')
+      expect(op.type).to.equal('ADD')
+      expect(op.reason).to.equal('Locks JWT alg.')
+    })
+
+    it('writes a log entry without review surfacing when meta omitted', async () => {
+      const kickoff = await kickoffSession({content: 'x', projectRoot})
+      const result = await continueSession({
+        projectRoot,
+        response: envelope(VALID_TOPIC_HTML_RAW),
+        sessionId: kickoff.sessionId!,
+      })
+      expect(result.status).to.equal('done')
+
+      const entries = await readLogEntries(projectRoot)
+      expect(entries).to.have.lengthOf(1)
+      const op = entries[0].operations[0]
+      expect(op.needsReview).to.be.undefined
+      expect(op.reviewStatus).to.be.undefined
+      expect(op.impact).to.be.undefined
+    })
+
+    it('suppresses needsReview when project has reviewDisabled=true', async () => {
+      // Write a BrvConfig with reviewDisabled=true into .brv/config.json
+      await mkdir(join(projectRoot, BRV_DIR), {recursive: true})
+      await writeFile(
+        join(projectRoot, BRV_DIR, 'config.json'),
+        JSON.stringify({createdAt: new Date().toISOString(), reviewDisabled: true, version: '1'}),
+        'utf8',
+      )
+
+      const kickoff = await kickoffSession({content: 'x', projectRoot})
+      await continueSession({
+        projectRoot,
+        response: envelope(VALID_TOPIC_HTML_RAW, {impact: 'high', type: 'ADD'}),
+        sessionId: kickoff.sessionId!,
+      })
+
+      const entries = await readLogEntries(projectRoot)
+      const op = entries[0].operations[0]
+      expect(op.needsReview).to.equal(false)
+      expect(op.reviewStatus).to.be.undefined
+      expect(op.impact).to.equal('high') // still recorded for telemetry
+    })
+
+    it('writes an error log entry on validation failure (still auditable)', async () => {
+      const kickoff = await kickoffSession({content: 'x', projectRoot})
+      await continueSession({
+        projectRoot,
+        response: envelope(TOPIC_WITHOUT_PATH_RAW, {impact: 'high', type: 'ADD'}),
+        sessionId: kickoff.sessionId!,
+      })
+
+      const entries = await readLogEntries(projectRoot)
+      expect(entries).to.have.lengthOf(1)
+      const entry = entries[0]
+      expect(entry.status).to.equal('error')
+      const op = entry.operations[0]
+      expect(op.status).to.equal('failed')
+      expect(op.needsReview).to.equal(false)
+    })
+
+    it('does NOT write a log entry when envelope itself is unparseable', async () => {
+      // Protocol-level failures (invalid JSON) happen before we have a
+      // valid {html, meta} pair; nothing to log.
+      const kickoff = await kickoffSession({content: 'x', projectRoot})
+      await continueSession({projectRoot, response: 'not-json{', sessionId: kickoff.sessionId!})
+
+      const entries = await readLogEntries(projectRoot)
+      expect(entries).to.have.lengthOf(0)
     })
   })
 })

--- a/test/unit/server/core/domain/render/curate-prompt-builder.test.ts
+++ b/test/unit/server/core/domain/render/curate-prompt-builder.test.ts
@@ -159,6 +159,24 @@ describe('curate-prompt-builder', () => {
       expect(prompt).to.include('Exactly one `<bv-topic>`')
     })
 
+    it('teaches the JSON envelope `{html, meta?}` output shape (M4)', () => {
+      const prompt = buildGeneratePrompt({userIntent: 'x'})
+      // The agent now emits a JSON envelope on `--response`, not raw HTML.
+      // The contract section must explain both keys and show an example.
+      expect(prompt).to.include('JSON envelope')
+      expect(prompt).to.include('"html"')
+      expect(prompt).to.include('"meta"')
+    })
+
+    it('documents the meta field semantics for review surfacing', () => {
+      const prompt = buildGeneratePrompt({userIntent: 'x'})
+      expect(prompt).to.include('impact')
+      expect(prompt).to.include('high')
+      expect(prompt).to.include('reason')
+      // Optional — explicit so the agent knows omission still curates
+      expect(prompt.toLowerCase()).to.include('optional')
+    })
+
     it('includes path-format guidance', () => {
       const prompt = buildGeneratePrompt({userIntent: 'x'})
       expect(prompt).to.include('<domain>/<topic>')
@@ -332,6 +350,20 @@ describe('curate-prompt-builder', () => {
     it('falls back to a generic instruction when given zero errors', () => {
       const prompt = buildCorrectionPrompt({errors: [], previousHtml, userIntent})
       expect(prompt).to.include('No structured errors')
+    })
+
+    it('teaches the JSON envelope on the correction step too (so agent re-emits in the right shape)', () => {
+      // The correction prompt must remind the agent of the envelope
+      // contract — otherwise after the first failure the agent might
+      // revert to raw HTML and trigger an invalid-response-format
+      // error on top of the original validation issue.
+      const prompt = buildCorrectionPrompt({
+        errors: [{kind: 'missing-path-attribute', message: 'm'}],
+        previousHtml,
+        userIntent,
+      })
+      expect(prompt).to.include('JSON envelope')
+      expect(prompt).to.include('"html"')
     })
 
     it('includes the output contract so the LLM still gets the bare-HTML rule', () => {

--- a/test/unit/shared/curate-meta.test.ts
+++ b/test/unit/shared/curate-meta.test.ts
@@ -1,0 +1,56 @@
+import {expect} from 'chai'
+
+import {CurateMetaSchema} from '../../../src/shared/curate-meta.js'
+
+describe('CurateMetaSchema', () => {
+  it('accepts an empty object (all fields optional)', () => {
+    const result = CurateMetaSchema.safeParse({})
+    expect(result.success).to.equal(true)
+  })
+
+  it('accepts every documented field with valid values', () => {
+    const result = CurateMetaSchema.safeParse({
+      confidence: 'high',
+      impact: 'high',
+      previousSummary: 'Prior summary.',
+      reason: 'Locks the JWT signing algorithm.',
+      summary: 'JWT: RS256 over HS256.',
+      type: 'ADD',
+    })
+    expect(result.success).to.equal(true)
+  })
+
+  it('accepts ADD / UPDATE / MERGE for type', () => {
+    for (const type of ['ADD', 'UPDATE', 'MERGE'] as const) {
+      const result = CurateMetaSchema.safeParse({type})
+      expect(result.success, `expected ${type} to parse`).to.equal(true)
+    }
+  })
+
+  it('rejects DELETE / UPSERT for type (CurateMeta is the agent-asserted subset)', () => {
+    for (const type of ['DELETE', 'UPSERT']) {
+      const result = CurateMetaSchema.safeParse({type})
+      expect(result.success, `expected ${type} to be rejected`).to.equal(false)
+    }
+  })
+
+  it('rejects invalid impact enum values', () => {
+    const result = CurateMetaSchema.safeParse({impact: 'severe'})
+    expect(result.success).to.equal(false)
+  })
+
+  it('rejects invalid confidence enum values', () => {
+    const result = CurateMetaSchema.safeParse({confidence: 'maybe'})
+    expect(result.success).to.equal(false)
+  })
+
+  it('rejects extra keys (.strict catches typos like `importance`)', () => {
+    const result = CurateMetaSchema.safeParse({importance: 'high'})
+    expect(result.success).to.equal(false)
+  })
+
+  it('rejects non-string reason', () => {
+    const result = CurateMetaSchema.safeParse({reason: 42})
+    expect(result.success).to.equal(false)
+  })
+})

--- a/test/unit/shared/transport/curate-html-content.test.ts
+++ b/test/unit/shared/transport/curate-html-content.test.ts
@@ -61,5 +61,36 @@ describe('curate-html-content', () => {
       expect(decoded.html).to.equal(original.html)
       expect(decoded.confirmOverwrite).to.be.undefined
     })
+
+    it('roundtrips meta field losslessly', () => {
+      const original = {
+        confirmOverwrite: false,
+        html: '<bv-topic path="security/auth"></bv-topic>',
+        meta: {
+          impact: 'high' as const,
+          reason: 'Locks JWT signing algorithm.',
+          summary: 'JWT: RS256 over HS256.',
+          type: 'ADD' as const,
+        },
+      }
+      const decoded = decodeCurateHtmlContent(encodeCurateHtmlContent(original))
+      expect(decoded.html).to.equal(original.html)
+      expect(decoded.meta).to.deep.equal(original.meta)
+    })
+
+    it('returns meta: undefined when payload omits it', () => {
+      const content = JSON.stringify({html: '<bv-topic></bv-topic>'})
+      const decoded = decodeCurateHtmlContent(content)
+      expect(decoded.meta).to.be.undefined
+    })
+
+    it('returns meta: undefined when meta is present but invalid (graceful forward-compat)', () => {
+      const content = JSON.stringify({
+        html: '<bv-topic></bv-topic>',
+        meta: {impact: 'severe'},
+      })
+      const decoded = decodeCurateHtmlContent(content)
+      expect(decoded.meta).to.be.undefined
+    })
   })
 })


### PR DESCRIPTION
## Summary

- **Problem:** On `proj/byterover-tool-mode`, both user-initiated curate surfaces are inert for HITL review. MCP `brv-curate` (daemon `case 'curate-html-direct'`) and the CLI session protocol (`continueSession`) both validate + write the HTML topic but persist zero curate-log entries. Net effect: `brv review pending` always empty, `brv review --enable/--disable` a silent no-op, `brv push` review gating never blocks curate writes, TUI `pendingReviewCount` stuck at 0. Only `dream` still produces review entries.
- **Why it matters:** HITL review is a documented user-facing feature on this branch. Currently it works only for dream — every tool-mode curate slides through unreviewed.
- **What changed:** Introduced a structured `{html, meta?}` response envelope on both surfaces. The calling agent's LLM supplies operation metadata (`type`, `impact`, `reason`, `summary`, `previousSummary`, `confidence`) alongside the HTML. Both surfaces converge through a new shared `buildCurateHtmlLogEntry` helper that builds a `CurateLogEntry` + `CurateLogOperation` matching the legacy curate-log shape, persisted via `FileCurateLogStore`. The existing review-handler / status / push aggregation read from the log unchanged — they were never broken; the log was what was missing.
- **What did NOT change (scope boundary):** Dream HITL (already works). `previousSummary` auto-derivation (agent-supplied only for v1). `confidence` promotion to required. Review UI (read-side). `additionalFilePaths` (multi-file curate ops). Backfilling missing log entries. DELETE operations (no surface in tool-mode). Curate-completion notification broadcast (only dream emits today; follow-up).

## Type of change

- [x] New feature

## Scope (select all touched areas)

- [x] Agent / Tools (MCP `brv-curate` schema)
- [x] Server / Daemon (`case 'curate-html-direct'` log persistence)
- [x] Shared (`curate-meta.ts`, transport encoder extension)
- [x] CLI Commands (oclif `curate-session` envelope parsing + log persistence)

## Linked issues

(linkage via branch name + commit subject)

## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause: N/A — feature work

## Test plan

- Coverage added:
  - [x] Unit test
  - [x] Integration test (via CLI session log persistence tests)
  - [x] Manual verification (CLI + MCP × ADD / UPDATE / MERGE)
- Test file(s):
  - `test/unit/shared/curate-meta.test.ts` (new — 8 zod cases)
  - `test/unit/infra/process/curate-html-log.test.ts` (new — 16 helper permutations)
  - `test/unit/shared/transport/curate-html-content.test.ts` (extended — `meta` round-trip + graceful downgrade)
  - `test/unit/infra/mcp/tools/brv-curate-tool.test.ts` (extended — `meta` zod validation + encoding round-trip + tool-description documentation)
  - `test/unit/oclif/lib/curate-session.test.ts` (extended — `parseCurateResponse` × 7, log persistence × 5, `reviewDisabled` suppression)
  - `test/unit/server/core/domain/render/curate-prompt-builder.test.ts` (extended — JSON envelope contract + meta semantics in both `generate-html` and `correct-html` prompts)
- Key scenario(s) covered:
  - Success with `meta.impact: 'high'` → `needsReview: true`, `reviewStatus: 'pending'`
  - Success without `meta` → operation written, no review surfacing
  - `reviewDisabled: true` suppresses `needsReview` even when `impact: 'high'`
  - Validation failure → `status: 'error'` entry written for audit, `needsReview: false`
  - `type` defaults from writer state (`existedBefore && confirmOverwrite ? 'UPDATE' : 'ADD'`); agent-asserted `meta.type` wins (`MERGE`, etc.)
  - Malformed envelope → `kind: 'invalid-response-format'` envelope error, no log entry
  - `.strict()` zod schema catches typos (`importance` vs `impact`)
  - End-to-end matrix manually verified: CLI + MCP × ADD / UPDATE / MERGE, all 6 surface correctly in `brv review pending` with correct `previousSummary` → `summary` chaining; `brv review approve` / `reject` mutate state and disk as expected

## User-visible changes

- `brv review pending` now lists tool-mode curate operations (CLI and MCP) when `meta.impact: 'high'`. Previously always empty for these surfaces.
- `brv review --disable` / `--enable` now functional for the tool-mode curate path (was a silent no-op for these surfaces).
- TUI `pendingReviewCount` and push-handler aggregation pick up tool-mode curates.
- **Breaking change (CLI):** `brv curate --session <id> --response <X>` now expects `<X>` to be a JSON envelope `{"html": "...", "meta": {...}}` instead of raw HTML. M1's protocol shipped behind tool-mode and has no significant external user base yet, so the switch is essentially free now; doing it later would split the agent's mental model with a second emission shape.
- MCP `brv-curate` tool gains an optional typed `meta` input field (back-compat: omitting `meta` still curates successfully, just without review surfacing).

## Evidence

- [x] Passing tests: `npm test` → **8057 passing**, 16 pending
- [x] Lint clean (`npm run lint -- --quiet` → 0 errors)
- [x] Typecheck clean (`npm run typecheck` → 0 errors)
- [x] Build clean (`npm run build`)
- [x] Manual matrix: full ADD / UPDATE / MERGE × CLI / MCP exercised against a real daemon; entries appear in `brv review pending` with correct `previousSummary` → `summary` chaining; approve / reject mutate state and disk correctly. Naive sub-agent fairness test: spawned an agent with no M4 context, gave it the kickoff prompt, it produced a valid envelope unaided.

## Checklist

- [x] Tests added or updated and passing (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated — N/A (no end-user docs for tool-mode internals yet; SKILL.md authoring docs unchanged)
- [x] Breaking change to CLI `--response` shape clearly documented above
- [x] Branch is up to date with `proj/byterover-tool-mode`

## Risks and mitigations

- **Risk:** CLI `--response` shape switch breaks any internal script / fixture currently using raw HTML on continuation.
  - **Mitigation:** Grepped before flipping — no internal callers found (M1 just landed, no broad adoption). Error envelope on invalid response is explicit (`kind: 'invalid-response-format'`, message names the offending field), so failures fail loudly.
- **Risk:** New `op.filePath` convention (absolute, mirroring dream-executor) — a regression here makes `brv review approve` silently no-op.
  - **Mitigation:** Caught during manual testing; absolute-path convention pinned by a dedicated regression test in `curate-html-log.test.ts > filePath convention`.
- **Risk:** `meta` decoder downgrades invalid meta to `undefined` (forward-compat for newer clients against older daemon) — risk is silently losing review surfacing on a future field rename.
  - **Mitigation:** Behaviour documented in source comment + covered by test. CLI path differs intentionally — there it's a hard error so the calling agent gets immediate feedback.
- **Risk:** Curate-completion does not yet broadcast `ReviewEvents.NOTIFY` (only dream does). User can see pending entries via `brv review pending` or refreshing the webui, but no auto-toast on curate.
  - **Mitigation:** Out-of-scope per spec, but flagged as a follow-up gap that can be addressed separately.