### PR TITLE
feat: [ENG-2898] restore HITL settings panel in WebUI configuration

### DIFF
--- a/src/webui/pages/configuration/version-control.tsx
+++ b/src/webui/pages/configuration/version-control.tsx
@@ -1,3 +1,4 @@
+import {HitlSettingsPanel} from '../../features/vc/components/hitl-settings-panel'
 import {IdentityPanel} from '../../features/vc/components/identity-panel'
 import {RemotesPanel} from '../../features/vc/components/remotes-panel'
 
@@ -6,6 +7,7 @@ export function VersionControlSection() {
     <>
       <IdentityPanel />
       <RemotesPanel />
+      <HitlSettingsPanel />
     </>
   )
 }


### PR DESCRIPTION
## Summary
- Re-adds `HitlSettingsPanel` ("Agent supervision") under WebUI Configuration → Version control, restoring the agent-review toggle that was orphaned by PR #673.
- Placed under Version control (not General) because the panel lives in `features/vc/`, pending operations render in the Changes tab, reject restores file snapshots, and HITL is project-scoped like `Identity`/`Remotes` (General holds global `~/.brv/settings.json` keys).
- Other panels listed in the ticket (`IdentityPanel`, `RemotesPanel`, `ConnectorsPanel`) were already restored by PR #673's new configuration sub-routes — no further action needed.

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm run dev:ui` → open WebUI → Configuration → Version control: "Agent supervision" appears below Remotes
- [ ] Toggle "Highlight agent edits" off/on; confirm persistence by reloading the page
- [ ] Toggled state matches `brv review --enable`/`--disable` from CLI

Closes ENG-2898