### PR TITLE
refactor: [ENG-2880] drop legacy flags from brv curate / brv query

### DIFF
--- a/src/oclif/commands/curate/index.ts
+++ b/src/oclif/commands/curate/index.ts
@@ -3,7 +3,7 @@ import {Args, Command, Flags} from '@oclif/core'
 import {continueSession, kickoffSession, resolveProjectRoot} from '../../lib/curate-session.js'
 import {type DaemonClientOptions} from '../../lib/daemon-client.js'
 import {writeJsonResponse} from '../../lib/json-response.js'
-import {assertNoRemovedFlags, CURATE_REMOVED_FLAGS} from '../../lib/removed-flags.js'
+import {argvRequestsJsonFormat, CURATE_REMOVED_FLAGS, findRemovedFlagMessage} from '../../lib/removed-flags.js'
 
 /** Parsed flags type */
 type CurateFlags = {
@@ -77,7 +77,26 @@ Bad examples:
     // provider on this command. (The env-var `BRV_CURATE_TOOL_MODE`
     // scaffolding from M1 is removed in M3 — presence/absence is a
     // no-op now.)
-    assertNoRemovedFlags(process.argv.slice(2), CURATE_REMOVED_FLAGS)
+    const rawArgv = process.argv.slice(2)
+    const removedFlagMessage = findRemovedFlagMessage(rawArgv, CURATE_REMOVED_FLAGS)
+    if (removedFlagMessage) {
+      // Surface as a JSON envelope when the caller asked for JSON — agents
+      // parsing stdout-JSON treat unexpected stderr lines as a hard crash.
+      if (argvRequestsJsonFormat(rawArgv)) {
+        this.emitToolModeEnvelope(
+          {
+            errors: [{kind: 'removed-flag', message: removedFlagMessage}],
+            ok: false,
+            status: 'failed',
+          },
+          'json',
+        )
+        return
+      }
+
+      this.error(removedFlagMessage, {exit: 1})
+    }
+
     const {args, flags: rawFlags} = await this.parse(Curate)
     const flags: CurateFlags = {
       format: rawFlags.format === 'json' ? 'json' : rawFlags.format === 'text' ? 'text' : undefined,

--- a/src/oclif/commands/curate/index.ts
+++ b/src/oclif/commands/curate/index.ts
@@ -3,18 +3,14 @@ import {Args, Command, Flags} from '@oclif/core'
 import {continueSession, kickoffSession, resolveProjectRoot} from '../../lib/curate-session.js'
 import {type DaemonClientOptions} from '../../lib/daemon-client.js'
 import {writeJsonResponse} from '../../lib/json-response.js'
-import {DEFAULT_TIMEOUT_SECONDS, MAX_TIMEOUT_SECONDS, MIN_TIMEOUT_SECONDS} from '../../lib/task-client.js'
+import {assertNoRemovedFlags, CURATE_REMOVED_FLAGS} from '../../lib/removed-flags.js'
 
 /** Parsed flags type */
 type CurateFlags = {
-  detach?: boolean
-  files?: string[]
-  folder?: string[]
   format?: 'json' | 'text'
   overwrite?: boolean
   response?: string
   session?: string
-  timeout?: number
 }
 
 export default class Curate extends Command {
@@ -43,20 +39,6 @@ Bad examples:
     '<%= config.bin %> <%= command.id %> --session <id> --response "..." --overwrite --format json',
   ]
   public static flags = {
-    detach: Flags.boolean({
-      default: false,
-      description: 'Queue task and exit without waiting for completion',
-    }),
-    files: Flags.string({
-      char: 'f',
-      description: 'Include specific file paths for critical context (max 5 files)',
-      multiple: true,
-    }),
-    folder: Flags.string({
-      char: 'd',
-      description: 'Folder path to pack and analyze (triggers folder pack flow)',
-      multiple: true,
-    }),
     format: Flags.string({
       default: 'text',
       description: 'Output format (text or json)',
@@ -83,12 +65,6 @@ Bad examples:
       // --session implies the continuation step.
       description: 'Session id to continue (returned by a prior kickoff)',
     }),
-    timeout: Flags.integer({
-      default: DEFAULT_TIMEOUT_SECONDS,
-      description: 'Maximum seconds to wait for task completion',
-      max: MAX_TIMEOUT_SECONDS,
-      min: MIN_TIMEOUT_SECONDS,
-    }),
   }
 
   protected getDaemonClientOptions(): DaemonClientOptions {
@@ -101,16 +77,13 @@ Bad examples:
     // provider on this command. (The env-var `BRV_CURATE_TOOL_MODE`
     // scaffolding from M1 is removed in M3 — presence/absence is a
     // no-op now.)
+    assertNoRemovedFlags(process.argv.slice(2), CURATE_REMOVED_FLAGS)
     const {args, flags: rawFlags} = await this.parse(Curate)
     const flags: CurateFlags = {
-      detach: rawFlags.detach,
-      files: rawFlags.files,
-      folder: rawFlags.folder,
       format: rawFlags.format === 'json' ? 'json' : rawFlags.format === 'text' ? 'text' : undefined,
       overwrite: rawFlags.overwrite,
       response: rawFlags.response,
       session: rawFlags.session,
-      timeout: rawFlags.timeout,
     }
     const format: 'json' | 'text' = flags.format ?? 'text'
 

--- a/src/oclif/commands/query.ts
+++ b/src/oclif/commands/query.ts
@@ -9,7 +9,7 @@ import {
 } from '../lib/daemon-client.js'
 import {writeJsonResponse} from '../lib/json-response.js'
 import {type QueryToolModeEnvelope, runRetrieval} from '../lib/query-retrieval.js'
-import {DEFAULT_TIMEOUT_SECONDS, MAX_TIMEOUT_SECONDS, MIN_TIMEOUT_SECONDS} from '../lib/task-client.js'
+import {assertNoRemovedFlags, QUERY_REMOVED_FLAGS} from '../lib/removed-flags.js'
 
 /** Default match cap. Locked to 10 (matches `brv search`). */
 const DEFAULT_QUERY_LIMIT = 10
@@ -51,12 +51,6 @@ Bad:
       max: MAX_QUERY_LIMIT,
       min: MIN_QUERY_LIMIT,
     }),
-    timeout: Flags.integer({
-      default: DEFAULT_TIMEOUT_SECONDS,
-      description: 'Maximum seconds to wait for task completion',
-      max: MAX_TIMEOUT_SECONDS,
-      min: MIN_TIMEOUT_SECONDS,
-    }),
   }
   public static strict = false
 
