### PR TITLE
feat: [ENG-2861] context-tree index generator + regeneration hooks

### DIFF
--- a/src/oclif/commands/index/rebuild.ts
+++ b/src/oclif/commands/index/rebuild.ts
@@ -35,6 +35,9 @@ export default class IndexRebuild extends Command {
 
     const result = await generateContextTreeIndex({
       contextTreeRoot,
+      // Surface non-fatal walk problems (e.g. an unreadable subdirectory)
+      // so a partial rebuild is diagnosable rather than silently truncated.
+      log: (msg) => this.warn(msg),
       projectName: basename(projectRoot),
     })
 

--- a/src/oclif/commands/index/rebuild.ts
+++ b/src/oclif/commands/index/rebuild.ts
@@ -1,0 +1,71 @@
+import {Command, Flags} from '@oclif/core'
+import {basename, join} from 'node:path'
+
+import {BRV_DIR, CONTEXT_TREE_DIR} from '../../../server/constants.js'
+import {generateContextTreeIndex} from '../../../server/infra/context-tree/index-generator.js'
+import {resolveProjectRoot} from '../../lib/curate-session.js'
+import {writeJsonResponse} from '../../lib/json-response.js'
+
+/**
+ * `brv index rebuild` — manual full regeneration of the context-tree
+ * index (`_index.html`).
+ *
+ * The index is normally regenerated automatically after each curate and
+ * dream-finalize. This command exists for first-time adoption on an
+ * existing tree, recovery after a best-effort regeneration failed, or
+ * after manual edits to the tree. Pure filesystem — runs in-process, no
+ * daemon connection required.
+ */
+export default class IndexRebuild extends Command {
+  public static description = 'Rebuild the context-tree index (_index.html) from the current set of topics.'
+  public static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --format json',
+  ]
+  public static flags = {
+    format: Flags.string({default: 'text', description: 'Output format (text or json)', options: ['text', 'json']}),
+  }
+
+  public async run(): Promise<void> {
+    const {flags: raw} = await this.parse(IndexRebuild)
+    const format = raw.format === 'json' ? 'json' : 'text'
+
+    const projectRoot = resolveProjectRoot()
+    const contextTreeRoot = join(projectRoot, BRV_DIR, CONTEXT_TREE_DIR)
+
+    const result = await generateContextTreeIndex({
+      contextTreeRoot,
+      projectName: basename(projectRoot),
+    })
+
+    if (!result.ok) {
+      if (format === 'json') {
+        writeJsonResponse({command: 'index-rebuild', data: {error: result.error, status: 'error'}, success: false})
+      } else {
+        this.log(`✗ Index rebuild failed: ${result.error}`)
+      }
+
+      this.exit(1)
+      return
+    }
+
+    if (format === 'json') {
+      writeJsonResponse({
+        command: 'index-rebuild',
+        data: {
+          domainCount: result.domainCount,
+          status: 'ok',
+          topicCount: result.topicCount,
+          written: result.written,
+        },
+        success: true,
+      })
+    } else {
+      const topicLabel = result.topicCount === 1 ? 'topic' : 'topics'
+      const domainLabel = result.domainCount === 1 ? 'domain' : 'domains'
+      this.log(
+        `✓ Rebuilt _index.html — ${result.topicCount} ${topicLabel} across ${result.domainCount} ${domainLabel}`,
+      )
+    }
+  }
+}

--- a/src/oclif/lib/curate-session.ts
+++ b/src/oclif/lib/curate-session.ts
@@ -409,6 +409,11 @@ export async function continueSession(options: ContinueOptions): Promise<CurateS
 
   // Regenerate the context-tree index so the new topic appears in
   // _index.html. Best-effort — the topic write already succeeded.
