### PR TITLE
feat: [ENG-2906] surface ctrl+q in TUI footer, fix selector FIFO, suppress stray 'q'

### DIFF
--- a/src/tui/components/command-input.tsx
+++ b/src/tui/components/command-input.tsx
@@ -32,6 +32,7 @@ export const CommandInput = () => {
   const [inputKey, setInputKey] = useState(0)
   const [activeDialog, setActiveDialog] = useState<ReactNode>(null)
   const ctrlOPressedRef = useRef(false)
+  const ctrlQPressedRef = useRef(false)
   const previousInputRef = useRef('')
 
   // Placeholder based on onboarding step
@@ -40,23 +41,37 @@ export const CommandInput = () => {
     return 'Type a command...'
   }, [isStreaming])
 
-  // Filter out "o" character when Ctrl+O is pressed
+  // Filter out the chord-suffix character when Ctrl+O or Ctrl+Q is pressed:
+  // ink-text-input receives the literal "o"/"q" alongside the modifier and
+  // appends it before our useInput handler runs, so we strip it here.
   useEffect(() => {
     if (ctrlOPressedRef.current) {
-      // Check if "o" was just added to the end
       if (inputValue === previousInputRef.current + 'o') {
         setInputValue(previousInputRef.current)
       }
 
       ctrlOPressedRef.current = false
     }
+
+    if (ctrlQPressedRef.current) {
+      if (inputValue === previousInputRef.current + 'q') {
+        setInputValue(previousInputRef.current)
+      }
+
+      ctrlQPressedRef.current = false
+    }
   }, [inputValue])
 
