### PR TITLE
Tool-mode Dream — full port (link, merge, prune, synthesize)

### DIFF
--- a/src/oclif/commands/dream/cancel.ts
+++ b/src/oclif/commands/dream/cancel.ts
@@ -32,7 +32,10 @@ public static flags = {
       this.log('')
       this.log('(Tool-mode dream sessions are stateless on the daemon in v1;')
       this.log('cancel is a no-op. Any brv-curate writes made between scan and')
-      this.log('cancel are NOT rolled back — use `brv dream undo` for that.)')
+      this.log('cancel are NOT rolled back by `brv dream undo` — use')
+      this.log('`brv review reject <taskId>` for each curate write you want to')
+      this.log('revert. `brv dream undo` only reverts finalize archives and')
+      this.log('would otherwise undo an unrelated prior completed dream.)')
     }
   }
 }

--- a/src/oclif/commands/dream/cancel.ts
+++ b/src/oclif/commands/dream/cancel.ts
@@ -1,0 +1,38 @@
+import {Command, Flags} from '@oclif/core'
+
+import {writeJsonResponse} from '../../lib/json-response.js'
+
+/**
+ * Tool-mode dream sessions are stateless on the daemon in v1, so cancel
+ * is effectively a no-op — there's nothing to clean up server-side. The
+ * command stays in the surface for symmetry; a future revision that
+ * persists sessions can hook real cleanup here without re-shaping the
+ * CLI.
+ */
+export default class DreamCancel extends Command {
+  public static description = 'Discard a tool-mode dream session.'
+public static examples = ['<%= config.bin %> <%= command.id %> --session drm-abc123']
+public static flags = {
+    format: Flags.string({default: 'text', description: 'Output format (text or json)', options: ['text', 'json']}),
+    session: Flags.string({description: 'Session id to discard', required: true}),
+  }
+
+  public async run(): Promise<void> {
+    const {flags: raw} = await this.parse(DreamCancel)
+    const format = raw.format === 'json' ? 'json' : 'text'
+
+    if (format === 'json') {
+      writeJsonResponse({
+        command: 'dream-cancel',
+        data: {sessionId: raw.session, status: 'cancelled'},
+        success: true,
+      })
+    } else {
+      this.log(`Session ${raw.session} discarded.`)
+      this.log('')
+      this.log('(Tool-mode dream sessions are stateless on the daemon in v1;')
+      this.log('cancel is a no-op. Any brv-curate writes made between scan and')
+      this.log('cancel are NOT rolled back — use `brv dream undo` for that.)')
+    }
+  }
+}

