### PR TITLE
feat: [ENG-2885] adopt callback-based topic-viewer in webui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3301,7 +3301,7 @@
     },
     "node_modules/@campfirein/byterover-packages": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/campfirein/byterover-packages.git#64bd6c7a903ddc0e785a4f397f4564de0e73b7ed",
+      "resolved": "git+ssh://git@github.com/campfirein/byterover-packages.git#2dec813d8dcb473d46ff575d043391ddb423efd2",
       "inBundle": true,
       "dependencies": {
         "@base-ui/react": "^1.3.0",

--- a/src/webui/features/context/components/conflict-content-view.tsx
+++ b/src/webui/features/context/components/conflict-content-view.tsx
@@ -1,0 +1,50 @@
+import {AlertTriangle} from 'lucide-react'
+
+const DEFAULT_WRAPPER_CLASS =
+  'bg-card text-secondary-foreground mx-auto min-h-0 w-full flex-1 space-y-2 overflow-y-auto break-words text-sm leading-7'
+
+interface ConflictContentViewProps {
+  className?: string
+  content: string
+}
+
+export function ConflictContentView({className, content}: ConflictContentViewProps) {
+  return (
+    <div className={className ?? DEFAULT_WRAPPER_CLASS}>
+      <div className="bg-[#4f3422] text-[#ffc53d] mb-2 flex items-center gap-2 rounded-md px-3 py-2 text-xs">
+        <AlertTriangle className="size-3.5 shrink-0" />
+        <span>Unresolved conflict markers — showing raw content with side highlighting.</span>
+      </div>
+      <ConflictRawView content={content} />
+    </div>
+  )
+}
+
+function ConflictRawView({content}: {content: string}) {
+  const lines = content.split('\n')
+  let region: 'none' | 'ours' | 'theirs' = 'none'
+
+  return (
+    <pre className="bg-card overflow-x-auto rounded-md py-2 font-mono text-xs leading-6">
+      {lines.map((line, i) => {
+        let cls = 'block px-3 whitespace-pre-wrap break-all'
+        if (line.startsWith('<<<<<<<')) {
+          cls += ' bg-[#4f3422] text-[#ffc53d] font-semibold'
+          region = 'ours'
+        } else if (line.startsWith('=======') && region !== 'none') {
+          cls += ' bg-[#4f3422] text-[#ffc53d] font-semibold'
+          region = 'theirs'
+        } else if (line.startsWith('>>>>>>>')) {
+          cls += ' bg-[#4f3422] text-[#ffc53d] font-semibold'
+          region = 'none'
+        }
+
+        return (
+          <span className={cls} key={i}>
+            {line || '\u00A0'}
+          </span>
+        )
+      })}
+    </pre>
+  )
+}

--- a/src/webui/features/context/components/conflict-content-view.tsx
+++ b/src/webui/features/context/components/conflict-content-view.tsx
@@ -1,6 +1,6 @@
 import {AlertTriangle} from 'lucide-react'
 
-const DEFAULT_WRAPPER_CLASS =
+export const DEFAULT_WRAPPER_CLASS =
   'bg-card text-secondary-foreground mx-auto min-h-0 w-full flex-1 space-y-2 overflow-y-auto break-words text-sm leading-7'
 
 interface ConflictContentViewProps {
@@ -13,32 +13,40 @@ export function ConflictContentView({className, content}: ConflictContentViewPro
     <div className={className ?? DEFAULT_WRAPPER_CLASS}>
       <div className="bg-[#4f3422] text-[#ffc53d] mb-2 flex items-center gap-2 rounded-md px-3 py-2 text-xs">
         <AlertTriangle className="size-3.5 shrink-0" />
-        <span>Unresolved conflict markers — showing raw content with side highlighting.</span>
+        <span>Unresolved conflict markers — showing raw content with marker lines highlighted.</span>
       </div>
       <ConflictRawView content={content} />
     </div>
   )
 }
 
+function classifyMarkerLines(lines: string[]): boolean[] {
+  let insideConflict = false
+  return lines.map((line) => {
+    if (line.startsWith('<<<<<<<')) {
+      insideConflict = true
+      return true
+    }
+
+    if (line.startsWith('>>>>>>>')) {
+      insideConflict = false
+      return true
+    }
+
+    return insideConflict && line.startsWith('=======')
+  })
+}
+
 function ConflictRawView({content}: {content: string}) {
   const lines = content.split('\n')
-  let region: 'none' | 'ours' | 'theirs' = 'none'
+  const isMarker = classifyMarkerLines(lines)
 
   return (
     <pre className="bg-card overflow-x-auto rounded-md py-2 font-mono text-xs leading-6">
       {lines.map((line, i) => {
-        let cls = 'block px-3 whitespace-pre-wrap break-all'
-        if (line.startsWith('<<<<<<<')) {
-          cls += ' bg-[#4f3422] text-[#ffc53d] font-semibold'
-          region = 'ours'
-        } else if (line.startsWith('=======') && region !== 'none') {
-          cls += ' bg-[#4f3422] text-[#ffc53d] font-semibold'
-          region = 'theirs'
-        } else if (line.startsWith('>>>>>>>')) {
-          cls += ' bg-[#4f3422] text-[#ffc53d] font-semibold'
-          region = 'none'
-        }
-
+        const cls = isMarker[i]
+          ? 'block px-3 whitespace-pre-wrap break-all bg-[#4f3422] text-[#ffc53d] font-semibold'
+          : 'block px-3 whitespace-pre-wrap break-all'
         return (
           <span className={cls} key={i}>
             {line || '\u00A0'}

--- a/src/webui/features/context/components/context-detail-panel.tsx
+++ b/src/webui/features/context/components/context-detail-panel.tsx
@@ -9,13 +9,18 @@ import {useMemo} from 'react'
 
 import type {ContextNode} from '../types'
 
+import {hasConflictMarkers} from '../../../../shared/utils/conflict-markers'
 import {noop} from '../../../lib/noop'
 import {useGetContextFileMetadata} from '../api/get-context-file-metadata'
 import {useGetContextHistory} from '../api/get-context-history'
 import {useContextTree} from '../hooks/use-context-tree'
+import {useTopicViewerNavigation} from '../hooks/use-topic-viewer-navigation'
+import {hasRootIndex} from '../utils/has-root-index'
 import {isFilePath} from '../utils/tree-utils'
+import {ConflictContentView} from './conflict-content-view'
 import {ContextBreadcrumb} from './context-breadcrumb'
 import {MarkdownView} from './markdown-view'
+import {RootIndexDetail} from './root-index-detail'
 
 const isHtmlPath = (path: string | undefined): boolean => Boolean(path && path.toLowerCase().endsWith('.html'))
 
@@ -49,6 +54,7 @@ export function ContextDetailPanel({onToggleHistory}: ContextDetailPanelProps) {
     selectedPath,
     setEditContent,
   } = useContextTree()
+  const {onBreadcrumbClick, onEntryClick, onRelatedClick} = useTopicViewerNavigation()
 
   const {data: historyData, isPending: isHistoryPending} = useGetContextHistory({
     enabled: Boolean(selectedPath) && isFilePath(selectedPath),
@@ -57,7 +63,6 @@ export function ContextDetailPanel({onToggleHistory}: ContextDetailPanelProps) {
 
   const lastCommit = historyData?.pages[0]?.commits[0]
 
-  // For folder view: show children of selected folder, or root nodes
   const folderChildren = useMemo(() => {
     if (!selectedNode || selectedNode.type !== 'tree') {
       return selectedNode ? [] : nodes
@@ -118,8 +123,8 @@ export function ContextDetailPanel({onToggleHistory}: ContextDetailPanelProps) {
     handleSelect(parentNode)
   }
 
-  // File detail view
   if (selectedNode?.type === 'blob') {
+    const isHtml = isHtmlPath(selectedNode.path)
     return (
       <div className="flex h-full flex-1 flex-col">
         <div className="px-5 pt-5">
@@ -130,8 +135,15 @@ export function ContextDetailPanel({onToggleHistory}: ContextDetailPanelProps) {
           content={fileData?.content ?? ''}
           contentView={
             !isEditMode && fileData?.content ? (
-              isHtmlPath(selectedNode.path) ? (
-                <TopicViewer html={fileData.content} />
+              hasConflictMarkers(fileData.content) ? (
+                <ConflictContentView content={fileData.content} />
+              ) : isHtml ? (
+                <TopicViewer
+                  breadcrumb={{onBreadcrumbClick}}
+                  html={fileData.content}
+                  index={{onEntryClick}}
+                  related={{onRelatedClick}}
+                />
               ) : (
                 <MarkdownView content={fileData.content} />
               )
@@ -150,7 +162,7 @@ export function ContextDetailPanel({onToggleHistory}: ContextDetailPanelProps) {
           }
           fileName={fileData?.title ?? selectedNode.name}
           hasChanges={hasChanges}
-          headerClassName="pt-4 pb-0"
+          headerClassName={isHtml ? 'py-4' : 'pt-4 pb-0'}
           isEditMode={isEditMode}
           isHistoryVisible={false}
           isLoading={isFetchingFile}
@@ -182,7 +194,10 @@ export function ContextDetailPanel({onToggleHistory}: ContextDetailPanelProps) {
     )
   }
 
-  // Folder detail view (or root)
+  if (hasRootIndex(nodes, selectedPath)) {
+    return <RootIndexDetail onToggleHistory={onToggleHistory} />
+  }
+
   return (
     <div className="flex-1 h-full flex-col flex p-5 gap-4">
       <ContextBreadcrumb />

--- a/src/webui/features/context/components/markdown-view.tsx
+++ b/src/webui/features/context/components/markdown-view.tsx
@@ -1,5 +1,5 @@
 import {Button} from '@campfirein/byterover-packages/components/button'
-import {AlertTriangle, Check, Copy} from 'lucide-react'
+import {Check, Copy} from 'lucide-react'
 import {Children, createElement, type FC, isValidElement, memo, ReactElement, type ReactNode, useState} from 'react'
 import ReactMarkdown, {type Components, type Options} from 'react-markdown'
 import remarkFrontmatter from 'remark-frontmatter'
@@ -7,6 +7,7 @@ import remarkGfm from 'remark-gfm'
 
 import {hasConflictMarkers} from '../../../../shared/utils/conflict-markers'
 import {oneDark, SyntaxHighlighter} from '../../../lib/syntax-highlighter'
+import {ConflictContentView} from './conflict-content-view'
 
 // ── CodeBlock ──────────────────────────────────────────────────────────────
 
@@ -176,53 +177,12 @@ interface MarkdownViewProps {
   content: string
 }
 
-/**
- * Renders file content as monospace text with conflict-marker LINES highlighted
- * (amber background). Content lines between markers stay un-tinted so the user
- * can focus on the markers themselves.
- */
-function ConflictView({content}: {content: string}) {
-  const lines = content.split('\n')
-  let region: 'none' | 'ours' | 'theirs' = 'none'
-
-  return (
-    <pre className="bg-card overflow-x-auto rounded-md py-2 font-mono text-xs leading-6">
-      {lines.map((line, i) => {
-        let cls = 'block px-3 whitespace-pre-wrap break-all'
-        if (line.startsWith('<<<<<<<')) {
-          cls += ' bg-[#4f3422] text-[#ffc53d] font-semibold'
-          region = 'ours'
-        } else if (line.startsWith('=======') && region !== 'none') {
-          cls += ' bg-[#4f3422] text-[#ffc53d] font-semibold'
-          region = 'theirs'
-        } else if (line.startsWith('>>>>>>>')) {
-          cls += ' bg-[#4f3422] text-[#ffc53d] font-semibold'
-          region = 'none'
-        }
-
-        return <span className={cls} key={i}>{line || '\u00A0'}</span>
-      })}
-    </pre>
-  )
-}
-
 export function MarkdownView({className, content}: MarkdownViewProps) {
-  const wrapperClass = className ?? 'bg-card text-secondary-foreground mx-auto min-h-0 w-full flex-1 space-y-2 overflow-y-auto break-words text-sm leading-7'
-
-  // Markdown rendering breaks on conflict markers (`=======` is a setext heading underline,
-  // `<<<<<<<` may be parsed as autolink), producing a misleading preview. Render a structured
-  // conflict view instead so users can see exactly what's in each side of the conflict.
   if (hasConflictMarkers(content)) {
-    return (
-      <div className={wrapperClass}>
-        <div className="bg-[#4f3422] text-[#ffc53d] mb-2 flex items-center gap-2 rounded-md px-3 py-2 text-xs">
-          <AlertTriangle className="size-3.5 shrink-0" />
-          <span>Unresolved conflict markers — showing raw content with side highlighting.</span>
-        </div>
-        <ConflictView content={content} />
-      </div>
-    )
+    return <ConflictContentView className={className} content={content} />
   }
+
+  const wrapperClass = className ?? 'bg-card text-secondary-foreground mx-auto min-h-0 w-full flex-1 space-y-2 overflow-y-auto break-words text-sm leading-7'
 
   return (
     <div className={wrapperClass}>

--- a/src/webui/features/context/components/markdown-view.tsx
+++ b/src/webui/features/context/components/markdown-view.tsx
@@ -7,7 +7,7 @@ import remarkGfm from 'remark-gfm'
 
 import {hasConflictMarkers} from '../../../../shared/utils/conflict-markers'
 import {oneDark, SyntaxHighlighter} from '../../../lib/syntax-highlighter'
-import {ConflictContentView} from './conflict-content-view'
+import {ConflictContentView, DEFAULT_WRAPPER_CLASS} from './conflict-content-view'
 
 // ── CodeBlock ──────────────────────────────────────────────────────────────
 
@@ -182,7 +182,7 @@ export function MarkdownView({className, content}: MarkdownViewProps) {
     return <ConflictContentView className={className} content={content} />
   }
 
-  const wrapperClass = className ?? 'bg-card text-secondary-foreground mx-auto min-h-0 w-full flex-1 space-y-2 overflow-y-auto break-words text-sm leading-7'
+  const wrapperClass = className ?? DEFAULT_WRAPPER_CLASS
 
   return (
     <div className={wrapperClass}>

--- a/src/webui/features/context/components/root-index-detail.tsx
+++ b/src/webui/features/context/components/root-index-detail.tsx
@@ -1,0 +1,121 @@
+import {AuthorInfo} from '@campfirein/byterover-packages/components/contexts/author-info'
+import {DetailBody} from '@campfirein/byterover-packages/components/contexts/detail-body'
+import {Skeleton} from '@campfirein/byterover-packages/components/skeleton'
+import {TopicEditor} from '@campfirein/byterover-packages/components/topic-viewer/topic-editor'
+import {TopicViewer} from '@campfirein/byterover-packages/components/topic-viewer/topic-viewer'
+import {formatDistanceToNow} from 'date-fns'
+import {useCallback, useState} from 'react'
+
+import {hasConflictMarkers} from '../../../../shared/utils/conflict-markers'
+import {noop} from '../../../lib/noop'
+import {useGetContextFile} from '../api/get-context-file'
+import {useGetContextHistory} from '../api/get-context-history'
+import {useUpdateContextFile} from '../api/update-context-file'
+import {useContextTree} from '../hooks/use-context-tree'
+import {useTopicViewerNavigation} from '../hooks/use-topic-viewer-navigation'
+import {ROOT_INDEX_PATH} from '../utils/has-root-index'
+import {ConflictContentView} from './conflict-content-view'
+import {ContextBreadcrumb} from './context-breadcrumb'
+
+interface RootIndexDetailProps {
+  onToggleHistory?: () => void
+}
+
+export function RootIndexDetail({onToggleHistory}: RootIndexDetailProps) {
+  const {branch} = useContextTree()
+  const {onBreadcrumbClick, onEntryClick, onRelatedClick} = useTopicViewerNavigation()
+
+  const {data: fileResponse, isFetching: isFetchingFile} = useGetContextFile({
+    branch,
+    path: ROOT_INDEX_PATH,
+  })
+  const fileData = fileResponse?.file
+
+  const {data: historyData, isPending: isHistoryPending} = useGetContextHistory({path: ROOT_INDEX_PATH})
+  const lastCommit = historyData?.pages[0]?.commits[0]
+
+  const [isEditMode, setIsEditMode] = useState(false)
+  const [editContent, setEditContent] = useState('')
+  const updateMutation = useUpdateContextFile()
+
+  const enterEditMode = useCallback(() => {
+    if (fileData) {
+      setEditContent(fileData.content)
+      setIsEditMode(true)
+    }
+  }, [fileData])
+
+  const cancelEdit = useCallback(() => {
+    setIsEditMode(false)
+    setEditContent('')
+  }, [])
+
+  const saveChanges = useCallback(async () => {
+    if (!isEditMode) return
+    await updateMutation.mutateAsync({content: editContent, path: ROOT_INDEX_PATH})
+    setIsEditMode(false)
+  }, [editContent, isEditMode, updateMutation])
+
+  const hasChanges = isEditMode && fileData !== undefined && editContent !== fileData.content
+
+  return (
+    <div className="flex h-full flex-1 flex-col">
+      <div className="px-5 pt-5">
+        <ContextBreadcrumb />
+      </div>
+      <DetailBody
+        canEdit
+        content={fileData?.content ?? ''}
+        contentView={
+          !isEditMode && fileData?.content ? (
+            hasConflictMarkers(fileData.content) ? (
+              <ConflictContentView content={fileData.content} />
+            ) : (
+              <TopicViewer
+                breadcrumb={{onBreadcrumbClick}}
+                html={fileData.content}
+                index={{onEntryClick}}
+                related={{onRelatedClick}}
+              />
+            )
+          ) : undefined
+        }
+        editContent={editContent}
+        editView={
+          isEditMode ? (
+            <TopicEditor disabled={updateMutation.isPending} language="html" onChange={setEditContent} value={editContent} />
+          ) : undefined
+        }
+        fileName={fileData?.title ?? ROOT_INDEX_PATH}
+        hasChanges={hasChanges}
+        headerClassName="py-4"
+        isEditMode={isEditMode}
+        isHistoryVisible={false}
+        isLoading={isFetchingFile}
+        isUpdating={updateMutation.isPending}
+        onCancelEdit={cancelEdit}
+        onContentChange={setEditContent}
+        onEnterEditMode={enterEditMode}
+        onSaveChanges={saveChanges}
+        onToggleHistory={onToggleHistory ?? noop}
+        showTags={false}
+        tags={fileData?.tags}
+        timeline={
+          lastCommit ? (
+            <AuthorInfo
+              className="mx-5 mb-5"
+              description={`${lastCommit.author.name} updated ${ROOT_INDEX_PATH}`}
+              name={lastCommit.author.name}
+              timestamp={formatDistanceToNow(new Date(lastCommit.timestamp), {addSuffix: true})}
+            />
+          ) : isHistoryPending ? (
+            <div className="border-border mx-5 mb-5 flex items-center gap-2 border-b py-2">
+              <Skeleton className="size-6 shrink-0 rounded-full" />
+              <Skeleton className="h-4 w-56" />
+            </div>
+          ) : undefined
+        }
+      />
+    </div>
+  )
+}

--- a/src/webui/features/context/hooks/use-context-tree.tsx
+++ b/src/webui/features/context/hooks/use-context-tree.tsx
@@ -24,6 +24,7 @@ interface ContextTreeContextValue {
   isFetchingTree: boolean
   isUpdating: boolean
   navigateHome: () => void
+  navigateToPath: (path: string) => void
   nodes: ContextTreeNodeDTO[]
   saveChanges: () => Promise<void>
   selectedNode: ContextTreeNodeDTO | undefined
@@ -91,14 +92,14 @@ export function ContextTreeProvider({children}: {children: ReactNode}) {
     })
   }, [])
 
-  const handleSelect = useCallback(
-    (node: ContextTreeNodeDTO) => {
-      expandNestedPath(node.path)
+  const navigateToPath = useCallback(
+    (path: string) => {
+      expandNestedPath(path)
 
       setSearchParams(
         (prev) => {
           const next = new URLSearchParams(prev)
-          next.set('path', node.path)
+          next.set('path', path)
           return next
         },
         {replace: true},
@@ -109,6 +110,8 @@ export function ContextTreeProvider({children}: {children: ReactNode}) {
     },
     [expandNestedPath, setSearchParams],
   )
+
+  const handleSelect = useCallback((node: ContextTreeNodeDTO) => navigateToPath(node.path), [navigateToPath])
 
   const navigateHome = useCallback(() => {
     setSearchParams(
@@ -166,6 +169,7 @@ export function ContextTreeProvider({children}: {children: ReactNode}) {
     isFetchingTree,
     isUpdating: updateMutation.isPending,
     navigateHome,
+    navigateToPath,
     nodes,
     saveChanges,
     selectedNode,

--- a/src/webui/features/context/hooks/use-topic-viewer-navigation.ts
+++ b/src/webui/features/context/hooks/use-topic-viewer-navigation.ts
@@ -1,0 +1,20 @@
+import {useMemo} from 'react'
+import {toast} from 'sonner'
+
+import {createTopicViewerNavigation} from '../utils/topic-viewer-navigation'
+import {findNodeByPath} from '../utils/tree-utils'
+import {useContextTree} from './use-context-tree'
+
+export function useTopicViewerNavigation() {
+  const {navigateToPath, nodes} = useContextTree()
+
+  return useMemo(
+    () =>
+      createTopicViewerNavigation({
+        navigate: navigateToPath,
+        onStalePath: (path) => toast.error(`Path not found in context tree: ${path}`),
+        pathExists: (path) => findNodeByPath(nodes, path) !== undefined,
+      }),
+    [navigateToPath, nodes],
+  )
+}

--- a/src/webui/features/context/utils/has-root-index.ts
+++ b/src/webui/features/context/utils/has-root-index.ts
@@ -1,0 +1,8 @@
+import type {ContextTreeNodeDTO} from '../../../../shared/transport/events'
+
+export const ROOT_INDEX_PATH = 'index.html'
+
+export function hasRootIndex(nodes: ContextTreeNodeDTO[], selectedPath: string): boolean {
+  if (selectedPath) return false
+  return nodes.some((node) => node.path === ROOT_INDEX_PATH && node.type === 'blob')
+}

--- a/src/webui/features/context/utils/topic-viewer-navigation.ts
+++ b/src/webui/features/context/utils/topic-viewer-navigation.ts
@@ -1,0 +1,28 @@
+interface TopicViewerNavigationDeps {
+  navigate: (path: string) => void
+  onStalePath: (path: string) => void
+  pathExists: (path: string) => boolean
+}
+
+export function createTopicViewerNavigation({navigate, onStalePath, pathExists}: TopicViewerNavigationDeps) {
+  const safeNavigate = (path: string) => {
+    if (pathExists(path)) {
+      navigate(path)
+    } else {
+      onStalePath(path)
+    }
+  }
+
+  return {
+    onBreadcrumbClick(segments: string[]) {
+      if (segments.length === 0) return
+      safeNavigate(segments.join('/'))
+    },
+    onEntryClick(entry: {format?: string; path: string; title?: string}) {
+      safeNavigate(entry.path)
+    },
+    onRelatedClick(path: string) {
+      safeNavigate(path.replace(/^@/, ''))
+    },
+  }
+}

--- a/src/webui/features/context/utils/topic-viewer-navigation.ts
+++ b/src/webui/features/context/utils/topic-viewer-navigation.ts
@@ -18,7 +18,7 @@ export function createTopicViewerNavigation({navigate, onStalePath, pathExists}:
       if (segments.length === 0) return
       safeNavigate(segments.join('/'))
     },
-    onEntryClick(entry: {format?: string; path: string; title?: string}) {
+    onEntryClick(entry: {path: string}) {
       safeNavigate(entry.path)
     },
     onRelatedClick(path: string) {

--- a/src/webui/features/tasks/components/curate-html-direct-sections.tsx
+++ b/src/webui/features/tasks/components/curate-html-direct-sections.tsx
@@ -25,7 +25,7 @@ export function CurateHtmlDirectInputView({payload}: {payload: CurateHtmlDirectI
           </div>
         )}
         <Card className="ring-border bg-card p-4" size="sm">
-          <TopicViewer html={payload.html} />
+          <TopicViewer breadcrumb={{show: false}} html={payload.html} />
         </Card>
       </div>
     </section>
@@ -85,7 +85,7 @@ function WriteErrorItem({error}: {error: CurateHtmlWriteError}) {
         <div className="ml-6">
           <p className="text-muted-foreground mono mb-1 text-[10px] uppercase tracking-wider">Existing content</p>
           <Card className="ring-border bg-background p-3" size="sm">
-            <TopicViewer html={error.existingContent} />
+            <TopicViewer breadcrumb={{show: false}} html={error.existingContent} />
           </Card>
         </div>
       )}

--- a/src/webui/features/tasks/components/task-detail-sections.tsx
+++ b/src/webui/features/tasks/components/task-detail-sections.tsx
@@ -70,7 +70,7 @@ export function LiveStreamSection({task}: {task: StoredTask}) {
         className={cn('pl-3 text-foreground/90 text-sm border-l-2', isLive ? 'border-blue-500/30' : 'border-border')}
       >
         {isBvTopicHtml(content) ? (
-          <TopicViewer html={content} />
+          <TopicViewer breadcrumb={{show: false}} html={content} />
         ) : (
           <MarkdownInline className="text-foreground/90 text-sm">{content || ' '}</MarkdownInline>
         )}
@@ -92,7 +92,7 @@ export function ResultSection({content, taskType}: {content: string; taskType?: 
       <SectionLabel>Result</SectionLabel>
       <Card className="ring-border bg-card p-5" size="sm">
         {isBvTopicHtml(content) ? (
-          <TopicViewer html={content} />
+          <TopicViewer breadcrumb={{show: false}} html={content} />
         ) : (
           <MarkdownInline className="text-foreground/90 text-sm">{content}</MarkdownInline>
         )}

--- a/src/webui/features/tasks/components/task-detail-view.tsx
+++ b/src/webui/features/tasks/components/task-detail-view.tsx
@@ -72,7 +72,12 @@ export function TaskDetailView({taskId}: TaskDetailViewProps) {
     <div className="flex h-full min-h-0 flex-col">
       <DetailHeader now={now} task={task} />
       <div className="border-border/50 border-t" />
-      <div className="flex min-h-0 flex-1 flex-col gap-7 overflow-y-auto px-6 py-5" onScroll={onScroll} ref={scrollRef}>
+      <div
+        className="flex min-h-0 flex-1 flex-col gap-7 overflow-y-auto px-6 py-5"
+        data-stick-to-bottom
+        onScroll={onScroll}
+        ref={scrollRef}
+      >
         <InputSection task={task} />
         <EventLogSection now={now} task={task} />
         {showLive && <LiveStreamSection task={task} />}

--- a/src/webui/styles/index.css
+++ b/src/webui/styles/index.css
@@ -225,7 +225,10 @@
  * so we target any scroll container that contains a .bv-topic-viewer descendant.
  * Containers marked [data-stick-to-bottom] (e.g., the task streaming view) opt out because
  * scroll-behavior:smooth would animate useStickToBottom's scrollTop writes and fight the snap.
+ * Wrapped in prefers-reduced-motion so users who opt out of motion don't get the animation.
  */
-.overflow-y-auto:not([data-stick-to-bottom]):has(.bv-topic-viewer) {
-  scroll-behavior: smooth;
+@media (prefers-reduced-motion: no-preference) {
+  .overflow-y-auto:not([data-stick-to-bottom]):has(.bv-topic-viewer) {
+    scroll-behavior: smooth;
+  }
 }

--- a/src/webui/styles/index.css
+++ b/src/webui/styles/index.css
@@ -217,3 +217,15 @@
   background: transparent;
   backdrop-filter: none;
 }
+
+/*
+ * Smooth hash-anchor scrolling for TopicViewer surfaces.
+ * <bv-index> renders <a href="#domain-..."> links that scroll to <section id="domain-...">.
+ * The actual scroll container lives inside the shared DetailBody, which we can't class directly,
+ * so we target any scroll container that contains a .bv-topic-viewer descendant.
+ * Containers marked [data-stick-to-bottom] (e.g., the task streaming view) opt out because
+ * scroll-behavior:smooth would animate useStickToBottom's scrollTop writes and fight the snap.
+ */
+.overflow-y-auto:not([data-stick-to-bottom]):has(.bv-topic-viewer) {
+  scroll-behavior: smooth;
+}

--- a/test/unit/webui/features/context/utils/has-root-index.test.ts
+++ b/test/unit/webui/features/context/utils/has-root-index.test.ts
@@ -1,0 +1,46 @@
+import {expect} from 'chai'
+
+import type {ContextTreeNodeDTO} from '../../../../../../src/shared/transport/events/index.js'
+
+import {hasRootIndex} from '../../../../../../src/webui/features/context/utils/has-root-index.js'
+
+function blob(path: string): ContextTreeNodeDTO {
+  const segments = path.split('/').filter(Boolean)
+  return {name: segments.at(-1) ?? '', path, type: 'blob'}
+}
+
+function tree(path: string, children: ContextTreeNodeDTO[] = []): ContextTreeNodeDTO {
+  const segments = path.split('/').filter(Boolean)
+  return {children, name: segments.at(-1) ?? '', path, type: 'tree'}
+}
+
+describe('hasRootIndex', () => {
+  it('returns true when selectedPath is empty and root contains index.html as a blob', () => {
+    const nodes: ContextTreeNodeDTO[] = [blob('index.html'), blob('architecture.md')]
+    expect(hasRootIndex(nodes, '')).to.equal(true)
+  })
+
+  it('returns false when selectedPath is set', () => {
+    const nodes: ContextTreeNodeDTO[] = [blob('index.html')]
+    expect(hasRootIndex(nodes, 'architecture.md')).to.equal(false)
+  })
+
+  it('returns false when root has no index.html', () => {
+    const nodes: ContextTreeNodeDTO[] = [blob('architecture.md'), tree('domains')]
+    expect(hasRootIndex(nodes, '')).to.equal(false)
+  })
+
+  it('returns false when index.html is a folder (type tree), not a blob', () => {
+    const nodes: ContextTreeNodeDTO[] = [tree('index.html')]
+    expect(hasRootIndex(nodes, '')).to.equal(false)
+  })
+
+  it('ignores a nested index.html (only root-level counts)', () => {
+    const nodes: ContextTreeNodeDTO[] = [tree('domains', [blob('domains/index.html')])]
+    expect(hasRootIndex(nodes, '')).to.equal(false)
+  })
+
+  it('returns false when nodes is empty', () => {
+    expect(hasRootIndex([], '')).to.equal(false)
+  })
+})

--- a/test/unit/webui/features/context/utils/topic-viewer-navigation.test.ts
+++ b/test/unit/webui/features/context/utils/topic-viewer-navigation.test.ts
@@ -1,0 +1,107 @@
+import {expect} from 'chai'
+import sinon from 'sinon'
+
+import {createTopicViewerNavigation} from '../../../../../../src/webui/features/context/utils/topic-viewer-navigation.js'
+
+function makeNav({existing}: {existing: ReadonlySet<string>}) {
+  const navigate = sinon.spy()
+  const onStalePath = sinon.spy()
+  const pathExists = (path: string) => existing.has(path)
+  const nav = createTopicViewerNavigation({navigate, onStalePath, pathExists})
+  return {nav, navigate, onStalePath}
+}
+
+describe('createTopicViewerNavigation', () => {
+  describe('onBreadcrumbClick', () => {
+    it('navigates to the joined segment path when it exists', () => {
+      const {nav, navigate, onStalePath} = makeNav({existing: new Set(['architecture/auth/login.md'])})
+
+      nav.onBreadcrumbClick(['architecture', 'auth', 'login.md'])
+
+      expect(navigate.calledOnceWithExactly('architecture/auth/login.md')).to.equal(true)
+      expect(onStalePath.called).to.equal(false)
+    })
+
+    it('handles a single-segment breadcrumb', () => {
+      const {nav, navigate} = makeNav({existing: new Set(['root.md'])})
+
+      nav.onBreadcrumbClick(['root.md'])
+
+      expect(navigate.calledOnceWithExactly('root.md')).to.equal(true)
+    })
+
+    it('does not navigate when segments array is empty', () => {
+      const {nav, navigate, onStalePath} = makeNav({existing: new Set()})
+
+      nav.onBreadcrumbClick([])
+
+      expect(navigate.called).to.equal(false)
+      expect(onStalePath.called).to.equal(false)
+    })
+
+    it('calls onStalePath when the joined path does not exist', () => {
+      const {nav, navigate, onStalePath} = makeNav({existing: new Set()})
+
+      nav.onBreadcrumbClick(['architecture', 'gone.md'])
+
+      expect(navigate.called).to.equal(false)
+      expect(onStalePath.calledOnceWithExactly('architecture/gone.md')).to.equal(true)
+    })
+  })
+
+  describe('onRelatedClick', () => {
+    it('strips a leading @ before checking existence and navigating', () => {
+      const {nav, navigate, onStalePath} = makeNav({existing: new Set(['architecture/auth.md'])})
+
+      nav.onRelatedClick('@architecture/auth.md')
+
+      expect(navigate.calledOnceWithExactly('architecture/auth.md')).to.equal(true)
+      expect(onStalePath.called).to.equal(false)
+    })
+
+    it('leaves a non-prefixed path untouched', () => {
+      const {nav, navigate} = makeNav({existing: new Set(['architecture/auth.md'])})
+
+      nav.onRelatedClick('architecture/auth.md')
+
+      expect(navigate.calledOnceWithExactly('architecture/auth.md')).to.equal(true)
+    })
+
+    it('only strips a single leading @ (not multiple)', () => {
+      const {nav, navigate} = makeNav({existing: new Set(['@weird/path.md'])})
+
+      nav.onRelatedClick('@@weird/path.md')
+
+      expect(navigate.calledOnceWithExactly('@weird/path.md')).to.equal(true)
+    })
+
+    it('calls onStalePath with the @-stripped path when it does not exist', () => {
+      const {nav, navigate, onStalePath} = makeNav({existing: new Set()})
+
+      nav.onRelatedClick('@gone/path.md')
+
+      expect(navigate.called).to.equal(false)
+      expect(onStalePath.calledOnceWithExactly('gone/path.md')).to.equal(true)
+    })
+  })
+
+  describe('onEntryClick', () => {
+    it('navigates to entry.path when it exists', () => {
+      const {nav, navigate, onStalePath} = makeNav({existing: new Set(['domains/auth/login.html'])})
+
+      nav.onEntryClick({format: 'html', path: 'domains/auth/login.html', title: 'Login'})
+
+      expect(navigate.calledOnceWithExactly('domains/auth/login.html')).to.equal(true)
+      expect(onStalePath.called).to.equal(false)
+    })
+
+    it('calls onStalePath when entry.path does not exist', () => {
+      const {nav, navigate, onStalePath} = makeNav({existing: new Set()})
+
+      nav.onEntryClick({path: 'domains/gone.html'})
+
+      expect(navigate.called).to.equal(false)
+      expect(onStalePath.calledOnceWithExactly('domains/gone.html')).to.equal(true)
+    })
+  })
+})

--- a/test/unit/webui/features/context/utils/topic-viewer-navigation.test.ts
+++ b/test/unit/webui/features/context/utils/topic-viewer-navigation.test.ts
@@ -89,7 +89,7 @@ describe('createTopicViewerNavigation', () => {
     it('navigates to entry.path when it exists', () => {
       const {nav, navigate, onStalePath} = makeNav({existing: new Set(['domains/auth/login.html'])})
 
-      nav.onEntryClick({format: 'html', path: 'domains/auth/login.html', title: 'Login'})
+      nav.onEntryClick({path: 'domains/auth/login.html'})
 
       expect(navigate.calledOnceWithExactly('domains/auth/login.html')).to.equal(true)
       expect(onStalePath.called).to.equal(false)


### PR DESCRIPTION
## Summary

Consumer-side adoption of the new callback-based `TopicViewer` API from ENG-2843 (shared at `@campfirein/byterover-packages`), plus a few related additions the ticket called for.

- **Callback nav wired**: `breadcrumb` / `related` / `index` configs on `<TopicViewer>` at `context-detail-panel.tsx` and `root-index-detail.tsx`, via `useTopicViewerNavigation` (which wraps the pure `createTopicViewerNavigation` factory).
- **Stale-path guard**: clicks on paths not present in the context tree surface a sonner toast and don't navigate.
- **Root `index.html` landing**: when no path is selected and root contains `index.html` (blob), `RootIndexDetail` renders it via `TopicViewer` instead of the folder listing. Scope is root-only; `<folder>/index.html` still shows the folder listing.
- **Conflict-marker fallback for HTML**: extracted `ConflictContentView` from `MarkdownView` so both HTML and MD short-circuit to the banner + side-highlighted raw view when Git conflict markers are present.
- **Task/curate TopicViewer surfaces** pass `breadcrumb={{show: false}}` so the otherwise-clickable-but-dead breadcrumb is hidden in read-only artifact contexts.
- **Per-type header padding** in `DetailBody` (`py-4` for HTML, `pt-4 pb-0` for MD).
- **Smooth hash-anchor scrolling** for `TopicViewer` surfaces, with `data-stick-to-bottom` opt-out on the streaming task-detail container so `useStickToBottom`'s scrollTop writes don't animate.
- **`useContextTree.navigateToPath(path)`** exposed as the path-only nav primitive; `handleSelect(node)` is now a thin wrapper. Removes the prior synthetic-node fabrication in the topic-viewer navigation helper.
- **Shared package bumped** to `2dec813` (ENG-2843 callbacks + viewer-controls `height: 0` fix that resolves the rounded-corner clipping).

Three new unit-test files (10 + 6 cases) cover `createTopicViewerNavigation` (happy + stale-path for all three callbacks) and `hasRootIndex`.

## Test plan

- [ ] **Context detail panel** (Contexts tab → open `.html` file with bv-topic):
  - In-topic breadcrumb segments navigate via `?path=`.
  - Related pills navigate; leading `@` is stripped.
  - `<bv-index-entry>` clicks navigate to `entry.path`.
  - Sticky FULLSCREEN / PREVIEW / CODE buttons stay pinned within the panel.
- [ ] **Root index landing** (drop a `<bv-topic>` HTML at `.brv/context-tree/index.html`):
  - Root view (no `?path=`) renders TopicViewer instead of folder listing.
  - Edit / Save / Cancel work on `index.html`.
  - `<folder>/index.html` does NOT trigger the dispatch.
  - Removing root `index.html` falls back to folder listing.
- [ ] **Stale path handling**: clicking a related pill / index entry / breadcrumb segment for a non-existent path surfaces `toast.error("Path not found in context tree: …")` and does NOT change the URL.
- [ ] **Conflict-marker fallback**: edit an HTML file to embed `<<<<<<<` / `=======` / `>>>>>>>` markers — panel renders the conflict banner + raw side-highlighted view instead of TopicViewer. Same check still works for `.md` files (regression watch).
- [ ] **Task / curate surfaces**: `LiveStreamSection`, `ResultSection`, `CurateHtmlDirectInputView`, `WriteErrorItem.existingContent` render bv-topic HTML without an in-topic breadcrumb row.
- [ ] **Smooth scroll**: click an `<a href="#domain-...">` inside a `<bv-index>` — scroll animates smoothly. Streaming task auto-stick-to-bottom still feels fine (opt-out applied via `data-stick-to-bottom`).
- [ ] **Header padding**: HTML files get `py-4` (top + bottom), MD files keep `pt-4 pb-0`.
- [ ] `npm run lint`, `npm run typecheck`, `npm test` (or `./node_modules/.bin/mocha "test/unit/webui/**/*.test.ts"`) all green.

Detailed manual test plan in `ENG-2885-test-plan.md` (not committed — local QA notes).