-  // Detect Ctrl+O to prevent "o" from being inserted
+  // Detect Ctrl+O / Ctrl+Q to prevent their letter from being inserted.
+  // Ctrl+Q is the cancel-task chord; see useCancelRunningTaskKeybind.
   useInput((input, key) => {
-    if (key.ctrl && input === 'o') {
+    if (!key.ctrl) return
+    if (input === 'o') {
       previousInputRef.current = inputValue
       ctrlOPressedRef.current = true
+    } else if (input === 'q') {
+      previousInputRef.current = inputValue
+      ctrlQPressedRef.current = true
     }
   })
 

--- a/src/tui/components/footer.tsx
+++ b/src/tui/components/footer.tsx
@@ -6,6 +6,7 @@ import {Box, Spacer, Text} from 'ink'
 import React from 'react'
 
 import {useAppViewMode} from '../features/onboarding/hooks/use-app-view-mode.js'
+import {selectCancelTargetTaskId} from '../features/tasks/hooks/select-cancel-target.js'
 import {useTasksStore} from '../features/tasks/stores/tasks-store.js'
 import {useMode, useTheme} from '../hooks/index.js'
 
@@ -16,6 +17,9 @@ export const Footer: React.FC = () => {
     theme: {colors},
   } = useTheme()
   const taskStats = useTasksStore((s) => s.stats)
+  // Mirrors the keybind in useCancelRunningTaskKeybind so the hint is visible
+  // exactly when ctrl+q is armed — never advertised when nothing is cancellable.
+  const hasCancellableTask = useTasksStore((s) => selectCancelTargetTaskId(s.tasks) !== undefined)
 
   if (viewMode.type === 'loading' || viewMode.type === 'config-provider') {
     return <Box height={1} paddingX={1} width="100%" />
@@ -30,13 +34,29 @@ export const Footer: React.FC = () => {
         <Text color={colors.primary}>{taskStats?.started ?? 0}</Text>
       </Box>
       <Spacer />
-      {shortcuts.map((shortcut, index) => (
-        <Box key={shortcut.key}>
-          {index > 0 && <Text color={colors.dimText}> • </Text>}
-          <Text color={colors.text}>{shortcut.key}</Text>
-          <Text color={colors.dimText}> {shortcut.description}</Text>
-        </Box>
-      ))}
+      {shortcuts.map((shortcut, index) => {
+        // Inject the cancel-task hint after the first shortcut (navigate)
+        // so the order reads `↑↓ navigate · ctrl+q cancel task · ctrl+c quit`.
+        // The hint piggybacks on `selectCancelTargetTaskId`, so it appears
+        // exactly while the keybind is armed and never advertises a no-op.
+        const showCancelHintBefore = hasCancellableTask && index === 1
+        return (
+          <React.Fragment key={shortcut.key}>
+            {showCancelHintBefore && (
+              <Box>
+                <Text color={colors.dimText}> • </Text>
+                <Text color={colors.text}>ctrl+q</Text>
+                <Text color={colors.dimText}> cancel task</Text>
+              </Box>
+            )}
+            <Box>
+              {index > 0 && <Text color={colors.dimText}> • </Text>}
+              <Text color={colors.text}>{shortcut.key}</Text>
+              <Text color={colors.dimText}> {shortcut.description}</Text>
+            </Box>
+          </React.Fragment>
+        )
+      })}
     </Box>
   )
 }

--- a/src/tui/features/tasks/hooks/select-cancel-target.ts
+++ b/src/tui/features/tasks/hooks/select-cancel-target.ts
@@ -4,19 +4,35 @@ import type {Task, TaskStatus} from '../stores/tasks-store.js'
 const TERMINAL_STATUSES: ReadonlySet<TaskStatus> = new Set(['cancelled', 'completed', 'error'])
 
 /**
- * Pick the taskId Ctrl+Q should target. Returns the most recently created
- * non-terminal task in the tasks map, or undefined when there is nothing
- * cancellable. Pure function — extracted from the React hook so it can be
- * unit-tested without Ink.
+ * Pick the taskId Ctrl+Q should target.
+ *
+ * Policy: prefer the currently-running task over any queued task, and within
+ * each group prefer the OLDEST. Rationale: when a user has several curate
+ * tasks in flight and presses Ctrl+Q, the natural expectation is "stop what
+ * is happening now" — which is the running task occupying the agent slot.
+ * Cancelling it frees the slot so the next queued task starts immediately.
+ * The previous "most recent non-terminal" policy violated this intuition
+ * by silently cancelling whichever task was submitted last instead of the
+ * one the user perceived as active.
+ *
+ * Returns undefined when nothing is cancellable. Pure function — extracted
+ * from the React hook so it can be unit-tested without Ink.
  */
 export function selectCancelTargetTaskId(tasks: ReadonlyMap<string, Task>): string | undefined {
-  let candidate: Task | undefined
+  // Two-pass: first scan for a `started` task (running), then fall back to
+  // any non-terminal task (covers `created`/queued).
+  let runningCandidate: Task | undefined
+  let queuedCandidate: Task | undefined
   for (const task of tasks.values()) {
     if (TERMINAL_STATUSES.has(task.status)) continue
-    if (!candidate || task.createdAt > candidate.createdAt) {
-      candidate = task
+    if (task.status === 'started') {
+      if (!runningCandidate || task.createdAt < runningCandidate.createdAt) {
+        runningCandidate = task
+      }
+    } else if (!queuedCandidate || task.createdAt < queuedCandidate.createdAt) {
+      queuedCandidate = task
     }
   }
 
-  return candidate?.taskId
+  return (runningCandidate ?? queuedCandidate)?.taskId
 }

--- a/src/tui/features/tasks/hooks/use-cancel-running-task-keybind.ts
+++ b/src/tui/features/tasks/hooks/use-cancel-running-task-keybind.ts
@@ -15,9 +15,10 @@
  *   intercepted everywhere — text inputs, REPL prompt, search box, modals, etc.
  * - DO NOT bind Ctrl+Q to any other action while a curate/query/dream task can
  *   be in flight; the global cancel will eat the chord first.
- * - The binding targets `selectCancelTargetTaskId`'s "most recently created
- *   non-terminal task." With multiple in-flight tasks, Ctrl+Q always cancels
- *   the most recent one, not the one currently focused in the UI.
+ * - The binding targets `selectCancelTargetTaskId`'s "oldest running task,
+ *   falling back to the oldest queued task." With multiple in-flight tasks,
+ *   Ctrl+Q cancels the task occupying the agent slot (FIFO) so the queue
+ *   drains; it does NOT cancel whichever task is currently focused in the UI.
  * - There is no confirmation step today — the cancel network round-trip starts
  *   the instant the chord lands. If a real-world conflict surfaces (user
  *   accidentally cancelling), the recommended follow-up is to mirror the SIGINT

--- a/test/unit/tui/features/tasks/hooks/select-cancel-target.test.ts
+++ b/test/unit/tui/features/tasks/hooks/select-cancel-target.test.ts
@@ -37,13 +37,40 @@ describe('selectCancelTargetTaskId', () => {
     expect(selectCancelTargetTaskId(tasks)).to.equal('b')
   })
 
-  it('returns the most recently created non-terminal task when several are running', () => {
+  it('returns the OLDEST running task when several are concurrently running', () => {
+    // Policy: Ctrl+Q stops what is currently happening. Among running tasks,
+    // pick the oldest — it has occupied the agent slot longest and is the
+    // most natural "active" task in the user's mental model.
     const tasks = new Map<string, Task>([
       ['mid', makeTask({createdAt: 200, status: 'started', taskId: 'mid', type: 'query'})],
       ['new', makeTask({createdAt: 300, status: 'started', taskId: 'new', type: 'curate'})],
       ['old', makeTask({createdAt: 100, status: 'started', taskId: 'old', type: 'curate'})],
     ])
-    expect(selectCancelTargetTaskId(tasks)).to.equal('new')
+    expect(selectCancelTargetTaskId(tasks)).to.equal('old')
+  })
+
+  it('prefers a running task over any queued (created-status) task', () => {
+    // Regression for the multi-curate bug: ctrl+q must stop the running task,
+    // not the most-recently-queued one. Cancelling the runner also frees the
+    // slot so the queue drains naturally.
+    const tasks = new Map<string, Task>([
+      ['queued-newer', makeTask({createdAt: 300, status: 'created', taskId: 'queued-newer', type: 'curate'})],
+      ['queued-older', makeTask({createdAt: 150, status: 'created', taskId: 'queued-older', type: 'curate'})],
+      ['running', makeTask({createdAt: 100, status: 'started', taskId: 'running', type: 'curate'})],
+    ])
+    expect(selectCancelTargetTaskId(tasks)).to.equal('running')
+  })
+
+  it('falls back to the OLDEST queued task when nothing is running yet', () => {
+    // Cold-start scenario: the agent has not yet picked anything up. The
+    // oldest queued task is closest to dispatch, so cancelling it is the
+    // FIFO-consistent choice (matches what the user just submitted first).
+    const tasks = new Map<string, Task>([
+      ['a', makeTask({createdAt: 100, status: 'created', taskId: 'a', type: 'curate'})],
+      ['b', makeTask({createdAt: 200, status: 'created', taskId: 'b', type: 'curate'})],
+      ['c', makeTask({createdAt: 300, status: 'created', taskId: 'c', type: 'curate'})],
+    ])
+    expect(selectCancelTargetTaskId(tasks)).to.equal('a')
   })
 
   it('treats `created` status as non-terminal (still cancellable before task:started)', () => {


### PR DESCRIPTION

- Footer hint reads `ctrl+q cancel task`, placed between `↑↓ navigate` and `ctrl+c quit`, mirroring the keybind via selectCancelTargetTaskId so it appears exactly when ctrl+q is armed.
- Selector now prefers the OLDEST running task over any queued task, with FIFO fallback to the oldest queued. Fixes the multi-curate bug where ctrl+q cancelled the most-recently submitted task instead of the one occupying the agent slot.
- Mirror the existing ctrl+o suppression for ctrl+q in command-input so the chord no longer types a stray `q` into the prompt and subsequent ctrl+q presses still register cleanly.

## Summary

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [ ] Agent / Tools
- [ ] LLM Providers
- [ ] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes #
- Related #

## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause:
- Why this was not caught earlier:

## Test plan

- Coverage added:
  - [ ] Unit test
  - [ ] Integration test
  - [ ] Manual verification only
- Test file(s):
- Key scenario(s) covered:

## User-visible changes

List user-visible changes (including defaults, config, or CLI output).
If none, write `None`.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording

## Checklist

- [ ] Tests added or updated and passing (`npm test`)
- [ ] Lint passes (`npm run lint`)
- [ ] Type check passes (`npm run typecheck`)
- [ ] Build succeeds (`npm run build`)
- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or clearly documented above)
- [ ] Branch is up to date with `main`

## Risks and mitigations

List real risks for this PR. If none, write `None`.

- Risk:
  - Mitigation:
