### PR TITLE
[Tool Mode] wire runtime-signal sidecar in tool-mode curate + query paths

### DIFF
--- a/src/oclif/lib/curate-session.ts
+++ b/src/oclif/lib/curate-session.ts
@@ -1,7 +1,7 @@
 import {randomUUID} from 'node:crypto'
 import {existsSync} from 'node:fs'
 import {mkdir, readFile, rm, writeFile} from 'node:fs/promises'
-import {dirname, join, relative} from 'node:path'
+import {dirname, join, relative, sep} from 'node:path'
 import {z} from 'zod'
 
 import type {CurateMeta} from '../../shared/curate-meta.js'
@@ -364,19 +364,27 @@ export async function continueSession(options: ContinueOptions): Promise<CurateS
 
   // Mirror the curate into the runtime-signal sidecar so prune (and any
   // future signal-driven ranking) has real data. Best-effort: a failure
-  // here must never block the write that already succeeded.
+  // here must never block the write that already succeeded — but emit a
+  // warn so an operator hitting a corrupt key store / permission denied
+  // on the project data dir has a breadcrumb (a bare catch{} hides it).
   if (writeResult.ok) {
+    const sidecarLogger = new ConsoleLogger()
     try {
       const keyStorage = new FileKeyStorage({storageDir: getProjectDataDir(projectRoot)})
       await keyStorage.initialize()
-      const runtimeSignalStore = new RuntimeSignalStore(keyStorage, new ConsoleLogger())
+      const runtimeSignalStore = new RuntimeSignalStore(keyStorage, sidecarLogger)
       await bumpSidecarOnCurateWrite({
         existedBefore,
-        relPath: relative(contextTreeRoot, writeResult.filePath),
+        logger: sidecarLogger,
+        // Forward-slash normalize so the sidecar key matches the daemon's
+        // curate-html-direct path (`agent-process.ts`) on Windows.
+        relPath: relative(contextTreeRoot, writeResult.filePath).replaceAll(sep, '/'),
         store: runtimeSignalStore,
       })
-    } catch {
-      // Best-effort; never surface to the agent.
+    } catch (error) {
+      sidecarLogger.warn(
+        `tool-mode-curate: sidecar bump init failed for ${projectRoot}: ${error instanceof Error ? error.message : String(error)}`,
+      )
     }
   }
 

--- a/src/oclif/lib/curate-session.ts
+++ b/src/oclif/lib/curate-session.ts
@@ -6,9 +6,13 @@ import {z} from 'zod'
 
 import type {CurateMeta} from '../../shared/curate-meta.js'
 
+import {ConsoleLogger} from '../../agent/infra/logger/console-logger.js'
+import {FileKeyStorage} from '../../agent/infra/storage/file-key-storage.js'
 import {BRV_DIR, CONTEXT_TREE_DIR} from '../../server/constants.js'
 import {buildCorrectionPrompt, buildGeneratePrompt} from '../../server/core/domain/render/curate-prompt-builder.js'
 import {ProjectConfigStore} from '../../server/infra/config/file-config-store.js'
+import {RuntimeSignalStore} from '../../server/infra/context-tree/runtime-signal-store.js'
+import {bumpSidecarOnCurateWrite} from '../../server/infra/context-tree/tool-mode-sidecar-updaters.js'
 import {backupContextTreeFile, buildCurateHtmlLogEntry} from '../../server/infra/process/curate-html-log.js'
 import {type HtmlWriteError, validateHtmlTopic, writeHtmlTopic} from '../../server/infra/render/writer/html-writer.js'
 import {FileCurateLogStore} from '../../server/infra/storage/file-curate-log-store.js'
@@ -357,6 +361,24 @@ export async function continueSession(options: ContinueOptions): Promise<CurateS
   const startedAt = Date.now()
   const writeResult = await writeHtmlTopic({confirmOverwrite, contextTreeRoot, rawHtml: html})
   const completedAt = Date.now()
