### PR TITLE
feat: [ENG-2823] render folder metadata in webui context tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "@ai-sdk/xai": "^2.0.57",
         "@anthropic-ai/sdk": "^0.70.1",
         "@campfirein/brv-transport-client": "github:campfirein/brv-transport-client#1.1.0",
-        "@campfirein/byterover-packages": "github:campfirein/byterover-packages#1.0.3",
+        "@campfirein/byterover-packages": "github:campfirein/byterover-packages#1.0.5",
         "@google/genai": "^1.29.0",
         "@inkjs/ui": "^2.0.0",
         "@inquirer/prompts": "^7.9.0",
@@ -3355,7 +3355,7 @@
     },
     "node_modules/@campfirein/byterover-packages": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/campfirein/byterover-packages.git#991078c884ee1af6e44b866a03a29e16c099ca2b",
+      "resolved": "git+ssh://git@github.com/campfirein/byterover-packages.git#72327af1e8b9506d65cd989fb6879e28cadee663",
       "inBundle": true,
       "dependencies": {
         "@base-ui/react": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@ai-sdk/xai": "^2.0.57",
     "@anthropic-ai/sdk": "^0.70.1",
     "@campfirein/brv-transport-client": "github:campfirein/brv-transport-client#1.1.0",
-    "@campfirein/byterover-packages": "github:campfirein/byterover-packages#1.0.3",
+    "@campfirein/byterover-packages": "github:campfirein/byterover-packages#1.0.5",
     "@google/genai": "^1.29.0",
     "@inkjs/ui": "^2.0.0",
     "@inquirer/prompts": "^7.9.0",

--- a/src/shared/transport/events/context-tree-events.ts
+++ b/src/shared/transport/events/context-tree-events.ts
@@ -82,7 +82,7 @@ export interface ContextTreeUpdateFileResponse {
 export interface ContextTreeGetFileMetadataRequest {
   /**
    * File or folder paths to fetch metadata for. Folder paths resolve to the
-   * latest commit touching any descendant (via isomorphic-git tree-oid walk).
+   * latest commit that modified any descendant of the folder.
    */
   paths: string[]
   /** Explicit project path. When omitted, uses the client's registered project. */

--- a/src/shared/transport/events/context-tree-events.ts
+++ b/src/shared/transport/events/context-tree-events.ts
@@ -80,7 +80,10 @@ export interface ContextTreeUpdateFileResponse {
 // --- GET_FILE_METADATA ---
 
 export interface ContextTreeGetFileMetadataRequest {
-  /** File paths to fetch metadata for. */
+  /**
+   * File or folder paths to fetch metadata for. Folder paths resolve to the
+   * latest commit touching any descendant (via isomorphic-git tree-oid walk).
+   */
   paths: string[]
   /** Explicit project path. When omitted, uses the client's registered project. */
   projectPath?: string

--- a/src/webui/features/context/components/context-detail-panel.tsx
+++ b/src/webui/features/context/components/context-detail-panel.tsx
@@ -54,14 +54,14 @@ export function ContextDetailPanel({ onToggleHistory }: ContextDetailPanelProps)
     return selectedNode.children ?? []
   }, [selectedNode, nodes])
 
-  const blobPaths = useMemo(
-    () => folderChildren.filter((n) => n.type === 'blob').map((n) => n.path),
+  const metadataPaths = useMemo(
+    () => folderChildren.map((n) => n.path),
     [folderChildren],
   )
 
   const {data: metadataResponse} = useGetContextFileMetadata({
-    enabled: blobPaths.length > 0,
-    paths: blobPaths,
+    enabled: metadataPaths.length > 0,
+    paths: metadataPaths,
   })
 
   const folderNodes: FolderNode[] = useMemo(() => {

--- a/test/unit/infra/transport/handlers/context-tree-handler.test.ts
+++ b/test/unit/infra/transport/handlers/context-tree-handler.test.ts
@@ -516,5 +516,58 @@ describe('ContextTreeHandler', () => {
       expect(result.files[0].path).to.equal('file.md')
       expect(result.files[0].lastUpdatedBy).to.be.undefined
     })
+
+    it('should pass folder paths to gitService.log unchanged', async () => {
+      deps.gitService.log.resolves([])
+
+      await createHandler()
+      await callHandler(ContextTreeEvents.GET_FILE_METADATA, {
+        paths: ['architecture', 'testing'],
+      })
+
+      const filepaths = deps.gitService.log.getCalls().map((c) => c.args[0].filepath)
+      expect(filepaths).to.have.members(['architecture', 'testing'])
+    })
+
+    it('should return folder metadata from the latest tree-touching commit', async () => {
+      const commitDate = new Date('2026-04-15T09:00:00Z')
+      deps.gitService.log.resolves([{
+        author: {email: 'bob@test.com', name: 'Bob'},
+        message: 'update folder',
+        sha: 'def456',
+        timestamp: commitDate,
+      }])
+
+      await createHandler()
+      const result = await callHandler(ContextTreeEvents.GET_FILE_METADATA, {
+        paths: ['authentication'],
+      })
+
+      expect(result.files).to.have.length(1)
+      expect(result.files[0].path).to.equal('authentication')
+      expect(result.files[0].lastUpdatedBy).to.equal('Bob')
+      expect(result.files[0].lastUpdatedWhen).to.equal(commitDate.toISOString())
+    })
+
+    it('should accept a mix of file and folder paths in one request', async () => {
+      deps.gitService.log.callsFake(async ({filepath}: {filepath: string}) => [{
+        author: {email: 'carol@test.com', name: 'Carol'},
+        message: `update ${filepath}`,
+        sha: 'xyz789',
+        timestamp: new Date('2026-05-01T00:00:00Z'),
+      }])
+
+      await createHandler()
+      const result = await callHandler(ContextTreeEvents.GET_FILE_METADATA, {
+        paths: ['architecture', 'patterns.md', 'testing/integration.md'],
+      })
+
+      expect(result.files).to.have.length(3)
+      const paths = result.files.map((f: {path: string}) => f.path)
+      expect(paths).to.have.members(['architecture', 'patterns.md', 'testing/integration.md'])
+      for (const file of result.files) {
+        expect(file.lastUpdatedBy).to.equal('Carol')
+      }
+    })
   })
 })

--- a/test/unit/infra/transport/handlers/context-tree-handler.test.ts
+++ b/test/unit/infra/transport/handlers/context-tree-handler.test.ts
@@ -551,7 +551,7 @@ describe('ContextTreeHandler', () => {
 
     it('should accept a mix of file and folder paths in one request', async () => {
       deps.gitService.log.callsFake(async ({filepath}: {filepath: string}) => [{
-        author: {email: 'carol@test.com', name: 'Carol'},
+        author: {email: 'carol@test.com', name: `Carol-${filepath}`},
         message: `update ${filepath}`,
         sha: 'xyz789',
         timestamp: new Date('2026-05-01T00:00:00Z'),
@@ -563,11 +563,12 @@ describe('ContextTreeHandler', () => {
       })
 
       expect(result.files).to.have.length(3)
-      const paths = result.files.map((f: {path: string}) => f.path)
-      expect(paths).to.have.members(['architecture', 'patterns.md', 'testing/integration.md'])
-      for (const file of result.files) {
-        expect(file.lastUpdatedBy).to.equal('Carol')
-      }
+      const byPath = new Map(
+        result.files.map((f: {lastUpdatedBy: string; path: string}) => [f.path, f.lastUpdatedBy]),
+      )
+      expect(byPath.get('architecture')).to.equal('Carol-architecture')
+      expect(byPath.get('patterns.md')).to.equal('Carol-patterns.md')
+      expect(byPath.get('testing/integration.md')).to.equal('Carol-testing/integration.md')
     })
   })
 })


### PR DESCRIPTION
## Summary

Fixes the Updated by / Last Modified columns showing `-` for every folder row on the WebUI context tree dashboard (incl. root view). [ENG-2823](https://linear.app/byterover/issue/ENG-2823).

- **Webui** (`context-detail-panel.tsx`): drop the `type === 'blob'` filter so folder paths are included in the metadata request (`blobPaths` → `metadataPaths`).
- **Shared UI** (`@campfirein/byterover-packages` → `1.0.5`): drop the `node.type === "blob"` guard in `FolderDetail` so folders render their values.
- **Transport JSDoc** (`context-tree-events.ts`): clarify `paths` accepts file *or* folder paths.
- **Server tests** (`context-tree-handler.test.ts`): three new `GET_FILE_METADATA` cases pin the folder-path contract — paths flow through to `gitService.log` unchanged, response shape matches files.

No server production-code change needed: the handler is already path-agnostic, and `isomorphic-git`'s `log({filepath})` resolves the path to a tree-oid for folders (latest commit touching any descendant) or a blob-oid for files, transparently.

## Test plan

- [x] `npm test` — 7853 passing, 16 pending
- [x] `npm run typecheck` — clean (root + webui)
- [x] `npm run lint` — 0 errors on changed files
- [x] `npm run build` — clean (tsc + Vite + PWA)
- [ ] Manual: open `brv webui`, navigate to root context view, confirm `Updated by` / `Last Modified` populate for each folder (latest commit touching any descendant)
- [ ] Manual: drill into a folder containing files, confirm file rows still show per-file metadata