### PR TITLE
Correct tool-mode dream candidate-action mechanism in SKILL.md

### DIFF
--- a/src/server/templates/skill/SKILL.md
+++ b/src/server/templates/skill/SKILL.md
@@ -391,10 +391,10 @@ brv vc clone https://byterover.dev/<team>/<space>.git
 brv dream scan --format json
 ```
 Returns a `sessionId` (uuid) and `candidates` keyed by kind:
-- `link`: BM25-similar topic pairs that aren't cross-linked yet. Act by calling `brv curate` UPDATE on both topics to add `<bv-related>` edges.
-- `merge`: BM25-near-duplicates. Pick a survivor, call `brv curate` UPDATE with the merged body, then archive the loser via `brv dream finalize`.
-- `prune`: Low-importance or stale-mtime topics. Decide per candidate: ARCHIVE (via `finalize`), KEEP (no action), or MERGE_INTO another topic.
-- `synthesize`: Per-domain topic groups plus existing synthesis topics. Decide whether to author a new cross-cutting `<bv-topic>` under `synthesis/<slug>` via `brv curate` ADD.
+- `link`: BM25-similar topic pairs that aren't cross-linked yet. To act: extend each topic's `related=` attribute on `<bv-topic>` (comma-separated `@domain/topic` refs — no `.html` extension) with the partner's path, then re-call `brv curate` at each existing path. The path-exists kickoff branch in section 3 returns the topic's `existingContent`; merge your additions in and re-emit with `--overwrite` to apply the write.
+- `merge`: BM25-near-duplicates. Pick a survivor, author HTML combining both topics' bodies, write it via the same `brv curate` path-exists / `--overwrite` flow (section 3) at the survivor's existing path, then archive the loser via `brv dream finalize`.
+- `prune`: Low-importance or stale-mtime topics. Decide per candidate: archive it via `brv dream finalize`, leave it alone, or treat it as a `merge` candidate against another topic (using the `merge` flow above).
+- `synthesize`: Per-domain topic groups plus existing synthesis topics. To act: author a new `<bv-topic>` at a fresh path under `synthesis/<slug>` and call `brv curate` to write it — no path-exists branch applies because the path is new.
 
 Filter scope or kinds:
 ```bash


### PR DESCRIPTION
## Summary

Section 7 of `SKILL.md` (tool-mode dream) instructed agents to call \`brv curate UPDATE\` and to add \`<bv-related>\` edges. Both terms are inaccurate:

- **\`UPDATE\` / \`ADD\` are not subcommands or flags.** They appear elsewhere in SKILL.md only as items in a list of curate-log operation types in section 4. An agent following the previous wording would guess at non-existent syntax.
- **\`<bv-related>\` is not a real element.** The bv-topic vocabulary stores cross-links in the \`related=\` attribute on \`<bv-topic>\` itself (\`src/server/infra/render/elements/bv-topic/schema.ts:29\`), as a comma-separated list of \`@domain/topic\` refs. The fixture \`test/fixtures/render/sample-topic.html\` demonstrates the canonical format.

The four candidate-kind descriptions are rewritten to name the actual mechanism: extend the \`related=\` attribute and write via the existing \`brv curate\` path-exists / \`--overwrite\` flow already documented in section 3. Synthesize's new-topic case correctly notes that the path-exists branch does not apply.

## How this was caught

An SKILL.md-only fidelity test: a fresh agent given only sections 3 and 7 of SKILL.md (no \`--help\`, no source). It successfully ran \`scan → finalize → undo\` but could not author the link / merge writes from the previous wording alone, because the cited element and command form do not exist.

## Test plan

- [x] No code change; behavioral test suite unchanged (8213 passing)
- [x] \`npm run typecheck\` clean
- [x] No remaining occurrences of \`<bv-related>\` or \`curate. UPDATE\` / \`curate. ADD\` syntax in SKILL.md