+  //
+  // Inline (not deferred like the daemon's postWorkRegistry path): a
+  // `brv curate` CLI invocation is a single in-process operation, so
+  // there is no concurrency to serialize against — the daemon's
+  // per-project postWork mutex has no analogue or need here.
   if (writeResult.ok) {
     await regenerateContextTreeIndex({
       contextTreeRoot,

--- a/src/oclif/lib/curate-session.ts
+++ b/src/oclif/lib/curate-session.ts
@@ -1,7 +1,7 @@
 import {randomUUID} from 'node:crypto'
 import {existsSync} from 'node:fs'
 import {mkdir, readFile, rm, writeFile} from 'node:fs/promises'
-import {dirname, join, relative, sep} from 'node:path'
+import {basename, dirname, join, relative, sep} from 'node:path'
 import {z} from 'zod'
 
 import type {CurateMeta} from '../../shared/curate-meta.js'
@@ -11,6 +11,7 @@ import {FileKeyStorage} from '../../agent/infra/storage/file-key-storage.js'
 import {BRV_DIR, CONTEXT_TREE_DIR} from '../../server/constants.js'
 import {buildCorrectionPrompt, buildGeneratePrompt} from '../../server/core/domain/render/curate-prompt-builder.js'
 import {ProjectConfigStore} from '../../server/infra/config/file-config-store.js'
+import {regenerateContextTreeIndex} from '../../server/infra/context-tree/index-generator.js'
 import {RuntimeSignalStore} from '../../server/infra/context-tree/runtime-signal-store.js'
 import {bumpSidecarOnCurateWrite} from '../../server/infra/context-tree/tool-mode-sidecar-updaters.js'
 import {backupContextTreeFile, buildCurateHtmlLogEntry} from '../../server/infra/process/curate-html-log.js'
@@ -405,6 +406,16 @@ export async function continueSession(options: ContinueOptions): Promise<CurateS
     topicPath,
     writeResult,
   })
+
+  // Regenerate the context-tree index so the new topic appears in
+  // _index.html. Best-effort — the topic write already succeeded.
+  if (writeResult.ok) {
+    await regenerateContextTreeIndex({
+      contextTreeRoot,
+      log: (msg) => new ConsoleLogger().warn(`tool-mode-curate: ${msg}`),
+      projectName: basename(projectRoot),
+    })
+  }
 
   state.attempts += 1
   state.lastResponse = response

--- a/src/server/infra/context-tree/index-generator.ts
+++ b/src/server/infra/context-tree/index-generator.ts
@@ -1,0 +1,279 @@
+/**
+ * Context-tree index generator.
+ *
+ * Deterministic, no-LLM. Walks `.brv/context-tree/`, aggregates the
+ * topic metadata the agent already authored (`title`, `summary`,
+ * `tags`), groups topics by domain, and writes the `<bv-index>`
+ * navigation document to `_index.html` at the context-tree root.
+ *
+ * Full regeneration on every call — the index is a pure function of the
+ * current tree, so a full rebuild is trivially correct. For trees up to
+ * a few hundred topics the walk is sub-second; an incremental
+ * (manifest-delta) path is the optimization to reach for only if
+ * profiling shows the walk is slow.
+ *
+ * Output is deterministic except for the `generatedat` timestamp:
+ * domains and entries are sorted, so an unchanged tree produces a
+ * byte-stable index (clean diffs in CoGit-tracked trees).
+ */
+
+import {readdir, readFile} from 'node:fs/promises'
+import {join, relative, sep} from 'node:path'
+
+import {INDEX_HTML_FILE} from '../../constants.js'
+import {DirectoryManager} from '../../core/domain/knowledge/directory-manager.js'
+import {MarkdownWriter} from '../../core/domain/knowledge/markdown-writer.js'
+import {validateHtmlIndex} from '../render/index-elements/index.js'
+import {escapeHtmlAttributeValue} from '../render/writer/html-writer.js'
+import {isDerivedArtifact} from './derived-artifact.js'
+
+/** Legacy archive directory inside the context tree — its topics are excluded. */
+const ARCHIVED_DIR = '_archived'
+
+/** Domain bucket for topics that sit at the context-tree root with no domain segment. */
+const UNCATEGORIZED_DOMAIN = 'general'
+
+/** Matches the opening `<bv-topic ...>` tag — cheap metadata extraction without a full parse. */
+const BV_TOPIC_RE = /<bv-topic\b([^>]*)>/i
+
+type TopicEntry = {
+  format: 'html' | 'markdown'
+  /** Relative path under the context-tree root, forward-slash normalized. */
+  path: string
+  summary: string
+  tags: string
+  title: string
+}
+
+export type GenerateIndexResult =
+  | {domainCount: number; ok: true; topicCount: number; written: string}
+  | {error: string; ok: false}
+
+/**
+ * Walk the context tree, build the `<bv-index>` document, and write it
+ * atomically to `_index.html`. Pure filesystem — no daemon, no LLM.
+ */
+export async function generateContextTreeIndex(input: {
+  contextTreeRoot: string
+  projectName: string
+}): Promise<GenerateIndexResult> {
+  const {contextTreeRoot, projectName} = input
+
+  let files: string[]
+  try {
+    files = []
+    await walkTopicFiles(contextTreeRoot, contextTreeRoot, files)
+  } catch (error) {
+    return {error: `index walk failed: ${String(error)}`, ok: false}
+  }
+
+  const entries: TopicEntry[] = []
+  for (const absolutePath of files) {
+    const relPath = relative(contextTreeRoot, absolutePath).replaceAll(sep, '/')
+    // eslint-disable-next-line no-await-in-loop
+    const entry = await readTopicEntry(absolutePath, relPath)
+    if (entry) entries.push(entry)
+  }
+
+  const html = renderIndex(projectName, entries)
+
+  // Self-check: the generator controls its output, but a generator bug
+  // should surface loudly here rather than write a malformed _index.html.
+  const validation = validateHtmlIndex(html)
+  if (!validation.ok) {
+    const messages = validation.errors.map((e) => e.message).join('; ')
+    return {error: `generated index failed self-validation: ${messages}`, ok: false}
+  }
+
+  const indexPath = join(contextTreeRoot, INDEX_HTML_FILE)
+  try {
+    await DirectoryManager.writeFileAtomic(indexPath, html)
+  } catch (error) {
+    return {error: `index write failed: ${String(error)}`, ok: false}
+  }
+
+  const domainCount = new Set(entries.map((e) => domainOf(e.path))).size
+  return {domainCount, ok: true, topicCount: entries.length, written: indexPath}
+}
+
+/**
+ * Best-effort index regeneration for post-write hooks (curate, dream
+ * finalize). The triggering operation has already succeeded; a failed
+ * index refresh must never propagate. Failures are logged and swallowed
+ * — `brv index rebuild` recovers a stale index.
+ */
+export async function regenerateContextTreeIndex(input: {
+  contextTreeRoot: string
+  log: (msg: string) => void
+  projectName: string
+}): Promise<void> {
+  try {
+    const result = await generateContextTreeIndex({
+      contextTreeRoot: input.contextTreeRoot,
+      projectName: input.projectName,
+    })
+    if (!result.ok) input.log(`context-tree index regeneration failed: ${result.error}`)
+  } catch (error) {
+    input.log(`context-tree index regeneration threw: ${error instanceof Error ? error.message : String(error)}`)
+  }
+}
+
+// ── Tree walk ─────────────────────────────────────────────────────────
+
+async function walkTopicFiles(rootDir: string, current: string, accumulator: string[]): Promise<void> {
+  let dirEntries
+  try {
+    dirEntries = await readdir(current, {withFileTypes: true})
+  } catch {
+    return
+  }
+
+  const subwalks: Array<Promise<void>> = []
+  for (const dirEntry of dirEntries) {
+    // Skip dot-dirs (.git, …) and the legacy `_archived/` subtree —
+    // archived topics must not appear in the navigation index.
+    if (dirEntry.name.startsWith('.') || dirEntry.name === ARCHIVED_DIR) continue
+    const next = join(current, dirEntry.name)
+    if (dirEntry.isDirectory()) {
+      subwalks.push(walkTopicFiles(rootDir, next, accumulator))
+      continue
+    }
+
+    if (dirEntry.isFile() && (dirEntry.name.endsWith('.html') || dirEntry.name.endsWith('.md'))) {
+      accumulator.push(next)
+    }
+  }
+
+  await Promise.all(subwalks)
+}
+
+// ── Per-topic metadata extraction ─────────────────────────────────────
+
+async function readTopicEntry(absolutePath: string, relPath: string): Promise<TopicEntry | undefined> {
+  // Derived artifacts (_index.html, _index.md, _manifest.json, …) are
+  // navigation/summary files, not topics — never index them.
+  if (isDerivedArtifact(relPath)) return undefined
+
+  let content: string
+  try {
+    content = await readFile(absolutePath, 'utf8')
+  } catch {
+    return undefined
+  }
+
+  if (!content.trim()) return undefined
+
+  return relPath.toLowerCase().endsWith('.html')
+    ? readHtmlEntry(content, relPath)
+    : readMarkdownEntry(content, relPath)
+}
+
+/** Extract entry metadata from an HTML topic's `<bv-topic>` opening tag. */
+function readHtmlEntry(content: string, relPath: string): TopicEntry | undefined {
+  const match = BV_TOPIC_RE.exec(content)
+  if (!match) return undefined
+
+  const attrs = parseTagAttributes(match[1] ?? '')
+  const title = attrs.title?.trim()
+  if (!title) return undefined
+
+  return {
+    format: 'html',
+    path: relPath,
+    summary: attrs.summary?.trim() ?? '',
+    tags: attrs.tags?.trim() ?? '',
+    title,
+  }
+}
+
+/** Extract entry metadata from a legacy Markdown topic's frontmatter. */
+function readMarkdownEntry(content: string, relPath: string): TopicEntry | undefined {
+  let parsed
+  try {
+    parsed = MarkdownWriter.parseContent(content, relPath)
+  } catch {
+    return undefined
+  }
+
+  const title = parsed.name?.trim()
+  if (!title) return undefined
+
+  return {
+    format: 'markdown',
+    path: relPath,
+    summary: parsed.summary?.trim() ?? '',
+    tags: parsed.tags.join(','),
+    title,
+  }
+}
+
+/**
+ * Parse attributes out of an opening tag's inner text. Accepts double-
+ * and single-quoted values; attribute names are lowercased to match
+ * HTML5 parsing semantics.
+ */
+function parseTagAttributes(rawAttrs: string): Record<string, string> {
+  const result: Record<string, string> = {}
+  const attrRe = /([\w-]+)\s*=\s*(?:"([^"]*)"|'([^']*)')/g
+  let match: null | RegExpExecArray
+  while ((match = attrRe.exec(rawAttrs)) !== null) {
+    const name = match[1]?.toLowerCase()
+    const value = match[2] ?? match[3]
+    if (name && value !== undefined) result[name] = value
+  }
+
+  return result
+}
+
+// ── Rendering ─────────────────────────────────────────────────────────
+
+/** First path segment, or the uncategorized bucket for root-level topics. */
+function domainOf(relPath: string): string {
+  const slash = relPath.indexOf('/')
+  return slash > 0 ? relPath.slice(0, slash) : UNCATEGORIZED_DOMAIN
+}
+
+function escapeHtmlText(value: string): string {
+  return value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+}
+
+function renderIndex(projectName: string, entries: readonly TopicEntry[]): string {
+  // Group by domain.
+  const byDomain = new Map<string, TopicEntry[]>()
+  for (const entry of entries) {
+    const domain = domainOf(entry.path)
+    const bucket = byDomain.get(domain)
+    if (bucket) bucket.push(entry)
+    else byDomain.set(domain, [entry])
+  }
+
+  const domains = [...byDomain.keys()].sort((a, b) => a.localeCompare(b))
+  const generatedAt = new Date().toISOString()
+
+  const lines: string[] = []
+  lines.push(
+    `<bv-index project="${escapeHtmlAttributeValue(projectName)}" generatedat="${generatedAt}"` +
+      ` topiccount="${entries.length}" domaincount="${domains.length}">`,
+  )
+
+  for (const domain of domains) {
+    const domainEntries = (byDomain.get(domain) ?? []).sort((a, b) => a.path.localeCompare(b.path))
+    lines.push(
+      `  <bv-index-domain name="${escapeHtmlAttributeValue(domain)}" count="${domainEntries.length}">`,
+    )
+    for (const entry of domainEntries) {
+      const tagsAttr = entry.tags ? ` tags="${escapeHtmlAttributeValue(entry.tags)}"` : ''
+      lines.push(
+        `    <bv-index-entry path="${escapeHtmlAttributeValue(entry.path)}"` +
+          ` title="${escapeHtmlAttributeValue(entry.title)}" format="${entry.format}"${tagsAttr}>` +
+          escapeHtmlText(entry.summary) +
+          `</bv-index-entry>`,
+      )
+    }
+
+    lines.push('  </bv-index-domain>')
+  }
+
+  lines.push('</bv-index>')
+  return lines.join('\n') + '\n'
+}