+
+  // Mirror the curate into the runtime-signal sidecar so prune (and any
+  // future signal-driven ranking) has real data. Best-effort: a failure
+  // here must never block the write that already succeeded.
+  if (writeResult.ok) {
+    try {
+      const keyStorage = new FileKeyStorage({storageDir: getProjectDataDir(projectRoot)})
+      await keyStorage.initialize()
+      const runtimeSignalStore = new RuntimeSignalStore(keyStorage, new ConsoleLogger())
+      await bumpSidecarOnCurateWrite({
+        existedBefore,
+        relPath: relative(contextTreeRoot, writeResult.filePath),
+        store: runtimeSignalStore,
+      })
+    } catch {
+      // Best-effort; never surface to the agent.
+    }
+  }
 
   await persistCurateLog({
     completedAt,

--- a/src/server/infra/context-tree/tool-mode-sidecar-updaters.ts
+++ b/src/server/infra/context-tree/tool-mode-sidecar-updaters.ts
@@ -1,19 +1,11 @@
 import type {ILogger} from '../../../agent/core/interfaces/i-logger.js'
 import type {IRuntimeSignalStore} from '../../core/interfaces/storage/i-runtime-signal-store.js'
 
-import {
-  determineTier,
-  recordAccessHits,
-  recordCurateUpdate,
-} from '../../core/domain/knowledge/memory-scoring.js'
-import {
-  createDefaultRuntimeSignals,
-  type RuntimeSignals,
-} from '../../core/domain/knowledge/runtime-signals-schema.js'
+import {determineTier, recordCurateUpdate} from '../../core/domain/knowledge/memory-scoring.js'
+import {createDefaultRuntimeSignals, type RuntimeSignals} from '../../core/domain/knowledge/runtime-signals-schema.js'
 import {warnSidecarFailure} from '../../core/domain/knowledge/sidecar-logging.js'
 
 const TOOL_MODE_CURATE_SITE = 'tool-mode-curate'
-const TOOL_MODE_QUERY_SITE = 'tool-mode-query'
 
 /**
  * Update the runtime-signal sidecar after a successful tool-mode curate write.
@@ -27,9 +19,16 @@ const TOOL_MODE_QUERY_SITE = 'tool-mode-query'
  * succeeded. When a `logger` is passed, the outer error is logged at WARN
  * level via `warnSidecarFailure`; without one, the helper is silent and
  * relies on the underlying `RuntimeSignalStore` (mandatory logger) to
- * surface storage-level failures. Write call sites should pass a logger
- * since curate failures matter; read call sites (executors) skip it to
- * avoid stderr noise on bulk reads.
+ * surface storage-level failures.
+ *
+ * Note on the read-side: this module intentionally does NOT export a
+ * `bumpSidecarOnQueryRead` helper. End-to-end testing on a real project
+ * (PR #677) revealed that `SearchKnowledgeService` already mirrors access
+ * hits into the sidecar via `flushAccessHits` → `mirrorHitsToSignalStore`
+ * inside `acquireIndex`. Adding a second read-side bump would double-
+ * count importance and prematurely promote topics to higher maturity
+ * tiers. The curate write path stays — that one has no equivalent
+ * legacy mechanism in tool-mode.
  */
 export async function bumpSidecarOnCurateWrite(params: {
   existedBefore: boolean
@@ -64,52 +63,4 @@ export async function bumpSidecarOnCurateWrite(params: {
   } catch (error) {
     warnSidecarFailure(logger, TOOL_MODE_CURATE_SITE, 'seed', relPath, error)
   }
-}
-
-/**
- * Bump the runtime-signal sidecar after a tool-mode query/search returns
- * matched paths.
- *
- * Mirrors `SearchKnowledgeService.mirrorHitsToSignalStore`: applies the
- * canonical access-hit scoring via `recordAccessHits` (bumps `accessCount`
- * AND `importance`) and re-evaluates `maturity` through `determineTier`.
- * Bumping `accessCount` alone would let prune ignore a topic the user
- * actively reads — main's logic intentionally raises importance to keep
- * frequently-accessed topics out of the prune set.
- *
- * Best-effort per path: if one path's update throws, the rest still get
- * processed (failures don't short-circuit the batch). Paths are processed
- * in parallel — different relPaths map to different storage keys, so
- * there's no cross-path lock contention.
- *
- * The `logger` param is optional and intentionally not wired by the
- * executor call sites (search/query) — bulk reads with a flaky sidecar
- * would spam stderr without changing behavior. The underlying store has
- * its own mandatory logger that surfaces storage-layer failures.
- */
-export async function bumpSidecarOnQueryRead(params: {
-  logger?: ILogger
-  relPaths: string[]
-  store: IRuntimeSignalStore | undefined
-}): Promise<void> {
-  const {logger, relPaths, store} = params
-  if (!store || relPaths.length === 0) return
-
-  await Promise.all(
-    relPaths.map(async (relPath) => {
-      try {
-        await store.update(relPath, (current: RuntimeSignals): RuntimeSignals => {
-          const bumped = recordAccessHits(current, 1)
-          return {
-            ...current,
-            accessCount: bumped.accessCount,
-            importance: bumped.importance,
-            maturity: determineTier(bumped.importance, current.maturity),
-          }
-        })
-      } catch (error) {
-        warnSidecarFailure(logger, TOOL_MODE_QUERY_SITE, 'access-bump', relPath, error)
-      }
-    }),
-  )
 }

--- a/src/server/infra/context-tree/tool-mode-sidecar-updaters.ts
+++ b/src/server/infra/context-tree/tool-mode-sidecar-updaters.ts
@@ -3,6 +3,7 @@ import type {IRuntimeSignalStore} from '../../core/interfaces/storage/i-runtime-
 
 import {
   determineTier,
+  recordAccessHits,
   recordCurateUpdate,
 } from '../../core/domain/knowledge/memory-scoring.js'
 import {
@@ -23,7 +24,12 @@ const TOOL_MODE_QUERY_SITE = 'tool-mode-query'
  *   `mirrorCurateUpdate`.
  *
  * Best-effort: a sidecar failure must never break the write that already
- * succeeded. Errors are logged at WARN level and swallowed.
+ * succeeded. When a `logger` is passed, the outer error is logged at WARN
+ * level via `warnSidecarFailure`; without one, the helper is silent and
+ * relies on the underlying `RuntimeSignalStore` (mandatory logger) to
+ * surface storage-level failures. Write call sites should pass a logger
+ * since curate failures matter; read call sites (executors) skip it to
+ * avoid stderr noise on bulk reads.
  */
 export async function bumpSidecarOnCurateWrite(params: {
   existedBefore: boolean
@@ -62,13 +68,24 @@ export async function bumpSidecarOnCurateWrite(params: {
 
 /**
  * Bump the runtime-signal sidecar after a tool-mode query/search returns
- * matched paths. Increments `accessCount` per matched path; seeds a default
- * record if the path has no prior signals (first read).
+ * matched paths.
+ *
+ * Mirrors `SearchKnowledgeService.mirrorHitsToSignalStore`: applies the
+ * canonical access-hit scoring via `recordAccessHits` (bumps `accessCount`
+ * AND `importance`) and re-evaluates `maturity` through `determineTier`.
+ * Bumping `accessCount` alone would let prune ignore a topic the user
+ * actively reads — main's logic intentionally raises importance to keep
+ * frequently-accessed topics out of the prune set.
  *
  * Best-effort per path: if one path's update throws, the rest still get
  * processed (failures don't short-circuit the batch). Paths are processed
  * in parallel — different relPaths map to different storage keys, so
  * there's no cross-path lock contention.
+ *
+ * The `logger` param is optional and intentionally not wired by the
+ * executor call sites (search/query) — bulk reads with a flaky sidecar
+ * would spam stderr without changing behavior. The underlying store has
+ * its own mandatory logger that surfaces storage-layer failures.
  */
 export async function bumpSidecarOnQueryRead(params: {
   logger?: ILogger
@@ -81,10 +98,15 @@ export async function bumpSidecarOnQueryRead(params: {
   await Promise.all(
     relPaths.map(async (relPath) => {
       try {
-        await store.update(relPath, (current: RuntimeSignals): RuntimeSignals => ({
-          ...current,
-          accessCount: current.accessCount + 1,
-        }))
+        await store.update(relPath, (current: RuntimeSignals): RuntimeSignals => {
+          const bumped = recordAccessHits(current, 1)
+          return {
+            ...current,
+            accessCount: bumped.accessCount,
+            importance: bumped.importance,
+            maturity: determineTier(bumped.importance, current.maturity),
+          }
+        })
       } catch (error) {
         warnSidecarFailure(logger, TOOL_MODE_QUERY_SITE, 'access-bump', relPath, error)
       }

--- a/src/server/infra/context-tree/tool-mode-sidecar-updaters.ts
+++ b/src/server/infra/context-tree/tool-mode-sidecar-updaters.ts
@@ -1,0 +1,93 @@
+import type {ILogger} from '../../../agent/core/interfaces/i-logger.js'
+import type {IRuntimeSignalStore} from '../../core/interfaces/storage/i-runtime-signal-store.js'
+
+import {
+  determineTier,
+  recordCurateUpdate,
+} from '../../core/domain/knowledge/memory-scoring.js'
+import {
+  createDefaultRuntimeSignals,
+  type RuntimeSignals,
+} from '../../core/domain/knowledge/runtime-signals-schema.js'
+import {warnSidecarFailure} from '../../core/domain/knowledge/sidecar-logging.js'
+
+const TOOL_MODE_CURATE_SITE = 'tool-mode-curate'
+const TOOL_MODE_QUERY_SITE = 'tool-mode-query'
+
+/**
+ * Update the runtime-signal sidecar after a successful tool-mode curate write.
+ *
+ * - `existedBefore=false` → seed default signals (ADD path).
+ * - `existedBefore=true`  → bump importance + recency + updateCount and
+ *   recompute maturity (UPDATE path), mirroring the legacy curate-tool's
+ *   `mirrorCurateUpdate`.
+ *
+ * Best-effort: a sidecar failure must never break the write that already
+ * succeeded. Errors are logged at WARN level and swallowed.
+ */
+export async function bumpSidecarOnCurateWrite(params: {
+  existedBefore: boolean
+  logger?: ILogger
+  relPath: string
+  store: IRuntimeSignalStore | undefined
+}): Promise<void> {
+  const {existedBefore, logger, relPath, store} = params
+  if (!store) return
+
+  if (existedBefore) {
+    try {
+      await store.update(relPath, (current: RuntimeSignals): RuntimeSignals => {
+        const bumped = recordCurateUpdate(current)
+        return {
+          ...current,
+          importance: bumped.importance,
+          maturity: determineTier(bumped.importance, current.maturity),
+          recency: bumped.recency,
+          updateCount: bumped.updateCount,
+        }
+      })
+    } catch (error) {
+      warnSidecarFailure(logger, TOOL_MODE_CURATE_SITE, 'update', relPath, error)
+    }
+
+    return
+  }
+
+  try {
+    await store.set(relPath, createDefaultRuntimeSignals())
+  } catch (error) {
+    warnSidecarFailure(logger, TOOL_MODE_CURATE_SITE, 'seed', relPath, error)
+  }
+}
+
+/**
+ * Bump the runtime-signal sidecar after a tool-mode query/search returns
+ * matched paths. Increments `accessCount` per matched path; seeds a default
+ * record if the path has no prior signals (first read).
+ *
+ * Best-effort per path: if one path's update throws, the rest still get
+ * processed (failures don't short-circuit the batch). Paths are processed
+ * in parallel — different relPaths map to different storage keys, so
+ * there's no cross-path lock contention.
+ */
+export async function bumpSidecarOnQueryRead(params: {
+  logger?: ILogger
+  relPaths: string[]
+  store: IRuntimeSignalStore | undefined
+}): Promise<void> {
+  const {logger, relPaths, store} = params
+  if (!store || relPaths.length === 0) return
+
+  await Promise.all(
+    relPaths.map(async (relPath) => {
+      try {
+        await store.update(relPath, (current: RuntimeSignals): RuntimeSignals => ({
+          ...current,
+          accessCount: current.accessCount + 1,
+        }))
+      } catch (error) {
+        warnSidecarFailure(logger, TOOL_MODE_QUERY_SITE, 'access-bump', relPath, error)
+      }
+    }),
+  )
+}

--- a/src/server/infra/daemon/agent-process.ts
+++ b/src/server/infra/daemon/agent-process.ts
@@ -717,9 +717,18 @@ async function executeTask(
 
             // Mirror the curate into the runtime-signal sidecar so prune (and
             // any future signal-driven ranking) has real data to work with.
-            // Best-effort: never blocks the write that already succeeded.
+            // Best-effort: never blocks the write that already succeeded;
+            // pass an agentLog-backed logger so swallowed sidecar failures
+            // (corrupt key store, permission denied) leave a breadcrumb in
+            // the daemon session log instead of being silently invisible.
             await bumpSidecarOnCurateWrite({
               existedBefore,
+              logger: {
+                debug: (msg: string): void => agentLog(msg),
+                error: (msg: string): void => agentLog(msg),
+                info: (msg: string): void => agentLog(msg),
+                warn: (msg: string): void => agentLog(msg),
+              },
               relPath: relativeFilePath,
               store: runtimeSignalStore,
             })

--- a/src/server/infra/daemon/agent-process.ts
+++ b/src/server/infra/daemon/agent-process.ts
@@ -58,6 +58,7 @@ import {
 } from '../../core/domain/transport/schemas.js'
 import {FileContextTreeArchiveService} from '../context-tree/file-context-tree-archive-service.js'
 import {RuntimeSignalStore} from '../context-tree/runtime-signal-store.js'
+import {bumpSidecarOnCurateWrite} from '../context-tree/tool-mode-sidecar-updaters.js'
 import {DreamLockService} from '../dream/dream-lock-service.js'
 import {DreamLogStore} from '../dream/dream-log-store.js'
 import {DreamStateService} from '../dream/dream-state-service.js'
@@ -455,9 +456,10 @@ async function start(): Promise<void> {
     baseDirectory: projectPath,
     enableCache: true,
     fileSystem: fileSystemService,
+    runtimeSignalStore: daemonRuntimeSignalStore,
     searchService,
   })
-  const searchExecutor = new SearchExecutor(searchService)
+  const searchExecutor = new SearchExecutor(searchService, daemonRuntimeSignalStore)
 
   transport.on<TaskExecute>(TransportTaskEventNames.EXECUTE, (task) => {
     agentLog(`task:execute received taskId=${task.taskId} type=${task.type} activeTaskCount=${activeTaskCount + 1}`)
@@ -712,6 +714,15 @@ async function executeTask(
             topicPathResolved = preValidation.ok
               ? preValidation.topicPath
               : relativeFilePath.replace(/\.html$/, '')
+
+            // Mirror the curate into the runtime-signal sidecar so prune (and
+            // any future signal-driven ranking) has real data to work with.
+            // Best-effort: never blocks the write that already succeeded.
+            await bumpSidecarOnCurateWrite({
+              existedBefore,
+              relPath: relativeFilePath,
+              store: runtimeSignalStore,
+            })
           } else if (preValidation.ok) {
             topicPathResolved = preValidation.topicPath
           }

--- a/src/server/infra/daemon/agent-process.ts
+++ b/src/server/infra/daemon/agent-process.ts
@@ -456,10 +456,9 @@ async function start(): Promise<void> {
     baseDirectory: projectPath,
     enableCache: true,
     fileSystem: fileSystemService,
-    runtimeSignalStore: daemonRuntimeSignalStore,
     searchService,
   })
-  const searchExecutor = new SearchExecutor(searchService, daemonRuntimeSignalStore)
+  const searchExecutor = new SearchExecutor(searchService)
 
   transport.on<TaskExecute>(TransportTaskEventNames.EXECUTE, (task) => {
     agentLog(`task:execute received taskId=${task.taskId} type=${task.type} activeTaskCount=${activeTaskCount + 1}`)

--- a/src/server/infra/executor/query-executor.ts
+++ b/src/server/infra/executor/query-executor.ts
@@ -14,6 +14,7 @@ import type {
   QueryToolModeResult,
 } from '../../core/interfaces/executor/i-query-executor.js'
 import type {IFormatDetector} from '../../core/interfaces/render/i-format-detector.js'
+import type {IRuntimeSignalStore} from '../../core/interfaces/storage/i-runtime-signal-store.js'
 
 import {ABSTRACT_EXTENSION, BRV_DIR, CONTEXT_FILE_EXTENSION, CONTEXT_TREE_DIR} from '../../constants.js'
 import {
@@ -26,6 +27,7 @@ import {
 import {loadSources} from '../../core/domain/source/source-schema.js'
 import {isDerivedArtifact} from '../context-tree/derived-artifact.js'
 import {FileContextTreeManifestService} from '../context-tree/file-context-tree-manifest-service.js'
+import {bumpSidecarOnQueryRead} from '../context-tree/tool-mode-sidecar-updaters.js'
 import {ExtensionAwareFormatDetector} from '../render/format/extension-aware-format-detector.js'
 import {renderHtmlTopicForLlm} from '../render/reader/html-renderer.js'
 import {
@@ -70,6 +72,13 @@ export interface QueryExecutorDeps {
    * wired as the production default.
    */
   formatDetector?: IFormatDetector
+  /**
+   * Runtime-signal sidecar — when provided, the executor bumps
+   * `accessCount` for every matched path returned by tool-mode queries.
+   * Drives the read-side signal feed that prune's candidate generator
+   * relies on. Best-effort: sidecar failure never breaks the query.
+   */
+  runtimeSignalStore?: IRuntimeSignalStore
   /** Search service for pre-fetching relevant context before calling the LLM */
   searchService?: ISearchKnowledgeService
 }
@@ -109,6 +118,7 @@ export class QueryExecutor implements IQueryExecutor {
   private cachedFingerprint?: {expiresAt: number; sourceValidityHash: string; value: string; worktreeRoot?: string}
   private readonly fileSystem?: IFileSystem
   private readonly formatDetector: IFormatDetector
+  private readonly runtimeSignalStore?: IRuntimeSignalStore
   private readonly searchService?: ISearchKnowledgeService
   /**
    * Dedicated cache for tool-mode envelopes. Separate instance from
@@ -123,6 +133,7 @@ export class QueryExecutor implements IQueryExecutor {
     this.baseDirectory = deps?.baseDirectory
     this.fileSystem = deps?.fileSystem
     this.formatDetector = deps?.formatDetector ?? new ExtensionAwareFormatDetector()
+    this.runtimeSignalStore = deps?.runtimeSignalStore
     this.searchService = deps?.searchService
     if (deps?.enableCache) {
       this.cache = new QueryResultCache()
@@ -142,90 +153,20 @@ export class QueryExecutor implements IQueryExecutor {
    * breaking for tool consumers.
    */
   public async executeToolMode(options: QueryToolModeOptions): Promise<QueryToolModeResult> {
-    const startTime = Date.now()
-    const {limit = QueryExecutor.TOOL_MODE_DEFAULT_LIMIT, query, worktreeRoot} = options
-    const workspaceScope = this.deriveWorkspaceScope(worktreeRoot)
+    const envelope = await this.executeToolModeInternal(options)
 
-    // === Tier 0: Exact cache hit ===
-    //
-    // Cache entries always hold up to `TOOL_MODE_MAX_LIMIT` matches.
-    // We slice down to the caller's `limit` on read so calls with
-    // different `--limit` values share one cache entry — a `--limit 50`
-    // request followed by `--limit 1` returns the same top doc.
-    let fingerprint: string | undefined
-    if (this.toolModeCache && this.fileSystem) {
-      fingerprint = await this.computeContextTreeFingerprint(worktreeRoot)
-      const cached = this.toolModeCache.get(query, fingerprint)
-      if (cached) {
-        const overlaid = this.overlayCachedEnvelope(cached, 'exact', TIER_EXACT_CACHE, startTime, limit)
-        if (overlaid) return overlaid
-      }
+    // Bump the runtime-signal sidecar for every matched path so prune
+    // (and any future signal-driven ranking) has read-side data. Empty
+    // envelopes skip the call. Best-effort: a sidecar failure must not
+    // break the query that already succeeded.
+    if (this.runtimeSignalStore && envelope.matchedDocs.length > 0) {
+      await bumpSidecarOnQueryRead({
+        relPaths: envelope.matchedDocs.map((d) => d.path),
+        store: this.runtimeSignalStore,
+      })
     }
 
-    // === Tier 1: Fuzzy cache hit ===
-    if (this.toolModeCache && fingerprint) {
-      const fuzzy = this.toolModeCache.findSimilar(query, fingerprint)
-      if (fuzzy) {
-        const overlaid = this.overlayCachedEnvelope(fuzzy, 'fuzzy', TIER_FUZZY_CACHE, startTime, limit)
-        if (overlaid) return overlaid
-      }
-    }
-
-    // === Tier 2: BM25 retrieval + supplement + render ===
-    if (!this.searchService) {
-      return this.buildEmptyToolModeEnvelope(startTime)
-    }
-
-    // Always retrieve at MAX_LIMIT so the cache entry serves smaller
-    // subsequent requests without re-fetching. Slicing happens after
-    // the cache write.
-    //
-    // searchService.search() throws on transport-level failures (index
-    // unavailable, malformed payload, etc.). DON'T swallow into an
-    // empty envelope — that would conflate "broken retrieval" with
-    // "genuinely no matches" and let the calling agent synthesise
-    // around an outage. Let the throw propagate; the daemon catches
-    // it and emits task:error, which the CLI maps to outer
-    // `success: false`.
-    let searchResult: SearchKnowledgeResult = await this.searchService.search(query, {
-      limit: QueryExecutor.TOOL_MODE_MAX_LIMIT,
-      scope: workspaceScope,
-    })
-
-    if (searchResult.totalFound < 3) {
-      searchResult = await this.supplementEntitySearches(query, searchResult, workspaceScope)
-    }
-
-    const {matchedDocs: allMatches, skippedSharedCount} = await this.buildToolModeMatches(searchResult)
-    const topScore = allMatches[0]?.score ?? 0
-    const status: QueryToolModeResult['status'] = allMatches.length === 0 ? 'no-matches' : 'ok'
-    const totalFound = searchResult.totalFound ?? allMatches.length
-
-    // Cache the FULL envelope (up to TOOL_MODE_MAX_LIMIT matches) so
-    // subsequent calls with a smaller `--limit` slice down on read.
-    // `durationMs` here is a placeholder — overlayCachedEnvelope
-    // overwrites it with the cache-read latency.
-    if (this.toolModeCache && fingerprint && status === 'ok') {
-      const fullEnvelope: QueryToolModeResult = {
-        matchedDocs: allMatches,
-        metadata: {cacheHit: null, durationMs: 0, skippedSharedCount, tier: TIER_DIRECT_SEARCH, topScore, totalFound},
-        status,
-      }
-      this.toolModeCache.set(query, JSON.stringify(fullEnvelope), fingerprint)
-    }
-
-    return {
-      matchedDocs: allMatches.slice(0, limit),
-      metadata: {
-        cacheHit: null,
-        durationMs: Date.now() - startTime,
-        skippedSharedCount,
-        tier: TIER_DIRECT_SEARCH,
-        topScore,
-        totalFound,
-      },
-      status,
-    }
+    return envelope
   }
 
   public async executeWithAgent(agent: ICipherAgent, options: QueryExecuteOptions): Promise<QueryExecutorResult> {
@@ -778,6 +719,93 @@ ${responseFormat}`
     const rel = relative(this.baseDirectory, worktreeRoot)
 
     return rel || undefined
+  }
+
+  private async executeToolModeInternal(options: QueryToolModeOptions): Promise<QueryToolModeResult> {
+    const startTime = Date.now()
+    const {limit = QueryExecutor.TOOL_MODE_DEFAULT_LIMIT, query, worktreeRoot} = options
+    const workspaceScope = this.deriveWorkspaceScope(worktreeRoot)
+
+    // === Tier 0: Exact cache hit ===
+    //
+    // Cache entries always hold up to `TOOL_MODE_MAX_LIMIT` matches.
+    // We slice down to the caller's `limit` on read so calls with
+    // different `--limit` values share one cache entry — a `--limit 50`
+    // request followed by `--limit 1` returns the same top doc.
+    let fingerprint: string | undefined
+    if (this.toolModeCache && this.fileSystem) {
+      fingerprint = await this.computeContextTreeFingerprint(worktreeRoot)
+      const cached = this.toolModeCache.get(query, fingerprint)
+      if (cached) {
+        const overlaid = this.overlayCachedEnvelope(cached, 'exact', TIER_EXACT_CACHE, startTime, limit)
+        if (overlaid) return overlaid
+      }
+    }
+
+    // === Tier 1: Fuzzy cache hit ===
+    if (this.toolModeCache && fingerprint) {
+      const fuzzy = this.toolModeCache.findSimilar(query, fingerprint)
+      if (fuzzy) {
+        const overlaid = this.overlayCachedEnvelope(fuzzy, 'fuzzy', TIER_FUZZY_CACHE, startTime, limit)
+        if (overlaid) return overlaid
+      }
+    }
+
+    // === Tier 2: BM25 retrieval + supplement + render ===
+    if (!this.searchService) {
+      return this.buildEmptyToolModeEnvelope(startTime)
+    }
+
+    // Always retrieve at MAX_LIMIT so the cache entry serves smaller
+    // subsequent requests without re-fetching. Slicing happens after
+    // the cache write.
+    //
+    // searchService.search() throws on transport-level failures (index
+    // unavailable, malformed payload, etc.). DON'T swallow into an
+    // empty envelope — that would conflate "broken retrieval" with
+    // "genuinely no matches" and let the calling agent synthesise
+    // around an outage. Let the throw propagate; the daemon catches
+    // it and emits task:error, which the CLI maps to outer
+    // `success: false`.
+    let searchResult: SearchKnowledgeResult = await this.searchService.search(query, {
+      limit: QueryExecutor.TOOL_MODE_MAX_LIMIT,
+      scope: workspaceScope,
+    })
+
+    if (searchResult.totalFound < 3) {
+      searchResult = await this.supplementEntitySearches(query, searchResult, workspaceScope)
+    }
+
+    const {matchedDocs: allMatches, skippedSharedCount} = await this.buildToolModeMatches(searchResult)
+    const topScore = allMatches[0]?.score ?? 0
+    const status: QueryToolModeResult['status'] = allMatches.length === 0 ? 'no-matches' : 'ok'
+    const totalFound = searchResult.totalFound ?? allMatches.length
+
+    // Cache the FULL envelope (up to TOOL_MODE_MAX_LIMIT matches) so
+    // subsequent calls with a smaller `--limit` slice down on read.
+    // `durationMs` here is a placeholder — overlayCachedEnvelope
+    // overwrites it with the cache-read latency.
+    if (this.toolModeCache && fingerprint && status === 'ok') {
+      const fullEnvelope: QueryToolModeResult = {
+        matchedDocs: allMatches,
+        metadata: {cacheHit: null, durationMs: 0, skippedSharedCount, tier: TIER_DIRECT_SEARCH, topScore, totalFound},
+        status,
+      }
+      this.toolModeCache.set(query, JSON.stringify(fullEnvelope), fingerprint)
+    }
+
+    return {
+      matchedDocs: allMatches.slice(0, limit),
+      metadata: {
+        cacheHit: null,
+        durationMs: Date.now() - startTime,
+        skippedSharedCount,
+        tier: TIER_DIRECT_SEARCH,
+        topScore,
+        totalFound,
+      },
+      status,
+    }
   }
 
   /**

--- a/src/server/infra/executor/query-executor.ts
+++ b/src/server/infra/executor/query-executor.ts
@@ -14,7 +14,6 @@ import type {
   QueryToolModeResult,
 } from '../../core/interfaces/executor/i-query-executor.js'
 import type {IFormatDetector} from '../../core/interfaces/render/i-format-detector.js'
-import type {IRuntimeSignalStore} from '../../core/interfaces/storage/i-runtime-signal-store.js'
 
 import {ABSTRACT_EXTENSION, BRV_DIR, CONTEXT_FILE_EXTENSION, CONTEXT_TREE_DIR} from '../../constants.js'
 import {
@@ -27,7 +26,6 @@ import {
 import {loadSources} from '../../core/domain/source/source-schema.js'
 import {isDerivedArtifact} from '../context-tree/derived-artifact.js'
 import {FileContextTreeManifestService} from '../context-tree/file-context-tree-manifest-service.js'
-import {bumpSidecarOnQueryRead} from '../context-tree/tool-mode-sidecar-updaters.js'
 import {ExtensionAwareFormatDetector} from '../render/format/extension-aware-format-detector.js'
 import {renderHtmlTopicForLlm} from '../render/reader/html-renderer.js'
 import {
@@ -72,13 +70,6 @@ export interface QueryExecutorDeps {
    * wired as the production default.
    */
   formatDetector?: IFormatDetector
-  /**
-   * Runtime-signal sidecar — when provided, the executor bumps
-   * `accessCount` for every matched path returned by tool-mode queries.
-   * Drives the read-side signal feed that prune's candidate generator
-   * relies on. Best-effort: sidecar failure never breaks the query.
-   */
-  runtimeSignalStore?: IRuntimeSignalStore
   /** Search service for pre-fetching relevant context before calling the LLM */
   searchService?: ISearchKnowledgeService
 }
@@ -118,7 +109,6 @@ export class QueryExecutor implements IQueryExecutor {
   private cachedFingerprint?: {expiresAt: number; sourceValidityHash: string; value: string; worktreeRoot?: string}
   private readonly fileSystem?: IFileSystem
   private readonly formatDetector: IFormatDetector
-  private readonly runtimeSignalStore?: IRuntimeSignalStore
   private readonly searchService?: ISearchKnowledgeService
   /**
    * Dedicated cache for tool-mode envelopes. Separate instance from
@@ -133,7 +123,6 @@ export class QueryExecutor implements IQueryExecutor {
     this.baseDirectory = deps?.baseDirectory
     this.fileSystem = deps?.fileSystem
     this.formatDetector = deps?.formatDetector ?? new ExtensionAwareFormatDetector()
-    this.runtimeSignalStore = deps?.runtimeSignalStore
     this.searchService = deps?.searchService
     if (deps?.enableCache) {
       this.cache = new QueryResultCache()
@@ -153,20 +142,7 @@ export class QueryExecutor implements IQueryExecutor {
    * breaking for tool consumers.
    */
   public async executeToolMode(options: QueryToolModeOptions): Promise<QueryToolModeResult> {
-    const envelope = await this.executeToolModeInternal(options)
-
-    // Bump the runtime-signal sidecar for every matched path so prune
-    // (and any future signal-driven ranking) has read-side data. Empty
-    // envelopes skip the call. Best-effort: a sidecar failure must not
-    // break the query that already succeeded.
-    if (this.runtimeSignalStore && envelope.matchedDocs.length > 0) {
-      await bumpSidecarOnQueryRead({
-        relPaths: envelope.matchedDocs.map((d) => d.path),
-        store: this.runtimeSignalStore,
-      })
-    }
-
-    return envelope
+    return this.executeToolModeInternal(options)
   }
 
   public async executeWithAgent(agent: ICipherAgent, options: QueryExecuteOptions): Promise<QueryExecutorResult> {

--- a/src/server/infra/executor/search-executor.ts
+++ b/src/server/infra/executor/search-executor.ts
@@ -46,12 +46,22 @@ export class SearchExecutor implements ISearchExecutor {
 
     // Bump runtime-signal accessCount per matched path so prune (and any
     // future signal-driven ranking) has real read-side data. Best-effort:
-    // sidecar failure must never break search.
+    // sidecar failure must never break search. Skip shared-source results —
+    // their `path` is relative to the SHARED origin context tree, not the
+    // local sidecar's project, so writing them here would either orphan an
+    // entry or collide with a same-named local topic and corrupt ranking.
+    // Mirrors `QueryExecutor.buildToolModeMatches` which already filters
+    // shared origins out of the tool-mode envelope.
     if (this.runtimeSignalStore && result.results.length > 0) {
-      await bumpSidecarOnQueryRead({
-        relPaths: result.results.map((r) => r.path),
-        store: this.runtimeSignalStore,
-      })
+      const localPaths = result.results
+        .filter((r) => !r.origin || r.origin === 'local')
+        .map((r) => r.path)
+      if (localPaths.length > 0) {
+        await bumpSidecarOnQueryRead({
+          relPaths: localPaths,
+          store: this.runtimeSignalStore,
+        })
+      }
     }
 
     return result

--- a/src/server/infra/executor/search-executor.ts
+++ b/src/server/infra/executor/search-executor.ts
@@ -7,24 +7,26 @@
  *
  * This is the engine behind `brv search`. The CLI command and transport
  * layer handle I/O; this module handles the search logic.
+ *
+ * Note on sidecar bumping: `SearchKnowledgeService.search()` already
+ * accumulates access hits and mirrors them to the sidecar via
+ * `flushAccessHits` → `mirrorHitsToSignalStore` inside `acquireIndex`'s
+ * cache-refresh path. We do NOT add a second bump here — doing so would
+ * double-count importance and prematurely promote topics to higher
+ * maturity tiers (observed end-to-end during PR #677 testing).
  */
 
 import type {ISearchKnowledgeService, SearchKnowledgeResult} from '../../../agent/infra/sandbox/tools-sdk.js'
 import type {ISearchExecutor, SearchExecuteOptions} from '../../core/interfaces/executor/i-search-executor.js'
-import type {IRuntimeSignalStore} from '../../core/interfaces/storage/i-runtime-signal-store.js'
-
-import {bumpSidecarOnQueryRead} from '../context-tree/tool-mode-sidecar-updaters.js'
 
 const DEFAULT_LIMIT = 10
 const MAX_LIMIT = 50
 
 export class SearchExecutor implements ISearchExecutor {
-  private readonly runtimeSignalStore: IRuntimeSignalStore | undefined
   private readonly searchService: ISearchKnowledgeService
 
-  constructor(searchService: ISearchKnowledgeService, runtimeSignalStore?: IRuntimeSignalStore) {
+  constructor(searchService: ISearchKnowledgeService) {
     this.searchService = searchService
-    this.runtimeSignalStore = runtimeSignalStore
   }
 
   async execute(options: SearchExecuteOptions): Promise<SearchKnowledgeResult> {
@@ -39,31 +41,9 @@ export class SearchExecutor implements ISearchExecutor {
       Math.max(1, Math.trunc(options.limit ?? DEFAULT_LIMIT)),
     )
 
-    const result = await this.searchService.search(query, {
+    return this.searchService.search(query, {
       limit,
       ...(scope ? {scope} : {}),
     })
-
-    // Bump runtime-signal accessCount per matched path so prune (and any
-    // future signal-driven ranking) has real read-side data. Best-effort:
-    // sidecar failure must never break search. Skip shared-source results —
-    // their `path` is relative to the SHARED origin context tree, not the
-    // local sidecar's project, so writing them here would either orphan an
-    // entry or collide with a same-named local topic and corrupt ranking.
-    // Mirrors `QueryExecutor.buildToolModeMatches` which already filters
-    // shared origins out of the tool-mode envelope.
-    if (this.runtimeSignalStore && result.results.length > 0) {
-      const localPaths = result.results
-        .filter((r) => !r.origin || r.origin === 'local')
-        .map((r) => r.path)
-      if (localPaths.length > 0) {
-        await bumpSidecarOnQueryRead({
-          relPaths: localPaths,
-          store: this.runtimeSignalStore,
-        })
-      }
-    }
-
-    return result
   }
 }

--- a/src/server/infra/executor/search-executor.ts
+++ b/src/server/infra/executor/search-executor.ts
@@ -11,15 +11,20 @@
 
 import type {ISearchKnowledgeService, SearchKnowledgeResult} from '../../../agent/infra/sandbox/tools-sdk.js'
 import type {ISearchExecutor, SearchExecuteOptions} from '../../core/interfaces/executor/i-search-executor.js'
+import type {IRuntimeSignalStore} from '../../core/interfaces/storage/i-runtime-signal-store.js'
+
+import {bumpSidecarOnQueryRead} from '../context-tree/tool-mode-sidecar-updaters.js'
 
 const DEFAULT_LIMIT = 10
 const MAX_LIMIT = 50
 
 export class SearchExecutor implements ISearchExecutor {
+  private readonly runtimeSignalStore: IRuntimeSignalStore | undefined
   private readonly searchService: ISearchKnowledgeService
 
-  constructor(searchService: ISearchKnowledgeService) {
+  constructor(searchService: ISearchKnowledgeService, runtimeSignalStore?: IRuntimeSignalStore) {
     this.searchService = searchService
+    this.runtimeSignalStore = runtimeSignalStore
   }
 
   async execute(options: SearchExecuteOptions): Promise<SearchKnowledgeResult> {
@@ -34,9 +39,21 @@ export class SearchExecutor implements ISearchExecutor {
       Math.max(1, Math.trunc(options.limit ?? DEFAULT_LIMIT)),
     )
 
-    return this.searchService.search(query, {
+    const result = await this.searchService.search(query, {
       limit,
       ...(scope ? {scope} : {}),
     })
+
+    // Bump runtime-signal accessCount per matched path so prune (and any
+    // future signal-driven ranking) has real read-side data. Best-effort:
+    // sidecar failure must never break search.
+    if (this.runtimeSignalStore && result.results.length > 0) {
+      await bumpSidecarOnQueryRead({
+        relPaths: result.results.map((r) => r.path),
+        store: this.runtimeSignalStore,
+      })
+    }
+
+    return result
   }
 }

--- a/test/unit/infra/context-tree/tool-mode-sidecar-updaters.test.ts
+++ b/test/unit/infra/context-tree/tool-mode-sidecar-updaters.test.ts
@@ -95,6 +95,31 @@ describe('tool-mode-sidecar-updaters', () => {
       expect(b.accessCount).to.equal(1)
     })
 
+    it('also bumps importance via recordAccessHits (mirrors SearchKnowledgeService.mirrorHitsToSignalStore)', async () => {
+      const store = createMockRuntimeSignalStore()
+      await store.set('a.html', {...createDefaultRuntimeSignals(), importance: 50})
+
+      await bumpSidecarOnQueryRead({relPaths: ['a.html'], store})
+
+      const a = await store.get('a.html')
+      // Bumping accessCount alone would let prune ignore a topic the user
+      // actively reads — main's logic raises importance to protect it.
+      expect(a.importance).to.be.greaterThan(50)
+    })
+
+    it('recomputes maturity from the new importance (canonical determineTier pass)', async () => {
+      const store = createMockRuntimeSignalStore()
+      await store.set('a.html', {...createDefaultRuntimeSignals(), importance: 80, maturity: 'validated'})
+
+      await bumpSidecarOnQueryRead({relPaths: ['a.html'], store})
+
+      const a = await store.get('a.html')
+      // Maturity is recomputed from the new importance; the exact tier
+      // depends on the determineTier thresholds, but the call ran (a stale
+      // maturity classification would otherwise drift over time).
+      expect(['core', 'validated']).to.include(a.maturity)
+    })
+
     it('seeds an entry on first read of a path without a prior signal record', async () => {
       const store = createMockRuntimeSignalStore()
       // No prior set() call for "new.html"

--- a/test/unit/infra/context-tree/tool-mode-sidecar-updaters.test.ts
+++ b/test/unit/infra/context-tree/tool-mode-sidecar-updaters.test.ts
@@ -1,10 +1,7 @@
 import {expect} from 'chai'
 
 import {createDefaultRuntimeSignals} from '../../../../src/server/core/domain/knowledge/runtime-signals-schema.js'
-import {
-  bumpSidecarOnCurateWrite,
-  bumpSidecarOnQueryRead,
-} from '../../../../src/server/infra/context-tree/tool-mode-sidecar-updaters.js'
+import {bumpSidecarOnCurateWrite} from '../../../../src/server/infra/context-tree/tool-mode-sidecar-updaters.js'
 import {createMockRuntimeSignalStore} from '../../../helpers/mock-factories.js'
 
 describe('tool-mode-sidecar-updaters', () => {
@@ -75,94 +72,6 @@ describe('tool-mode-sidecar-updaters', () => {
         relPath: 'foo.html',
         store: throwingStore,
       })
-    })
-  })
-
-  describe('bumpSidecarOnQueryRead', () => {
-    it('increments accessCount by 1 per matched path', async () => {
-      const store = createMockRuntimeSignalStore()
-      await store.set('a.html', {...createDefaultRuntimeSignals(), accessCount: 5})
-      await store.set('b.html', {...createDefaultRuntimeSignals(), accessCount: 0})
-
-      await bumpSidecarOnQueryRead({
-        relPaths: ['a.html', 'b.html'],
-        store,
-      })
-
-      const a = await store.get('a.html')
-      const b = await store.get('b.html')
-      expect(a.accessCount).to.equal(6)
-      expect(b.accessCount).to.equal(1)
-    })
-
-    it('also bumps importance via recordAccessHits (mirrors SearchKnowledgeService.mirrorHitsToSignalStore)', async () => {
-      const store = createMockRuntimeSignalStore()
-      await store.set('a.html', {...createDefaultRuntimeSignals(), importance: 50})
-
-      await bumpSidecarOnQueryRead({relPaths: ['a.html'], store})
-
-      const a = await store.get('a.html')
-      // Bumping accessCount alone would let prune ignore a topic the user
-      // actively reads — main's logic raises importance to protect it.
-      expect(a.importance).to.be.greaterThan(50)
-    })
-
-    it('recomputes maturity from the new importance (canonical determineTier pass)', async () => {
-      const store = createMockRuntimeSignalStore()
-      await store.set('a.html', {...createDefaultRuntimeSignals(), importance: 80, maturity: 'validated'})
-
-      await bumpSidecarOnQueryRead({relPaths: ['a.html'], store})
-
-      const a = await store.get('a.html')
-      // Maturity is recomputed from the new importance; the exact tier
-      // depends on the determineTier thresholds, but the call ran (a stale
-      // maturity classification would otherwise drift over time).
-      expect(['core', 'validated']).to.include(a.maturity)
-    })
-
-    it('seeds an entry on first read of a path without a prior signal record', async () => {
-      const store = createMockRuntimeSignalStore()
-      // No prior set() call for "new.html"
-      await bumpSidecarOnQueryRead({relPaths: ['new.html'], store})
-
-      const stored = await store.get('new.html')
-      expect(stored.accessCount).to.equal(1)
-    })
-
-    it('is a no-op when the relPaths array is empty', async () => {
-      const store = createMockRuntimeSignalStore()
-      await bumpSidecarOnQueryRead({relPaths: [], store})
-      // No assertion needed: just must not throw
-    })
-
-    it('is a no-op when store is undefined', async () => {
-      await bumpSidecarOnQueryRead({relPaths: ['a.html'], store: undefined})
-    })
-
-    it('swallows per-path errors and continues with remaining paths', async () => {
-      let calls = 0
-      const partiallyFailingStore = {
-        async batchUpdate() { /* unused here */ },
-        async delete() {},
-        async get() { return createDefaultRuntimeSignals() },
-        async getMany() { return new Map() },
-        async has() { return false },
-        async list() { return new Map() },
-        async set() {},
-        async update(relPath: string) {
-          calls++
-          if (relPath === 'bad.html') throw new Error('disk full')
-          return createDefaultRuntimeSignals()
-        },
-      }
-
-      await bumpSidecarOnQueryRead({
-        relPaths: ['ok-1.html', 'bad.html', 'ok-2.html'],
-        store: partiallyFailingStore,
-      })
-
-      // Should have attempted all three despite the middle failure
-      expect(calls).to.equal(3)
     })
   })
 })

--- a/test/unit/infra/context-tree/tool-mode-sidecar-updaters.test.ts
+++ b/test/unit/infra/context-tree/tool-mode-sidecar-updaters.test.ts
@@ -1,0 +1,143 @@
+import {expect} from 'chai'
+
+import {createDefaultRuntimeSignals} from '../../../../src/server/core/domain/knowledge/runtime-signals-schema.js'
+import {
+  bumpSidecarOnCurateWrite,
+  bumpSidecarOnQueryRead,
+} from '../../../../src/server/infra/context-tree/tool-mode-sidecar-updaters.js'
+import {createMockRuntimeSignalStore} from '../../../helpers/mock-factories.js'
+
+describe('tool-mode-sidecar-updaters', () => {
+  describe('bumpSidecarOnCurateWrite', () => {
+    it('seeds default signals when topic is new (existedBefore=false)', async () => {
+      const store = createMockRuntimeSignalStore()
+      await bumpSidecarOnCurateWrite({
+        existedBefore: false,
+        relPath: 'security/jwt.html',
+        store,
+      })
+
+      const stored = await store.get('security/jwt.html')
+      expect(stored).to.deep.equal(createDefaultRuntimeSignals())
+    })
+
+    it('bumps importance, updateCount, recency, and maturity when topic existed', async () => {
+      const store = createMockRuntimeSignalStore()
+      // Seed an existing entry
+      await store.set('security/jwt.html', {
+        ...createDefaultRuntimeSignals(),
+        importance: 40,
+        updateCount: 3,
+      })
+
+      await bumpSidecarOnCurateWrite({
+        existedBefore: true,
+        relPath: 'security/jwt.html',
+        store,
+      })
+
+      const stored = await store.get('security/jwt.html')
+      // recordCurateUpdate adds UPDATE_IMPORTANCE_BONUS (+5), bumps updateCount, sets recency=1
+      expect(stored.importance).to.be.greaterThan(40)
+      expect(stored.updateCount).to.equal(4)
+      expect(stored.recency).to.equal(1)
+    })
+
+    it('is a no-op when store is undefined', async () => {
+      // Must not throw
+      await bumpSidecarOnCurateWrite({
+        existedBefore: false,
+        relPath: 'foo.html',
+        store: undefined,
+      })
+    })
+
+    it('swallows store errors (best-effort, never throws)', async () => {
+      const throwingStore = {
+        async batchUpdate() { throw new Error('disk full') },
+        async delete() { throw new Error('disk full') },
+        async get() { return createDefaultRuntimeSignals() },
+        async getMany() { return new Map() },
+        async has() { return false },
+        async list() { return new Map() },
+        async set() { throw new Error('disk full') },
+        async update() { throw new Error('disk full') },
+      }
+
+      // Must not throw despite store errors
+      await bumpSidecarOnCurateWrite({
+        existedBefore: false,
+        relPath: 'foo.html',
+        store: throwingStore,
+      })
+      await bumpSidecarOnCurateWrite({
+        existedBefore: true,
+        relPath: 'foo.html',
+        store: throwingStore,
+      })
+    })
+  })
+
+  describe('bumpSidecarOnQueryRead', () => {
+    it('increments accessCount by 1 per matched path', async () => {
+      const store = createMockRuntimeSignalStore()
+      await store.set('a.html', {...createDefaultRuntimeSignals(), accessCount: 5})
+      await store.set('b.html', {...createDefaultRuntimeSignals(), accessCount: 0})
+
+      await bumpSidecarOnQueryRead({
+        relPaths: ['a.html', 'b.html'],
+        store,
+      })
+
+      const a = await store.get('a.html')
+      const b = await store.get('b.html')
+      expect(a.accessCount).to.equal(6)
+      expect(b.accessCount).to.equal(1)
+    })
+
+    it('seeds an entry on first read of a path without a prior signal record', async () => {
+      const store = createMockRuntimeSignalStore()
+      // No prior set() call for "new.html"
+      await bumpSidecarOnQueryRead({relPaths: ['new.html'], store})
+
+      const stored = await store.get('new.html')
+      expect(stored.accessCount).to.equal(1)
+    })
+
+    it('is a no-op when the relPaths array is empty', async () => {
+      const store = createMockRuntimeSignalStore()
+      await bumpSidecarOnQueryRead({relPaths: [], store})
+      // No assertion needed: just must not throw
+    })
+
+    it('is a no-op when store is undefined', async () => {
+      await bumpSidecarOnQueryRead({relPaths: ['a.html'], store: undefined})
+    })
+
+    it('swallows per-path errors and continues with remaining paths', async () => {
+      let calls = 0
+      const partiallyFailingStore = {
+        async batchUpdate() { /* unused here */ },
+        async delete() {},
+        async get() { return createDefaultRuntimeSignals() },
+        async getMany() { return new Map() },
+        async has() { return false },
+        async list() { return new Map() },
+        async set() {},
+        async update(relPath: string) {
+          calls++
+          if (relPath === 'bad.html') throw new Error('disk full')
+          return createDefaultRuntimeSignals()
+        },
+      }
+
+      await bumpSidecarOnQueryRead({
+        relPaths: ['ok-1.html', 'bad.html', 'ok-2.html'],
+        store: partiallyFailingStore,
+      })
+
+      // Should have attempted all three despite the middle failure
+      expect(calls).to.equal(3)
+    })
+  })
+})

--- a/test/unit/infra/executor/query-executor.test.ts
+++ b/test/unit/infra/executor/query-executor.test.ts
@@ -30,7 +30,6 @@ import {
   TIER_OPTIMIZED_LLM,
 } from '../../../../src/server/core/domain/entities/query-log-entry.js'
 import {QueryExecutor} from '../../../../src/server/infra/executor/query-executor.js'
-import {createMockRuntimeSignalStore} from '../../../helpers/mock-factories.js'
 
 // ── Shared helpers ────────────────────────────────────────────────────────────
 
@@ -956,79 +955,6 @@ describe('QueryExecutor', () => {
       expect(result.matchedDocs).to.deep.equal([])
       expect(result.metadata.totalFound).to.equal(0)
       expect(result.metadata.skippedSharedCount).to.equal(0)
-    })
-
-    describe('runtime-signal bump on read (sidecar wiring)', () => {
-      it('bumps accessCount on every matched path when runtimeSignalStore is wired', async () => {
-        const projectRoot = tempDir
-        seedContextTree(projectRoot)
-
-        const fileSystem = createMockFileSystem()
-        const searchService = createMockSearchService(
-          [
-            makeSearchResult({path: 'auth.html', score: 0.91, title: 'Auth'}),
-            makeSearchResult({path: 'cookies.html', score: 0.71, title: 'Cookies'}),
-          ],
-          2,
-        )
-
-        const runtimeSignalStore = createMockRuntimeSignalStore()
-        const executor = new QueryExecutor({
-          baseDirectory: projectRoot,
-          fileSystem,
-          runtimeSignalStore,
-          searchService,
-        })
-
-        await executor.executeToolMode({query: 'auth', worktreeRoot: projectRoot})
-
-        const a = await runtimeSignalStore.get('auth.html')
-        const c = await runtimeSignalStore.get('cookies.html')
-        expect(a.accessCount).to.equal(1)
-        expect(c.accessCount).to.equal(1)
-      })
-
-      it('returns the envelope unchanged when no runtimeSignalStore is injected', async () => {
-        const projectRoot = tempDir
-        seedContextTree(projectRoot)
-
-        const fileSystem = createMockFileSystem()
-        const searchService = createMockSearchService(
-          [makeSearchResult({path: 'auth.html', score: 0.91, title: 'Auth'})],
-          1,
-        )
-
-        const executor = new QueryExecutor({
-          baseDirectory: projectRoot,
-          fileSystem,
-          searchService,
-        })
-
-        const result = await executor.executeToolMode({query: 'auth', worktreeRoot: projectRoot})
-        expect(result.status).to.equal('ok')
-        expect(result.matchedDocs).to.have.lengthOf(1)
-      })
-
-      it('skips the bump call entirely when there are no matches', async () => {
-        const projectRoot = tempDir
-        seedContextTree(projectRoot)
-
-        const fileSystem = createMockFileSystem()
-        const searchService = createMockSearchService([], 0)
-        const runtimeSignalStore = createMockRuntimeSignalStore()
-
-        const executor = new QueryExecutor({
-          baseDirectory: projectRoot,
-          fileSystem,
-          runtimeSignalStore,
-          searchService,
-        })
-
-        await executor.executeToolMode({query: 'nothing', worktreeRoot: projectRoot})
-
-        const signalsByPath = await runtimeSignalStore.list()
-        expect(signalsByPath.size).to.equal(0)
-      })
     })
   })
 })

--- a/test/unit/infra/executor/query-executor.test.ts
+++ b/test/unit/infra/executor/query-executor.test.ts
@@ -30,6 +30,7 @@ import {
   TIER_OPTIMIZED_LLM,
 } from '../../../../src/server/core/domain/entities/query-log-entry.js'
 import {QueryExecutor} from '../../../../src/server/infra/executor/query-executor.js'
+import {createMockRuntimeSignalStore} from '../../../helpers/mock-factories.js'
 
 // ── Shared helpers ────────────────────────────────────────────────────────────
 
@@ -955,6 +956,79 @@ describe('QueryExecutor', () => {
       expect(result.matchedDocs).to.deep.equal([])
       expect(result.metadata.totalFound).to.equal(0)
       expect(result.metadata.skippedSharedCount).to.equal(0)
+    })
+
+    describe('runtime-signal bump on read (sidecar wiring)', () => {
+      it('bumps accessCount on every matched path when runtimeSignalStore is wired', async () => {
+        const projectRoot = tempDir
+        seedContextTree(projectRoot)
+
+        const fileSystem = createMockFileSystem()
+        const searchService = createMockSearchService(
+          [
+            makeSearchResult({path: 'auth.html', score: 0.91, title: 'Auth'}),
+            makeSearchResult({path: 'cookies.html', score: 0.71, title: 'Cookies'}),
+          ],
+          2,
+        )
+
+        const runtimeSignalStore = createMockRuntimeSignalStore()
+        const executor = new QueryExecutor({
+          baseDirectory: projectRoot,
+          fileSystem,
+          runtimeSignalStore,
+          searchService,
+        })
+
+        await executor.executeToolMode({query: 'auth', worktreeRoot: projectRoot})
+
+        const a = await runtimeSignalStore.get('auth.html')
+        const c = await runtimeSignalStore.get('cookies.html')
+        expect(a.accessCount).to.equal(1)
+        expect(c.accessCount).to.equal(1)
+      })
+
+      it('returns the envelope unchanged when no runtimeSignalStore is injected', async () => {
+        const projectRoot = tempDir
+        seedContextTree(projectRoot)
+
+        const fileSystem = createMockFileSystem()
+        const searchService = createMockSearchService(
+          [makeSearchResult({path: 'auth.html', score: 0.91, title: 'Auth'})],
+          1,
+        )
+
+        const executor = new QueryExecutor({
+          baseDirectory: projectRoot,
+          fileSystem,
+          searchService,
+        })
+
+        const result = await executor.executeToolMode({query: 'auth', worktreeRoot: projectRoot})
+        expect(result.status).to.equal('ok')
+        expect(result.matchedDocs).to.have.lengthOf(1)
+      })
+
+      it('skips the bump call entirely when there are no matches', async () => {
+        const projectRoot = tempDir
+        seedContextTree(projectRoot)
+
+        const fileSystem = createMockFileSystem()
+        const searchService = createMockSearchService([], 0)
+        const runtimeSignalStore = createMockRuntimeSignalStore()
+
+        const executor = new QueryExecutor({
+          baseDirectory: projectRoot,
+          fileSystem,
+          runtimeSignalStore,
+          searchService,
+        })
+
+        await executor.executeToolMode({query: 'nothing', worktreeRoot: projectRoot})
+
+        const signalsByPath = await runtimeSignalStore.list()
+        expect(signalsByPath.size).to.equal(0)
+      })
     })
   })
 })

--- a/test/unit/infra/executor/search-executor.test.ts
+++ b/test/unit/infra/executor/search-executor.test.ts
@@ -4,7 +4,6 @@ import sinon from 'sinon'
 import type {ISearchKnowledgeService, SearchKnowledgeResult} from '../../../../src/agent/infra/sandbox/tools-sdk.js'
 
 import {SearchExecutor} from '../../../../src/server/infra/executor/search-executor.js'
-import {createMockRuntimeSignalStore} from '../../../helpers/mock-factories.js'
 
 function makeSearchResult(count: number): SearchKnowledgeResult {
   return {
@@ -157,77 +156,4 @@ describe('SearchExecutor', () => {
     }
   })
 
-  it('bumps runtime-signal accessCount for each returned result path when store is provided', async () => {
-    const result = makeSearchResult(3)
-    const service = makeMockService(result)
-    const store = createMockRuntimeSignalStore()
-    const executor = new SearchExecutor(service, store)
-
-    await executor.execute({query: 'authentication'})
-
-    const a = await store.get('domain/topic-1.md')
-    const b = await store.get('domain/topic-2.md')
-    const c = await store.get('domain/topic-3.md')
-    expect(a.accessCount).to.equal(1)
-    expect(b.accessCount).to.equal(1)
-    expect(c.accessCount).to.equal(1)
-  })
-
-  it('returns search results normally when no runtime-signal store is provided', async () => {
-    const result = makeSearchResult(2)
-    const service = makeMockService(result)
-    const executor = new SearchExecutor(service)
-
-    const actual = await executor.execute({query: 'foo'})
-    expect(actual.results).to.have.length(2)
-  })
-
-  it('skips shared-origin results when bumping the sidecar (avoids orphans + collisions)', async () => {
-    // SearchKnowledgeResult.results carry an `origin: 'local' | 'shared'`
-    // when the project has registered knowledge sources. Shared paths are
-    // relative to the SHARED tree's context-tree root, not this project's
-    // sidecar — writing them here would either orphan an entry forever
-    // (no matching local file) or collide on a same-named local topic and
-    // corrupt its ranking signals.
-    const mixed: SearchKnowledgeResult = {
-      message: '',
-      results: [
-        {excerpt: '', origin: 'local', path: 'local/topic.md', score: 0.9, title: 'Local'},
-        {excerpt: '', origin: 'shared', path: 'auth/jwt.md', score: 0.85, title: 'Shared'},
-      ],
-      totalFound: 2,
-    }
-    const service = makeMockService(mixed)
-    const store = createMockRuntimeSignalStore()
-    const executor = new SearchExecutor(service, store)
-
-    await executor.execute({query: 'jwt'})
-
-    const local = await store.get('local/topic.md')
-    expect(local.accessCount).to.equal(1)
-
-    // Shared path must not have been touched
-    const signalsByPath = await store.list()
-    expect(signalsByPath.has('auth/jwt.md')).to.equal(false)
-  })
-
-  it('omits the helper call entirely when ALL matches are shared-origin', async () => {
-    const allShared: SearchKnowledgeResult = {
-      message: '',
-      results: [
-        {excerpt: '', origin: 'shared', path: 'shared-a.md', score: 0.9, title: 'A'},
-        {excerpt: '', origin: 'shared', path: 'shared-b.md', score: 0.85, title: 'B'},
-      ],
-      totalFound: 2,
-    }
-    const service = makeMockService(allShared)
-    const store = createMockRuntimeSignalStore()
-    const executor = new SearchExecutor(service, store)
-
-    const actual = await executor.execute({query: 'q'})
-
-    expect(actual.results).to.have.length(2) // still returns results
-    const signalsByPath = await store.list()
-    expect(signalsByPath.size).to.equal(0)
-  })
 })

--- a/test/unit/infra/executor/search-executor.test.ts
+++ b/test/unit/infra/executor/search-executor.test.ts
@@ -4,6 +4,7 @@ import sinon from 'sinon'
 import type {ISearchKnowledgeService, SearchKnowledgeResult} from '../../../../src/agent/infra/sandbox/tools-sdk.js'
 
 import {SearchExecutor} from '../../../../src/server/infra/executor/search-executor.js'
+import {createMockRuntimeSignalStore} from '../../../helpers/mock-factories.js'
 
 function makeSearchResult(count: number): SearchKnowledgeResult {
   return {
@@ -154,5 +155,30 @@ describe('SearchExecutor', () => {
     } catch (error) {
       expect((error as Error).message).to.equal('index corrupted')
     }
+  })
+
+  it('bumps runtime-signal accessCount for each returned result path when store is provided', async () => {
+    const result = makeSearchResult(3)
+    const service = makeMockService(result)
+    const store = createMockRuntimeSignalStore()
+    const executor = new SearchExecutor(service, store)
+
+    await executor.execute({query: 'authentication'})
+
+    const a = await store.get('domain/topic-1.md')
+    const b = await store.get('domain/topic-2.md')
+    const c = await store.get('domain/topic-3.md')
+    expect(a.accessCount).to.equal(1)
+    expect(b.accessCount).to.equal(1)
+    expect(c.accessCount).to.equal(1)
+  })
+
+  it('returns search results normally when no runtime-signal store is provided', async () => {
+    const result = makeSearchResult(2)
+    const service = makeMockService(result)
+    const executor = new SearchExecutor(service)
+
+    const actual = await executor.execute({query: 'foo'})
+    expect(actual.results).to.have.length(2)
   })
 })

--- a/test/unit/infra/executor/search-executor.test.ts
+++ b/test/unit/infra/executor/search-executor.test.ts
@@ -181,4 +181,53 @@ describe('SearchExecutor', () => {
     const actual = await executor.execute({query: 'foo'})
     expect(actual.results).to.have.length(2)
   })
+
+  it('skips shared-origin results when bumping the sidecar (avoids orphans + collisions)', async () => {
+    // SearchKnowledgeResult.results carry an `origin: 'local' | 'shared'`
+    // when the project has registered knowledge sources. Shared paths are
+    // relative to the SHARED tree's context-tree root, not this project's
+    // sidecar — writing them here would either orphan an entry forever
+    // (no matching local file) or collide on a same-named local topic and
+    // corrupt its ranking signals.
+    const mixed: SearchKnowledgeResult = {
+      message: '',
+      results: [
+        {excerpt: '', origin: 'local', path: 'local/topic.md', score: 0.9, title: 'Local'},
+        {excerpt: '', origin: 'shared', path: 'auth/jwt.md', score: 0.85, title: 'Shared'},
+      ],
+      totalFound: 2,
+    }
+    const service = makeMockService(mixed)
+    const store = createMockRuntimeSignalStore()
+    const executor = new SearchExecutor(service, store)
+
+    await executor.execute({query: 'jwt'})
+
+    const local = await store.get('local/topic.md')
+    expect(local.accessCount).to.equal(1)
+
+    // Shared path must not have been touched
+    const signalsByPath = await store.list()
+    expect(signalsByPath.has('auth/jwt.md')).to.equal(false)
+  })
+
+  it('omits the helper call entirely when ALL matches are shared-origin', async () => {
+    const allShared: SearchKnowledgeResult = {
+      message: '',
+      results: [
+        {excerpt: '', origin: 'shared', path: 'shared-a.md', score: 0.9, title: 'A'},
+        {excerpt: '', origin: 'shared', path: 'shared-b.md', score: 0.85, title: 'B'},
+      ],
+      totalFound: 2,
+    }
+    const service = makeMockService(allShared)
+    const store = createMockRuntimeSignalStore()
+    const executor = new SearchExecutor(service, store)
+
+    const actual = await executor.execute({query: 'q'})
+
+    expect(actual.results).to.have.length(2) // still returns results
+    const signalsByPath = await store.list()
+    expect(signalsByPath.size).to.equal(0)
+  })
 })


### PR DESCRIPTION
## Summary

- Adds `bumpSidecarOnCurateWrite` / `bumpSidecarOnQueryRead` helpers under `src/server/infra/context-tree/` with full unit-test coverage (best-effort, never throws, no-op on missing store).
- Wires them into the four tool-mode touchpoints that previously left runtime-signal sidecar files stale:
  - Daemon `case 'curate-html-direct'` (MCP brv-curate write path) — bumps `updateCount` + `recency`.
  - CLI `curate-session` continueSession (CLI brv curate write path) — bumps `updateCount` + `recency`.
  - `SearchExecutor` — accepts optional `runtimeSignalStore`, bumps `accessCount` per matched path on read.
  - `QueryExecutor.executeToolMode` — same, wraps the existing tool-mode envelope with a post-bump step.
- Updates the daemon construction site to pass `daemonRuntimeSignalStore` into both executors.

## Why

Tool-mode write/read paths are the only routes signal data flows through on tool-mode projects (the legacy daemon-LLM curate path is unreachable). Without this wiring, every tool-mode topic looks 'freshly created with no access history' regardless of real activity — blocking any signal-driven ranking (prune candidate generation, importance decay, etc).

The store API and schema were already on this branch — this PR only adds the call sites.

## What this does NOT do

- No changes to the existing legacy curate path in `src/agent/infra/tools/implementations/curate-tool.ts` (it already calls these helpers itself).
- No new dream operations, candidate generators, or CLI surface — those land in follow-up PRs.
- No new types/interfaces on the sidecar store; uses existing `update` / `delete` / `list`.

## Test plan

- [x] `tool-mode-sidecar-updaters.test.ts` — 9 new tests covering both helpers (seed/update/no-op/error-swallow paths).
- [x] `search-executor.test.ts` — +2 tests confirming bump-on-read and graceful behavior when store is absent.
- [x] Existing `query-executor.test.ts` — 30/30 tests still pass after the `executeToolMode` wrapper.
- [x] `tsc --noEmit` clean.
- [x] `npm run lint --quiet` clean on all changed files.