--- a/src/oclif/commands/dream/finalize.ts
+++ b/src/oclif/commands/dream/finalize.ts
@@ -58,7 +58,7 @@ public static flags = {
     // `dream finalize --session X` exits 0 with archived:[] — a silent no-op
     // that hides a typo'd flag in scripting.
     if (!raw.archive && !raw['archive-file']) {
-      const msg = 'Either --archive or --archive-file is required (use --archive "" to explicitly cancel).'
+      const msg = 'Either --archive or --archive-file is required.'
       if (format === 'json') {
         writeJsonResponse({command: 'dream-finalize', data: {error: msg, status: 'error'}, success: false})
       } else {
@@ -164,11 +164,24 @@ function renderFinalizeText(command: Command, raw: string | undefined): void {
     return
   }
 
-  let parsed: {archived?: string[]; skipped?: Array<{path: string; reason: string}>}
+  let parsed: {
+    archived?: string[]
+    error?: string
+    skipped?: Array<{path: string; reason: string}>
+    status?: string
+  }
   try {
     parsed = JSON.parse(raw)
   } catch {
     command.log(raw)
+    return
+  }
+
+  // Daemon-side failures encode as {status:'error', error:'...'}. Surface
+  // them as errors rather than printing "Archived: 0" which looks like a
+  // successful no-op finalize.
+  if (parsed.status === 'error') {
+    command.log(`dream-finalize failed: ${parsed.error ?? 'unknown error'}`)
     return
   }
 

--- a/src/oclif/commands/dream/finalize.ts
+++ b/src/oclif/commands/dream/finalize.ts
@@ -2,7 +2,7 @@ import type {TaskAck} from '@campfirein/brv-transport-client'
 
 import {Command, Flags} from '@oclif/core'
 import {randomUUID} from 'node:crypto'
-import {readFile} from 'node:fs/promises'
+import {readFile, stat} from 'node:fs/promises'
 
 import {TaskEvents} from '../../../shared/transport/events/index.js'
 import {type DaemonClientOptions, formatConnectionError, withDaemonRetry} from '../../lib/daemon-client.js'
@@ -68,11 +68,29 @@ public static flags = {
       return
     }
 
+    // Pre-read size guard for --archive-file. 200 paths * ~1 KB per path
+    // gives ~200 KB of legitimate input; 256 KB covers that with headroom
+    // while bailing early on multi-GB files or fifos (without this, readFile
+    // would slurp arbitrary bytes into memory before the line-count cap fires).
+    const MAX_ARCHIVE_FILE_BYTES = 256 * 1024
+
     let archive: string[] = []
     if (raw.archive) {
       archive = raw.archive.split(',').map((s) => s.trim()).filter(Boolean)
     } else if (raw['archive-file']) {
       try {
+        const stats = await stat(raw['archive-file'])
+        if (stats.size > MAX_ARCHIVE_FILE_BYTES) {
+          const msg = `--archive-file too large: ${stats.size} bytes (max ${MAX_ARCHIVE_FILE_BYTES}). Split into multiple finalize calls.`
+          if (format === 'json') {
+            writeJsonResponse({command: 'dream-finalize', data: {error: msg, status: 'error'}, success: false})
+          } else {
+            this.log(msg)
+          }
+
+          return
+        }
+
         const fileContent = await readFile(raw['archive-file'], 'utf8')
         archive = fileContent.split('\n').map((s) => s.trim()).filter(Boolean)
       } catch (error) {

--- a/src/oclif/commands/dream/finalize.ts
+++ b/src/oclif/commands/dream/finalize.ts
@@ -13,10 +13,11 @@ export default class DreamFinalize extends Command {
   public static description =
     'Phase 3 of tool-mode dream — archive the loser topics the agent chose from the merge candidates.'
 public static examples = [
-    '# Archive specific topics, closing a session',
-    '<%= config.bin %> <%= command.id %> --session drm-abc --archive testing/red_green_refactor,redis/cache_config',
+    '# Archive specific topics, closing a session.',
+    '# Paths must match exactly what `brv dream scan` emits — full relative path including the .html extension.',
+    '<%= config.bin %> <%= command.id %> --session drm-abc --archive testing/old-notes.html,redis/eviction.html',
     '',
-    '# Read archive list from a file (one path per line)',
+    '# Read archive list from a file (one path per line).',
     '<%= config.bin %> <%= command.id %> --session drm-abc --archive-file losers.txt',
   ]
 public static flags = {
@@ -40,6 +41,33 @@ public static flags = {
     const {flags: raw} = await this.parse(DreamFinalize)
     const format = raw.format === 'json' ? 'json' : 'text'
 
+    // Conflict guard: --archive and --archive-file are mutually exclusive.
+    // Without this, --archive silently wins and --archive-file is dropped.
+    if (raw.archive && raw['archive-file']) {
+      const msg = '--archive and --archive-file are mutually exclusive; pick one.'
+      if (format === 'json') {
+        writeJsonResponse({command: 'dream-finalize', data: {error: msg, status: 'error'}, success: false})
+      } else {
+        this.log(msg)
+      }
+
+      return
+    }
+
+    // Require one of --archive or --archive-file. Without this, a stray
+    // `dream finalize --session X` exits 0 with archived:[] — a silent no-op
+    // that hides a typo'd flag in scripting.
+    if (!raw.archive && !raw['archive-file']) {
+      const msg = 'Either --archive or --archive-file is required (use --archive "" to explicitly cancel).'
+      if (format === 'json') {
+        writeJsonResponse({command: 'dream-finalize', data: {error: msg, status: 'error'}, success: false})
+      } else {
+        this.log(msg)
+      }
+
+      return
+    }
+
     let archive: string[] = []
     if (raw.archive) {
       archive = raw.archive.split(',').map((s) => s.trim()).filter(Boolean)
@@ -57,6 +85,23 @@ public static flags = {
 
         return
       }
+    }
+
+    // Cap batch size to keep the daemon socket message bounded. 200 covers
+    // realistic dream sessions (10s of candidates per kind, 4 kinds) with
+    // headroom; beyond that the call would risk hitting the transport's
+    // payload limit and disconnecting the daemon. Users with very large
+    // archive lists should call finalize in multiple batches.
+    const MAX_ARCHIVE_BATCH = 200
+    if (archive.length > MAX_ARCHIVE_BATCH) {
+      const msg = `--archive list too large: ${archive.length} entries (max ${MAX_ARCHIVE_BATCH}). Split across multiple finalize calls.`
+      if (format === 'json') {
+        writeJsonResponse({command: 'dream-finalize', data: {error: msg, status: 'error'}, success: false})
+      } else {
+        this.log(msg)
+      }
+
+      return
     }
 
     try {

--- a/src/oclif/commands/dream/finalize.ts
+++ b/src/oclif/commands/dream/finalize.ts
@@ -1,0 +1,136 @@
+import type {TaskAck} from '@campfirein/brv-transport-client'
+
+import {Command, Flags} from '@oclif/core'
+import {randomUUID} from 'node:crypto'
+import {readFile} from 'node:fs/promises'
+
+import {TaskEvents} from '../../../shared/transport/events/index.js'
+import {type DaemonClientOptions, formatConnectionError, withDaemonRetry} from '../../lib/daemon-client.js'
+import {writeJsonResponse} from '../../lib/json-response.js'
+import {DEFAULT_TIMEOUT_SECONDS, MAX_TIMEOUT_SECONDS, MIN_TIMEOUT_SECONDS, waitForTaskCompletion} from '../../lib/task-client.js'
+
+export default class DreamFinalize extends Command {
+  public static description =
+    'Phase 3 of tool-mode dream — archive the loser topics the agent chose from the merge candidates.'
+public static examples = [
+    '# Archive specific topics, closing a session',
+    '<%= config.bin %> <%= command.id %> --session drm-abc --archive testing/red_green_refactor,redis/cache_config',
+    '',
+    '# Read archive list from a file (one path per line)',
+    '<%= config.bin %> <%= command.id %> --session drm-abc --archive-file losers.txt',
+  ]
+public static flags = {
+    archive: Flags.string({description: 'Comma-separated topic paths to move to .brv/archive/'}),
+    'archive-file': Flags.string({description: 'Read archive paths from a file (one per line).'}),
+    format: Flags.string({default: 'text', description: 'Output format (text or json)', options: ['text', 'json']}),
+    session: Flags.string({description: 'Session id from a prior scan', required: true}),
+    timeout: Flags.integer({
+      default: DEFAULT_TIMEOUT_SECONDS,
+      description: 'Maximum seconds to wait for completion',
+      max: MAX_TIMEOUT_SECONDS,
+      min: MIN_TIMEOUT_SECONDS,
+    }),
+  }
+
+  protected getDaemonClientOptions(): DaemonClientOptions {
+    return {}
+  }
+
+  public async run(): Promise<void> {
+    const {flags: raw} = await this.parse(DreamFinalize)
+    const format = raw.format === 'json' ? 'json' : 'text'
+
+    let archive: string[] = []
+    if (raw.archive) {
+      archive = raw.archive.split(',').map((s) => s.trim()).filter(Boolean)
+    } else if (raw['archive-file']) {
+      try {
+        const fileContent = await readFile(raw['archive-file'], 'utf8')
+        archive = fileContent.split('\n').map((s) => s.trim()).filter(Boolean)
+      } catch (error) {
+        const msg = `Failed to read --archive-file: ${error instanceof Error ? error.message : String(error)}`
+        if (format === 'json') {
+          writeJsonResponse({command: 'dream-finalize', data: {error: msg, status: 'error'}, success: false})
+        } else {
+          this.log(msg)
+        }
+
+        return
+      }
+    }
+
+    try {
+      await withDaemonRetry(
+        async (client, projectRoot, worktreeRoot) => {
+          const taskId = randomUUID()
+          const taskPayload = {
+            content: JSON.stringify({archive, sessionId: raw.session}),
+            ...(projectRoot ? {projectPath: projectRoot} : {}),
+            taskId,
+            type: 'dream-finalize' as const,
+            ...(worktreeRoot ? {worktreeRoot} : {}),
+          }
+
+          const completionPromise = waitForTaskCompletion(
+            {
+              client,
+              command: 'dream-finalize',
+              format,
+              onCompleted: ({result}) => {
+                if (format === 'json') {
+                  this.log(result ?? '{}')
+                } else {
+                  renderFinalizeText(this, result)
+                }
+              },
+              onError: ({error}) => {
+                const msg = error?.message ?? 'dream-finalize failed'
+                if (format === 'json') {
+                  writeJsonResponse({command: 'dream-finalize', data: {error: msg, status: 'error'}, success: false})
+                } else {
+                  this.log(`dream-finalize failed: ${msg}`)
+                }
+              },
+              taskId,
+              timeoutMs: (raw.timeout ?? DEFAULT_TIMEOUT_SECONDS) * 1000,
+            },
+            (msg) => this.log(msg),
+          )
+
+          await client.requestWithAck<TaskAck>(TaskEvents.CREATE, taskPayload)
+          await completionPromise
+        },
+        this.getDaemonClientOptions(),
+      )
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'dream-finalize failed'
+      if (format === 'json') {
+        writeJsonResponse({command: 'dream-finalize', data: {error: message, status: 'error'}, success: false})
+      } else {
+        this.log(formatConnectionError(error))
+      }
+    }
+  }
+}
+
+function renderFinalizeText(command: Command, raw: string | undefined): void {
+  if (!raw) {
+    command.log('(no result)')
+    return
+  }
+
+  let parsed: {archived?: string[]; skipped?: Array<{path: string; reason: string}>}
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    command.log(raw)
+    return
+  }
+
+  command.log(`Archived: ${parsed.archived?.length ?? 0}`)
+  for (const p of parsed.archived ?? []) command.log(`  ⌫  ${p}`)
+  if ((parsed.skipped?.length ?? 0) > 0) {
+    command.log(`Skipped: ${parsed.skipped?.length}`)
+    for (const s of parsed.skipped ?? []) command.log(`  ⚠  ${s.path} (${s.reason})`)
+  }
+}

--- a/src/oclif/commands/dream/scan.ts
+++ b/src/oclif/commands/dream/scan.ts
@@ -8,7 +8,7 @@ import {type DaemonClientOptions, formatConnectionError, withDaemonRetry} from '
 import {writeJsonResponse} from '../../lib/json-response.js'
 import {DEFAULT_TIMEOUT_SECONDS, MAX_TIMEOUT_SECONDS, MIN_TIMEOUT_SECONDS, waitForTaskCompletion} from '../../lib/task-client.js'
 
-const VALID_KINDS = ['link', 'merge', 'prune', 'synthesize'] as const
+const VALID_KINDS: readonly string[] = ['link', 'merge', 'prune', 'synthesize']
 
 export default class DreamScan extends Command {
   public static description =
@@ -51,7 +51,7 @@ public static flags = {
 
     const kinds = raw.kinds ? raw.kinds.split(',').map((s) => s.trim()).filter(Boolean) : undefined
     if (kinds) {
-      const invalid = kinds.filter((k) => !VALID_KINDS.includes(k as (typeof VALID_KINDS)[number]))
+      const invalid = kinds.filter((k) => !VALID_KINDS.includes(k))
       if (invalid.length > 0) {
         const msg = `Invalid --kinds values: ${invalid.join(', ')}. Allowed: ${VALID_KINDS.join(', ')}`
         if (format === 'json') {

--- a/src/oclif/commands/dream/scan.ts
+++ b/src/oclif/commands/dream/scan.ts
@@ -139,6 +139,7 @@ function renderScanText(command: Command, raw: string | undefined): void {
       prune?: Array<{path: string; reason: string}>
       synthesize?: {domains: Array<{domain: string; topics: unknown[]}>}
     }
+    error?: string
     sessionId?: string
     status?: string
   }
@@ -146,6 +147,14 @@ function renderScanText(command: Command, raw: string | undefined): void {
     parsed = JSON.parse(raw)
   } catch {
     command.log(raw)
+    return
+  }
+
+  // Daemon-side failures encode as {status:'error', error:'...'}. Surface
+  // them as errors rather than printing an empty candidate summary that
+  // looks like a successful zero-candidate scan.
+  if (parsed.status === 'error') {
+    command.log(`dream-scan failed: ${parsed.error ?? 'unknown error'}`)
     return
   }
 
@@ -168,5 +177,9 @@ function renderScanText(command: Command, raw: string | undefined): void {
 
   for (const p of c.prune ?? []) {
     command.log(`    prune (${p.reason})  ${p.path}`)
+  }
+
+  for (const d of c.synthesize?.domains ?? []) {
+    command.log(`    synth (${d.topics.length} topic${d.topics.length === 1 ? '' : 's'})  ${d.domain || '<root>'}`)
   }
 }

--- a/src/oclif/commands/dream/scan.ts
+++ b/src/oclif/commands/dream/scan.ts
@@ -1,0 +1,169 @@
+import type {TaskAck} from '@campfirein/brv-transport-client'
+
+import {Command, Flags} from '@oclif/core'
+import {randomUUID} from 'node:crypto'
+
+import {TaskEvents} from '../../../shared/transport/events/index.js'
+import {type DaemonClientOptions, formatConnectionError, withDaemonRetry} from '../../lib/daemon-client.js'
+import {writeJsonResponse} from '../../lib/json-response.js'
+import {DEFAULT_TIMEOUT_SECONDS, MAX_TIMEOUT_SECONDS, MIN_TIMEOUT_SECONDS, waitForTaskCompletion} from '../../lib/task-client.js'
+
+const VALID_KINDS = ['link', 'merge', 'prune', 'synthesize'] as const
+
+export default class DreamScan extends Command {
+  public static description =
+    'Phase 1 of tool-mode dream — scan the context tree for cleanup candidates (link, merge, prune, synthesize).'
+public static examples = [
+    '# Scan all four kinds with defaults',
+    '<%= config.bin %> <%= command.id %>',
+    '',
+    '# Limit to link + merge, scoped to one domain',
+    '<%= config.bin %> <%= command.id %> --kinds link,merge --scope security/',
+    '',
+    '# JSON output for scripting',
+    '<%= config.bin %> <%= command.id %> --format json',
+  ]
+public static flags = {
+    format: Flags.string({default: 'text', description: 'Output format (text or json)', options: ['text', 'json']}),
+    kinds: Flags.string({
+      description: 'Comma-separated list of candidate kinds (link,merge,prune,synthesize). Defaults to all.',
+    }),
+    'max-candidates': Flags.integer({
+      description: 'Cap on returned candidates per kind. Default 20.',
+      min: 1,
+    }),
+    scope: Flags.string({description: 'Limit scan to topics under this path prefix.'}),
+    timeout: Flags.integer({
+      default: DEFAULT_TIMEOUT_SECONDS,
+      description: 'Maximum seconds to wait for completion',
+      max: MAX_TIMEOUT_SECONDS,
+      min: MIN_TIMEOUT_SECONDS,
+    }),
+  }
+
+  protected getDaemonClientOptions(): DaemonClientOptions {
+    return {}
+  }
+
+  public async run(): Promise<void> {
+    const {flags: raw} = await this.parse(DreamScan)
+    const format = raw.format === 'json' ? 'json' : 'text'
+
+    const kinds = raw.kinds ? raw.kinds.split(',').map((s) => s.trim()).filter(Boolean) : undefined
+    if (kinds) {
+      const invalid = kinds.filter((k) => !VALID_KINDS.includes(k as (typeof VALID_KINDS)[number]))
+      if (invalid.length > 0) {
+        const msg = `Invalid --kinds values: ${invalid.join(', ')}. Allowed: ${VALID_KINDS.join(', ')}`
+        if (format === 'json') {
+          writeJsonResponse({command: 'dream-scan', data: {error: msg, status: 'error'}, success: false})
+        } else {
+          this.log(msg)
+        }
+
+        return
+      }
+    }
+
+    const payload: Record<string, unknown> = {}
+    if (kinds) payload.kinds = kinds
+    if (raw.scope) payload.scope = raw.scope
+    if (raw['max-candidates'] !== undefined) payload.maxCandidates = raw['max-candidates']
+
+    try {
+      await withDaemonRetry(
+        async (client, projectRoot, worktreeRoot) => {
+          const taskId = randomUUID()
+          const taskPayload = {
+            content: JSON.stringify(payload),
+            ...(projectRoot ? {projectPath: projectRoot} : {}),
+            taskId,
+            type: 'dream-scan' as const,
+            ...(worktreeRoot ? {worktreeRoot} : {}),
+          }
+
+          const completionPromise = waitForTaskCompletion(
+            {
+              client,
+              command: 'dream-scan',
+              format,
+              onCompleted: ({result}) => {
+                if (format === 'json') {
+                  this.log(result ?? '{}')
+                } else {
+                  renderScanText(this, result)
+                }
+              },
+              onError: ({error}) => {
+                const msg = error?.message ?? 'dream-scan failed'
+                if (format === 'json') {
+                  writeJsonResponse({command: 'dream-scan', data: {error: msg, status: 'error'}, success: false})
+                } else {
+                  this.log(`dream-scan failed: ${msg}`)
+                }
+              },
+              taskId,
+              timeoutMs: (raw.timeout ?? DEFAULT_TIMEOUT_SECONDS) * 1000,
+            },
+            (msg) => this.log(msg),
+          )
+
+          await client.requestWithAck<TaskAck>(TaskEvents.CREATE, taskPayload)
+          await completionPromise
+        },
+        this.getDaemonClientOptions(),
+      )
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'dream-scan failed'
+      if (format === 'json') {
+        writeJsonResponse({command: 'dream-scan', data: {error: message, status: 'error'}, success: false})
+      } else {
+        this.log(formatConnectionError(error))
+      }
+    }
+  }
+}
+
+function renderScanText(command: Command, raw: string | undefined): void {
+  if (!raw) {
+    command.log('(no result)')
+    return
+  }
+
+  let parsed: {
+    candidates?: {
+      link?: Array<{pair: [string, string]; score: number}>
+      merge?: Array<{pair: [string, string]; score: number}>
+      prune?: Array<{path: string; reason: string}>
+      synthesize?: {domains: Array<{domain: string; topics: unknown[]}>}
+    }
+    sessionId?: string
+    status?: string
+  }
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    command.log(raw)
+    return
+  }
+
+  command.log(`Session: ${parsed.sessionId ?? '(none)'}`)
+  command.log('')
+  const c = parsed.candidates ?? {}
+  command.log(`  link candidates:        ${c.link?.length ?? 0}`)
+  command.log(`  merge candidates:       ${c.merge?.length ?? 0}`)
+  command.log(`  prune candidates:       ${c.prune?.length ?? 0}`)
+  const domains = c.synthesize?.domains?.length ?? 0
+  command.log(`  synthesize candidates:  ${domains} domain${domains === 1 ? '' : 's'}`)
+
+  for (const pair of c.link ?? []) {
+    command.log(`    link  [${pair.score.toFixed(2)}]  ${pair.pair[0]}  ↔  ${pair.pair[1]}`)
+  }
+
+  for (const pair of c.merge ?? []) {
+    command.log(`    merge [${pair.score.toFixed(2)}]  ${pair.pair[0]}  ⊕  ${pair.pair[1]}`)
+  }
+
+  for (const p of c.prune ?? []) {
+    command.log(`    prune (${p.reason})  ${p.path}`)
+  }
+}

--- a/src/oclif/commands/dream/scan.ts
+++ b/src/oclif/commands/dream/scan.ts
@@ -3,12 +3,15 @@ import type {TaskAck} from '@campfirein/brv-transport-client'
 import {Command, Flags} from '@oclif/core'
 import {randomUUID} from 'node:crypto'
 
+import {ALL_DREAM_KINDS} from '../../../server/infra/dream/tool-mode/dream-session.js'
 import {TaskEvents} from '../../../shared/transport/events/index.js'
 import {type DaemonClientOptions, formatConnectionError, withDaemonRetry} from '../../lib/daemon-client.js'
 import {writeJsonResponse} from '../../lib/json-response.js'
 import {DEFAULT_TIMEOUT_SECONDS, MAX_TIMEOUT_SECONDS, MIN_TIMEOUT_SECONDS, waitForTaskCompletion} from '../../lib/task-client.js'
 
-const VALID_KINDS: readonly string[] = ['link', 'merge', 'prune', 'synthesize']
+// Canonical kinds list lives on the daemon side (dream-session.ts:ALL_DREAM_KINDS).
+// Importing it here keeps the CLI validator from drifting if a new kind is added.
+const VALID_KINDS: readonly string[] = ALL_DREAM_KINDS
 
 export default class DreamScan extends Command {
   public static description =

--- a/src/oclif/commands/dream/sessions.ts
+++ b/src/oclif/commands/dream/sessions.ts
@@ -1,0 +1,39 @@
+import {Command, Flags} from '@oclif/core'
+
+import {writeJsonResponse} from '../../lib/json-response.js'
+
+/**
+ * Tool-mode dream sessions are stateless on the daemon in v1 — the agent
+ * holds session state between scan and finalize. This command exists for
+ * surface symmetry with the proposal and to give us a place to hang a
+ * persistent session listing in a follow-up.
+ */
+export default class DreamSessions extends Command {
+  public static description = 'List active tool-mode dream sessions.'
+public static examples = [
+    '# Plain text',
+    '<%= config.bin %> <%= command.id %>',
+    '',
+    '# JSON for scripting',
+    '<%= config.bin %> <%= command.id %> --format json',
+  ]
+public static flags = {
+    format: Flags.string({default: 'text', description: 'Output format (text or json)', options: ['text', 'json']}),
+  }
+
+  public async run(): Promise<void> {
+    const {flags: raw} = await this.parse(DreamSessions)
+    const format = raw.format === 'json' ? 'json' : 'text'
+
+    if (format === 'json') {
+      writeJsonResponse({command: 'dream-sessions', data: {sessions: [], status: 'ok'}, success: true})
+    } else {
+      this.log(
+        'No active sessions.\n\n' +
+          '(Tool-mode dream sessions are stateless on the daemon in v1 — the\n' +
+          'agent holds the session id between `brv dream scan` and\n' +
+          '`brv dream finalize`.)',
+      )
+    }
+  }
+}

--- a/src/oclif/commands/dream/undo.ts
+++ b/src/oclif/commands/dream/undo.ts
@@ -11,9 +11,12 @@ import {buildUndoDeps} from '../dream.js'
 
 /**
  * Revert the most recent completed dream — restores any topics archived
- * during finalize and rolls back curate writes via the existing review-
- * backup mechanism. Mirrors `brv dream --undo`; both call into the same
- * `undoLastDream` helper.
+ * during finalize (tool-mode) and any CONSOLIDATE/SYNTHESIZE writes from
+ * legacy LLM-driven dreams. `brv curate` writes that the agent made
+ * between `brv dream scan` and `brv dream finalize` are NOT rolled back
+ * here — they are independent curate-log entries; use
+ * `brv review reject <taskId>` for those. Mirrors `brv dream --undo`;
+ * both call into the same `undoLastDream` helper.
  */
 export default class DreamUndo extends Command {
   public static description = 'Revert the most recent completed dream (legacy LLM-driven or tool-mode).'

--- a/src/oclif/commands/dream/undo.ts
+++ b/src/oclif/commands/dream/undo.ts
@@ -1,0 +1,57 @@
+import {Command, Flags} from '@oclif/core'
+
+import type {ILogger} from '../../../agent/core/interfaces/i-logger.js'
+
+import {NoOpLogger} from '../../../agent/core/interfaces/i-logger.js'
+import {ConsoleLogger} from '../../../agent/infra/logger/console-logger.js'
+import {undoLastDream} from '../../../server/infra/dream/dream-undo.js'
+import {resolveProject} from '../../../server/infra/project/resolve-project.js'
+import {writeJsonResponse} from '../../lib/json-response.js'
+import {buildUndoDeps} from '../dream.js'
+
+/**
+ * Revert the most recent completed dream — restores any topics archived
+ * during finalize and rolls back curate writes via the existing review-
+ * backup mechanism. Mirrors `brv dream --undo`; both call into the same
+ * `undoLastDream` helper.
+ */
+export default class DreamUndo extends Command {
+  public static description = 'Revert the most recent completed dream (legacy LLM-driven or tool-mode).'
+public static examples = ['<%= config.bin %> <%= command.id %>', '<%= config.bin %> <%= command.id %> --format json']
+public static flags = {
+    format: Flags.string({default: 'text', description: 'Output format (text or json)', options: ['text', 'json']}),
+  }
+
+  public async run(): Promise<void> {
+    const {flags: raw} = await this.parse(DreamUndo)
+    const format = raw.format === 'json' ? 'json' : 'text'
+
+    const projectRoot = resolveProject()?.projectRoot ?? process.cwd()
+    const logger: ILogger = format === 'json' ? new NoOpLogger() : new ConsoleLogger()
+    const deps = await buildUndoDeps(projectRoot, logger)
+
+    try {
+      const result = await undoLastDream(deps)
+
+      if (format === 'json') {
+        writeJsonResponse({command: 'dream-undo', data: {...result, status: 'undone'}, success: true})
+      } else {
+        this.log(`Undone dream ${result.dreamId}`)
+        this.log(`  Restored: ${result.restoredFiles.length} files`)
+        this.log(`  Deleted: ${result.deletedFiles.length} files`)
+        this.log(`  Restored archives: ${result.restoredArchives.length} files`)
+        if (result.errors.length > 0) {
+          this.log(`  Errors: ${result.errors.length}`)
+          for (const e of result.errors) this.log(`    - ${e}`)
+        }
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Undo failed'
+      if (format === 'json') {
+        writeJsonResponse({command: 'dream-undo', data: {error: message, status: 'error'}, success: false})
+      } else {
+        this.log(`Undo failed: ${message}`)
+      }
+    }
+  }
+}

--- a/src/server/core/domain/transport/schemas.ts
+++ b/src/server/core/domain/transport/schemas.ts
@@ -445,7 +445,7 @@ export const TaskExecuteSchema = z.object({
   /** Dream trigger source — how this dream was initiated */
   trigger: z.enum(['agent-idle', 'cli', 'manual']).optional(),
   /** Task type */
-  type: z.enum(['curate', 'curate-folder', 'curate-html-direct', 'dream', 'query', 'query-tool-mode', 'search']),
+  type: z.enum(['curate', 'curate-folder', 'curate-html-direct', 'dream', 'dream-finalize', 'dream-scan', 'query', 'query-tool-mode', 'search']),
   /** Workspace root for scoped query/curate */
   worktreeRoot: z.string().optional(),
 })
@@ -551,6 +551,8 @@ export const TaskTypeSchema = z.enum([
   'curate-folder',
   'curate-html-direct',
   'dream',
+  'dream-finalize',
+  'dream-scan',
   'query',
   'query-tool-mode',
   'search',

--- a/src/server/infra/daemon/agent-process.ts
+++ b/src/server/infra/daemon/agent-process.ts
@@ -63,6 +63,7 @@ import {DreamLockService} from '../dream/dream-lock-service.js'
 import {DreamLogStore} from '../dream/dream-log-store.js'
 import {DreamStateService} from '../dream/dream-state-service.js'
 import {DreamTrigger} from '../dream/dream-trigger.js'
+import {type DreamKind, finalizeDreamSession, scanDreamCandidates} from '../dream/tool-mode/dream-session.js'
 import {CurateExecutor} from '../executor/curate-executor.js'
 import {DreamExecutor} from '../executor/dream-executor.js'
 import {FolderPackExecutor} from '../executor/folder-pack-executor.js'
@@ -500,7 +501,13 @@ async function executeTask(
   // paths — no LLM, no provider needed. Skip provider validation so they
   // work even without a configured provider (the headline promise of
   // tool mode).
-  if (type !== 'search' && type !== 'query-tool-mode' && type !== 'curate-html-direct') {
+  if (
+    type !== 'search' &&
+    type !== 'query-tool-mode' &&
+    type !== 'curate-html-direct' &&
+    type !== 'dream-scan' &&
+    type !== 'dream-finalize'
+  ) {
     const freshProviderConfig = await transport.requestWithAck<ProviderConfigResponse>(
       TransportStateEventNames.GET_PROVIDER_CONFIG,
     )
@@ -823,6 +830,71 @@ async function executeTask(
           })
           result = dreamResult.result
           logId = dreamResult.logId
+
+          break
+        }
+
+        case 'dream-finalize': {
+          // Archive the loser topics the agent picked. Stateless on
+          // daemon side — `sessionId` is opaque; we don't track sessions
+          // in v1.
+          const brvDir = join(projectPath, BRV_DIR)
+          const contextTreeRoot = join(brvDir, CONTEXT_TREE_DIR)
+          let parsed: {archive?: string[]; sessionId?: string}
+          try {
+            parsed = content ? JSON.parse(content) : {}
+          } catch {
+            result = JSON.stringify({error: 'dream-finalize: invalid JSON content', status: 'error'})
+            break
+          }
+
+          try {
+            const finalizeResult = await finalizeDreamSession({
+              archive: parsed.archive ?? [],
+              brvDir,
+              contextTreeRoot,
+              runtimeSignalStore,
+              sessionId: parsed.sessionId ?? '',
+            })
+            result = JSON.stringify({...finalizeResult, status: 'ok'})
+          } catch (error) {
+            result = JSON.stringify({
+              error: error instanceof Error ? error.message : String(error),
+              status: 'error',
+            })
+          }
+
+          break
+        }
+
+        case 'dream-scan': {
+          // Tool-mode dream — no LLM, no provider. The daemon enumerates
+          // candidates and returns them; the calling agent does all
+          // semantic judgment via brv-curate UPDATE/MERGE/ADD writes
+          // before invoking dream-finalize to archive losers.
+          const contextTreeRoot = join(projectPath, BRV_DIR, CONTEXT_TREE_DIR)
+          let parsed: {kinds?: DreamKind[]; maxCandidates?: number; scope?: string}
+          try {
+            parsed = content ? JSON.parse(content) : {}
+          } catch {
+            result = JSON.stringify({error: 'dream-scan: invalid JSON content', status: 'error'})
+            break
+          }
+
+          try {
+            const scanResult = await scanDreamCandidates({
+              contextTreeRoot,
+              options: parsed,
+              runtimeSignalStore,
+              searchService: searchKnowledgeService,
+            })
+            result = JSON.stringify({...scanResult, status: 'ok'})
+          } catch (error) {
+            result = JSON.stringify({
+              error: error instanceof Error ? error.message : String(error),
+              status: 'error',
+            })
+          }
 
           break
         }

--- a/src/server/infra/daemon/agent-process.ts
+++ b/src/server/infra/daemon/agent-process.ts
@@ -593,8 +593,18 @@ async function executeTask(
     // on this project drains. `query` / `search` are intentionally NOT
     // gated — they read the manifest and tolerate a stale snapshot via
     // `readManifestIfFresh` + rebuild fallback, so blocking them would
-    // be a needless latency hit.
-    if (type === 'curate' || type === 'curate-folder' || type === 'dream') {
+    // be a needless latency hit. `dream-finalize` renames topic files
+    // and so MUST gate (otherwise an in-flight Phase 4 `_index.md`
+    // rebuild can reference files we just archived). `dream-scan` is
+    // read-only but we gate it too so a scan never observes a tree
+    // mid-rebuild and returns inconsistent candidates.
+    if (
+      type === 'curate' ||
+      type === 'curate-folder' ||
+      type === 'dream' ||
+      type === 'dream-finalize' ||
+      type === 'dream-scan'
+    ) {
       await postWorkRegistry.awaitProject(projectPath)
     }
 
@@ -887,7 +897,7 @@ async function executeTask(
                   synthesized: 0,
                 },
                 taskId,
-                trigger: 'cli',
+                trigger: trigger ?? 'cli',
               })
               await dreamStateService.update((state) => ({
                 ...state,

--- a/src/server/infra/daemon/agent-process.ts
+++ b/src/server/infra/daemon/agent-process.ts
@@ -837,7 +837,7 @@ async function executeTask(
         case 'dream-finalize': {
           // Archive the loser topics the agent picked. Stateless on
           // daemon side — `sessionId` is opaque; we don't track sessions
-          // in v1.
+          // in v1. Writes a DreamLogEntry so `brv dream undo` can restore.
           const brvDir = join(projectPath, BRV_DIR)
           const contextTreeRoot = join(brvDir, CONTEXT_TREE_DIR)
           let parsed: {archive?: string[]; sessionId?: string}
@@ -848,6 +848,7 @@ async function executeTask(
             break
           }
 
+          const startedAt = Date.now()
           try {
             const finalizeResult = await finalizeDreamSession({
               archive: parsed.archive ?? [],
@@ -856,7 +857,57 @@ async function executeTask(
               runtimeSignalStore,
               sessionId: parsed.sessionId ?? '',
             })
-            result = JSON.stringify({...finalizeResult, status: 'ok'})
+
+            // Write a dream-log entry so `brv dream undo` can revert. Skipped
+            // when nothing was actually archived — no-op finalizes shouldn't
+            // pollute the undo history.
+            if (finalizeResult.archived.length > 0) {
+              const dreamLogStore = new DreamLogStore({baseDir: brvDir})
+              const dreamStateService = new DreamStateService({baseDir: brvDir})
+              const logId = await dreamLogStore.getNextId()
+              const completedAt = Date.now()
+              await dreamLogStore.save({
+                completedAt,
+                id: logId,
+                operations: finalizeResult.archived.map((path) => ({
+                  action: 'ARCHIVE',
+                  file: path,
+                  needsReview: false,
+                  previousTexts: {[path]: finalizeResult.previousTexts[path] ?? ''},
+                  reason: 'tool-mode dream finalize',
+                  type: 'PRUNE',
+                })),
+                startedAt,
+                status: 'completed',
+                summary: {
+                  consolidated: 0,
+                  errors: 0,
+                  flaggedForReview: 0,
+                  pruned: finalizeResult.archived.length,
+                  synthesized: 0,
+                },
+                taskId,
+                trigger: 'cli',
+              })
+              await dreamStateService.update((state) => ({
+                ...state,
+                lastDreamAt: new Date().toISOString(),
+                lastDreamLogId: logId,
+                totalDreams: state.totalDreams + 1,
+              }))
+              result = JSON.stringify({
+                archived: finalizeResult.archived,
+                logId,
+                skipped: finalizeResult.skipped,
+                status: 'ok',
+              })
+            } else {
+              result = JSON.stringify({
+                archived: finalizeResult.archived,
+                skipped: finalizeResult.skipped,
+                status: 'ok',
+              })
+            }
           } catch (error) {
             result = JSON.stringify({
               error: error instanceof Error ? error.message : String(error),

--- a/src/server/infra/dream/dream-log-schema.ts
+++ b/src/server/infra/dream/dream-log-schema.ts
@@ -26,6 +26,11 @@ const PruneOperationSchema = z.object({
   file: z.string(),
   mergeTarget: z.string().optional(),
   needsReview: z.boolean(),
+  // Tool-mode finalize captures the file's content before archiving so undo
+  // can restore from the log alone (no archive-service / stub indirection).
+  // Legacy LLM-driven prune still uses stubPath; both forms are supported by
+  // dream-undo at runtime.
+  previousTexts: z.record(z.string(), z.string()).optional(),
   reason: z.string(),
   stubPath: z.string().optional(),
   type: z.literal('PRUNE'),

--- a/src/server/infra/dream/dream-undo.ts
+++ b/src/server/infra/dream/dream-undo.ts
@@ -6,7 +6,7 @@
  */
 
 import {mkdir, unlink, writeFile} from 'node:fs/promises'
-import {dirname, resolve} from 'node:path'
+import {dirname, join, resolve} from 'node:path'
 
 import type {CurateLogEntry, CurateLogOperation} from '../../core/domain/entities/curate-log-entry.js'
 import type {ICurateLogStore} from '../../core/interfaces/storage/i-curate-log-store.js'
@@ -378,6 +378,30 @@ async function undoPrune(
 ): Promise<void> {
   switch (op.action) {
     case 'ARCHIVE': {
+      // Tool-mode finalize writes a flat .brv/archive/<relPath> copy and
+      // captures the body inline as previousTexts; restore from the log
+      // directly so we don't depend on archive-service-managed stubs.
+      if (op.previousTexts && Object.keys(op.previousTexts).length > 0) {
+        const archiveDir = join(dirname(ctx.contextTreeDir), 'archive')
+        for (const [filePath, content] of Object.entries(op.previousTexts)) {
+          const fullPath = safePath(ctx.contextTreeDir, filePath)
+          // eslint-disable-next-line no-await-in-loop
+          await mkdir(dirname(fullPath), {recursive: true})
+          // eslint-disable-next-line no-await-in-loop
+          await writeFile(fullPath, content, 'utf8')
+          ctx.result.restoredFiles.push(filePath)
+
+          // Clean up the .brv/archive/<relPath> duplicate so we don't leave
+          // a stale copy alongside the restored original. Best-effort —
+          // ENOENT is fine, real errors get surfaced via the per-op try/catch.
+          // eslint-disable-next-line no-await-in-loop
+          await unlinkSafe(join(archiveDir, filePath))
+        }
+
+        break
+      }
+
+      // Legacy LLM-driven prune path — archive service round-trip.
       if (!ctx.deps.archiveService) {
         throw new Error(`Cannot undo PRUNE/ARCHIVE: no archive service available for ${op.file}`)
       }

--- a/src/server/infra/dream/tool-mode/bm25-pair-discovery.ts
+++ b/src/server/infra/dream/tool-mode/bm25-pair-discovery.ts
@@ -1,0 +1,95 @@
+/**
+ * Shared BM25 pair-discovery helper for link + merge candidate generators.
+ *
+ * Both kinds use the same recipe — search each topic by `title + summary`,
+ * collect hits above a per-kind threshold, dedup symmetric pairs, sort by
+ * score descending, cap. The only behavioral difference is whether already-
+ * linked pairs are filtered out (link) or kept (merge), which is supplied
+ * via the optional `skipPair` predicate.
+ */
+
+import type {ISearchKnowledgeService} from '../../../../agent/infra/sandbox/tools-sdk.js'
+
+export type PairDiscoveryTopic = {
+  /** Full raw HTML — preserved on the output candidate so the agent reads without a second round-trip. */
+  html: string
+  /** Relative path under .brv/context-tree/. */
+  path: string
+  /** Topic summary attr value, or empty string. */
+  summary: string
+  /** Topic title attr value. */
+  title: string
+}
+
+export type BM25Pair = {
+  htmlA: string
+  htmlB: string
+  /** [pathA, pathB], lex-sorted. */
+  pair: [string, string]
+  score: number
+}
+
+export type FindBM25PairsParams = {
+  maxCandidates: number
+  scope?: string
+  scoreThreshold: number
+  /** BM25 results requested per source topic. */
+  searchLimitPerTopic: number
+  searchService: ISearchKnowledgeService
+  /**
+   * Optional predicate to drop a candidate pair before dedup. Receives the
+   * source (the topic the search was issued from) and the hit (the matched
+   * topic). Return `true` to skip. Link uses this to honor existing
+   * `related=` edges; merge passes nothing.
+   */
+  skipPair?: (sourcePath: string, hitPath: string) => boolean
+  topics: PairDiscoveryTopic[]
+}
+
+export async function findBM25Pairs(params: FindBM25PairsParams): Promise<BM25Pair[]> {
+  const {maxCandidates, scope, scoreThreshold, searchLimitPerTopic, searchService, skipPair, topics} = params
+
+  const inScope = scope ? topics.filter((t) => t.path.startsWith(scope)) : topics
+  if (inScope.length < 2) return []
+
+  const byPath = new Map<string, PairDiscoveryTopic>(inScope.map((t) => [t.path, t]))
+
+  const perTopicHits = await Promise.all(
+    inScope.map(async (source) => {
+      // Title-only query. Appending the summary makes the query too
+      // specific and BM25 ends up ranking only the source topic itself —
+      // see regression test in link-candidates.test.ts.
+      const query = source.title.trim()
+      if (!query) return {hits: [], source}
+      const result = await searchService.search(query, {limit: searchLimitPerTopic})
+      return {hits: result.results, source}
+    }),
+  )
+
+  const pairs = new Map<string, {pair: [string, string]; score: number}>()
+  for (const {hits, source} of perTopicHits) {
+    for (const hit of hits) {
+      if (hit.score < scoreThreshold) continue
+      if (hit.path === source.path) continue
+      if (!byPath.has(hit.path)) continue
+      if (skipPair?.(source.path, hit.path)) continue
+
+      const [a, b] = source.path < hit.path ? [source.path, hit.path] : [hit.path, source.path]
+      const key = `${a}|${b}`
+      const existing = pairs.get(key)
+      if (!existing || hit.score > existing.score) {
+        pairs.set(key, {pair: [a, b], score: hit.score})
+      }
+    }
+  }
+
+  return [...pairs.values()]
+    .sort((x, y) => y.score - x.score)
+    .slice(0, maxCandidates)
+    .map(({pair, score}): BM25Pair => {
+      const topicA = byPath.get(pair[0])
+      const topicB = byPath.get(pair[1])
+      if (!topicA || !topicB) throw new Error(`bm25-pair-discovery: pair lookup failed for ${pair[0]} or ${pair[1]}`)
+      return {htmlA: topicA.html, htmlB: topicB.html, pair, score}
+    })
+}

--- a/src/server/infra/dream/tool-mode/dream-session.ts
+++ b/src/server/infra/dream/tool-mode/dream-session.ts
@@ -16,12 +16,13 @@
 
 import {randomUUID} from 'node:crypto'
 import {existsSync} from 'node:fs'
-import {mkdir, rename} from 'node:fs/promises'
+import {mkdir, readFile, rename} from 'node:fs/promises'
 import {dirname, join} from 'node:path'
 
 import type {ISearchKnowledgeService} from '../../../../agent/infra/sandbox/tools-sdk.js'
 import type {IRuntimeSignalStore} from '../../../core/interfaces/storage/i-runtime-signal-store.js'
 
+import {isDescendantOf} from '../../../utils/path-utils.js'
 import {findLinkCandidates, type LinkCandidate} from './link-candidates.js'
 import {findMergeCandidates, type MergeCandidate} from './merge-candidates.js'
 import {findPruneCandidates, type PruneCandidate} from './prune-candidates.js'
@@ -128,11 +129,18 @@ export type DreamFinalizeInput = {
 
 export type DreamFinalizeSkipped = {
   path: string
-  reason: 'not-found' | 'rename-failed'
+  reason: 'not-found' | 'rename-failed' | 'unsafe-path'
 }
 
 export type DreamFinalizeResult = {
   archived: string[]
+  /**
+   * Original file content keyed by relative path, captured before the rename.
+   * Empty entries are not included (skipped files have no previous content
+   * to restore). Consumed by `undoPrune` for tool-mode undo without needing
+   * an archive service.
+   */
+  previousTexts: Record<string, string>
   /** Files that weren't archived, with a coarse reason for each. */
   skipped: DreamFinalizeSkipped[]
 }
@@ -148,12 +156,30 @@ export async function finalizeDreamSession(input: DreamFinalizeInput): Promise<D
   const {archive, brvDir, contextTreeRoot, runtimeSignalStore} = input
   const archiveRoot = join(brvDir, ARCHIVE_SUBDIR)
 
+  type ArchivedOutcome = {content: string; path: string; result: 'archived'}
+  type SkippedOutcome = {path: string; reason: DreamFinalizeSkipped['reason']; result: 'skipped'}
+
   const outcomes = await Promise.all(
-    archive.map(async (relPath): Promise<{path: string; reason: DreamFinalizeSkipped['reason']; result: 'skipped'} | {path: string; result: 'archived'}> => {
+    archive.map(async (relPath): Promise<ArchivedOutcome | SkippedOutcome> => {
       const source = join(contextTreeRoot, relPath)
+      const target = join(archiveRoot, relPath)
+      // Guard against agent-supplied path traversal (e.g. relPath = "../../etc/passwd").
+      // Both source and target must resolve inside their respective roots.
+      if (!isDescendantOf(source, contextTreeRoot) || !isDescendantOf(target, archiveRoot)) {
+        return {path: relPath, reason: 'unsafe-path', result: 'skipped'}
+      }
+
       if (!existsSync(source)) return {path: relPath, reason: 'not-found', result: 'skipped'}
 
-      const target = join(archiveRoot, relPath)
+      // Read content before the rename so undo can restore it from the log
+      // alone. If we read after the rename, the source path no longer exists.
+      let content: string
+      try {
+        content = await readFile(source, 'utf8')
+      } catch {
+        return {path: relPath, reason: 'rename-failed', result: 'skipped'}
+      }
+
       try {
         await mkdir(dirname(target), {recursive: true})
         await rename(source, target)
@@ -167,16 +193,21 @@ export async function finalizeDreamSession(input: DreamFinalizeInput): Promise<D
         // best-effort sidecar cleanup; the topic is already archived
       }
 
-      return {path: relPath, result: 'archived'}
+      return {content, path: relPath, result: 'archived'}
     }),
   )
 
   const archived: string[] = []
+  const previousTexts: Record<string, string> = {}
   const skipped: DreamFinalizeSkipped[] = []
   for (const outcome of outcomes) {
-    if (outcome.result === 'archived') archived.push(outcome.path)
-    else skipped.push({path: outcome.path, reason: outcome.reason})
+    if (outcome.result === 'archived') {
+      archived.push(outcome.path)
+      previousTexts[outcome.path] = outcome.content
+    } else {
+      skipped.push({path: outcome.path, reason: outcome.reason})
+    }
   }
 
-  return {archived, skipped}
+  return {archived, previousTexts, skipped}
 }

--- a/src/server/infra/dream/tool-mode/dream-session.ts
+++ b/src/server/infra/dream/tool-mode/dream-session.ts
@@ -1,0 +1,182 @@
+/**
+ * Tool-mode dream session manager — orchestrates scan + finalize.
+ *
+ * `scanDreamCandidates` loads every topic in the context tree, runs the
+ * requested per-kind candidate generators in parallel, and returns a
+ * unified envelope keyed by kind. The calling agent then decides what to
+ * do per candidate (link via brv-curate UPDATE, merge via brv-curate
+ * MERGE, etc.) and finally calls `finalizeDreamSession` with the loser
+ * paths to archive.
+ *
+ * The session id is opaque — a uuid the agent passes through scan →
+ * finalize so future versions can persist per-session state for resume
+ * support. v1 doesn't persist it; the session is effectively stateless on
+ * the daemon side.
+ */
+
+import {randomUUID} from 'node:crypto'
+import {existsSync} from 'node:fs'
+import {mkdir, rename} from 'node:fs/promises'
+import {dirname, join} from 'node:path'
+
+import type {ISearchKnowledgeService} from '../../../../agent/infra/sandbox/tools-sdk.js'
+import type {IRuntimeSignalStore} from '../../../core/interfaces/storage/i-runtime-signal-store.js'
+
+import {findLinkCandidates, type LinkCandidate} from './link-candidates.js'
+import {findMergeCandidates, type MergeCandidate} from './merge-candidates.js'
+import {findPruneCandidates, type PruneCandidate} from './prune-candidates.js'
+import {findSynthesizeCandidates, type SynthesizeCandidates} from './synthesize-candidates.js'
+import {loadToolModeTopics} from './topic-loader.js'
+
+export type DreamKind = 'link' | 'merge' | 'prune' | 'synthesize'
+
+export const ALL_DREAM_KINDS: readonly DreamKind[] = ['link', 'merge', 'prune', 'synthesize']
+
+/** Tool-mode dream archive lives under `.brv/archive/` so undo can find it. */
+const ARCHIVE_SUBDIR = 'archive'
+
+export type DreamScanInput = {
+  contextTreeRoot: string
+  options?: {
+    /** Default: all four. */
+    kinds?: DreamKind[]
+    maxCandidates?: number
+    scope?: string
+  }
+  runtimeSignalStore: IRuntimeSignalStore
+  searchService: ISearchKnowledgeService
+}
+
+export type DreamCandidateBundle = {
+  link: LinkCandidate[]
+  merge: MergeCandidate[]
+  prune: PruneCandidate[]
+  synthesize: SynthesizeCandidates
+}
+
+export type DreamScanResult = {
+  candidates: DreamCandidateBundle
+  sessionId: string
+}
+
+/**
+ * Load topics + run all requested candidate generators in parallel.
+ *
+ * Returns one envelope with four keys — each key is empty when its kind
+ * isn't requested via `options.kinds`. Empty kinds keep the shape stable
+ * for the CLI / agent consumer.
+ */
+export async function scanDreamCandidates(input: DreamScanInput): Promise<DreamScanResult> {
+  const {contextTreeRoot, options, runtimeSignalStore, searchService} = input
+  const requestedKinds = new Set<DreamKind>(options?.kinds ?? ALL_DREAM_KINDS)
+
+  const topics = await loadToolModeTopics({contextTreeRoot, runtimeSignalStore})
+
+  const empty: DreamCandidateBundle = {link: [], merge: [], prune: [], synthesize: {domains: [], existingSyntheses: []}}
+
+  const [link, merge, prune, synthesize] = await Promise.all([
+    requestedKinds.has('link')
+      ? findLinkCandidates({
+          options: {maxCandidates: options?.maxCandidates, scope: options?.scope},
+          searchService,
+          topics: topics.map((t) => ({
+            alreadyLinkedTo: t.related,
+            html: t.html,
+            path: t.path,
+            summary: t.summary,
+            title: t.title,
+          })),
+        })
+      : Promise.resolve(empty.link),
+    requestedKinds.has('merge')
+      ? findMergeCandidates({
+          options: {maxCandidates: options?.maxCandidates, scope: options?.scope},
+          searchService,
+          topics: topics.map((t) => ({html: t.html, path: t.path, summary: t.summary, title: t.title})),
+        })
+      : Promise.resolve(empty.merge),
+    requestedKinds.has('prune')
+      ? findPruneCandidates({
+          options: {maxCandidates: options?.maxCandidates, scope: options?.scope},
+          topics: topics.map((t) => ({html: t.html, mtimeMs: t.mtimeMs, path: t.path, signals: t.signals})),
+        })
+      : Promise.resolve(empty.prune),
+    requestedKinds.has('synthesize')
+      ? findSynthesizeCandidates({
+          options: {scope: options?.scope},
+          topics: topics.map((t) => ({path: t.path, summary: t.summary, title: t.title})),
+        })
+      : Promise.resolve(empty.synthesize),
+  ])
+
+  return {
+    candidates: {link, merge, prune, synthesize},
+    sessionId: randomUUID(),
+  }
+}
+
+export type DreamFinalizeInput = {
+  /** Relative paths under .brv/context-tree/ to archive. */
+  archive: string[]
+  /** Absolute path to `.brv` (parent of `context-tree/` and `archive/`). */
+  brvDir: string
+  contextTreeRoot: string
+  runtimeSignalStore: IRuntimeSignalStore
+  /** Opaque session id; v1 doesn't persist sessions but downstream tooling may track it. */
+  sessionId: string
+}
+
+export type DreamFinalizeSkipped = {
+  path: string
+  reason: 'not-found' | 'rename-failed'
+}
+
+export type DreamFinalizeResult = {
+  archived: string[]
+  /** Files that weren't archived, with a coarse reason for each. */
+  skipped: DreamFinalizeSkipped[]
+}
+
+/**
+ * Move each named topic from `.brv/context-tree/<path>` to
+ * `.brv/archive/<path>`, preserving the relative directory structure.
+ * Drops the sidecar entry on success. Skips (rather than throws) when a
+ * named path is missing or unreadable so partial failure is recoverable
+ * via re-scan.
+ */
+export async function finalizeDreamSession(input: DreamFinalizeInput): Promise<DreamFinalizeResult> {
+  const {archive, brvDir, contextTreeRoot, runtimeSignalStore} = input
+  const archiveRoot = join(brvDir, ARCHIVE_SUBDIR)
+
+  const outcomes = await Promise.all(
+    archive.map(async (relPath): Promise<{path: string; reason: DreamFinalizeSkipped['reason']; result: 'skipped'} | {path: string; result: 'archived'}> => {
+      const source = join(contextTreeRoot, relPath)
+      if (!existsSync(source)) return {path: relPath, reason: 'not-found', result: 'skipped'}
+
+      const target = join(archiveRoot, relPath)
+      try {
+        await mkdir(dirname(target), {recursive: true})
+        await rename(source, target)
+      } catch {
+        return {path: relPath, reason: 'rename-failed', result: 'skipped'}
+      }
+
+      try {
+        await runtimeSignalStore.delete(relPath)
+      } catch {
+        // best-effort sidecar cleanup; the topic is already archived
+      }
+
+      return {path: relPath, result: 'archived'}
+    }),
+  )
+
+  const archived: string[] = []
+  const skipped: DreamFinalizeSkipped[] = []
+  for (const outcome of outcomes) {
+    if (outcome.result === 'archived') archived.push(outcome.path)
+    else skipped.push({path: outcome.path, reason: outcome.reason})
+  }
+
+  return {archived, skipped}
+}

--- a/src/server/infra/dream/tool-mode/dream-session.ts
+++ b/src/server/infra/dream/tool-mode/dream-session.ts
@@ -129,7 +129,7 @@ export type DreamFinalizeInput = {
 
 export type DreamFinalizeSkipped = {
   path: string
-  reason: 'not-found' | 'rename-failed' | 'unsafe-path'
+  reason: 'already-archived' | 'not-found' | 'rename-failed' | 'unsafe-path'
 }
 
 export type DreamFinalizeResult = {
@@ -176,14 +176,28 @@ export async function finalizeDreamSession(input: DreamFinalizeInput): Promise<D
       let content: string
       try {
         content = await readFile(source, 'utf8')
-      } catch {
+      } catch (error) {
+        // ENOENT here means another finalize moved the file between our
+        // existsSync check and our readFile — same race window as below.
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          return {path: relPath, reason: 'already-archived', result: 'skipped'}
+        }
+
         return {path: relPath, reason: 'rename-failed', result: 'skipped'}
       }
 
       try {
         await mkdir(dirname(target), {recursive: true})
         await rename(source, target)
-      } catch {
+      } catch (error) {
+        // ENOENT during rename means a concurrent finalize won the race
+        // and archived this file before us. Surface that distinctly so
+        // agents triaging skipped paths don't re-scan to figure out
+        // which 'rename-failed' entries were really benign races.
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          return {path: relPath, reason: 'already-archived', result: 'skipped'}
+        }
+
         return {path: relPath, reason: 'rename-failed', result: 'skipped'}
       }
 

--- a/src/server/infra/dream/tool-mode/link-candidates.ts
+++ b/src/server/infra/dream/tool-mode/link-candidates.ts
@@ -1,23 +1,16 @@
 /**
  * Link candidate generator for tool-mode dream.
  *
- * Deterministic — no LLM. The daemon enumerates topics, BM25-searches each
- * one's title+summary to discover related topics, filters out self-matches
- * and existing links, and dedup'es symmetric pairs. The calling agent then
- * decides per pair whether to actually link by emitting UPDATE HTML through
- * `brv curate`.
- *
- * The generator does NOT touch the existing `operations/consolidate.ts` —
- * tool-mode runs alongside the legacy daemon-LLM dream and reuses only the
- * BM25 search service.
+ * Deterministic — no LLM. Reuses the shared BM25 pair-discovery helper and
+ * adds one filter: already-linked pairs are dropped, since link's purpose
+ * is to surface *new* complementary relationships. Merge does NOT apply
+ * that filter — see `merge-candidates.ts` for the higher-threshold counterpart.
  */
 
 import type {ISearchKnowledgeService} from '../../../../agent/infra/sandbox/tools-sdk.js'
 
-/**
- * Pre-parsed topic input. The session manager reads each topic's HTML
- * once upstream so the generator can stay pure and fast.
- */
+import {type BM25Pair, findBM25Pairs} from './bm25-pair-discovery.js'
+
 export type LinkCandidateTopic = {
   /** Parsed `related=` attribute on <bv-topic>, lowercase paths. Empty if no related attr. */
   alreadyLinkedTo: string[]
@@ -31,16 +24,7 @@ export type LinkCandidateTopic = {
   title: string
 }
 
-export type LinkCandidate = {
-  /** Full HTML of the lex-smaller path's topic. */
-  htmlA: string
-  /** Full HTML of the lex-larger path's topic. */
-  htmlB: string
-  /** [pathA, pathB], lex-sorted. */
-  pair: [string, string]
-  /** BM25 score — max of the two symmetric search hits between the pair. */
-  score: number
-}
+export type LinkCandidate = BM25Pair
 
 export type FindLinkCandidatesOptions = {
   /** Default 20. Cap on returned candidates after sorting by score desc. */
@@ -56,69 +40,28 @@ const DEFAULT_SCORE_THRESHOLD = 0.5
 /** BM25 limit per source-topic search. Generous so we don't miss high-score hits. */
 const SEARCH_LIMIT_PER_TOPIC = 10
 
-/**
- * Find link candidates across the supplied topics.
- *
- * For each in-scope topic, search using `title + " " + summary` as the
- * BM25 query and consider every hit above the score threshold. Symmetric
- * pairs (A→B and B→A) are dedup'ed and keep the higher of the two scores.
- *
- * Returns at most `maxCandidates` pairs, sorted by score descending.
- */
 export async function findLinkCandidates(params: {
   options?: FindLinkCandidatesOptions
   searchService: ISearchKnowledgeService
   topics: LinkCandidateTopic[]
 }): Promise<LinkCandidate[]> {
   const {options, searchService, topics} = params
-  const maxCandidates = options?.maxCandidates ?? DEFAULT_MAX_CANDIDATES
-  const scoreThreshold = options?.scoreThreshold ?? DEFAULT_SCORE_THRESHOLD
-  const scope = options?.scope
 
-  const inScope = scope ? topics.filter((t) => t.path.startsWith(scope)) : topics
-  if (inScope.length < 2) return []
-
-  const byPath = new Map<string, LinkCandidateTopic>(inScope.map((t) => [t.path, t]))
-
-  // Search all topics in parallel. Each per-topic search is independent;
-  // sequencing them would just add wall-clock latency without correctness benefit.
-  const perTopicHits = await Promise.all(
-    inScope.map(async (source) => {
-      const query = `${source.title} ${source.summary}`.trim()
-      if (!query) return {hits: [], source}
-      const result = await searchService.search(query, {limit: SEARCH_LIMIT_PER_TOPIC})
-      return {hits: result.results, source}
-    }),
+  const linksByPath = new Map<string, Set<string>>(
+    topics.map((t) => [t.path, new Set(t.alreadyLinkedTo)]),
   )
 
-  // Accumulate symmetric pairs keyed by the lex-canonical "a|b" form.
-  const pairs = new Map<string, {pair: [string, string]; score: number}>()
-  for (const {hits, source} of perTopicHits) {
-    for (const hit of hits) {
-      if (hit.score < scoreThreshold) continue
-      if (hit.path === source.path) continue
-      if (!byPath.has(hit.path)) continue // out-of-scope target
-      if (source.alreadyLinkedTo.includes(hit.path)) continue
-      const target = byPath.get(hit.path)
-      if (target?.alreadyLinkedTo.includes(source.path)) continue
-
-      const [a, b] = source.path < hit.path ? [source.path, hit.path] : [hit.path, source.path]
-      const key = `${a}|${b}`
-      const existing = pairs.get(key)
-      if (!existing || hit.score > existing.score) {
-        pairs.set(key, {pair: [a, b], score: hit.score})
-      }
-    }
-  }
-
-  return [...pairs.values()]
-    .sort((x, y) => y.score - x.score)
-    .slice(0, maxCandidates)
-    .map(({pair, score}): LinkCandidate => {
-      const topicA = byPath.get(pair[0])
-      const topicB = byPath.get(pair[1])
-      // Map guard — both must exist since we sourced both from the same map.
-      if (!topicA || !topicB) throw new Error(`link-candidates: pair lookup failed for ${pair[0]} or ${pair[1]}`)
-      return {htmlA: topicA.html, htmlB: topicB.html, pair, score}
-    })
+  return findBM25Pairs({
+    maxCandidates: options?.maxCandidates ?? DEFAULT_MAX_CANDIDATES,
+    scope: options?.scope,
+    scoreThreshold: options?.scoreThreshold ?? DEFAULT_SCORE_THRESHOLD,
+    searchLimitPerTopic: SEARCH_LIMIT_PER_TOPIC,
+    searchService,
+    skipPair(sourcePath, hitPath) {
+      // Drop pairs where either side already lists the other in its
+      // `related=` edges. Link is for *new* connections only.
+      return Boolean(linksByPath.get(sourcePath)?.has(hitPath)) || Boolean(linksByPath.get(hitPath)?.has(sourcePath))
+    },
+    topics: topics.map((t) => ({html: t.html, path: t.path, summary: t.summary, title: t.title})),
+  })
 }

--- a/src/server/infra/dream/tool-mode/link-candidates.ts
+++ b/src/server/infra/dream/tool-mode/link-candidates.ts
@@ -1,0 +1,124 @@
+/**
+ * Link candidate generator for tool-mode dream.
+ *
+ * Deterministic — no LLM. The daemon enumerates topics, BM25-searches each
+ * one's title+summary to discover related topics, filters out self-matches
+ * and existing links, and dedup'es symmetric pairs. The calling agent then
+ * decides per pair whether to actually link by emitting UPDATE HTML through
+ * `brv curate`.
+ *
+ * The generator does NOT touch the existing `operations/consolidate.ts` —
+ * tool-mode runs alongside the legacy daemon-LLM dream and reuses only the
+ * BM25 search service.
+ */
+
+import type {ISearchKnowledgeService} from '../../../../agent/infra/sandbox/tools-sdk.js'
+
+/**
+ * Pre-parsed topic input. The session manager reads each topic's HTML
+ * once upstream so the generator can stay pure and fast.
+ */
+export type LinkCandidateTopic = {
+  /** Parsed `related=` attribute on <bv-topic>, lowercase paths. Empty if no related attr. */
+  alreadyLinkedTo: string[]
+  /** Full raw HTML of the topic — included in candidates so the agent reads without a second round-trip. */
+  html: string
+  /** Relative path under .brv/context-tree/, e.g. "security/jwt.html". */
+  path: string
+  /** Topic summary attr value, or empty string. */
+  summary: string
+  /** Topic title attr value. */
+  title: string
+}
+
+export type LinkCandidate = {
+  /** Full HTML of the lex-smaller path's topic. */
+  htmlA: string
+  /** Full HTML of the lex-larger path's topic. */
+  htmlB: string
+  /** [pathA, pathB], lex-sorted. */
+  pair: [string, string]
+  /** BM25 score — max of the two symmetric search hits between the pair. */
+  score: number
+}
+
+export type FindLinkCandidatesOptions = {
+  /** Default 20. Cap on returned candidates after sorting by score desc. */
+  maxCandidates?: number
+  /** Optional path prefix; topics outside it are neither sources nor targets. */
+  scope?: string
+  /** Default 0.5. Pairs below this score are dropped. */
+  scoreThreshold?: number
+}
+
+const DEFAULT_MAX_CANDIDATES = 20
+const DEFAULT_SCORE_THRESHOLD = 0.5
+/** BM25 limit per source-topic search. Generous so we don't miss high-score hits. */
+const SEARCH_LIMIT_PER_TOPIC = 10
+
+/**
+ * Find link candidates across the supplied topics.
+ *
+ * For each in-scope topic, search using `title + " " + summary` as the
+ * BM25 query and consider every hit above the score threshold. Symmetric
+ * pairs (A→B and B→A) are dedup'ed and keep the higher of the two scores.
+ *
+ * Returns at most `maxCandidates` pairs, sorted by score descending.
+ */
+export async function findLinkCandidates(params: {
+  options?: FindLinkCandidatesOptions
+  searchService: ISearchKnowledgeService
+  topics: LinkCandidateTopic[]
+}): Promise<LinkCandidate[]> {
+  const {options, searchService, topics} = params
+  const maxCandidates = options?.maxCandidates ?? DEFAULT_MAX_CANDIDATES
+  const scoreThreshold = options?.scoreThreshold ?? DEFAULT_SCORE_THRESHOLD
+  const scope = options?.scope
+
+  const inScope = scope ? topics.filter((t) => t.path.startsWith(scope)) : topics
+  if (inScope.length < 2) return []
+
+  const byPath = new Map<string, LinkCandidateTopic>(inScope.map((t) => [t.path, t]))
+
+  // Search all topics in parallel. Each per-topic search is independent;
+  // sequencing them would just add wall-clock latency without correctness benefit.
+  const perTopicHits = await Promise.all(
+    inScope.map(async (source) => {
+      const query = `${source.title} ${source.summary}`.trim()
+      if (!query) return {hits: [], source}
+      const result = await searchService.search(query, {limit: SEARCH_LIMIT_PER_TOPIC})
+      return {hits: result.results, source}
+    }),
+  )
+
+  // Accumulate symmetric pairs keyed by the lex-canonical "a|b" form.
+  const pairs = new Map<string, {pair: [string, string]; score: number}>()
+  for (const {hits, source} of perTopicHits) {
+    for (const hit of hits) {
+      if (hit.score < scoreThreshold) continue
+      if (hit.path === source.path) continue
+      if (!byPath.has(hit.path)) continue // out-of-scope target
+      if (source.alreadyLinkedTo.includes(hit.path)) continue
+      const target = byPath.get(hit.path)
+      if (target?.alreadyLinkedTo.includes(source.path)) continue
+
+      const [a, b] = source.path < hit.path ? [source.path, hit.path] : [hit.path, source.path]
+      const key = `${a}|${b}`
+      const existing = pairs.get(key)
+      if (!existing || hit.score > existing.score) {
+        pairs.set(key, {pair: [a, b], score: hit.score})
+      }
+    }
+  }
+
+  return [...pairs.values()]
+    .sort((x, y) => y.score - x.score)
+    .slice(0, maxCandidates)
+    .map(({pair, score}): LinkCandidate => {
+      const topicA = byPath.get(pair[0])
+      const topicB = byPath.get(pair[1])
+      // Map guard — both must exist since we sourced both from the same map.
+      if (!topicA || !topicB) throw new Error(`link-candidates: pair lookup failed for ${pair[0]} or ${pair[1]}`)
+      return {htmlA: topicA.html, htmlB: topicB.html, pair, score}
+    })
+}

--- a/src/server/infra/dream/tool-mode/merge-candidates.ts
+++ b/src/server/infra/dream/tool-mode/merge-candidates.ts
@@ -1,0 +1,95 @@
+/**
+ * Merge candidate generator for tool-mode dream.
+ *
+ * Same BM25 path as `link-candidates` but with a higher default threshold
+ * (0.85 vs 0.5) and no awareness of existing `related` edges — merge is
+ * for *near-duplicates*, link is for *complementary topics*. An already-
+ * linked pair can still be a merge candidate if the similarity is high.
+ *
+ * The calling agent decides per pair which topic becomes the survivor and
+ * authors the merged HTML via `brv curate` UPDATE; the loser is archived
+ * later via `brv dream finalize --archive`.
+ */
+
+import type {ISearchKnowledgeService} from '../../../../agent/infra/sandbox/tools-sdk.js'
+
+export type MergeCandidateTopic = {
+  /** Full raw HTML — supplied to the agent so it can author the merge body without a second fetch. */
+  html: string
+  /** Relative path under .brv/context-tree/. */
+  path: string
+  /** Topic summary attr value, or empty string. */
+  summary: string
+  /** Topic title attr value. */
+  title: string
+}
+
+export type MergeCandidate = {
+  htmlA: string
+  htmlB: string
+  /** [pathA, pathB], lex-sorted. */
+  pair: [string, string]
+  score: number
+}
+
+export type FindMergeCandidatesOptions = {
+  maxCandidates?: number
+  scope?: string
+  /** Default 0.85. Higher than link's 0.5 — merge needs near-duplicate similarity. */
+  scoreThreshold?: number
+}
+
+const DEFAULT_MAX_CANDIDATES = 20
+const DEFAULT_SCORE_THRESHOLD = 0.85
+const SEARCH_LIMIT_PER_TOPIC = 10
+
+export async function findMergeCandidates(params: {
+  options?: FindMergeCandidatesOptions
+  searchService: ISearchKnowledgeService
+  topics: MergeCandidateTopic[]
+}): Promise<MergeCandidate[]> {
+  const {options, searchService, topics} = params
+  const maxCandidates = options?.maxCandidates ?? DEFAULT_MAX_CANDIDATES
+  const scoreThreshold = options?.scoreThreshold ?? DEFAULT_SCORE_THRESHOLD
+  const scope = options?.scope
+
+  const inScope = scope ? topics.filter((t) => t.path.startsWith(scope)) : topics
+  if (inScope.length < 2) return []
+
+  const byPath = new Map<string, MergeCandidateTopic>(inScope.map((t) => [t.path, t]))
+
+  const perTopicHits = await Promise.all(
+    inScope.map(async (source) => {
+      const query = `${source.title} ${source.summary}`.trim()
+      if (!query) return {hits: [], source}
+      const result = await searchService.search(query, {limit: SEARCH_LIMIT_PER_TOPIC})
+      return {hits: result.results, source}
+    }),
+  )
+
+  const pairs = new Map<string, {pair: [string, string]; score: number}>()
+  for (const {hits, source} of perTopicHits) {
+    for (const hit of hits) {
+      if (hit.score < scoreThreshold) continue
+      if (hit.path === source.path) continue
+      if (!byPath.has(hit.path)) continue
+
+      const [a, b] = source.path < hit.path ? [source.path, hit.path] : [hit.path, source.path]
+      const key = `${a}|${b}`
+      const existing = pairs.get(key)
+      if (!existing || hit.score > existing.score) {
+        pairs.set(key, {pair: [a, b], score: hit.score})
+      }
+    }
+  }
+
+  return [...pairs.values()]
+    .sort((x, y) => y.score - x.score)
+    .slice(0, maxCandidates)
+    .map(({pair, score}): MergeCandidate => {
+      const topicA = byPath.get(pair[0])
+      const topicB = byPath.get(pair[1])
+      if (!topicA || !topicB) throw new Error(`merge-candidates: pair lookup failed for ${pair[0]} or ${pair[1]}`)
+      return {htmlA: topicA.html, htmlB: topicB.html, pair, score}
+    })
+}

--- a/src/server/infra/dream/tool-mode/merge-candidates.ts
+++ b/src/server/infra/dream/tool-mode/merge-candidates.ts
@@ -13,6 +13,8 @@
 
 import type {ISearchKnowledgeService} from '../../../../agent/infra/sandbox/tools-sdk.js'
 
+import {type BM25Pair, findBM25Pairs} from './bm25-pair-discovery.js'
+
 export type MergeCandidateTopic = {
   /** Full raw HTML — supplied to the agent so it can author the merge body without a second fetch. */
   html: string
@@ -24,13 +26,7 @@ export type MergeCandidateTopic = {
   title: string
 }
 
-export type MergeCandidate = {
-  htmlA: string
-  htmlB: string
-  /** [pathA, pathB], lex-sorted. */
-  pair: [string, string]
-  score: number
-}
+export type MergeCandidate = BM25Pair
 
 export type FindMergeCandidatesOptions = {
   maxCandidates?: number
@@ -49,47 +45,13 @@ export async function findMergeCandidates(params: {
   topics: MergeCandidateTopic[]
 }): Promise<MergeCandidate[]> {
   const {options, searchService, topics} = params
-  const maxCandidates = options?.maxCandidates ?? DEFAULT_MAX_CANDIDATES
-  const scoreThreshold = options?.scoreThreshold ?? DEFAULT_SCORE_THRESHOLD
-  const scope = options?.scope
 
-  const inScope = scope ? topics.filter((t) => t.path.startsWith(scope)) : topics
-  if (inScope.length < 2) return []
-
-  const byPath = new Map<string, MergeCandidateTopic>(inScope.map((t) => [t.path, t]))
-
-  const perTopicHits = await Promise.all(
-    inScope.map(async (source) => {
-      const query = `${source.title} ${source.summary}`.trim()
-      if (!query) return {hits: [], source}
-      const result = await searchService.search(query, {limit: SEARCH_LIMIT_PER_TOPIC})
-      return {hits: result.results, source}
-    }),
-  )
-
-  const pairs = new Map<string, {pair: [string, string]; score: number}>()
-  for (const {hits, source} of perTopicHits) {
-    for (const hit of hits) {
-      if (hit.score < scoreThreshold) continue
-      if (hit.path === source.path) continue
-      if (!byPath.has(hit.path)) continue
-
-      const [a, b] = source.path < hit.path ? [source.path, hit.path] : [hit.path, source.path]
-      const key = `${a}|${b}`
-      const existing = pairs.get(key)
-      if (!existing || hit.score > existing.score) {
-        pairs.set(key, {pair: [a, b], score: hit.score})
-      }
-    }
-  }
-
-  return [...pairs.values()]
-    .sort((x, y) => y.score - x.score)
-    .slice(0, maxCandidates)
-    .map(({pair, score}): MergeCandidate => {
-      const topicA = byPath.get(pair[0])
-      const topicB = byPath.get(pair[1])
-      if (!topicA || !topicB) throw new Error(`merge-candidates: pair lookup failed for ${pair[0]} or ${pair[1]}`)
-      return {htmlA: topicA.html, htmlB: topicB.html, pair, score}
-    })
+  return findBM25Pairs({
+    maxCandidates: options?.maxCandidates ?? DEFAULT_MAX_CANDIDATES,
+    scope: options?.scope,
+    scoreThreshold: options?.scoreThreshold ?? DEFAULT_SCORE_THRESHOLD,
+    searchLimitPerTopic: SEARCH_LIMIT_PER_TOPIC,
+    searchService,
+    topics,
+  })
 }

--- a/src/server/infra/dream/tool-mode/prune-candidates.ts
+++ b/src/server/infra/dream/tool-mode/prune-candidates.ts
@@ -1,0 +1,127 @@
+/**
+ * Prune candidate generator for tool-mode dream.
+ *
+ * Sidecar-driven, no LLM. Surfaces topics that look prune-worthy by two
+ * deterministic signals:
+ *
+ *   - Importance below threshold (default 35) → `low-importance`
+ *   - Mtime stale past tier threshold (60d draft / 120d validated) → `stale-mtime`
+ *
+ * A topic hitting both signals is returned once with `reason: 'both'`.
+ * `maturity === 'core'` topics are NEVER surfaced — they're load-bearing
+ * by definition. The agent decides per candidate whether to ARCHIVE,
+ * KEEP (no-op), or MERGE_INTO another topic.
+ *
+ * Cold-start note: on freshly-installed projects, signals will be defaults
+ * and few candidates will surface. That's expected — prune gets useful as
+ * sidecar history accumulates.
+ */
+
+import type {MaturityTier, RuntimeSignals} from '../../../core/domain/knowledge/runtime-signals-schema.js'
+
+export type PruneCandidateTopic = {
+  /** Full HTML for the agent's review. */
+  html: string
+  /** File modification time in milliseconds since epoch. */
+  mtimeMs: number
+  /** Relative path under .brv/context-tree/. */
+  path: string
+  /** Sidecar signals — drives the importance/maturity filter. */
+  signals: RuntimeSignals
+}
+
+export type PruneReason = 'both' | 'low-importance' | 'stale-mtime'
+
+export type PruneCandidate = {
+  daysSinceModified: number
+  html: string
+  path: string
+  reason: PruneReason
+  signals: RuntimeSignals
+}
+
+export type FindPruneCandidatesOptions = {
+  /** Draft topics older than this are stale. Default 60. */
+  draftStalenessDays?: number
+  /** Importance strictly below this counts as low-importance. Default 35. */
+  importanceThreshold?: number
+  /** Default 20. */
+  maxCandidates?: number
+  /** Override clock for testing. Default Date.now(). */
+  now?: number
+  /** Optional path prefix. */
+  scope?: string
+  /** Validated topics older than this are stale. Default 120. */
+  validatedStalenessDays?: number
+}
+
+const DEFAULT_DRAFT_STALENESS_DAYS = 60
+const DEFAULT_VALIDATED_STALENESS_DAYS = 120
+const DEFAULT_IMPORTANCE_THRESHOLD = 35
+const DEFAULT_MAX_CANDIDATES = 20
+const DAY_MS = 24 * 60 * 60 * 1000
+
+export async function findPruneCandidates(params: {
+  options?: FindPruneCandidatesOptions
+  topics: PruneCandidateTopic[]
+}): Promise<PruneCandidate[]> {
+  const {options, topics} = params
+  const now = options?.now ?? Date.now()
+  const draftDays = options?.draftStalenessDays ?? DEFAULT_DRAFT_STALENESS_DAYS
+  const validatedDays = options?.validatedStalenessDays ?? DEFAULT_VALIDATED_STALENESS_DAYS
+  const importanceThreshold = options?.importanceThreshold ?? DEFAULT_IMPORTANCE_THRESHOLD
+  const maxCandidates = options?.maxCandidates ?? DEFAULT_MAX_CANDIDATES
+  const scope = options?.scope
+
+  const inScope = scope ? topics.filter((t) => t.path.startsWith(scope)) : topics
+
+  const candidates: PruneCandidate[] = []
+  for (const t of inScope) {
+    if (t.signals.maturity === 'core') continue
+
+    const daysSinceModified = (now - t.mtimeMs) / DAY_MS
+    const lowImportance = t.signals.importance < importanceThreshold
+    const staleMtime = isStaleForMaturity(t.signals.maturity, daysSinceModified, draftDays, validatedDays)
+
+    if (!lowImportance && !staleMtime) continue
+
+    candidates.push({
+      daysSinceModified,
+      html: t.html,
+      path: t.path,
+      reason: lowImportance && staleMtime ? 'both' : lowImportance ? 'low-importance' : 'stale-mtime',
+      signals: t.signals,
+    })
+  }
+
+  return candidates
+    .sort((x, y) => y.daysSinceModified - x.daysSinceModified)
+    .slice(0, maxCandidates)
+}
+
+function isStaleForMaturity(
+  maturity: MaturityTier,
+  daysSinceModified: number,
+  draftDays: number,
+  validatedDays: number,
+): boolean {
+  switch (maturity) {
+    case 'core': {
+      return false
+    }
+
+    case 'draft': {
+      return daysSinceModified >= draftDays
+    }
+
+    case 'validated': {
+      return daysSinceModified >= validatedDays
+    }
+
+    default: {
+      // exhaustive
+      const _never: never = maturity
+      return _never
+    }
+  }
+}

--- a/src/server/infra/dream/tool-mode/prune-candidates.ts
+++ b/src/server/infra/dream/tool-mode/prune-candidates.ts
@@ -79,7 +79,10 @@ export async function findPruneCandidates(params: {
   for (const t of inScope) {
     if (t.signals.maturity === 'core') continue
 
-    const daysSinceModified = (now - t.mtimeMs) / DAY_MS
+    // Clamp negative deltas (future-dated mtimes from clock skew or
+    // restored backups) to zero so the sort below produces a strictly
+    // stalest-first list with no surprises.
+    const daysSinceModified = Math.max(0, (now - t.mtimeMs) / DAY_MS)
     const lowImportance = t.signals.importance < importanceThreshold
     const staleMtime = isStaleForMaturity(t.signals.maturity, daysSinceModified, draftDays, validatedDays)
 

--- a/src/server/infra/dream/tool-mode/synthesize-candidates.ts
+++ b/src/server/infra/dream/tool-mode/synthesize-candidates.ts
@@ -1,0 +1,87 @@
+/**
+ * Synthesize candidate generator for tool-mode dream.
+ *
+ * Returns a different shape from link / merge / prune: rather than pair
+ * candidates, it surfaces *domain overviews* (all topics grouped by
+ * domain) plus the list of existing synthesis topics. The calling agent
+ * reads the overviews and decides what new cross-cutting patterns are
+ * worth writing as a fresh `<bv-topic>` under `synthesis/`.
+ *
+ * The asymmetry is deliberate — flattening domains into pair-like
+ * candidates would hide what the agent actually needs to reason over.
+ *
+ * Existing synthesis topics are kept separate so the agent can dedup
+ * against them before authoring something redundant.
+ */
+
+export type SynthesizeCandidateTopic = {
+  path: string
+  summary: string
+  title: string
+}
+
+export type DomainOverview = {
+  domain: string
+  topics: SynthesizeCandidateTopic[]
+}
+
+export type ExistingSynthesis = {
+  path: string
+  summary: string
+  title: string
+}
+
+export type SynthesizeCandidates = {
+  domains: DomainOverview[]
+  existingSyntheses: ExistingSynthesis[]
+}
+
+export type FindSynthesizeCandidatesOptions = {
+  /** Skip domains with fewer topics than this. Default 2. */
+  minTopicsPerDomain?: number
+  /** Optional path prefix. Topics outside it are ignored for domains; existingSyntheses always returned. */
+  scope?: string
+}
+
+const DEFAULT_MIN_TOPICS_PER_DOMAIN = 2
+/** Path prefix used to recognise an existing synthesis topic. */
+const SYNTHESIS_DOMAIN_PREFIX = 'synthesis/'
+
+export async function findSynthesizeCandidates(params: {
+  options?: FindSynthesizeCandidatesOptions
+  topics: SynthesizeCandidateTopic[]
+}): Promise<SynthesizeCandidates> {
+  const {options, topics} = params
+  const minTopicsPerDomain = options?.minTopicsPerDomain ?? DEFAULT_MIN_TOPICS_PER_DOMAIN
+  const scope = options?.scope
+
+  const existingSyntheses: ExistingSynthesis[] = []
+  const byDomain = new Map<string, SynthesizeCandidateTopic[]>()
+
+  for (const topic of topics) {
+    if (topic.path.startsWith(SYNTHESIS_DOMAIN_PREFIX)) {
+      existingSyntheses.push({path: topic.path, summary: topic.summary, title: topic.title})
+      continue
+    }
+
+    if (scope && !topic.path.startsWith(scope)) continue
+
+    const domain = deriveDomain(topic.path)
+    const list = byDomain.get(domain) ?? []
+    list.push(topic)
+    byDomain.set(domain, list)
+  }
+
+  const domains: DomainOverview[] = [...byDomain.entries()]
+    .filter(([, list]) => list.length >= minTopicsPerDomain)
+    .map(([domain, list]) => ({domain, topics: list}))
+
+  return {domains, existingSyntheses}
+}
+
+/** First path segment (e.g. "security/jwt.html" → "security"). Returns "" for paths without a slash. */
+function deriveDomain(path: string): string {
+  const slashIndex = path.indexOf('/')
+  if (slashIndex === -1) return ''
+  return path.slice(0, slashIndex)
+}

--- a/src/server/infra/dream/tool-mode/topic-loader.ts
+++ b/src/server/infra/dream/tool-mode/topic-loader.ts
@@ -137,16 +137,17 @@ async function loadOne(
 
 /**
  * Extract a flat attr map from the inside of an opening `<bv-topic ...>` tag.
- * Handles double-quoted values; values without quotes are not allowed in
- * the bv-topic vocabulary so we don't try to recover them.
+ * Accepts both double- and single-quoted values (HTML5 allows both, and
+ * hand-authored topics may use either). Unquoted values are not allowed
+ * in the bv-topic vocabulary so we don't try to recover them.
  */
 function parseAttributes(rawAttrs: string): Record<string, string> {
   const result: Record<string, string> = {}
-  const attrRe = /([\w-]+)\s*=\s*"([^"]*)"/g
+  const attrRe = /([\w-]+)\s*=\s*(?:"([^"]*)"|'([^']*)')/g
   let match: null | RegExpExecArray
   while ((match = attrRe.exec(rawAttrs)) !== null) {
     const name = match[1]?.toLowerCase()
-    const value = match[2]
+    const value = match[2] ?? match[3]
     if (name && value !== undefined) result[name] = value
   }
 

--- a/src/server/infra/dream/tool-mode/topic-loader.ts
+++ b/src/server/infra/dream/tool-mode/topic-loader.ts
@@ -149,10 +149,24 @@ function parseAttributes(rawAttrs: string): Record<string, string> {
   return result
 }
 
-/** Parse a comma-separated `related=` attribute into a trimmed list. */
+/**
+ * Parse a comma-separated `related=` attribute into a list of filesystem-style
+ * paths. The bv-topic convention is `@domain/topic` (no `.html`), but byPath /
+ * searchService both emit `domain/topic.html`. Normalizing here keeps
+ * link-candidates' alreadyLinkedTo filter functional — without this step,
+ * already-linked pairs would keep resurfacing across scans.
+ */
 function parseRelated(raw: string): string[] {
   return raw
     .split(',')
     .map((s) => s.trim())
     .filter((s) => s.length > 0)
+    .map((s) => normalizeRelatedRef(s))
+}
+
+function normalizeRelatedRef(ref: string): string {
+  // Strip the topic-ref `@` prefix used by bv-topic frontmatter.
+  const stripped = ref.startsWith('@') ? ref.slice(1) : ref
+  // Append `.html` when missing so the ref matches search-service hit paths.
+  return stripped.endsWith('.html') ? stripped : `${stripped}.html`
 }

--- a/src/server/infra/dream/tool-mode/topic-loader.ts
+++ b/src/server/infra/dream/tool-mode/topic-loader.ts
@@ -1,0 +1,158 @@
+/**
+ * Topic loader for tool-mode dream.
+ *
+ * Walks `.brv/context-tree/` recursively, parses the `<bv-topic>` root of
+ * each `.html` file, and combines the resulting metadata with sidecar
+ * signals + file mtime so the per-kind candidate generators have a single
+ * input shape to work from.
+ *
+ * Best-effort: malformed / empty files are skipped (not thrown). Hidden
+ * dirs (`.git`, `.archive`, etc.) are skipped to avoid pulling in
+ * git-internal HTML files or archived content.
+ */
+
+import {readdir, readFile, stat} from 'node:fs/promises'
+import {join, relative, sep} from 'node:path'
+
+import type {RuntimeSignals} from '../../../core/domain/knowledge/runtime-signals-schema.js'
+import type {IRuntimeSignalStore} from '../../../core/interfaces/storage/i-runtime-signal-store.js'
+
+import {createDefaultRuntimeSignals} from '../../../core/domain/knowledge/runtime-signals-schema.js'
+
+/**
+ * Combined topic record used as the source-of-truth for every candidate
+ * generator. Each generator projects this down to its own input shape.
+ */
+export type ToolModeTopic = {
+  /** Full raw HTML. */
+  html: string
+  /** File modification time in ms since epoch. */
+  mtimeMs: number
+  /** Path under `.brv/context-tree/`, forward-slash normalized (e.g. `security/jwt.html`). */
+  path: string
+  /** Parsed `related=` attribute, lowercase paths. Empty if not present. */
+  related: string[]
+  /** Sidecar signals (falls back to defaults when the path has no sidecar entry). */
+  signals: RuntimeSignals
+  /** Parsed `summary=` attribute, or empty string. */
+  summary: string
+  /** Parsed `title=` attribute. */
+  title: string
+}
+
+const BV_TOPIC_RE = /<bv-topic\b([^>]*)>/i
+
+export async function loadToolModeTopics(params: {
+  contextTreeRoot: string
+  runtimeSignalStore: IRuntimeSignalStore
+}): Promise<ToolModeTopic[]> {
+  const {contextTreeRoot, runtimeSignalStore} = params
+
+  let signalsByPath: Map<string, RuntimeSignals>
+  try {
+    signalsByPath = await runtimeSignalStore.list()
+  } catch {
+    signalsByPath = new Map()
+  }
+
+  const htmlFiles: string[] = []
+  await walkHtmlFiles(contextTreeRoot, htmlFiles)
+
+  const topics = await Promise.all(htmlFiles.map((absolutePath) => loadOne(absolutePath, contextTreeRoot, signalsByPath)))
+
+  return topics.filter((t): t is ToolModeTopic => t !== undefined)
+}
+
+async function walkHtmlFiles(rootDir: string, accumulator: string[], current?: string): Promise<void> {
+  const dir = current ?? rootDir
+  let entries
+  try {
+    entries = await readdir(dir, {withFileTypes: true})
+  } catch {
+    return
+  }
+
+  const subwalks: Array<Promise<void>> = []
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) continue // skip .git, .archive, etc.
+    const next = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      subwalks.push(walkHtmlFiles(rootDir, accumulator, next))
+      continue
+    }
+
+    if (entry.isFile() && entry.name.endsWith('.html')) {
+      accumulator.push(next)
+    }
+  }
+
+  await Promise.all(subwalks)
+}
+
+async function loadOne(
+  absolutePath: string,
+  contextTreeRoot: string,
+  signalsByPath: Map<string, RuntimeSignals>,
+): Promise<ToolModeTopic | undefined> {
+  let html: string
+  try {
+    html = await readFile(absolutePath, 'utf8')
+  } catch {
+    return undefined
+  }
+
+  if (!html.trim()) return undefined
+
+  const topicMatch = BV_TOPIC_RE.exec(html)
+  if (!topicMatch) return undefined
+
+  const attrs = parseAttributes(topicMatch[1] ?? '')
+  if (!('title' in attrs)) return undefined
+
+  let mtimeMs = 0
+  try {
+    const stats = await stat(absolutePath)
+    mtimeMs = stats.mtimeMs
+  } catch {
+    // ignore
+  }
+
+  const relPath = relative(contextTreeRoot, absolutePath).replaceAll(sep, '/')
+  const signals = signalsByPath.get(relPath) ?? createDefaultRuntimeSignals()
+
+  return {
+    html,
+    mtimeMs,
+    path: relPath,
+    related: parseRelated(attrs.related ?? ''),
+    signals,
+    summary: attrs.summary ?? '',
+    title: attrs.title ?? '',
+  }
+}
+
+/**
+ * Extract a flat attr map from the inside of an opening `<bv-topic ...>` tag.
+ * Handles double-quoted values; values without quotes are not allowed in
+ * the bv-topic vocabulary so we don't try to recover them.
+ */
+function parseAttributes(rawAttrs: string): Record<string, string> {
+  const result: Record<string, string> = {}
+  const attrRe = /([\w-]+)\s*=\s*"([^"]*)"/g
+  let match: null | RegExpExecArray
+  while ((match = attrRe.exec(rawAttrs)) !== null) {
+    const name = match[1]?.toLowerCase()
+    const value = match[2]
+    if (name && value !== undefined) result[name] = value
+  }
+
+  return result
+}
+
+/** Parse a comma-separated `related=` attribute into a trimmed list. */
+function parseRelated(raw: string): string[] {
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+}

--- a/src/server/infra/dream/tool-mode/topic-loader.ts
+++ b/src/server/infra/dream/tool-mode/topic-loader.ts
@@ -74,7 +74,11 @@ async function walkHtmlFiles(rootDir: string, accumulator: string[], current?: s
 
   const subwalks: Array<Promise<void>> = []
   for (const entry of entries) {
-    if (entry.name.startsWith('.')) continue // skip .git, .archive, etc.
+    // Skip dot-prefixed dirs (.git, .DS_Store, etc.). Topics under dot-dirs
+    // are not supported. NOTE: archived topics live at .brv/archive/ (a
+    // sibling of context-tree/), not inside context-tree itself, so this
+    // walker would not encounter them regardless.
+    if (entry.name.startsWith('.')) continue
     const next = join(dir, entry.name)
     if (entry.isDirectory()) {
       subwalks.push(walkHtmlFiles(rootDir, accumulator, next))

--- a/src/server/templates/skill/SKILL.md
+++ b/src/server/templates/skill/SKILL.md
@@ -373,6 +373,50 @@ brv vc push -u origin main       # push and set upstream tracking
 brv vc clone https://byterover.dev/<team>/<space>.git
 ```
 
+### 7. Dream — Context Tree Cleanup
+**Overview:** `brv dream` is a three-phase deterministic pass over `.brv/context-tree/` that surfaces cleanup candidates (link / merge / prune / synthesize) for YOU (the calling agent) to act on. No LLM is invoked on the daemon side — the daemon enumerates structural candidates, you do the semantic judgment via `brv curate` writes, then `brv dream finalize` archives the loser topics. The pipeline runs without a provider configured.
+
+**Use this when:**
+- The user asks to consolidate, dedupe, prune, or organize the context tree
+- You notice the tree has accumulated near-duplicate or stale topics over time
+
+**Do NOT use this when:**
+- The tree is fresh / small (< ~10 topics) — there's nothing to clean up yet
+- The user only wants to search or query — use `brv query` / `brv search`
+
+**Three-phase workflow:**
+
+**Phase 1 — Scan:**
+```bash
+brv dream scan --format json
+```
+Returns a `sessionId` (uuid) and `candidates` keyed by kind:
+- `link`: BM25-similar topic pairs that aren't cross-linked yet. Act by calling `brv curate` UPDATE on both topics to add `<bv-related>` edges.
+- `merge`: BM25-near-duplicates. Pick a survivor, call `brv curate` UPDATE with the merged body, then archive the loser via `brv dream finalize`.
+- `prune`: Low-importance or stale-mtime topics. Decide per candidate: ARCHIVE (via `finalize`), KEEP (no action), or MERGE_INTO another topic.
+- `synthesize`: Per-domain topic groups plus existing synthesis topics. Decide whether to author a new cross-cutting `<bv-topic>` under `synthesis/<slug>` via `brv curate` ADD.
+
+Filter scope or kinds:
+```bash
+brv dream scan --kinds link,merge --scope security/ --max-candidates 20 --format json
+```
+
+**Phase 2 — Act:** invoke `brv curate` (per the Curate Context section above) for each candidate you decide to act on. Keep the `sessionId` from Phase 1 — you'll need it for finalize.
+
+**Phase 3 — Finalize:**
+```bash
+brv dream finalize --session <sessionId> --archive testing/old-notes.html,redis/cache.html --format json
+```
+Archive paths MUST match exactly what `dream scan` emitted (full relative path under `.brv/context-tree/`, with `.html` extension). Files move to `.brv/archive/<path>` and a dream-log entry is written so the operation is undoable. `--archive` and `--archive-file <path>` are mutually exclusive; exactly one is required. The archive list is capped at 200 entries per call; split into multiple finalize calls for larger batches.
+
+**Undo the most recent finalize:**
+```bash
+brv dream undo --format json
+```
+Restores archived topics to their original locations (content is byte-identical; mtime resets to current time). Curate writes from Phase 2 are NOT rolled back by undo — use `brv review reject <taskId>` for those (see Review Pending Changes section).
+
+**Stateless v1 notes:** `brv dream sessions` returns an empty list and `brv dream cancel --session <id>` is a no-op — sessions are tracked agent-side, not daemon-side. The `sessionId` from scan is for your bookkeeping between scan and finalize; the daemon doesn't enforce it.
+
 ### 8. Swarm Query
 **Overview:** Search across all active memory providers simultaneously — ByteRover context tree, Obsidian vault, Local Markdown folders, GBrain, and Memory Wiki. Results are fused via Reciprocal Rank Fusion (RRF) and ranked by provider weight and relevance. No LLM call — pure algorithmic search. When multiple memory providers are configured, run `brv swarm query` alongside `brv query` to broaden recall at near-zero token cost.
 

--- a/src/shared/transport/events/task-events.ts
+++ b/src/shared/transport/events/task-events.ts
@@ -29,7 +29,7 @@ export interface TaskCreateRequest {
   folderPath?: string
   projectPath?: string
   taskId: string
-  type: 'curate' | 'curate-folder' | 'curate-html-direct' | 'query' | 'query-tool-mode' | 'search'
+  type: 'curate' | 'curate-folder' | 'curate-html-direct' | 'dream-finalize' | 'dream-scan' | 'query' | 'query-tool-mode' | 'search'
   worktreeRoot?: string
 }
 

--- a/test/unit/infra/dream/dream-undo.test.ts
+++ b/test/unit/infra/dream/dream-undo.test.ts
@@ -336,6 +336,42 @@ describe('undoLastDream', () => {
     expect(result.restoredArchives).to.include('auth/old-doc.md')
   })
 
+  it('undoes PRUNE/ARCHIVE: restores from previousTexts (tool-mode) when present, ignoring stubPath', async () => {
+    // Tool-mode finalize writes a PRUNE/ARCHIVE op with `previousTexts`
+    // instead of `stubPath`. Undo should write the body back to its
+    // original location and remove the .brv/archive/<path> copy.
+    const brvDir = join(tmpdir(), `brv-undo-tm-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    await mkdir(join(brvDir, 'context-tree'), {recursive: true})
+    await mkdir(join(brvDir, 'archive', 'testing'), {recursive: true})
+    const originalContent = '<bv-topic path="testing/old" title="O">restored body</bv-topic>'
+    await writeFile(join(brvDir, 'archive', 'testing', 'old.html'), originalContent, 'utf8')
+
+    dreamLogStore.getById.resolves(completedLog([{
+      action: 'ARCHIVE',
+      file: 'testing/old.html',
+      needsReview: false,
+      previousTexts: {'testing/old.html': originalContent},
+      reason: 'tool-mode finalize',
+      type: 'PRUNE',
+    }]))
+
+    const result = await undoLastDream({
+      ...deps,
+      contextTreeDir: join(brvDir, 'context-tree'),
+    })
+
+    expect(result.restoredFiles).to.include('testing/old.html')
+    const restoredBody = await readFile(join(brvDir, 'context-tree', 'testing', 'old.html'), 'utf8')
+    expect(restoredBody).to.equal(originalContent)
+    // .brv/archive/<path> copy must be removed so we don't leave a stale duplicate.
+    try {
+      await access(join(brvDir, 'archive', 'testing', 'old.html'))
+      expect.fail('archive copy should have been deleted')
+    } catch (error) {
+      expect((error as NodeJS.ErrnoException).code).to.equal('ENOENT')
+    }
+  })
+
   it('skips PRUNE/KEEP (no-op)', async () => {
     dreamLogStore.getById.resolves(completedLog([{
       action: 'KEEP',

--- a/test/unit/infra/dream/tool-mode/dream-session.test.ts
+++ b/test/unit/infra/dream/tool-mode/dream-session.test.ts
@@ -67,8 +67,8 @@ describe('scanDreamCandidates', () => {
       options: {kinds: ['link']},
       runtimeSignalStore: createMockRuntimeSignalStore(),
       searchService: searchStubReturning({
-        'JWT auth': [{path: 'b.html', score: 0.8}],
-        'OAuth auth': [{path: 'a.html', score: 0.8}],
+        JWT: [{path: 'b.html', score: 0.8}],
+        OAuth: [{path: 'a.html', score: 0.8}],
       }),
     })
 
@@ -205,6 +205,65 @@ describe('finalizeDreamSession', () => {
 
     const signals = await store.list()
     expect(signals.has('foo.html')).to.equal(false)
+  })
+
+  it('captures original content as previousTexts so undo can restore archives', async () => {
+    const ctRoot = join(dir, '.brv', 'context-tree')
+    const fooHtml = '<bv-topic path="foo" title="F">precious content here</bv-topic>'
+    const barHtml = '<bv-topic path="bar" title="B">other content</bv-topic>'
+    await writeFile(join(ctRoot, 'foo.html'), fooHtml, 'utf8')
+    await writeFile(join(ctRoot, 'bar.html'), barHtml, 'utf8')
+
+    const result = await finalizeDreamSession({
+      archive: ['foo.html', 'bar.html'],
+      brvDir: join(dir, '.brv'),
+      contextTreeRoot: ctRoot,
+      runtimeSignalStore: createMockRuntimeSignalStore(),
+      sessionId: 'sess-test',
+    })
+
+    expect(result.previousTexts).to.have.keys('foo.html', 'bar.html')
+    expect(result.previousTexts['foo.html']).to.equal(fooHtml)
+    expect(result.previousTexts['bar.html']).to.equal(barHtml)
+  })
+
+  it('omits previousTexts entries for paths that were skipped', async () => {
+    const ctRoot = join(dir, '.brv', 'context-tree')
+
+    const result = await finalizeDreamSession({
+      archive: ['ghost.html'],
+      brvDir: join(dir, '.brv'),
+      contextTreeRoot: ctRoot,
+      runtimeSignalStore: createMockRuntimeSignalStore(),
+      sessionId: 'sess-test',
+    })
+
+    expect(result.archived).to.deep.equal([])
+    expect(result.previousTexts).to.deep.equal({})
+  })
+
+  it('rejects archive paths that escape the context tree with reason="unsafe-path"', async () => {
+    const ctRoot = join(dir, '.brv', 'context-tree')
+    // Place a sentinel file outside the context tree that an attacker would target.
+    const sentinel = join(dir, 'outside.html')
+    await writeFile(sentinel, '<bv-topic path="outside" title="O"/>', 'utf8')
+
+    const result = await finalizeDreamSession({
+      archive: ['../../outside.html', 'foo/../../escape.html'],
+      brvDir: join(dir, '.brv'),
+      contextTreeRoot: ctRoot,
+      runtimeSignalStore: createMockRuntimeSignalStore(),
+      sessionId: 'sess-test',
+    })
+
+    expect(result.archived).to.deep.equal([])
+    expect(result.skipped).to.have.length(2)
+    for (const s of result.skipped) {
+      expect(s.reason).to.equal('unsafe-path')
+    }
+
+    // Sentinel must remain untouched.
+    expect(existsSync(sentinel)).to.equal(true)
   })
 
   it('returns empty summary for an empty archive list', async () => {

--- a/test/unit/infra/dream/tool-mode/dream-session.test.ts
+++ b/test/unit/infra/dream/tool-mode/dream-session.test.ts
@@ -242,6 +242,27 @@ describe('finalizeDreamSession', () => {
     expect(result.previousTexts).to.deep.equal({})
   })
 
+  it('reports reason="already-archived" when rename loses a concurrent-finalize race (ENOENT)', async () => {
+    const ctRoot = join(dir, '.brv', 'context-tree')
+    await writeFile(join(ctRoot, 'foo.html'), '<bv-topic path="foo" title="F"/>', 'utf8')
+
+    // finalizeDreamSession does Promise.all internally over the archive
+    // array. Listing the same path twice forces a real concurrent race:
+    // both callbacks pass existsSync + readFile, then both attempt
+    // rename — one wins (archived), one loses with ENOENT (should be
+    // surfaced as 'already-archived' rather than the generic 'rename-failed').
+    const result = await finalizeDreamSession({
+      archive: ['foo.html', 'foo.html'],
+      brvDir: join(dir, '.brv'),
+      contextTreeRoot: ctRoot,
+      runtimeSignalStore: createMockRuntimeSignalStore(),
+      sessionId: 'sess-test',
+    })
+
+    expect(result.archived).to.deep.equal(['foo.html'])
+    expect(result.skipped).to.deep.equal([{path: 'foo.html', reason: 'already-archived'}])
+  })
+
   it('rejects archive paths that escape the context tree with reason="unsafe-path"', async () => {
     const ctRoot = join(dir, '.brv', 'context-tree')
     // Place a sentinel file outside the context tree that an attacker would target.

--- a/test/unit/infra/dream/tool-mode/dream-session.test.ts
+++ b/test/unit/infra/dream/tool-mode/dream-session.test.ts
@@ -1,0 +1,224 @@
+import {expect} from 'chai'
+import {existsSync} from 'node:fs'
+import {mkdir, readFile, rm, writeFile} from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+import sinon from 'sinon'
+
+import type {ISearchKnowledgeService, SearchKnowledgeResult} from '../../../../../src/agent/infra/sandbox/tools-sdk.js'
+
+import {finalizeDreamSession, scanDreamCandidates} from '../../../../../src/server/infra/dream/tool-mode/dream-session.js'
+import {createMockRuntimeSignalStore} from '../../../../helpers/mock-factories.js'
+
+function searchStubReturning(map: Record<string, Array<{path: string; score: number}>>): ISearchKnowledgeService {
+  return {
+    search: sinon.stub().callsFake(async (query: string): Promise<SearchKnowledgeResult> => {
+      const hits = map[query] ?? []
+      return {
+        message: '',
+        results: hits.map((h) => ({excerpt: '', path: h.path, score: h.score, title: h.path})),
+        totalFound: hits.length,
+      }
+    }),
+  }
+}
+
+describe('dream-session', () => {
+describe('scanDreamCandidates', () => {
+  let dir: string
+
+  beforeEach(async () => {
+    dir = join(tmpdir(), `brv-dream-session-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    await mkdir(dir, {recursive: true})
+  })
+
+  afterEach(async () => {
+    await rm(dir, {force: true, recursive: true})
+  })
+
+  it('returns a session id and empty candidate sets when context tree is empty', async () => {
+    const result = await scanDreamCandidates({
+      contextTreeRoot: dir,
+      runtimeSignalStore: createMockRuntimeSignalStore(),
+      searchService: searchStubReturning({}),
+    })
+
+    expect(result.sessionId).to.match(/^[\da-f]{8}-[\da-f]{4}/i)
+    expect(result.candidates.link).to.deep.equal([])
+    expect(result.candidates.merge).to.deep.equal([])
+    expect(result.candidates.prune).to.deep.equal([])
+    expect(result.candidates.synthesize).to.deep.equal({domains: [], existingSyntheses: []})
+  })
+
+  it('surfaces link candidates for matching topics in two domains', async () => {
+    await writeFile(
+      join(dir, 'a.html'),
+      '<bv-topic path="security/jwt" title="JWT" summary="auth"/>',
+      'utf8',
+    )
+    await writeFile(
+      join(dir, 'b.html'),
+      '<bv-topic path="security/oauth" title="OAuth" summary="auth"/>',
+      'utf8',
+    )
+
+    const result = await scanDreamCandidates({
+      contextTreeRoot: dir,
+      options: {kinds: ['link']},
+      runtimeSignalStore: createMockRuntimeSignalStore(),
+      searchService: searchStubReturning({
+        'JWT auth': [{path: 'b.html', score: 0.8}],
+        'OAuth auth': [{path: 'a.html', score: 0.8}],
+      }),
+    })
+
+    expect(result.candidates.link).to.have.length(1)
+    expect(result.candidates.link[0].pair).to.deep.equal(['a.html', 'b.html'])
+  })
+
+  it('only surfaces the kinds requested via options.kinds', async () => {
+    await writeFile(join(dir, 'a.html'), '<bv-topic path="a" title="A"/>', 'utf8')
+    await writeFile(join(dir, 'b.html'), '<bv-topic path="b" title="B"/>', 'utf8')
+
+    const result = await scanDreamCandidates({
+      contextTreeRoot: dir,
+      options: {kinds: ['prune']},
+      runtimeSignalStore: createMockRuntimeSignalStore(),
+      searchService: searchStubReturning({}),
+    })
+
+    expect(result.candidates.link).to.deep.equal([])
+    expect(result.candidates.merge).to.deep.equal([])
+    // prune may or may not have entries based on signals; key is that link/merge are skipped
+  })
+
+  it('runs all four kinds when no kinds filter is given (default)', async () => {
+    await writeFile(join(dir, 'a.html'), '<bv-topic path="a" title="A"/>', 'utf8')
+    await writeFile(join(dir, 'b.html'), '<bv-topic path="b" title="B"/>', 'utf8')
+
+    const result = await scanDreamCandidates({
+      contextTreeRoot: dir,
+      runtimeSignalStore: createMockRuntimeSignalStore(),
+      searchService: searchStubReturning({}),
+    })
+
+    // All four fields are present (even if empty)
+    expect(result.candidates).to.have.keys('link', 'merge', 'prune', 'synthesize')
+  })
+})
+
+describe('finalizeDreamSession', () => {
+  let dir: string
+
+  beforeEach(async () => {
+    dir = join(tmpdir(), `brv-dream-finalize-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    await mkdir(join(dir, '.brv', 'context-tree'), {recursive: true})
+  })
+
+  afterEach(async () => {
+    await rm(dir, {force: true, recursive: true})
+  })
+
+  it('moves each named topic from context-tree to .brv/archive', async () => {
+    const ctRoot = join(dir, '.brv', 'context-tree')
+    await writeFile(join(ctRoot, 'foo.html'), '<bv-topic path="foo" title="F"/>', 'utf8')
+    await writeFile(join(ctRoot, 'bar.html'), '<bv-topic path="bar" title="B"/>', 'utf8')
+
+    const result = await finalizeDreamSession({
+      archive: ['foo.html', 'bar.html'],
+      brvDir: join(dir, '.brv'),
+      contextTreeRoot: ctRoot,
+      runtimeSignalStore: createMockRuntimeSignalStore(),
+      sessionId: 'sess-test',
+    })
+
+    expect(result.archived).to.deep.equal(['foo.html', 'bar.html'])
+    expect(result.skipped).to.deep.equal([])
+
+    expect(existsSync(join(ctRoot, 'foo.html'))).to.equal(false)
+    expect(existsSync(join(ctRoot, 'bar.html'))).to.equal(false)
+    expect(existsSync(join(dir, '.brv', 'archive', 'foo.html'))).to.equal(true)
+    expect(existsSync(join(dir, '.brv', 'archive', 'bar.html'))).to.equal(true)
+  })
+
+  it('preserves the topic content in the archived file', async () => {
+    const ctRoot = join(dir, '.brv', 'context-tree')
+    const html = '<bv-topic path="foo" title="F">precious content</bv-topic>'
+    await writeFile(join(ctRoot, 'foo.html'), html, 'utf8')
+
+    await finalizeDreamSession({
+      archive: ['foo.html'],
+      brvDir: join(dir, '.brv'),
+      contextTreeRoot: ctRoot,
+      runtimeSignalStore: createMockRuntimeSignalStore(),
+      sessionId: 'sess-test',
+    })
+
+    const archived = await readFile(join(dir, '.brv', 'archive', 'foo.html'), 'utf8')
+    expect(archived).to.equal(html)
+  })
+
+  it('preserves nested directory structure under .brv/archive', async () => {
+    const ctRoot = join(dir, '.brv', 'context-tree')
+    await mkdir(join(ctRoot, 'security'), {recursive: true})
+    await writeFile(join(ctRoot, 'security', 'old.html'), '<bv-topic path="security/old" title="O"/>', 'utf8')
+
+    await finalizeDreamSession({
+      archive: ['security/old.html'],
+      brvDir: join(dir, '.brv'),
+      contextTreeRoot: ctRoot,
+      runtimeSignalStore: createMockRuntimeSignalStore(),
+      sessionId: 'sess-test',
+    })
+
+    expect(existsSync(join(dir, '.brv', 'archive', 'security', 'old.html'))).to.equal(true)
+  })
+
+  it('skips paths that no longer exist with reason="not-found"', async () => {
+    const ctRoot = join(dir, '.brv', 'context-tree')
+
+    const result = await finalizeDreamSession({
+      archive: ['ghost.html'],
+      brvDir: join(dir, '.brv'),
+      contextTreeRoot: ctRoot,
+      runtimeSignalStore: createMockRuntimeSignalStore(),
+      sessionId: 'sess-test',
+    })
+
+    expect(result.archived).to.deep.equal([])
+    expect(result.skipped).to.deep.equal([{path: 'ghost.html', reason: 'not-found'}])
+  })
+
+  it('drops the sidecar entry for archived topics', async () => {
+    const ctRoot = join(dir, '.brv', 'context-tree')
+    await writeFile(join(ctRoot, 'foo.html'), '<bv-topic path="foo" title="F"/>', 'utf8')
+    const store = createMockRuntimeSignalStore()
+    await store.set('foo.html', (await store.get('foo.html')))
+
+    await finalizeDreamSession({
+      archive: ['foo.html'],
+      brvDir: join(dir, '.brv'),
+      contextTreeRoot: ctRoot,
+      runtimeSignalStore: store,
+      sessionId: 'sess-test',
+    })
+
+    const signals = await store.list()
+    expect(signals.has('foo.html')).to.equal(false)
+  })
+
+  it('returns empty summary for an empty archive list', async () => {
+    const ctRoot = join(dir, '.brv', 'context-tree')
+    const result = await finalizeDreamSession({
+      archive: [],
+      brvDir: join(dir, '.brv'),
+      contextTreeRoot: ctRoot,
+      runtimeSignalStore: createMockRuntimeSignalStore(),
+      sessionId: 'sess-test',
+    })
+
+    expect(result.archived).to.deep.equal([])
+    expect(result.skipped).to.deep.equal([])
+  })
+})
+})

--- a/test/unit/infra/dream/tool-mode/link-candidates.test.ts
+++ b/test/unit/infra/dream/tool-mode/link-candidates.test.ts
@@ -46,9 +46,12 @@ describe('findLinkCandidates', () => {
       topic({path: 'a.html', summary: 'auth', title: 'A'}),
       topic({path: 'b.html', summary: 'auth', title: 'B'}),
     ]
+    // Search keys are title-only — summary is intentionally NOT appended
+    // to the BM25 query, because doing so makes the query so specific
+    // that BM25 ranks only the source topic itself.
     const search = searchStubReturning({
-      'A auth': [{path: 'b.html', score: 0.72}],
-      'B auth': [{path: 'a.html', score: 0.72}],
+      A: [{path: 'b.html', score: 0.72}],
+      B: [{path: 'a.html', score: 0.72}],
     })
 
     const result = await findLinkCandidates({searchService: search, topics})
@@ -56,6 +59,30 @@ describe('findLinkCandidates', () => {
     expect(result).to.have.length(1)
     expect(result[0].pair).to.deep.equal(['a.html', 'b.html'])
     expect(result[0].score).to.be.closeTo(0.72, 0.001)
+  })
+
+  it('uses title only (not title+summary) as the BM25 query — regression for over-specific query bug', async () => {
+    const topics = [
+      topic({path: 'a.html', summary: 'this whole long summary would over-specify the query', title: 'JWT'}),
+      topic({path: 'b.html', summary: 'unrelated summary text', title: 'OAuth'}),
+    ]
+    const stub = sinon.stub<[string, ...unknown[]], Promise<SearchKnowledgeResult>>()
+    stub.callsFake(async (): Promise<SearchKnowledgeResult> => ({
+      message: '',
+      results: [{excerpt: '', path: 'b.html', score: 0.8, title: 'b'}],
+      totalFound: 1,
+    }))
+    const search: ISearchKnowledgeService = {search: stub}
+
+    await findLinkCandidates({searchService: search, topics})
+
+    // Each topic's search call should pass title only, no summary tokens.
+    const calledQueries = stub.getCalls().map((c) => c.args[0])
+    expect(calledQueries).to.include('JWT')
+    expect(calledQueries).to.include('OAuth')
+    for (const q of calledQueries) {
+      expect(q).to.not.match(/summary/i, `query "${q}" should not contain summary tokens`)
+    }
   })
 
   it('drops pairs whose score is below the threshold', async () => {

--- a/test/unit/infra/dream/tool-mode/link-candidates.test.ts
+++ b/test/unit/infra/dream/tool-mode/link-candidates.test.ts
@@ -1,0 +1,202 @@
+import {expect} from 'chai'
+import sinon from 'sinon'
+
+import type {ISearchKnowledgeService, SearchKnowledgeResult} from '../../../../../src/agent/infra/sandbox/tools-sdk.js'
+
+import {
+  findLinkCandidates,
+  type LinkCandidateTopic,
+} from '../../../../../src/server/infra/dream/tool-mode/link-candidates.js'
+
+function topic(overrides: Partial<LinkCandidateTopic>): LinkCandidateTopic {
+  return {
+    alreadyLinkedTo: [],
+    html: `<bv-topic path="${overrides.path ?? 'x.html'}" title="x"/>`,
+    path: 'x.html',
+    summary: '',
+    title: 'x',
+    ...overrides,
+  }
+}
+
+function searchStubReturning(map: Record<string, Array<{path: string; score: number}>>): ISearchKnowledgeService {
+  return {
+    search: sinon.stub().callsFake(async (query: string): Promise<SearchKnowledgeResult> => {
+      const hits = map[query] ?? []
+      return {
+        message: '',
+        results: hits.map((h) => ({excerpt: '', path: h.path, score: h.score, title: h.path})),
+        totalFound: hits.length,
+      }
+    }),
+  }
+}
+
+describe('findLinkCandidates', () => {
+  it('returns empty when there are no topics', async () => {
+    const result = await findLinkCandidates({
+      searchService: searchStubReturning({}),
+      topics: [],
+    })
+    expect(result).to.deep.equal([])
+  })
+
+  it('returns a pair when two topics match above the score threshold', async () => {
+    const topics = [
+      topic({path: 'a.html', summary: 'auth', title: 'A'}),
+      topic({path: 'b.html', summary: 'auth', title: 'B'}),
+    ]
+    const search = searchStubReturning({
+      'A auth': [{path: 'b.html', score: 0.72}],
+      'B auth': [{path: 'a.html', score: 0.72}],
+    })
+
+    const result = await findLinkCandidates({searchService: search, topics})
+
+    expect(result).to.have.length(1)
+    expect(result[0].pair).to.deep.equal(['a.html', 'b.html'])
+    expect(result[0].score).to.be.closeTo(0.72, 0.001)
+  })
+
+  it('drops pairs whose score is below the threshold', async () => {
+    const topics = [
+      topic({path: 'a.html', title: 'A'}),
+      topic({path: 'b.html', title: 'B'}),
+    ]
+    const search = searchStubReturning({
+      A: [{path: 'b.html', score: 0.4}],
+      B: [{path: 'a.html', score: 0.4}],
+    })
+
+    const result = await findLinkCandidates({
+      options: {scoreThreshold: 0.5},
+      searchService: search,
+      topics,
+    })
+
+    expect(result).to.deep.equal([])
+  })
+
+  it('excludes self-matches', async () => {
+    const topics = [topic({path: 'a.html', title: 'A'})]
+    const search = searchStubReturning({
+      A: [{path: 'a.html', score: 0.99}],
+    })
+
+    const result = await findLinkCandidates({searchService: search, topics})
+
+    expect(result).to.deep.equal([])
+  })
+
+  it('excludes pairs that are already linked (via bv-topic related attr)', async () => {
+    const topics = [
+      topic({alreadyLinkedTo: ['b.html'], path: 'a.html', title: 'A'}),
+      topic({alreadyLinkedTo: ['a.html'], path: 'b.html', title: 'B'}),
+    ]
+    const search = searchStubReturning({
+      A: [{path: 'b.html', score: 0.8}],
+      B: [{path: 'a.html', score: 0.8}],
+    })
+
+    const result = await findLinkCandidates({searchService: search, topics})
+
+    expect(result).to.deep.equal([])
+  })
+
+  it('deduplicates symmetric pairs (A→B and B→A become one pair)', async () => {
+    const topics = [
+      topic({path: 'a.html', title: 'A'}),
+      topic({path: 'b.html', title: 'B'}),
+    ]
+    const search = searchStubReturning({
+      A: [{path: 'b.html', score: 0.8}],
+      B: [{path: 'a.html', score: 0.6}],
+    })
+
+    const result = await findLinkCandidates({searchService: search, topics})
+
+    expect(result).to.have.length(1)
+    // Keeps the higher score of the two symmetric hits
+    expect(result[0].score).to.be.closeTo(0.8, 0.001)
+  })
+
+  it('respects maxCandidates by returning highest-scored pairs first', async () => {
+    const topics = [
+      topic({path: 'a.html', title: 'A'}),
+      topic({path: 'b.html', title: 'B'}),
+      topic({path: 'c.html', title: 'C'}),
+    ]
+    const search = searchStubReturning({
+      A: [
+        {path: 'b.html', score: 0.55},
+        {path: 'c.html', score: 0.95},
+      ],
+      B: [
+        {path: 'a.html', score: 0.55},
+        {path: 'c.html', score: 0.75},
+      ],
+      C: [
+        {path: 'a.html', score: 0.95},
+        {path: 'b.html', score: 0.75},
+      ],
+    })
+
+    const result = await findLinkCandidates({
+      options: {maxCandidates: 2},
+      searchService: search,
+      topics,
+    })
+
+    expect(result).to.have.length(2)
+    // Top two by score: A↔C (0.95) and B↔C (0.75)
+    expect(result[0].pair).to.deep.equal(['a.html', 'c.html'])
+    expect(result[1].pair).to.deep.equal(['b.html', 'c.html'])
+  })
+
+  it('filters topics by scope prefix when provided', async () => {
+    const topics = [
+      topic({path: 'security/a.html', title: 'A'}),
+      topic({path: 'security/b.html', title: 'B'}),
+      topic({path: 'other/c.html', title: 'C'}),
+    ]
+    const search = searchStubReturning({
+      A: [
+        {path: 'security/b.html', score: 0.8},
+        {path: 'other/c.html', score: 0.9},
+      ],
+      B: [
+        {path: 'security/a.html', score: 0.8},
+        {path: 'other/c.html', score: 0.85},
+      ],
+    })
+
+    const result = await findLinkCandidates({
+      options: {scope: 'security/'},
+      searchService: search,
+      topics,
+    })
+
+    // Only security/a.html ↔ security/b.html should appear; other/c.html
+    // is outside the scope so it's neither searched from nor included as a hit.
+    expect(result).to.have.length(1)
+    expect(result[0].pair).to.deep.equal(['security/a.html', 'security/b.html'])
+  })
+
+  it('includes both topics full HTML in the returned candidate', async () => {
+    const search = searchStubReturning({
+      A: [{path: 'b.html', score: 0.8}],
+      B: [{path: 'a.html', score: 0.8}],
+    })
+
+    const result = await findLinkCandidates({
+      searchService: search,
+      topics: [
+        {alreadyLinkedTo: [], html: '<bv-topic path="a.html" title="A">aaa</bv-topic>', path: 'a.html', summary: '', title: 'A'},
+        {alreadyLinkedTo: [], html: '<bv-topic path="b.html" title="B">bbb</bv-topic>', path: 'b.html', summary: '', title: 'B'},
+      ],
+    })
+
+    expect(result[0].htmlA).to.contain('aaa')
+    expect(result[0].htmlB).to.contain('bbb')
+  })
+})

--- a/test/unit/infra/dream/tool-mode/merge-candidates.test.ts
+++ b/test/unit/infra/dream/tool-mode/merge-candidates.test.ts
@@ -1,0 +1,178 @@
+import {expect} from 'chai'
+import sinon from 'sinon'
+
+import type {ISearchKnowledgeService, SearchKnowledgeResult} from '../../../../../src/agent/infra/sandbox/tools-sdk.js'
+
+import {
+  findMergeCandidates,
+  type MergeCandidateTopic,
+} from '../../../../../src/server/infra/dream/tool-mode/merge-candidates.js'
+
+function topic(overrides: Partial<MergeCandidateTopic>): MergeCandidateTopic {
+  return {
+    html: `<bv-topic path="${overrides.path ?? 'x.html'}" title="x"/>`,
+    path: 'x.html',
+    summary: '',
+    title: 'x',
+    ...overrides,
+  }
+}
+
+function searchStubReturning(map: Record<string, Array<{path: string; score: number}>>): ISearchKnowledgeService {
+  return {
+    search: sinon.stub().callsFake(async (query: string): Promise<SearchKnowledgeResult> => {
+      const hits = map[query] ?? []
+      return {
+        message: '',
+        results: hits.map((h) => ({excerpt: '', path: h.path, score: h.score, title: h.path})),
+        totalFound: hits.length,
+      }
+    }),
+  }
+}
+
+describe('findMergeCandidates', () => {
+  it('returns empty for fewer than two topics', async () => {
+    const result = await findMergeCandidates({
+      searchService: searchStubReturning({}),
+      topics: [topic({path: 'a.html'})],
+    })
+    expect(result).to.deep.equal([])
+  })
+
+  it('returns a merge pair when two topics match above the default 0.85 threshold', async () => {
+    const topics = [
+      topic({path: 'redis/cache_settings.html', title: 'Redis cache'}),
+      topic({path: 'redis/cache_config.html', title: 'Redis cache'}),
+    ]
+    const search = searchStubReturning({
+      'Redis cache': [
+        {path: 'redis/cache_settings.html', score: 0.92},
+        {path: 'redis/cache_config.html', score: 0.92},
+      ],
+    })
+
+    const result = await findMergeCandidates({searchService: search, topics})
+
+    expect(result).to.have.length(1)
+    expect(result[0].pair).to.deep.equal(['redis/cache_config.html', 'redis/cache_settings.html'])
+    expect(result[0].score).to.be.closeTo(0.92, 0.001)
+  })
+
+  it('uses a higher default threshold than link (0.85): drops pairs at 0.7', async () => {
+    const topics = [
+      topic({path: 'a.html', title: 'A'}),
+      topic({path: 'b.html', title: 'B'}),
+    ]
+    const search = searchStubReturning({
+      A: [{path: 'b.html', score: 0.7}],
+      B: [{path: 'a.html', score: 0.7}],
+    })
+
+    const result = await findMergeCandidates({searchService: search, topics})
+
+    expect(result).to.deep.equal([])
+  })
+
+  it('does NOT exclude already-linked pairs (linking is for distinct topics; merge is for duplicates)', async () => {
+    const topics = [
+      topic({path: 'a.html', title: 'A'}),
+      topic({path: 'b.html', title: 'B'}),
+    ]
+    const search = searchStubReturning({
+      A: [{path: 'b.html', score: 0.9}],
+      B: [{path: 'a.html', score: 0.9}],
+    })
+
+    const result = await findMergeCandidates({searchService: search, topics})
+
+    // Merge generator has no awareness of the existing `related` attribute —
+    // a near-duplicate that happens to already be linked is still a valid
+    // merge candidate.
+    expect(result).to.have.length(1)
+  })
+
+  it('excludes self-matches', async () => {
+    const topics = [topic({path: 'a.html', title: 'A'})]
+    const search = searchStubReturning({A: [{path: 'a.html', score: 0.99}]})
+
+    const result = await findMergeCandidates({searchService: search, topics})
+    expect(result).to.deep.equal([])
+  })
+
+  it('deduplicates symmetric pairs and keeps higher score', async () => {
+    const topics = [
+      topic({path: 'a.html', title: 'A'}),
+      topic({path: 'b.html', title: 'B'}),
+    ]
+    const search = searchStubReturning({
+      A: [{path: 'b.html', score: 0.9}],
+      B: [{path: 'a.html', score: 0.86}],
+    })
+
+    const result = await findMergeCandidates({searchService: search, topics})
+    expect(result).to.have.length(1)
+    expect(result[0].score).to.be.closeTo(0.9, 0.001)
+  })
+
+  it('respects maxCandidates cap, sorted by score desc', async () => {
+    const topics = [
+      topic({path: 'a.html', title: 'A'}),
+      topic({path: 'b.html', title: 'B'}),
+      topic({path: 'c.html', title: 'C'}),
+    ]
+    const search = searchStubReturning({
+      A: [
+        {path: 'b.html', score: 0.86},
+        {path: 'c.html', score: 0.95},
+      ],
+      B: [
+        {path: 'a.html', score: 0.86},
+        {path: 'c.html', score: 0.88},
+      ],
+      C: [
+        {path: 'a.html', score: 0.95},
+        {path: 'b.html', score: 0.88},
+      ],
+    })
+
+    const result = await findMergeCandidates({options: {maxCandidates: 2}, searchService: search, topics})
+    expect(result).to.have.length(2)
+    expect(result[0].pair).to.deep.equal(['a.html', 'c.html'])
+    expect(result[1].pair).to.deep.equal(['b.html', 'c.html'])
+  })
+
+  it('includes both topics full HTML in each candidate (for agent merge authoring)', async () => {
+    const topics = [
+      {html: '<bv-topic path="a.html" title="A">aaa-body</bv-topic>', path: 'a.html', summary: '', title: 'A'},
+      {html: '<bv-topic path="b.html" title="B">bbb-body</bv-topic>', path: 'b.html', summary: '', title: 'B'},
+    ]
+    const search = searchStubReturning({
+      A: [{path: 'b.html', score: 0.95}],
+      B: [{path: 'a.html', score: 0.95}],
+    })
+
+    const result = await findMergeCandidates({searchService: search, topics})
+    expect(result[0].htmlA).to.contain('aaa-body')
+    expect(result[0].htmlB).to.contain('bbb-body')
+  })
+
+  it('respects scope filter', async () => {
+    const topics = [
+      topic({path: 'redis/cache_a.html', title: 'cache A'}),
+      topic({path: 'redis/cache_b.html', title: 'cache A'}),
+      topic({path: 'other/cache_c.html', title: 'cache A'}),
+    ]
+    const search = searchStubReturning({
+      'cache A': [
+        {path: 'redis/cache_a.html', score: 0.95},
+        {path: 'redis/cache_b.html', score: 0.95},
+        {path: 'other/cache_c.html', score: 0.95},
+      ],
+    })
+
+    const result = await findMergeCandidates({options: {scope: 'redis/'}, searchService: search, topics})
+    expect(result).to.have.length(1)
+    expect(result[0].pair).to.deep.equal(['redis/cache_a.html', 'redis/cache_b.html'])
+  })
+})

--- a/test/unit/infra/dream/tool-mode/prune-candidates.test.ts
+++ b/test/unit/infra/dream/tool-mode/prune-candidates.test.ts
@@ -1,0 +1,148 @@
+import {expect} from 'chai'
+
+import {createDefaultRuntimeSignals} from '../../../../../src/server/core/domain/knowledge/runtime-signals-schema.js'
+import {
+  findPruneCandidates,
+  type PruneCandidateTopic,
+} from '../../../../../src/server/infra/dream/tool-mode/prune-candidates.js'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const NOW = 1_780_000_000_000 // fixed point for deterministic tests
+
+function topic(overrides: Partial<PruneCandidateTopic>): PruneCandidateTopic {
+  return {
+    html: '<bv-topic path="x" title="x"/>',
+    mtimeMs: NOW,
+    path: 'x.html',
+    signals: createDefaultRuntimeSignals(),
+    ...overrides,
+  }
+}
+
+describe('findPruneCandidates', () => {
+  it('returns empty when no topics qualify', async () => {
+    const result = await findPruneCandidates({
+      options: {now: NOW},
+      topics: [topic({})],
+    })
+    expect(result).to.deep.equal([])
+  })
+
+  it('surfaces a topic with importance below threshold (default 35)', async () => {
+    const t = topic({
+      path: 'old/topic.html',
+      signals: {...createDefaultRuntimeSignals(), importance: 20, maturity: 'draft'},
+    })
+
+    const result = await findPruneCandidates({options: {now: NOW}, topics: [t]})
+
+    expect(result).to.have.length(1)
+    expect(result[0].path).to.equal('old/topic.html')
+    expect(result[0].reason).to.equal('low-importance')
+  })
+
+  it('surfaces a draft topic stale beyond 60 days', async () => {
+    const t = topic({
+      mtimeMs: NOW - 70 * DAY_MS,
+      path: 'stale/topic.html',
+      signals: {...createDefaultRuntimeSignals(), importance: 80, maturity: 'draft'},
+    })
+
+    const result = await findPruneCandidates({options: {now: NOW}, topics: [t]})
+
+    expect(result).to.have.length(1)
+    expect(result[0].reason).to.equal('stale-mtime')
+    expect(result[0].daysSinceModified).to.be.closeTo(70, 0.001)
+  })
+
+  it('surfaces a validated topic stale beyond 120 days', async () => {
+    const t = topic({
+      mtimeMs: NOW - 150 * DAY_MS,
+      path: 'old/validated.html',
+      signals: {...createDefaultRuntimeSignals(), importance: 80, maturity: 'validated'},
+    })
+
+    const result = await findPruneCandidates({options: {now: NOW}, topics: [t]})
+
+    expect(result).to.have.length(1)
+    expect(result[0].reason).to.equal('stale-mtime')
+  })
+
+  it('does NOT surface a draft within 60 days even when importance is moderate', async () => {
+    const t = topic({
+      mtimeMs: NOW - 30 * DAY_MS,
+      signals: {...createDefaultRuntimeSignals(), importance: 60, maturity: 'draft'},
+    })
+
+    const result = await findPruneCandidates({options: {now: NOW}, topics: [t]})
+    expect(result).to.deep.equal([])
+  })
+
+  it('NEVER surfaces a core-maturity topic, even if low-importance and very stale', async () => {
+    const t = topic({
+      mtimeMs: NOW - 365 * DAY_MS,
+      signals: {...createDefaultRuntimeSignals(), importance: 5, maturity: 'core'},
+    })
+
+    const result = await findPruneCandidates({options: {now: NOW}, topics: [t]})
+    expect(result).to.deep.equal([])
+  })
+
+  it('marks a topic with both signals as reason="both" (single entry)', async () => {
+    const t = topic({
+      mtimeMs: NOW - 90 * DAY_MS,
+      signals: {...createDefaultRuntimeSignals(), importance: 10, maturity: 'draft'},
+    })
+
+    const result = await findPruneCandidates({options: {now: NOW}, topics: [t]})
+    expect(result).to.have.length(1)
+    expect(result[0].reason).to.equal('both')
+  })
+
+  it('sorts candidates stalest-first', async () => {
+    const topics = [
+      topic({mtimeMs: NOW - 70 * DAY_MS, path: 'mid.html', signals: {...createDefaultRuntimeSignals(), maturity: 'draft'}}),
+      topic({mtimeMs: NOW - 200 * DAY_MS, path: 'oldest.html', signals: {...createDefaultRuntimeSignals(), maturity: 'draft'}}),
+      topic({mtimeMs: NOW - 100 * DAY_MS, path: 'middle.html', signals: {...createDefaultRuntimeSignals(), maturity: 'draft'}}),
+    ]
+    const result = await findPruneCandidates({options: {now: NOW}, topics})
+
+    expect(result.map((c) => c.path)).to.deep.equal(['oldest.html', 'middle.html', 'mid.html'])
+  })
+
+  it('respects maxCandidates cap', async () => {
+    const topics: PruneCandidateTopic[] = Array.from({length: 25}, (_, i) =>
+      topic({
+        mtimeMs: NOW - (200 - i) * DAY_MS,
+        path: `t${i}.html`,
+        signals: {...createDefaultRuntimeSignals(), maturity: 'draft'},
+      }),
+    )
+
+    const result = await findPruneCandidates({options: {maxCandidates: 5, now: NOW}, topics})
+
+    expect(result).to.have.length(5)
+    // Stalest five (largest mtime delta = smallest i)
+    expect(result[0].path).to.equal('t0.html')
+  })
+
+  it('respects scope filter (paths outside scope are skipped)', async () => {
+    const topics = [
+      topic({mtimeMs: NOW - 70 * DAY_MS, path: 'security/old.html', signals: {...createDefaultRuntimeSignals(), maturity: 'draft'}}),
+      topic({mtimeMs: NOW - 70 * DAY_MS, path: 'other/old.html', signals: {...createDefaultRuntimeSignals(), maturity: 'draft'}}),
+    ]
+    const result = await findPruneCandidates({options: {now: NOW, scope: 'security/'}, topics})
+
+    expect(result).to.have.length(1)
+    expect(result[0].path).to.equal('security/old.html')
+  })
+
+  it('returns daysSinceModified for every candidate', async () => {
+    const t = topic({
+      mtimeMs: NOW - 42 * DAY_MS,
+      signals: {...createDefaultRuntimeSignals(), importance: 20, maturity: 'draft'},
+    })
+    const result = await findPruneCandidates({options: {now: NOW}, topics: [t]})
+    expect(result[0].daysSinceModified).to.be.closeTo(42, 0.001)
+  })
+})

--- a/test/unit/infra/dream/tool-mode/synthesize-candidates.test.ts
+++ b/test/unit/infra/dream/tool-mode/synthesize-candidates.test.ts
@@ -1,0 +1,134 @@
+import {expect} from 'chai'
+
+import {
+  findSynthesizeCandidates,
+  type SynthesizeCandidateTopic,
+} from '../../../../../src/server/infra/dream/tool-mode/synthesize-candidates.js'
+
+function t(path: string, title?: string, summary?: string): SynthesizeCandidateTopic {
+  return {path, summary: summary ?? '', title: title ?? path}
+}
+
+describe('findSynthesizeCandidates', () => {
+  it('returns empty shape when there are no topics', async () => {
+    const result = await findSynthesizeCandidates({topics: []})
+    expect(result).to.deep.equal({domains: [], existingSyntheses: []})
+  })
+
+  it('groups topics by domain (first path segment)', async () => {
+    const result = await findSynthesizeCandidates({
+      topics: [
+        t('security/jwt.html', 'JWT'),
+        t('security/oauth.html', 'OAuth'),
+        t('deploy/staging.html', 'Staging'),
+        t('deploy/production.html', 'Production'),
+      ],
+    })
+
+    expect(result.domains).to.have.length(2)
+    const security = result.domains.find((d) => d.domain === 'security')
+    const deploy = result.domains.find((d) => d.domain === 'deploy')
+    expect(security?.topics).to.have.length(2)
+    expect(deploy?.topics).to.have.length(2)
+  })
+
+  it('separates synthesis/ topics into existingSyntheses, NOT into domains', async () => {
+    const result = await findSynthesizeCandidates({
+      topics: [
+        t('security/jwt.html', 'JWT'),
+        t('security/oauth.html', 'OAuth'),
+        t('synthesis/auth_strategy.html', 'Auth strategy', 'Cross-cutting auth synthesis'),
+      ],
+    })
+
+    expect(result.domains).to.have.length(1)
+    expect(result.domains[0].domain).to.equal('security')
+    expect(result.existingSyntheses).to.have.length(1)
+    expect(result.existingSyntheses[0]).to.deep.equal({
+      path: 'synthesis/auth_strategy.html',
+      summary: 'Cross-cutting auth synthesis',
+      title: 'Auth strategy',
+    })
+  })
+
+  it('filters out domains with fewer than minTopicsPerDomain (default 2)', async () => {
+    const result = await findSynthesizeCandidates({
+      topics: [
+        t('security/jwt.html', 'JWT'),
+        t('security/oauth.html', 'OAuth'),
+        t('alone/single.html', 'Single'),
+      ],
+    })
+
+    expect(result.domains).to.have.length(1)
+    expect(result.domains[0].domain).to.equal('security')
+  })
+
+  it('respects scope: only domains whose paths start with scope are included', async () => {
+    const result = await findSynthesizeCandidates({
+      options: {scope: 'security/'},
+      topics: [
+        t('security/jwt.html', 'JWT'),
+        t('security/oauth.html', 'OAuth'),
+        t('deploy/a.html'),
+        t('deploy/b.html'),
+      ],
+    })
+
+    expect(result.domains).to.have.length(1)
+    expect(result.domains[0].domain).to.equal('security')
+  })
+
+  it('includes title and summary on every topic in domains[]', async () => {
+    const result = await findSynthesizeCandidates({
+      topics: [
+        t('security/jwt.html', 'JWT signing', 'RS256 chosen over HS256'),
+        t('security/oauth.html', 'OAuth flow', 'Authorization code with PKCE'),
+      ],
+    })
+
+    expect(result.domains[0].topics[0]).to.deep.equal({
+      path: 'security/jwt.html',
+      summary: 'RS256 chosen over HS256',
+      title: 'JWT signing',
+    })
+  })
+
+  it('handles topics at the root (no slash in path) by grouping them under an empty-string domain', async () => {
+    const result = await findSynthesizeCandidates({
+      topics: [
+        t('rootless-a.html', 'Rootless A'),
+        t('rootless-b.html', 'Rootless B'),
+      ],
+    })
+
+    expect(result.domains).to.have.length(1)
+    expect(result.domains[0].domain).to.equal('')
+  })
+
+  it('honors minTopicsPerDomain override', async () => {
+    const result = await findSynthesizeCandidates({
+      options: {minTopicsPerDomain: 3},
+      topics: [
+        t('security/jwt.html', 'JWT'),
+        t('security/oauth.html', 'OAuth'),
+      ],
+    })
+
+    expect(result.domains).to.deep.equal([])
+  })
+
+  it('returns the existingSyntheses regardless of the domain-min threshold', async () => {
+    const result = await findSynthesizeCandidates({
+      options: {minTopicsPerDomain: 10},
+      topics: [
+        t('security/jwt.html', 'JWT'),
+        t('security/oauth.html', 'OAuth'),
+        t('synthesis/x.html', 'X', 'X summary'),
+      ],
+    })
+
+    expect(result.domains).to.deep.equal([])
+    expect(result.existingSyntheses).to.have.length(1)
+  })
+})

--- a/test/unit/infra/dream/tool-mode/topic-loader.test.ts
+++ b/test/unit/infra/dream/tool-mode/topic-loader.test.ts
@@ -43,7 +43,61 @@ describe('loadToolModeTopics', () => {
     expect(result[0].path).to.equal('jwt.html')
     expect(result[0].title).to.equal('JWT signing')
     expect(result[0].summary).to.equal('RS256 over HS256')
-    expect(result[0].related).to.deep.equal(['security/oauth', 'billing/stripe'])
+    // Normalized to filesystem-style paths (matches what byPath / searchService
+    // emit) so link-candidates' alreadyLinkedTo filter actually works.
+    expect(result[0].related).to.deep.equal(['security/oauth.html', 'billing/stripe.html'])
+  })
+
+  it('normalizes canonical @-prefixed related refs to filesystem paths', async () => {
+    // bv-topic convention is `related="@domain/topic"` (no .html). Topic-loader
+    // must canonicalize to `domain/topic.html` so link/merge filtering can
+    // compare against search hit paths. Regression for ENG-2858 review.
+    await writeFile(
+      join(dir, 'jwt.html'),
+      '<bv-topic path="security/jwt" title="JWT" related="@security/oauth,@security/cookies">x</bv-topic>',
+      'utf8',
+    )
+
+    const result = await loadToolModeTopics({
+      contextTreeRoot: dir,
+      runtimeSignalStore: createMockRuntimeSignalStore(),
+    })
+
+    expect(result[0].related).to.deep.equal(['security/oauth.html', 'security/cookies.html'])
+  })
+
+  it('tolerates mixed canonical and bare related refs in one attribute', async () => {
+    await writeFile(
+      join(dir, 'jwt.html'),
+      '<bv-topic path="security/jwt" title="JWT" related="@security/oauth,billing/stripe,@deploy/k8s">x</bv-topic>',
+      'utf8',
+    )
+
+    const result = await loadToolModeTopics({
+      contextTreeRoot: dir,
+      runtimeSignalStore: createMockRuntimeSignalStore(),
+    })
+
+    expect(result[0].related).to.deep.equal([
+      'security/oauth.html',
+      'billing/stripe.html',
+      'deploy/k8s.html',
+    ])
+  })
+
+  it('preserves explicit .html extensions when already present', async () => {
+    await writeFile(
+      join(dir, 'jwt.html'),
+      '<bv-topic path="security/jwt" title="JWT" related="security/oauth.html,@billing/stripe.html">x</bv-topic>',
+      'utf8',
+    )
+
+    const result = await loadToolModeTopics({
+      contextTreeRoot: dir,
+      runtimeSignalStore: createMockRuntimeSignalStore(),
+    })
+
+    expect(result[0].related).to.deep.equal(['security/oauth.html', 'billing/stripe.html'])
   })
 
   it('treats missing optional attrs as empty / undefined', async () => {

--- a/test/unit/infra/dream/tool-mode/topic-loader.test.ts
+++ b/test/unit/infra/dream/tool-mode/topic-loader.test.ts
@@ -1,0 +1,152 @@
+import {expect} from 'chai'
+import {mkdir, rm, utimes, writeFile} from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+
+import {createDefaultRuntimeSignals} from '../../../../../src/server/core/domain/knowledge/runtime-signals-schema.js'
+import {loadToolModeTopics} from '../../../../../src/server/infra/dream/tool-mode/topic-loader.js'
+import {createMockRuntimeSignalStore} from '../../../../helpers/mock-factories.js'
+
+describe('loadToolModeTopics', () => {
+  let dir: string
+
+  beforeEach(async () => {
+    dir = join(tmpdir(), `brv-topic-loader-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    await mkdir(dir, {recursive: true})
+  })
+
+  afterEach(async () => {
+    await rm(dir, {force: true, recursive: true})
+  })
+
+  it('returns empty when the context tree is empty', async () => {
+    const result = await loadToolModeTopics({
+      contextTreeRoot: dir,
+      runtimeSignalStore: createMockRuntimeSignalStore(),
+    })
+    expect(result).to.deep.equal([])
+  })
+
+  it('parses title, summary, and related from a topic file', async () => {
+    await writeFile(
+      join(dir, 'jwt.html'),
+      '<bv-topic path="security/jwt" title="JWT signing" summary="RS256 over HS256" related="security/oauth,billing/stripe">x</bv-topic>',
+      'utf8',
+    )
+
+    const result = await loadToolModeTopics({
+      contextTreeRoot: dir,
+      runtimeSignalStore: createMockRuntimeSignalStore(),
+    })
+
+    expect(result).to.have.length(1)
+    expect(result[0].path).to.equal('jwt.html')
+    expect(result[0].title).to.equal('JWT signing')
+    expect(result[0].summary).to.equal('RS256 over HS256')
+    expect(result[0].related).to.deep.equal(['security/oauth', 'billing/stripe'])
+  })
+
+  it('treats missing optional attrs as empty / undefined', async () => {
+    await writeFile(
+      join(dir, 'minimal.html'),
+      '<bv-topic path="x" title="Minimal">body</bv-topic>',
+      'utf8',
+    )
+
+    const result = await loadToolModeTopics({
+      contextTreeRoot: dir,
+      runtimeSignalStore: createMockRuntimeSignalStore(),
+    })
+
+    expect(result[0].summary).to.equal('')
+    expect(result[0].related).to.deep.equal([])
+  })
+
+  it('walks nested directories', async () => {
+    await mkdir(join(dir, 'security'), {recursive: true})
+    await mkdir(join(dir, 'deploy', 'envs'), {recursive: true})
+    await writeFile(join(dir, 'security', 'a.html'), '<bv-topic path="security/a" title="A"/>', 'utf8')
+    await writeFile(join(dir, 'deploy', 'envs', 'b.html'), '<bv-topic path="deploy/envs/b" title="B"/>', 'utf8')
+
+    const result = await loadToolModeTopics({
+      contextTreeRoot: dir,
+      runtimeSignalStore: createMockRuntimeSignalStore(),
+    })
+
+    expect(result.map((t) => t.path).sort()).to.deep.equal([
+      'deploy/envs/b.html',
+      'security/a.html',
+    ])
+  })
+
+  it('skips non-.html files and hidden dot-dirs (.git, .archive)', async () => {
+    await mkdir(join(dir, '.git'), {recursive: true})
+    await writeFile(join(dir, 'topic.html'), '<bv-topic path="t" title="T"/>', 'utf8')
+    await writeFile(join(dir, 'notes.md'), 'markdown', 'utf8')
+    await writeFile(join(dir, '.git', 'hidden.html'), '<bv-topic path="hidden" title="H"/>', 'utf8')
+
+    const result = await loadToolModeTopics({
+      contextTreeRoot: dir,
+      runtimeSignalStore: createMockRuntimeSignalStore(),
+    })
+
+    expect(result.map((t) => t.path)).to.deep.equal(['topic.html'])
+  })
+
+  it('attaches sidecar signals when available, falls back to defaults', async () => {
+    await writeFile(join(dir, 'a.html'), '<bv-topic path="a" title="A"/>', 'utf8')
+    await writeFile(join(dir, 'b.html'), '<bv-topic path="b" title="B"/>', 'utf8')
+
+    const store = createMockRuntimeSignalStore()
+    await store.set('a.html', {...createDefaultRuntimeSignals(), importance: 80, maturity: 'core'})
+
+    const result = await loadToolModeTopics({contextTreeRoot: dir, runtimeSignalStore: store})
+
+    const a = result.find((t) => t.path === 'a.html')
+    const b = result.find((t) => t.path === 'b.html')
+    expect(a?.signals.importance).to.equal(80)
+    expect(a?.signals.maturity).to.equal('core')
+    expect(b?.signals).to.deep.equal(createDefaultRuntimeSignals())
+  })
+
+  it('captures mtime in milliseconds', async () => {
+    const filePath = join(dir, 't.html')
+    await writeFile(filePath, '<bv-topic path="t" title="T"/>', 'utf8')
+    // Force a specific mtime well in the past
+    const pastMs = Date.now() - 5 * 24 * 60 * 60 * 1000
+    await utimes(filePath, new Date(pastMs), new Date(pastMs))
+
+    const result = await loadToolModeTopics({
+      contextTreeRoot: dir,
+      runtimeSignalStore: createMockRuntimeSignalStore(),
+    })
+
+    expect(result[0].mtimeMs).to.be.closeTo(pastMs, 1500) // 1.5s tolerance for fs jitter
+  })
+
+  it('preserves the full HTML on each topic', async () => {
+    const html = '<bv-topic path="x" title="X">body content</bv-topic>'
+    await writeFile(join(dir, 'x.html'), html, 'utf8')
+
+    const result = await loadToolModeTopics({
+      contextTreeRoot: dir,
+      runtimeSignalStore: createMockRuntimeSignalStore(),
+    })
+
+    expect(result[0].html).to.equal(html)
+  })
+
+  it('handles empty/malformed HTML gracefully (skips, never throws)', async () => {
+    await writeFile(join(dir, 'good.html'), '<bv-topic path="g" title="G"/>', 'utf8')
+    await writeFile(join(dir, 'empty.html'), '', 'utf8')
+    await writeFile(join(dir, 'malformed.html'), '<not-a-bv-topic>x</not-a-bv-topic>', 'utf8')
+
+    const result = await loadToolModeTopics({
+      contextTreeRoot: dir,
+      runtimeSignalStore: createMockRuntimeSignalStore(),
+    })
+
+    // Only the good topic survives
+    expect(result.map((t) => t.path)).to.deep.equal(['good.html'])
+  })
+})

--- a/test/unit/infra/dream/tool-mode/topic-loader.test.ts
+++ b/test/unit/infra/dream/tool-mode/topic-loader.test.ts
@@ -85,6 +85,27 @@ describe('loadToolModeTopics', () => {
     ])
   })
 
+  it('parses single-quoted attribute values (hand-authored topics)', async () => {
+    // HTML5 allows both quote styles; tool-written topics use double quotes,
+    // but a human author writing a topic by hand might use singles. Without
+    // this support, `related` would silently be empty and already-linked
+    // pairs would resurface as link candidates.
+    await writeFile(
+      join(dir, 'jwt.html'),
+      "<bv-topic path='security/jwt' title='JWT' related='@security/oauth'>x</bv-topic>",
+      'utf8',
+    )
+
+    const result = await loadToolModeTopics({
+      contextTreeRoot: dir,
+      runtimeSignalStore: createMockRuntimeSignalStore(),
+    })
+
+    expect(result).to.have.length(1)
+    expect(result[0].title).to.equal('JWT')
+    expect(result[0].related).to.deep.equal(['security/oauth.html'])
+  })
+
   it('preserves explicit .html extensions when already present', async () => {
     await writeFile(
       join(dir, 'jwt.html'),


### PR DESCRIPTION
## Summary

- Adds three-phase tool-mode Dream: `brv dream scan` (deterministic candidate enumeration) → agent acts via `brv curate` writes → `brv dream finalize --archive` archives loser topics
- Four candidate kinds — `link` and `merge` (BM25 pair discovery, title-only query), `prune` (sidecar importance + maturity-aware staleness), `synthesize` (per-domain overviews + existing synthesis topics)
- `brv dream undo` works for tool-mode runs — finalize persists a `DreamLogEntry` with `previousTexts`; new undo branch in `undoPrune` restores from the log and cleans the `.brv/archive/<path>` copy

## What's NOT in this PR (by design)

- No `brv-dream` MCP wrapper — Dream is CLI-only for this milestone, parallel to `brv review`
- No daemon-enforced session state — sessions are agent-side bookkeeping in v1; `brv dream sessions` returns empty, `brv dream cancel` is a no-op
- Curate writes from Phase 2 are NOT rolled back by `brv dream undo` — use `brv review reject` for those (existing HITL pathway)

## CLI surface

```
brv dream scan       [--kinds link,merge,prune,synthesize] [--scope <path>] [--max-candidates N] [--format json|text]
brv dream finalize   --session <id> --archive <a,b,c> | --archive-file <path>  [--format json|text]
brv dream sessions   [--format json|text]
brv dream cancel     --session <id>
brv dream undo       [--format json|text]
```

`SKILL.md` updated with a new "Dream — Context Tree Cleanup" section so AI consumers can discover the workflow.

## Test plan

- [x] Unit: 61 tests in `test/unit/infra/dream/tool-mode/` covering all four candidate generators, the orchestrator, topic-loader (including related-ref normalization), and the new undo branch
- [x] Unit: full suite — 8211 passing, 0 failing
- [x] Lint + typecheck clean
- [x] Interactive smoke (main agent) — 30+ scenarios across every flag combination, JSON+text modes, path traversal probes, multi-archive finalize, double-undo, cancel-after-finalize semantics
- [x] Interactive (blind subagent) — fresh agent with only `--help` access completed scan → finalize → undo from CLI surface alone
- [x] Interactive (guided subagent) — agent given the design doc validated 7/8 candidate judgments against the daemon's recommendations on a duplicate-rich tree
- [x] Interactive (adversarial subagent) — 45 attacks across input validation, path traversal, concurrency, state exhaustion, filesystem games, and undo abuse
- [x] Fresh second-agent review pass against the diff caught one real bug (related-ref format mismatch) — fixed in the last commit

## Known limitations (deferred, not blocking)

- Archiving a manually-created symlink inside `.brv/context-tree/` then undoing it loses symlink semantics (restores as regular file)
- `chmod 555 .brv/` then `dream finalize` produces a non-atomic partial commit (file moved + log written, state pointer not updated) — undo cannot recover
- Non-`.html` files inside `.brv/context-tree/` can be archived (context tree is assumed to contain only HTML topics)

All three require unusual local setup or manual misuse. None are reachable by an agent that uses `brv dream scan` output verbatim.