--- a/src/server/infra/context-tree/index-generator.ts
+++ b/src/server/infra/context-tree/index-generator.ts
@@ -20,21 +20,21 @@
 import {readdir, readFile} from 'node:fs/promises'
 import {join, relative, sep} from 'node:path'
 
-import {INDEX_HTML_FILE} from '../../constants.js'
+import {ARCHIVE_DIR, INDEX_HTML_FILE} from '../../constants.js'
 import {DirectoryManager} from '../../core/domain/knowledge/directory-manager.js'
 import {MarkdownWriter} from '../../core/domain/knowledge/markdown-writer.js'
 import {validateHtmlIndex} from '../render/index-elements/index.js'
+import {parseHtml, walkElements} from '../render/reader/html-parser.js'
 import {escapeHtmlAttributeValue} from '../render/writer/html-writer.js'
 import {isDerivedArtifact} from './derived-artifact.js'
 
-/** Legacy archive directory inside the context tree — its topics are excluded. */
-const ARCHIVED_DIR = '_archived'
-
-/** Domain bucket for topics that sit at the context-tree root with no domain segment. */
-const UNCATEGORIZED_DOMAIN = 'general'
-
-/** Matches the opening `<bv-topic ...>` tag — cheap metadata extraction without a full parse. */
-const BV_TOPIC_RE = /<bv-topic\b([^>]*)>/i
+/**
+ * Domain bucket for topics that sit at the context-tree root with no
+ * domain segment. Underscore-prefixed so it cannot collide with a real
+ * domain directory (topic path segments are snake_case, never
+ * underscore-leading) — mirrors the `_archived/` convention.
+ */
+const UNCATEGORIZED_DOMAIN = '_uncategorized'
 
 type TopicEntry = {
   format: 'html' | 'markdown'
@@ -52,17 +52,22 @@ export type GenerateIndexResult =
 /**
  * Walk the context tree, build the `<bv-index>` document, and write it
  * atomically to `_index.html`. Pure filesystem — no daemon, no LLM.
+ *
+ * `log` (optional) receives diagnostics for non-fatal walk problems
+ * (e.g. an unreadable subdirectory) so an operator chasing "why is my
+ * index incomplete?" gets a breadcrumb instead of a silent gap.
  */
 export async function generateContextTreeIndex(input: {
   contextTreeRoot: string
+  log?: (msg: string) => void
   projectName: string
 }): Promise<GenerateIndexResult> {
-  const {contextTreeRoot, projectName} = input
+  const {contextTreeRoot, log, projectName} = input
 
   let files: string[]
   try {
     files = []
-    await walkTopicFiles(contextTreeRoot, contextTreeRoot, files)
+    await walkTopicFiles(contextTreeRoot, files, log)
   } catch (error) {
     return {error: `index walk failed: ${String(error)}`, ok: false}
   }
@@ -101,6 +106,9 @@ export async function generateContextTreeIndex(input: {
  * finalize). The triggering operation has already succeeded; a failed
  * index refresh must never propagate. Failures are logged and swallowed
  * — `brv index rebuild` recovers a stale index.
+ *
+ * On the daemon this is submitted to `postWorkRegistry` (per-project
+ * serialized, drained on shutdown) rather than awaited inline.
  */
 export async function regenerateContextTreeIndex(input: {
   contextTreeRoot: string
@@ -110,6 +118,7 @@ export async function regenerateContextTreeIndex(input: {
   try {
     const result = await generateContextTreeIndex({
       contextTreeRoot: input.contextTreeRoot,
+      log: input.log,
       projectName: input.projectName,
     })
     if (!result.ok) input.log(`context-tree index regeneration failed: ${result.error}`)
@@ -120,11 +129,23 @@ export async function regenerateContextTreeIndex(input: {
 
 // ── Tree walk ─────────────────────────────────────────────────────────
 
-async function walkTopicFiles(rootDir: string, current: string, accumulator: string[]): Promise<void> {
+async function walkTopicFiles(
+  current: string,
+  accumulator: string[],
+  log?: (msg: string) => void,
+): Promise<void> {
   let dirEntries
   try {
     dirEntries = await readdir(current, {withFileTypes: true})
-  } catch {
+  } catch (error) {
+    // A missing directory is normal (empty / uninitialized tree); a
+    // permission or IO error is not — surface it so an incomplete index
+    // is diagnosable rather than silently truncated.
+    const {code} = error as NodeJS.ErrnoException
+    if (code && code !== 'ENOENT') {
+      log?.(`index walk: could not read ${current} (${code})`)
+    }
+
     return
   }
 
@@ -132,10 +153,10 @@ async function walkTopicFiles(rootDir: string, current: string, accumulator: str
   for (const dirEntry of dirEntries) {
     // Skip dot-dirs (.git, …) and the legacy `_archived/` subtree —
     // archived topics must not appear in the navigation index.
-    if (dirEntry.name.startsWith('.') || dirEntry.name === ARCHIVED_DIR) continue
+    if (dirEntry.name.startsWith('.') || dirEntry.name === ARCHIVE_DIR) continue
     const next = join(current, dirEntry.name)
     if (dirEntry.isDirectory()) {
-      subwalks.push(walkTopicFiles(rootDir, next, accumulator))
+      subwalks.push(walkTopicFiles(next, accumulator, log))
       continue
     }
 
@@ -168,20 +189,24 @@ async function readTopicEntry(absolutePath: string, relPath: string): Promise<To
     : readMarkdownEntry(content, relPath)
 }
 
-/** Extract entry metadata from an HTML topic's `<bv-topic>` opening tag. */
+/**
+ * Extract entry metadata from an HTML topic's `<bv-topic>` element.
+ * Uses the parse5-backed `parseHtml` (not a regex) so HTML comments,
+ * CDATA, and entity-escaped attribute values are handled correctly —
+ * topic files can be human-edited, not just writer-produced.
+ */
 function readHtmlEntry(content: string, relPath: string): TopicEntry | undefined {
-  const match = BV_TOPIC_RE.exec(content)
-  if (!match) return undefined
+  const topic = walkElements(parseHtml(content)).find((e) => e.tagName === 'bv-topic')
+  if (!topic) return undefined
 
-  const attrs = parseTagAttributes(match[1] ?? '')
-  const title = attrs.title?.trim()
+  const title = topic.attributes.title?.trim()
   if (!title) return undefined
 
   return {
     format: 'html',
     path: relPath,
-    summary: attrs.summary?.trim() ?? '',
-    tags: attrs.tags?.trim() ?? '',
+    summary: topic.attributes.summary?.trim() ?? '',
+    tags: topic.attributes.tags?.trim() ?? '',
     title,
   }
 }
@@ -198,31 +223,18 @@ function readMarkdownEntry(content: string, relPath: string): TopicEntry | undef
   const title = parsed.name?.trim()
   if (!title) return undefined
 
+  // Frontmatter `tags` is a string[]; the entry's `tags` attribute is a
+  // comma-joined string. Strip commas from individual tags first so a
+  // tag that itself contains a comma cannot corrupt the delimiter.
+  const tags = parsed.tags.map((t) => t.replaceAll(',', ' ').trim()).filter(Boolean)
+
   return {
     format: 'markdown',
     path: relPath,
     summary: parsed.summary?.trim() ?? '',
-    tags: parsed.tags.join(','),
+    tags: tags.join(','),
     title,
   }
-}
-
-/**
- * Parse attributes out of an opening tag's inner text. Accepts double-
- * and single-quoted values; attribute names are lowercased to match
- * HTML5 parsing semantics.
- */
-function parseTagAttributes(rawAttrs: string): Record<string, string> {
-  const result: Record<string, string> = {}
-  const attrRe = /([\w-]+)\s*=\s*(?:"([^"]*)"|'([^']*)')/g
-  let match: null | RegExpExecArray
-  while ((match = attrRe.exec(rawAttrs)) !== null) {
-    const name = match[1]?.toLowerCase()
-    const value = match[2] ?? match[3]
-    if (name && value !== undefined) result[name] = value
-  }
-
-  return result
 }
 
 // ── Rendering ─────────────────────────────────────────────────────────
@@ -258,9 +270,7 @@ function renderIndex(projectName: string, entries: readonly TopicEntry[]): strin
 
   for (const domain of domains) {
     const domainEntries = (byDomain.get(domain) ?? []).sort((a, b) => a.path.localeCompare(b.path))
-    lines.push(
-      `  <bv-index-domain name="${escapeHtmlAttributeValue(domain)}" count="${domainEntries.length}">`,
-    )
+    lines.push(`  <bv-index-domain name="${escapeHtmlAttributeValue(domain)}" count="${domainEntries.length}">`)
     for (const entry of domainEntries) {
       const tagsAttr = entry.tags ? ` tags="${escapeHtmlAttributeValue(entry.tags)}"` : ''
       lines.push(

--- a/src/server/infra/daemon/agent-process.ts
+++ b/src/server/infra/daemon/agent-process.ts
@@ -785,13 +785,17 @@ async function executeTask(
           }
 
           // Regenerate the context-tree index so the new topic appears in
-          // _index.html. Best-effort — the topic write already succeeded.
+          // _index.html. Deferred to postWorkRegistry (drained below): it
+          // runs after task:completed — off the user-facing latency path —
+          // and is per-project serialized, so concurrent curate-html-direct
+          // tasks cannot race on _index.html.
           if (writeResult.ok) {
-            await regenerateContextTreeIndex({
-              contextTreeRoot,
-              log: (msg) => agentLog(`curate-html-direct ${taskId}: ${msg}`),
-              projectName: basename(projectPath),
-            })
+            postWork = () =>
+              regenerateContextTreeIndex({
+                contextTreeRoot,
+                log: (msg) => agentLog(`curate-html-direct ${taskId}: ${msg}`),
+                projectName: basename(projectPath),
+              })
           }
 
           // Validation failures emit task:completed (NOT task:error) so
@@ -918,12 +922,15 @@ async function executeTask(
               }))
 
               // Archiving removed topics — refresh _index.html so they
-              // drop out of the navigation index. Best-effort.
-              await regenerateContextTreeIndex({
-                contextTreeRoot,
-                log: (msg) => agentLog(`dream-finalize ${taskId}: ${msg}`),
-                projectName: basename(projectPath),
-              })
+              // drop out of the navigation index. Deferred to
+              // postWorkRegistry (per-project serialized, runs after
+              // task:completed) — same rationale as curate-html-direct.
+              postWork = () =>
+                regenerateContextTreeIndex({
+                  contextTreeRoot,
+                  log: (msg) => agentLog(`dream-finalize ${taskId}: ${msg}`),
+                  projectName: basename(projectPath),
+                })
 
               result = JSON.stringify({
                 archived: finalizeResult.archived,

--- a/src/server/infra/daemon/agent-process.ts
+++ b/src/server/infra/daemon/agent-process.ts
@@ -22,7 +22,7 @@
 import {connectToTransport, type ITransportClient} from '@campfirein/brv-transport-client'
 import {randomUUID} from 'node:crypto'
 import {appendFileSync, existsSync} from 'node:fs'
-import {join, relative, sep} from 'node:path'
+import {basename, join, relative, sep} from 'node:path'
 
 import type {ISearchKnowledgeService} from '../../../agent/infra/sandbox/tools-sdk.js'
 import type {BrvConfig} from '../../core/domain/entities/brv-config.js'
@@ -57,6 +57,7 @@ import {
   TransportTaskEventNames,
 } from '../../core/domain/transport/schemas.js'
 import {FileContextTreeArchiveService} from '../context-tree/file-context-tree-archive-service.js'
+import {regenerateContextTreeIndex} from '../context-tree/index-generator.js'
 import {RuntimeSignalStore} from '../context-tree/runtime-signal-store.js'
 import {bumpSidecarOnCurateWrite} from '../context-tree/tool-mode-sidecar-updaters.js'
 import {DreamLockService} from '../dream/dream-lock-service.js'
@@ -783,6 +784,16 @@ async function executeTask(
             )
           }
 
+          // Regenerate the context-tree index so the new topic appears in
+          // _index.html. Best-effort — the topic write already succeeded.
+          if (writeResult.ok) {
+            await regenerateContextTreeIndex({
+              contextTreeRoot,
+              log: (msg) => agentLog(`curate-html-direct ${taskId}: ${msg}`),
+              projectName: basename(projectPath),
+            })
+          }
+
           // Validation failures emit task:completed (NOT task:error) so
           // the calling agent sees the structured errors via the normal
           // result payload and can retry with corrected HTML. task:error
@@ -905,6 +916,15 @@ async function executeTask(
                 lastDreamLogId: logId,
                 totalDreams: state.totalDreams + 1,
               }))
+
+              // Archiving removed topics — refresh _index.html so they
+              // drop out of the navigation index. Best-effort.
+              await regenerateContextTreeIndex({
+                contextTreeRoot,
+                log: (msg) => agentLog(`dream-finalize ${taskId}: ${msg}`),
+                projectName: basename(projectPath),
+              })
+
               result = JSON.stringify({
                 archived: finalizeResult.archived,
                 logId,

--- a/src/server/infra/render/writer/html-writer.ts
+++ b/src/server/infra/render/writer/html-writer.ts
@@ -321,7 +321,7 @@ function setBvTopicAttribute(html: string, name: string, value: string): string 
 // contain none of these characters, but the helper is general-purpose by
 // shape and a future caller passing user-influenced content would
 // otherwise silently corrupt the tag.
-function escapeHtmlAttributeValue(value: string): string {
+export function escapeHtmlAttributeValue(value: string): string {
   return value
     .replaceAll('&', '&amp;')
     .replaceAll('<', '&lt;')

--- a/test/unit/server/infra/context-tree/index-generator.test.ts
+++ b/test/unit/server/infra/context-tree/index-generator.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Context-tree index generator tests.
+ */
+
+import {expect} from 'chai'
+import {mkdir, mkdtemp, readFile, rm, writeFile} from 'node:fs/promises'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+
+import {generateContextTreeIndex} from '../../../../../src/server/infra/context-tree/index-generator.js'
+import {validateHtmlIndex} from '../../../../../src/server/infra/render/index-elements/index.js'
+
+function htmlTopic(path: string, title: string, summary: string, tags = ''): string {
+  const tagsAttr = tags ? ` tags="${tags}"` : ''
+  return `<bv-topic path="${path}" title="${title}" summary="${summary}"${tagsAttr}>
+  <bv-reason>test fixture</bv-reason>
+</bv-topic>`
+}
+
+function mdTopic(title: string, summary: string): string {
+  return `---
+title: ${title}
+summary: ${summary}
+tags: []
+---
+## Reason
+fixture
+`
+}
+
+async function write(root: string, relPath: string, content: string): Promise<void> {
+  const full = join(root, relPath)
+  await mkdir(join(full, '..'), {recursive: true})
+  await writeFile(full, content, 'utf8')
+}
+
+/** Drop the nondeterministic generatedat so two runs can be compared. */
+function stripGeneratedAt(s: string): string {
+  return s.replace(/generatedat="[^"]*"/, 'generatedat="X"')
+}
+
+describe('generateContextTreeIndex', () => {
+  let root: string
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'index-generator-test-'))
+  })
+
+  afterEach(async () => {
+    await rm(root, {force: true, recursive: true})
+  })
+
+  it('writes a valid <bv-index> for a mixed html + markdown tree', async () => {
+    await write(root, 'features/auth.html', htmlTopic('features/auth', 'Auth', 'JWT auth.', 'security,jwt'))
+    await write(root, 'architecture/api.md', mdTopic('API', 'REST endpoints.'))
+
+    const result = await generateContextTreeIndex({contextTreeRoot: root, projectName: 'demo'})
+    expect(result.ok).to.equal(true)
+    if (!result.ok) return
+
+    expect(result.topicCount).to.equal(2)
+    expect(result.domainCount).to.equal(2)
+
+    const written = await readFile(join(root, '_index.html'), 'utf8')
+    expect(validateHtmlIndex(written).ok).to.equal(true)
+    expect(written).to.contain('format="html"')
+    expect(written).to.contain('format="markdown"')
+    expect(written).to.contain('project="demo"')
+  })
+
+  it('groups topics by first path segment and sorts deterministically', async () => {
+    await write(root, 'zeta/topic.html', htmlTopic('zeta/topic', 'Z', 'z.'))
+    await write(root, 'alpha/two.html', htmlTopic('alpha/two', 'Two', 't.'))
+    await write(root, 'alpha/one.html', htmlTopic('alpha/one', 'One', 'o.'))
+
+    const result = await generateContextTreeIndex({contextTreeRoot: root, projectName: 'demo'})
+    expect(result.ok).to.equal(true)
+    if (!result.ok) return
+    expect(result.domainCount).to.equal(2)
+
+    const written = await readFile(join(root, '_index.html'), 'utf8')
+    // alpha domain section before zeta
+    expect(written.indexOf('name="alpha"')).to.be.lessThan(written.indexOf('name="zeta"'))
+    // within alpha, one before two (sorted by path)
+    expect(written.indexOf('alpha/one.html')).to.be.lessThan(written.indexOf('alpha/two.html'))
+  })
+
+  it('extracts summary and tags into the entry', async () => {
+    await write(root, 'features/x.html', htmlTopic('features/x', 'X', 'A summary line.', 'a,b'))
+    const result = await generateContextTreeIndex({contextTreeRoot: root, projectName: 'demo'})
+    expect(result.ok).to.equal(true)
+
+    const written = await readFile(join(root, '_index.html'), 'utf8')
+    expect(written).to.contain('A summary line.')
+    expect(written).to.contain('tags="a,b"')
+  })
+
+  it('handles a topic with no summary without crashing', async () => {
+    await write(root, 'features/y.html', '<bv-topic path="features/y" title="Y"><bv-reason>r</bv-reason></bv-topic>')
+    const result = await generateContextTreeIndex({contextTreeRoot: root, projectName: 'demo'})
+    expect(result.ok).to.equal(true)
+    if (!result.ok) return
+    expect(result.topicCount).to.equal(1)
+  })
+
+  it('excludes derived artifacts from the index', async () => {
+    await write(root, 'features/real.html', htmlTopic('features/real', 'Real', 'real.'))
+    await write(root, '_index.html', '<bv-index project="stale" generatedat="2020-01-01T00:00:00.000Z"></bv-index>')
+    await write(root, '_manifest.json', '{}')
+    await write(root, '_index.md', '# stale legacy index')
+
+    const result = await generateContextTreeIndex({contextTreeRoot: root, projectName: 'demo'})
+    expect(result.ok).to.equal(true)
+    if (!result.ok) return
+    expect(result.topicCount).to.equal(1)
+  })
+
+  it('excludes the _archived/ subtree', async () => {
+    await write(root, 'features/live.html', htmlTopic('features/live', 'Live', 'live.'))
+    await write(root, '_archived/old/dead.html', htmlTopic('old/dead', 'Dead', 'dead.'))
+
+    const result = await generateContextTreeIndex({contextTreeRoot: root, projectName: 'demo'})
+    expect(result.ok).to.equal(true)
+    if (!result.ok) return
+    expect(result.topicCount).to.equal(1)
+  })
+
+  it('writes a valid empty index for a tree with no topics', async () => {
+    const result = await generateContextTreeIndex({contextTreeRoot: root, projectName: 'empty'})
+    expect(result.ok).to.equal(true)
+    if (!result.ok) return
+    expect(result.topicCount).to.equal(0)
+    expect(result.domainCount).to.equal(0)
+
+    const written = await readFile(join(root, '_index.html'), 'utf8')
+    expect(validateHtmlIndex(written).ok).to.equal(true)
+    expect(written).to.contain('topiccount="0"')
+  })
+
+  it('produces deterministic output (stable except generatedat)', async () => {
+    await write(root, 'features/auth.html', htmlTopic('features/auth', 'Auth', 'jwt.'))
+    await generateContextTreeIndex({contextTreeRoot: root, projectName: 'demo'})
+    const first = await readFile(join(root, '_index.html'), 'utf8')
+    await generateContextTreeIndex({contextTreeRoot: root, projectName: 'demo'})
+    const second = await readFile(join(root, '_index.html'), 'utf8')
+
+    expect(stripGeneratedAt(first)).to.equal(stripGeneratedAt(second))
+  })
+
+  it('escapes special characters in attributes and summary text', async () => {
+    await write(
+      root,
+      'features/esc.html',
+      htmlTopic('features/esc', 'Title &amp; &lt;tag&gt;', 'Summary with &amp; ampersand.'),
+    )
+    const result = await generateContextTreeIndex({contextTreeRoot: root, projectName: 'demo'})
+    expect(result.ok).to.equal(true)
+
+    const written = await readFile(join(root, '_index.html'), 'utf8')
+    // The generated index is itself parseable / valid — escaping held.
+    expect(validateHtmlIndex(written).ok).to.equal(true)
+  })
+})


### PR DESCRIPTION
## Summary

Generates and auto-maintains `_index.html` — the navigation index over the context tree, built from the ENG-2860 vocabulary. Task 2 of M6 (context-tree index).

**Stacked on #682 (ENG-2860).** Review/merge that first; this PR's base auto-retargets to `proj/byterover-tool-mode` once it lands.

## What's new

- **`IndexGenerator`** (`generateContextTreeIndex`) — walks the context tree, aggregates the `title`/`summary`/`tags` the agent already authored on each topic (HTML `<bv-topic>` attrs + legacy `.md` frontmatter), groups by domain, and atomically writes a `<bv-index>` document. Deterministic full regeneration — output is byte-stable except `generatedat`, so CoGit diffs stay clean. Self-checks via `validateHtmlIndex` before the write. No LLM, no provider.
- **Regeneration hooks** — best-effort, never fail the triggering operation:
  - `curate-html-direct` (daemon, MCP path)
  - CLI `continueSession` curate
  - `dream-finalize` (archived topics drop out of the index)
- **`brv index rebuild`** — manual full regen for first-time adoption on an existing tree, recovery after a best-effort regen failed, or post-manual-edit. In-process, no daemon required.
- `escapeHtmlAttributeValue` exported from `html-writer` for reuse.

## Design notes

- **Full regen, not incremental** — the index is a pure function of the tree, so a full rebuild is trivially correct. Sub-second for typical trees; incremental (manifest-delta) is a deferred optimization.
- **Best-effort hooks** — the curate/dream-finalize that triggered regeneration has already succeeded; a failed index refresh is logged and swallowed. `brv index rebuild` recovers a stale index.
- **Pure filesystem** — the generator needs no daemon/LLM/transport, so all three hook sites and the CLI command call it directly. No new task type.
- Mixed trees supported — `.html` topics (regex-extract the `<bv-topic>` open tag) and legacy `.md` topics (frontmatter). `_archived/` and derived artifacts excluded.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] Unit tests — generator: mixed html/md tree, domain grouping + deterministic sort, summary/tags extraction, no-summary topic, derived-artifact exclusion, `_archived/` exclusion, empty tree, determinism, attribute escaping
- [x] Full suite green (8253 passing)
- [x] **E2E auto-test** (`local-auto-test/context-tree-index-e2e/`, 3/3 passing against the built CLI): `brv index rebuild` builds a valid index; a tool-mode curate regenerates it with the new topic; `_index.html` is a derived artifact and never self-referenced.

## Related

Task 2 of M6. Built on #682 (ENG-2860 — the vocabulary). FE rendering is a separate handoff spec, not part of this PR.