@@ -69,12 +63,10 @@ Bad:
     // retrieval + render; no LLM. ByteRover never invokes a provider
     // on this command. (The env-var `BRV_QUERY_TOOL_MODE` scaffolding
     // from M2 is removed in M3 — presence/absence is a no-op now.)
+    assertNoRemovedFlags(process.argv.slice(2), QUERY_REMOVED_FLAGS)
     const {args, flags: rawFlags} = await this.parse(Query)
     const format: 'json' | 'text' = rawFlags.format === 'json' ? 'json' : 'text'
     const limit = rawFlags.limit ?? DEFAULT_QUERY_LIMIT
-    // `--timeout` is deprecated: completion liveness is heartbeat-driven
-    // (see waitForTaskCompletion). The flag still parses for back-compat
-    // but no longer bounds the wait.
 
     if (args.query.trim().length === 0) {
       if (format === 'json') {

--- a/src/oclif/commands/query.ts
+++ b/src/oclif/commands/query.ts
@@ -9,7 +9,7 @@ import {
 } from '../lib/daemon-client.js'
 import {writeJsonResponse} from '../lib/json-response.js'
 import {type QueryToolModeEnvelope, runRetrieval} from '../lib/query-retrieval.js'
-import {assertNoRemovedFlags, QUERY_REMOVED_FLAGS} from '../lib/removed-flags.js'
+import {argvRequestsJsonFormat, findRemovedFlagMessage, QUERY_REMOVED_FLAGS} from '../lib/removed-flags.js'
 
 /** Default match cap. Locked to 10 (matches `brv search`). */
 const DEFAULT_QUERY_LIMIT = 10
@@ -63,7 +63,21 @@ Bad:
     // retrieval + render; no LLM. ByteRover never invokes a provider
     // on this command. (The env-var `BRV_QUERY_TOOL_MODE` scaffolding
     // from M2 is removed in M3 — presence/absence is a no-op now.)
-    assertNoRemovedFlags(process.argv.slice(2), QUERY_REMOVED_FLAGS)
+    const rawArgv = process.argv.slice(2)
+    const removedFlagMessage = findRemovedFlagMessage(rawArgv, QUERY_REMOVED_FLAGS)
+    if (removedFlagMessage) {
+      if (argvRequestsJsonFormat(rawArgv)) {
+        writeJsonResponse({
+          command: 'query',
+          data: {error: removedFlagMessage, status: 'error'},
+          success: false,
+        })
+        return
+      }
+
+      this.error(removedFlagMessage, {exit: 1})
+    }
+
     const {args, flags: rawFlags} = await this.parse(Query)
     const format: 'json' | 'text' = rawFlags.format === 'json' ? 'json' : 'text'
     const limit = rawFlags.limit ?? DEFAULT_QUERY_LIMIT

--- a/src/oclif/lib/removed-flags.ts
+++ b/src/oclif/lib/removed-flags.ts
@@ -5,12 +5,18 @@
  *
  * Usage in a command's `run()`:
  *
- *   assertNoRemovedFlags(process.argv.slice(2), CURATE_REMOVED_FLAGS)
- *   const {flags} = await this.parse(MyCommand)
+ *   const removedMsg = findRemovedFlagMessage(process.argv.slice(2), CURATE_REMOVED_FLAGS)
+ *   if (removedMsg) {
+ *     // Emit JSON envelope when the caller asked for --format json,
+ *     // otherwise fall through to this.error(removedMsg).
+ *   }
  *
- * The scan runs before `this.parse()` so the user sees the migration text
- * regardless of whether the command is strict-parse (oclif's default) or
- * permissive (`public static strict = false`).
+ * The scan runs before `this.parse()` so the user sees the migration
+ * text regardless of strict / permissive parse mode. `--` is honored as
+ * a hard terminator (anything after is treated as positional content,
+ * not flags). Unquoted-positional collisions on permissive-parse
+ * commands (e.g. `brv query what does --timeout do`) are an accepted
+ * limitation — quote the query or pass `--` to disambiguate.
  */
 
 export type RemovedFlag = {
@@ -24,20 +30,38 @@ const formatRejection = (token: string, migration: string): string =>
   `Flag '${token}' was removed in tool-mode. ${migration}`
 
 /**
- * Scan an argv slice for any removed flag and throw with a migration
- * message on the first match. Recognises both `--flag value` and
- * `--flag=value` forms.
+ * Scan an argv slice for any removed flag. Returns the migration
+ * message on the first hit, or `undefined` when none of the removed
+ * flags appear. Recognises `--flag value`, `--flag=value`, and short
+ * aliases. Stops scanning at the standard `--` terminator.
  */
-export function assertNoRemovedFlags(argv: string[], removed: RemovedFlag[]): void {
-  for (const {flags, migration} of removed) {
-    for (const token of flags) {
-      const equalsPrefix = `${token}=`
-      const hit = argv.find((a) => a === token || a.startsWith(equalsPrefix))
-      if (hit) {
-        throw new Error(formatRejection(token, migration))
-      }
+export function findRemovedFlagMessage(argv: string[], removed: RemovedFlag[]): string | undefined {
+  for (const token of argv) {
+    if (token === '--') return undefined
+    for (const {flags, migration} of removed) {
+      const matched = flags.find((f) => token === f || token.startsWith(`${f}=`))
+      if (matched) return formatRejection(matched, migration)
     }
   }
+
+  return undefined
+}
+
+/**
+ * Inspect argv for the `--format json` selector so the caller can
+ * choose between emitting a JSON error envelope and surfacing a plain
+ * `this.error(...)` message. Mirrors the recognised forms
+ * (`--format json` and `--format=json`).
+ */
+export function argvRequestsJsonFormat(argv: string[]): boolean {
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i]
+    if (token === '--') return false
+    if (token === '--format' && argv[i + 1] === 'json') return true
+    if (token === '--format=json') return true
+  }
+
+  return false
 }
 
 /**

--- a/src/oclif/lib/removed-flags.ts
+++ b/src/oclif/lib/removed-flags.ts
@@ -1,0 +1,82 @@
+/**
+ * Helper for rejecting flags that have been removed from a CLI command,
+ * with a clear migration message instead of oclif's default `Nonexistent
+ * flag` error.
+ *
+ * Usage in a command's `run()`:
+ *
+ *   assertNoRemovedFlags(process.argv.slice(2), CURATE_REMOVED_FLAGS)
+ *   const {flags} = await this.parse(MyCommand)
+ *
+ * The scan runs before `this.parse()` so the user sees the migration text
+ * regardless of whether the command is strict-parse (oclif's default) or
+ * permissive (`public static strict = false`).
+ */
+
+export type RemovedFlag = {
+  /** Flag tokens to detect (long form first, then any short aliases). */
+  flags: string[]
+  /** One-sentence guidance the user should follow instead. */
+  migration: string
+}
+
+const formatRejection = (token: string, migration: string): string =>
+  `Flag '${token}' was removed in tool-mode. ${migration}`
+
+/**
+ * Scan an argv slice for any removed flag and throw with a migration
+ * message on the first match. Recognises both `--flag value` and
+ * `--flag=value` forms.
+ */
+export function assertNoRemovedFlags(argv: string[], removed: RemovedFlag[]): void {
+  for (const {flags, migration} of removed) {
+    for (const token of flags) {
+      const equalsPrefix = `${token}=`
+      const hit = argv.find((a) => a === token || a.startsWith(equalsPrefix))
+      if (hit) {
+        throw new Error(formatRejection(token, migration))
+      }
+    }
+  }
+}
+
+/**
+ * Flags removed from `brv curate` as of the tool-mode cleanup
+ * (see Linear ENG-2880). All four were no-ops in tool-mode — kept as
+ * dead declarations until the cleanup; surfaced here so any agent or
+ * script still passing them gets a clear migration message.
+ */
+export const CURATE_REMOVED_FLAGS: RemovedFlag[] = [
+  {
+    flags: ['--folder', '-d'],
+    migration:
+      'Pack the folder content into the <bv-topic> HTML directly before calling brv curate.',
+  },
+  {
+    flags: ['--files', '-f'],
+    migration:
+      'Read the files and inline the relevant content into the <bv-topic> HTML directly.',
+  },
+  {
+    flags: ['--detach'],
+    migration:
+      'Tool-mode curate runs as two cheap RPCs (kickoff + continuation); --detach is unnecessary.',
+  },
+  {
+    flags: ['--timeout'],
+    migration:
+      'Tool-mode curate has no long-running daemon LLM call; --timeout is unnecessary.',
+  },
+]
+
+/**
+ * Flags removed from `brv query` as of the tool-mode cleanup
+ * (see Linear ENG-2880).
+ */
+export const QUERY_REMOVED_FLAGS: RemovedFlag[] = [
+  {
+    flags: ['--timeout'],
+    migration:
+      'Tool-mode query is a deterministic local BM25 lookup; --timeout is unnecessary.',
+  },
+]

--- a/src/server/templates/sections/brv-instructions.md
+++ b/src/server/templates/sections/brv-instructions.md
@@ -55,20 +55,14 @@ brv query "What do I need to know about [relevant topic]?"
 - Found a bug root cause or fix pattern
 
 ```bash
-# CONTEXT argument MUST come BEFORE flags
-# Max 5 files per curate with -f flag
-brv curate "Specific insight with details" -f path/to/file.ts
-brv curate "Multi-file insight" -f file1.ts -f file2.ts
-
-# For folder pack (analyze entire folder), use -d or --folder flag
-brv curate "Analyze this module" -d path/to/folder/
-brv curate --folder src/auth/  # folder-only mode
+# CONTEXT argument is the kickoff intent — author the topic HTML on the continuation
+brv curate "Specific insight with details" --format json
+# → parse the response, author <bv-topic> HTML inlining any file content you need
+brv curate --session <id> --response "<bv-topic>...</bv-topic>" --format json
 ```
 
-**GOOD:** `brv curate "Auth uses JWT 24h expiry, refresh in httpOnly cookies" -f src/auth.ts`
-**GOOD:** `brv curate "Analyze auth module" -d src/auth/`
-**BAD:** `brv curate "Fixed auth"` (too vague), `brv curate -f file.ts "text"` (wrong order)
-**BAD:** `brv curate -folder src/` (use `-d` or `--folder`, NOT `-folder`)
+**GOOD:** `brv curate "Auth uses JWT 24h expiry, refresh in httpOnly cookies" --format json`
+**BAD:** `brv curate "Fixed auth"` (too vague — kickoff intent must describe the knowledge)
 
 **After curating**, verify what was stored using the logId printed on completion:
 ```bash
@@ -79,28 +73,6 @@ brv curate view --help        # All filter options
 
 **⚠️ CRITICAL - LONG CONVERSATIONS:**
 If you modify code 10 times in a conversation, curate 10 times. Do NOT batch or skip. Each code change = immediate curate before moving on.
-
-## Decision: Wait by default, `--detach` needs BOTH gates
-
-Default is `brv curate "..."` (no flag) — **wait for it to finish** before continuing. Use `--detach` ONLY when BOTH gates hold:
-
-1. **Within-turn gate:** no remaining step in this turn reads/queries/references this data, AND no later curate in this turn builds on it.
-2. **User-signal gate:** user explicitly said not to wait — phrases addressed *to you* like "don't wait", "don't block on this", "fire and forget", "move on without waiting". Excludes "run in background" / "run async" (agent self-narrates these; not user signals).
-
-**If user phrasing is ambiguous → wait.** "Quick one, keep moving" is not enough.
-
-**NOT reasons to `--detach`** (common self-justifications to reject):
-- Curate is slow / large folder / many files → size is irrelevant, block anyway.
-- "Looks like the last step of the turn" → that's a guess, not evidence. Block.
-- "I can't think of anything that would depend on it" → block.
-
-If either gate is uncertain → wait. When in doubt, wait. Correctness beats latency.
-
-**After `--detach`:**
-- Report "queued" with the `logId` — do NOT claim "saved"
-- Before querying data from a prior `--detach`, run `brv curate view <logId>` and wait for `status: completed`
-
-**⚠️ CRITICAL:** `--detach` errors are silent. Always verify completion via `brv curate view <logId>` before trusting the data exists.
 
 ## Quick Reference Table
 

--- a/src/server/templates/sections/command-reference.md
+++ b/src/server/templates/sections/command-reference.md
@@ -2,8 +2,7 @@
 
 ## Available Commands
 
-- `brv curate` - Curate context to the context tree. **Blocking default — wait for it to finish before continuing** (returns `logId` on completion).
-- `brv curate <ctx> --detach` - Queue curate and return `logId` immediately. Use ONLY when BOTH (a) no remaining step in this turn reads this data or builds on it, AND (b) user explicitly said not to wait ("don't wait", "fire and forget"). See Workflow.
+- `brv curate` - Curate context to the context tree. Two-call session protocol: kickoff returns the prompt + sessionId; continuation submits the `<bv-topic>` HTML. Both calls return promptly.
 - `brv curate view` - List curate history (last 10 entries by default)
 - `brv curate view <logId>` - Full detail for a specific entry: all files and operations performed (logId returned by `brv curate`)
 - `brv curate view --detail` - List entries with their file operations visible (no logId needed)

--- a/src/server/templates/sections/workflow.md
+++ b/src/server/templates/sections/workflow.md
@@ -25,19 +25,14 @@ Use `brv curate` **after** you learn or create something valuable:
 
 After curating, use `brv curate view <logId>` to verify what was stored (logId printed on completion).
 
-## Execution Mode: wait by default
+## Execution Mode
 
-Default is `brv curate "..."` (no flag) — **wait for it to finish** before continuing. Any follow-up (query, search, read, or a later curate that builds on this one) may depend on the curated data being live.
+Curate is a two-call session protocol:
 
-Use `--detach` only when BOTH are true:
-1. No remaining step in this turn reads/queries/references this data, AND no later curate in this turn builds on it.
-2. User explicitly said not to wait — addressed to the agent, e.g. "don't wait", "don't block on this", "fire and forget", "move on without waiting". Excludes "run in background" / "run async" (agent self-narrates these).
+1. **Kickoff** — `brv curate "<intent>" --format json` returns the next prompt + `sessionId`. Both kickoff and continuation are short — wait for each.
+2. **Continuation** — `brv curate --session <id> --response "<bv-topic>...</bv-topic>" --format json` writes the topic and returns `status: done` with the file path, or `status: needs-llm-step` with `step: correct-html` if validation failed.
 
-If user phrasing is ambiguous → wait. If either condition is uncertain → wait.
-
-Size/duration is NOT a reason to `--detach`. "Looks like the last step" is NOT a reason — it's a guess.
-
-After `--detach`, report "queued" (not "saved") and save the `logId`. Before any later read of that data, run `brv curate view <logId>` and wait for `status: completed`. Detach errors are silent.
+Any follow-up step (query, search, read, or a later curate that builds on this one) needs the just-curated topic live in the context tree — finish the continuation before moving on.
 
 ## Context Tree Guideline
 

--- a/src/server/templates/skill/SKILL.md
+++ b/src/server/templates/skill/SKILL.md
@@ -99,43 +99,16 @@ brv search "auth" --format json
 brv curate "Auth uses JWT with 24h expiry. Tokens stored in httpOnly cookies via authMiddleware.ts"
 ```
 
-**Include source files** (max 5, project-scoped only):
+To include file context, read the file yourself and inline the relevant content into the `<bv-topic>` HTML on the continuation step — see "Session protocol" below.
+
+**Execution mode**
+
+Curate runs as two cheap RPCs (kickoff + continuation) — both return promptly. Wait for each to finish before continuing. Any follow-up step (query, search, read, review, next curate that builds on this one) needs the just-curated data live in the context tree.
 
 ```bash
-brv curate "Authentication middleware details" -f src/middleware/auth.ts
+brv curate "..."                 # kickoff — returns the next prompt
+brv curate --session <id> --response "..." --format json   # continuation
 ```
-
-**Execution mode: wait by default**
-
-Default is **blocking** — call `brv curate "..."` with no flag and wait for it to finish before continuing. Any follow-up step (query, search, read, review, next curate that builds on this one) may depend on the just-curated data being live in the context tree.
-
-```bash
-brv curate "..."                 # DEFAULT — wait until done, then continue
-brv curate "..." --detach        # Only when BOTH conditions below hold
-```
-
-**Use `--detach` only when BOTH of the following are true:**
-
-1. No remaining step in this turn will query, search, read, or reference this curated data, AND no later curate in this turn builds on it.
-2. The user explicitly said not to wait — phrases addressed *to you* like "don't wait", "don't block on this", "fire and forget", "move on without waiting". The phrase must be something the user says to the agent, not something the agent would narrate about itself. This rules out "run in background" and "run async" as triggers — agents use those phrases to self-narrate at least as often as users use them to instruct, which creates a mirror-priming loop.
-
-**If the user's phrasing is ambiguous, wait.** Detach requires an unambiguous signal. "Quick one, keep moving" is not enough.
-
-If either condition is uncertain, do not `--detach`. Wait.
-
-**Size/duration is NOT a reason to `--detach`.** A slow curate whose output the next step reads must still block. **"Looks like the last step" is also NOT a reason** — that is a guess, not evidence.
-
-**Reporting:**
-- Blocking (default) → "Saved X"
-- `--detach` → "Queued X (log: `<logId>`)" — do NOT claim "saved" until verified
-
-**Cross-turn hygiene for detached curates (CRITICAL):** before any later tool call reads data a previous `--detach` submitted, run:
-
-```bash
-brv curate view <logId> --format json
-```
-
-Only proceed when `status: completed`. If `processing`, wait or tell the user. If `error`/`cancelled`, report and consider re-curate. `--detach` errors are silent — verification before trust is mandatory.
 
 **Session protocol**
 
@@ -174,7 +147,7 @@ The session protocol is request → response → request, all via `brv curate` i
        3. **Replace (data-destructive)**: re-emit with `--overwrite` carrying ONLY your new content. ONLY do this when the user has explicitly told you to replace prior content — it clobbers facts the user previously curated.
    - `failed` → surface `data.errors[].message` to the user. If `kind: "retry-cap-exceeded"`, your HTML still didn't validate after 3 corrections — ask the user to clarify intent and start a fresh kickoff.
 
-**Bounds:** at most 4 round-trips per session (1 generate + 3 corrections). Each `brv curate` invocation is short-lived — `--detach`, `-f` files, and `--folder` flags are parsed but not supported by the current session protocol (v1 is INSERT-only). Session state lives in `.brv/sessions/curate-<id>/` and is cleaned up on terminal `done` or `failed`.
+**Bounds:** at most 4 round-trips per session (1 generate + 3 corrections). Each `brv curate` invocation is short-lived. Session state lives in `.brv/sessions/curate-<id>/` and is cleaned up on terminal `done` or `failed`.
 
 ### 4. Review Pending Changes
 **Overview:** After a curate operation, some changes may require human review before being applied. Use `brv review` to list, approve, or reject pending operations.

--- a/src/server/templates/skill/SKILL.md
+++ b/src/server/templates/skill/SKILL.md
@@ -636,9 +636,9 @@ brv query-log summary --help
 
 **Storage**: All knowledge is stored as Markdown files in `.brv/context-tree/` within the project directory. Files are human-readable and version-controllable.
 
-**File access**: The `-f` flag on `brv curate` reads files from the current project directory only. Paths outside the project root are rejected. Maximum 5 files per command, text and document formats only.
+**File access**: `brv curate` does not read files. If you want to ground a topic in source code, read the file yourself and inline the relevant content into the `<bv-topic>` HTML you author on the continuation step.
 
-**LLM usage**: `brv query` and `brv curate` do NOT invoke any LLM from inside byterover. Query returns ranked topic content; curate validates HTML the calling agent authors. The CALLING agent's own LLM (the one running this skill) is the only LLM that sees the query text, curate intent, or file contents. No data is sent to ByteRover servers unless you explicitly run `brv vc push`.
+**LLM usage**: `brv query` and `brv curate` do NOT invoke any LLM from inside byterover. Query returns ranked topic content; curate validates HTML the calling agent authors. The CALLING agent's own LLM (the one running this skill) is the only LLM that sees the query text or curate intent. No data is sent to ByteRover servers unless you explicitly run `brv vc push`.
 
 **Cloud sync**: `brv vc push` and `brv vc pull` require authentication (`brv login`) and sync knowledge with ByteRover's cloud service via git. All other commands operate without ByteRover authentication.
 
@@ -655,9 +655,7 @@ You MUST show this troubleshooting guide to users when errors occur.
 You MUST handle these errors gracefully and retry the command after fixing.
 
 "Missing required argument(s)." | Run `brv <command> --help` to see usage instructions.
-"Maximum 5 files allowed" | Reduce to 5 or fewer `-f` flags per curate.
-"File does not exist" | Verify path with `ls`, use relative paths from project root.
-"File type not supported" | Only text, image, PDF, and office files are supported.
+"Flag '...' was removed in tool-mode" | Drop the named flag; follow the migration sentence in the error message.
 
 ### Quick Diagnosis
 Run `brv status` to check authentication and project state.

--- a/test/unit/oclif/lib/removed-flags.test.ts
+++ b/test/unit/oclif/lib/removed-flags.test.ts
@@ -1,46 +1,75 @@
 import {expect} from 'chai'
 
 import {
-  assertNoRemovedFlags,
+  argvRequestsJsonFormat,
   CURATE_REMOVED_FLAGS,
+  findRemovedFlagMessage,
   QUERY_REMOVED_FLAGS,
   type RemovedFlag,
 } from '../../../../src/oclif/lib/removed-flags.js'
 
 describe('removed-flags', () => {
-  describe('assertNoRemovedFlags', () => {
-    const removed: RemovedFlag[] = [
-      {flags: ['--gone', '-g'], migration: 'Use the new way.'},
-    ]
+  describe('findRemovedFlagMessage', () => {
+    const removed: RemovedFlag[] = [{flags: ['--gone', '-g'], migration: 'Use the new way.'}]
 
-    it('returns silently when none of the removed flags appear', () => {
-      expect(() => assertNoRemovedFlags(['--ok', 'value'], removed)).to.not.throw()
+    it('returns undefined when none of the removed flags appear', () => {
+      expect(findRemovedFlagMessage(['--ok', 'value'], removed)).to.equal(undefined)
     })
 
-    it('throws with the migration text when the long flag appears', () => {
-      expect(() => assertNoRemovedFlags(['--gone'], removed)).to.throw(
-        /Flag '--gone' was removed in tool-mode\. Use the new way\./,
+    it('returns the migration text when the long flag appears', () => {
+      expect(findRemovedFlagMessage(['--gone'], removed)).to.equal(
+        "Flag '--gone' was removed in tool-mode. Use the new way.",
       )
     })
 
-    it('throws when the short alias appears', () => {
-      expect(() => assertNoRemovedFlags(['-g', 'x'], removed)).to.throw(
-        /Flag '-g' was removed in tool-mode/,
+    it('returns the migration text when the short alias appears', () => {
+      expect(findRemovedFlagMessage(['-g', 'x'], removed)).to.equal(
+        "Flag '-g' was removed in tool-mode. Use the new way.",
       )
     })
 
-    it('throws when the flag is written in --flag=value form', () => {
-      expect(() => assertNoRemovedFlags(['--gone=oops'], removed)).to.throw(
-        /Flag '--gone' was removed in tool-mode/,
+    it('returns the migration text for --flag=value form', () => {
+      expect(findRemovedFlagMessage(['--gone=oops'], removed)).to.equal(
+        "Flag '--gone' was removed in tool-mode. Use the new way.",
       )
     })
 
-    it('throws on the first match and does not check the rest', () => {
+    it('reports the first match and short-circuits', () => {
       const multi: RemovedFlag[] = [
         {flags: ['--first'], migration: 'first migration'},
         {flags: ['--second'], migration: 'second migration'},
       ]
-      expect(() => assertNoRemovedFlags(['--second', '--first'], multi)).to.throw(/first migration/)
+      expect(findRemovedFlagMessage(['--second', '--first'], multi)).to.include('second migration')
+    })
+
+    it('stops scanning at the `--` terminator (positional content after the terminator is not scanned)', () => {
+      expect(findRemovedFlagMessage(['--', '--gone'], removed)).to.equal(undefined)
+    })
+
+    it('still matches flags that appear BEFORE `--`', () => {
+      expect(findRemovedFlagMessage(['--gone', '--', '--ignored'], removed)).to.include('Use the new way')
+    })
+  })
+
+  describe('argvRequestsJsonFormat', () => {
+    it('detects `--format json`', () => {
+      expect(argvRequestsJsonFormat(['--format', 'json'])).to.equal(true)
+    })
+
+    it('detects `--format=json`', () => {
+      expect(argvRequestsJsonFormat(['--format=json'])).to.equal(true)
+    })
+
+    it('returns false for `--format text`', () => {
+      expect(argvRequestsJsonFormat(['--format', 'text'])).to.equal(false)
+    })
+
+    it('returns false when --format is absent', () => {
+      expect(argvRequestsJsonFormat(['--limit', '5'])).to.equal(false)
+    })
+
+    it('stops at the `--` terminator (does not treat post-terminator tokens as flags)', () => {
+      expect(argvRequestsJsonFormat(['--', '--format', 'json'])).to.equal(false)
     })
   })
 

--- a/test/unit/oclif/lib/removed-flags.test.ts
+++ b/test/unit/oclif/lib/removed-flags.test.ts
@@ -1,0 +1,67 @@
+import {expect} from 'chai'
+
+import {
+  assertNoRemovedFlags,
+  CURATE_REMOVED_FLAGS,
+  QUERY_REMOVED_FLAGS,
+  type RemovedFlag,
+} from '../../../../src/oclif/lib/removed-flags.js'
+
+describe('removed-flags', () => {
+  describe('assertNoRemovedFlags', () => {
+    const removed: RemovedFlag[] = [
+      {flags: ['--gone', '-g'], migration: 'Use the new way.'},
+    ]
+
+    it('returns silently when none of the removed flags appear', () => {
+      expect(() => assertNoRemovedFlags(['--ok', 'value'], removed)).to.not.throw()
+    })
+
+    it('throws with the migration text when the long flag appears', () => {
+      expect(() => assertNoRemovedFlags(['--gone'], removed)).to.throw(
+        /Flag '--gone' was removed in tool-mode\. Use the new way\./,
+      )
+    })
+
+    it('throws when the short alias appears', () => {
+      expect(() => assertNoRemovedFlags(['-g', 'x'], removed)).to.throw(
+        /Flag '-g' was removed in tool-mode/,
+      )
+    })
+
+    it('throws when the flag is written in --flag=value form', () => {
+      expect(() => assertNoRemovedFlags(['--gone=oops'], removed)).to.throw(
+        /Flag '--gone' was removed in tool-mode/,
+      )
+    })
+
+    it('throws on the first match and does not check the rest', () => {
+      const multi: RemovedFlag[] = [
+        {flags: ['--first'], migration: 'first migration'},
+        {flags: ['--second'], migration: 'second migration'},
+      ]
+      expect(() => assertNoRemovedFlags(['--second', '--first'], multi)).to.throw(/first migration/)
+    })
+  })
+
+  describe('CURATE_REMOVED_FLAGS', () => {
+    it('covers --folder/-d, --files/-f, --detach, --timeout', () => {
+      const tokens = CURATE_REMOVED_FLAGS.flatMap((r) => r.flags)
+      expect(tokens).to.include.members(['--folder', '-d', '--files', '-f', '--detach', '--timeout'])
+    })
+
+    it('every entry has a non-empty migration sentence', () => {
+      for (const r of CURATE_REMOVED_FLAGS) {
+        expect(r.migration.length).to.be.greaterThan(10)
+        expect(r.migration).to.match(/\.$/)
+      }
+    })
+  })
+
+  describe('QUERY_REMOVED_FLAGS', () => {
+    it('covers --timeout', () => {
+      const tokens = QUERY_REMOVED_FLAGS.flatMap((r) => r.flags)
+      expect(tokens).to.include('--timeout')
+    })
+  })
+})


### PR DESCRIPTION
These flags survived from the pre-tool-mode era when the daemon ran an internal LLM. In tool-mode they were already no-ops — declared on the oclif command but never read in the run() body. Cleaning up the surface so agents stop being told about them and so the help text reflects what the CLI actually does.

Removed from `brv curate`:
- `-d, --folder` (folder pack — agent inlines folder content into the topic HTML directly)
- `-f, --files` (file context — agent reads files and inlines content)
- `--detach` (curate is two cheap RPCs; nothing to detach from)
- `--timeout` (no long-running daemon LLM call to time-bound)

Removed from `brv query`:
- `--timeout` (deterministic local BM25 lookup; default 300s was legacy nonsense)

Migration UX: a new shared helper `assertNoRemovedFlags` scans argv before oclif's parser runs and throws a clear migration message naming the equivalent tool-mode pattern. Works for both strict (curate) and permissive-parse (query) commands.

Docs updated to match: the bundled SKILL.md, brv-instructions.md, workflow.md, and command-reference.md no longer instruct agents to use the removed flags. Replaced the `--detach` decision rubric with the two-call session protocol explanation.

Out of scope (intentional):
- `brv dream --timeout` and `--detach` — separate command, still needed; `timeout-deprecation.ts` helper stays for that path.
- Daemon-side `CurateExecutor` --files resolution code — runs on legacy LLM-configured projects, not reachable from tool-mode CLI after this commit. A separate dead-code pass.

Verified:
- npm run typecheck clean
- npm run lint: 0 errors (262 pre-existing warnings unchanged)
- npm test: 8514 passing, 16 pending, 0 failing (+ 8 new `removed-flags` unit cases)

## Summary

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [ ] Agent / Tools
- [ ] LLM Providers
- [ ] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes #
- Related #

## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause:
- Why this was not caught earlier:

## Test plan

- Coverage added:
  - [ ] Unit test
  - [ ] Integration test
  - [ ] Manual verification only
- Test file(s):
- Key scenario(s) covered:

## User-visible changes

List user-visible changes (including defaults, config, or CLI output).
If none, write `None`.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording

## Checklist

- [ ] Tests added or updated and passing (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Type check passes (`npm run typecheck`)
- [ ] Build succeeds (`npm run build`)
- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or clearly documented above)
- [ ] Branch is up to date with `main`

## Risks and mitigations

List real risks for this PR. If none, write `None`.

- Risk:
  - Mitigation:
