### PR TITLE
fix: [ENG-2941] tolerate missing body in auth:getState

### DIFF
--- a/src/server/infra/transport/handlers/auth-handler.ts
+++ b/src/server/infra/transport/handlers/auth-handler.ts
@@ -223,7 +223,7 @@ export class AuthHandler {
           return {isAuthorized: false}
         }
 
-        const {projectPath} = data
+        const projectPath = data?.projectPath
         const [user, brvConfig] = await Promise.all([
           this.userService.getCurrentUser(token.sessionKey),
           projectPath ? this.projectConfigStore.read(projectPath) : Promise.resolve(),

--- a/src/shared/transport/events/auth-events.ts
+++ b/src/shared/transport/events/auth-events.ts
@@ -13,7 +13,7 @@ export const AuthEvents = {
 } as const
 
 export interface AuthGetStateRequest {
-  projectPath: string
+  projectPath?: string
 }
 
 export interface AuthGetStateResponse {

--- a/test/unit/infra/transport/handlers/auth-handler.test.ts
+++ b/test/unit/infra/transport/handlers/auth-handler.test.ts
@@ -82,6 +82,39 @@ function createTestBrvConfig(): BrvConfig {
 
 // ==================== Tests ====================
 
+function makeValidTokenStoreFixture(): ITokenStore {
+  return {
+    clear: stub().resolves(),
+    load: stub().resolves(createValidToken()),
+    save: stub().resolves(),
+  } as unknown as ITokenStore
+}
+
+function makeMissingTokenStoreFixture(): ITokenStore {
+  return {
+    clear: stub().resolves(),
+    load: stub().resolves(),
+    save: stub().resolves(),
+  } as unknown as ITokenStore
+}
+
+function makeExpiredTokenStoreFixture(): ITokenStore {
+  const expired = new AuthToken({
+    accessToken: 'expired-access',
+    expiresAt: new Date(Date.now() - 60_000),
+    refreshToken: 'expired-refresh',
+    sessionKey: 'expired-session',
+    tokenType: 'Bearer',
+    userEmail: 'test@example.com',
+    userId: 'user-123',
+  })
+  return {
+    clear: stub().resolves(),
+    load: stub().resolves(expired),
+    save: stub().resolves(),
+  } as unknown as ITokenStore
+}
+
 function createMockProviderConfigStore(
   options: {isConnected?: boolean} = {},
 ): SinonStubbedInstance<IProviderConfigStore> {
@@ -522,6 +555,64 @@ describe('AuthHandler — setupExternalAuthSync', () => {
       expect(callOrder).to.include('LOGIN_COMPLETED')
       expect(callOrder.indexOf('loadToken'), 'loadToken should be called before LOGIN_COMPLETED broadcast')
         .to.be.lessThan(callOrder.indexOf('LOGIN_COMPLETED'))
+    })
+  })
+
+  describe('setupGetState', () => {
+    it('returns isAuthorized=true and skips brvConfig when body is undefined (TUI sends no body)', async () => {
+      createHandler({tokenStore: makeValidTokenStoreFixture()})
+      const handler = transport._handlers.get(AuthEvents.GET_STATE)!
+
+       
+      const result = await handler(undefined, 'client-1')
+
+      expect(result.isAuthorized).to.equal(true)
+      expect(result.user).to.deep.include({email: 'test@example.com', id: 'user-123'})
+      expect(result.brvConfig).to.equal(undefined)
+      expect(result.authToken).to.have.property('accessToken', 'test-access-token')
+      expect(projectConfigStore.read.called, 'projectConfigStore.read should not be called without projectPath').to.be
+        .false
+    })
+
+    it('returns full state including brvConfig when body has projectPath (WebUI happy path)', async () => {
+      createHandler({tokenStore: makeValidTokenStoreFixture()})
+      const handler = transport._handlers.get(AuthEvents.GET_STATE)!
+
+      const result = await handler({projectPath: '/foo'}, 'client-1')
+
+      expect(result.isAuthorized).to.equal(true)
+      expect(result.brvConfig).to.deep.include({spaceId: 'space-1', teamId: 'team-1'})
+      expect(projectConfigStore.read.calledOnceWith('/foo')).to.be.true
+    })
+
+    it('returns isAuthorized=true and skips brvConfig when body is empty object', async () => {
+      createHandler({tokenStore: makeValidTokenStoreFixture()})
+      const handler = transport._handlers.get(AuthEvents.GET_STATE)!
+
+      const result = await handler({}, 'client-1')
+
+      expect(result.isAuthorized).to.equal(true)
+      expect(result.brvConfig).to.equal(undefined)
+      expect(projectConfigStore.read.called).to.be.false
+    })
+
+    it('returns isAuthorized=false when token is missing, regardless of body', async () => {
+      createHandler({tokenStore: makeMissingTokenStoreFixture()})
+      const handler = transport._handlers.get(AuthEvents.GET_STATE)!
+
+       
+      const result = await handler(undefined, 'client-1')
+
+      expect(result).to.deep.equal({isAuthorized: false})
+    })
+
+    it('returns isAuthorized=false when token is expired, regardless of body', async () => {
+      createHandler({tokenStore: makeExpiredTokenStoreFixture()})
+      const handler = transport._handlers.get(AuthEvents.GET_STATE)!
+
+      const result = await handler({projectPath: '/foo'}, 'client-1')
+
+      expect(result).to.deep.equal({isAuthorized: false})
     })
   })
 })


### PR DESCRIPTION
TUI sends no body for auth:getState, so the `{projectPath}` destructure added in #653 threw and the existing catch-all swallowed it into `{isAuthorized: false}`, forcing the TUI into the provider chooser and re-prompting byterover login on every startup. The valid token already proves the user is logged in; treat `projectPath` as optional and pull it via optional chaining so a missing body returns the correct auth state.

## Summary

- Problem: brv TUI always landed on the provider-chooser screen at startup and re-asked the user to log in when they selected byterover, even though `brv status` (CLI) and the local WebUI dashboard both reported the user as logged in with the right provider.
- Why it matters: byterover users could not reach the REPL; reported as Urgent in ENG-2941.
- What changed: the daemon's `auth:getState` handler now reads `projectPath` via optional chaining (`data?.projectPath`) instead of destructuring, and the shared request type marks `projectPath` as optional. Five regression tests added under a new `setupGetState` describe block (the path had zero coverage, which is why the original change slipped through).
- What did NOT change (scope boundary): TUI client code is untouched. WebUI client code is untouched. The pre-existing broad `catch` that swallows `userService.getCurrentUser` failures into `{isAuthorized: false}` is also untouched (separate latent issue, predates #653, not part of ENG-2941's "always stuck" symptom).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [ ] Agent / Tools
- [ ] LLM Providers
- [x] Server / Daemon
- [x] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes ENG-2941 (https://linear.app/byterover/issue/ENG-2941)
- Related: regression introduced by #653 (commit `1c54787fe`)

## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause: PR #653 changed the daemon's `auth:getState` handler from `const projectPath = this.resolveProjectPath(clientId)` to `const {projectPath} = data` and updated the WebUI client to send `{projectPath}`. The TUI client (`src/tui/features/auth/api/get-auth-state.ts:17`) was missed and kept sending `undefined` as the body. On the daemon, destructuring `undefined` threw a `TypeError`, which the long-standing broad `catch` swallowed and converted into `{isAuthorized: false}`. The TUI's `useAppViewMode` then routed to `ConfigProviderPage`, and `provider-flow.tsx`'s byterover branch re-prompted login.
- Why this was not caught earlier: `setupGetState` had zero test coverage. The existing `auth-handler.test.ts` exercised broadcast, login, logout, and the external-auth-sync paths, but never the request/response path. TypeScript could not catch the gap either because the contract was changed in the type def (required) without updating the TUI caller.

## Test plan

- Coverage added:
  - [x] Unit test
  - [ ] Integration test
  - [ ] Manual verification only
- Test file(s): `test/unit/infra/transport/handlers/auth-handler.test.ts` (new `describe('setupGetState')` block with five cases).
- Key scenario(s) covered:
  1. Valid token + body `undefined` returns `{isAuthorized: true}` with user, no `projectConfigStore.read` call. This is the ENG-2941 regression guard.
  2. Valid token + body `{projectPath: '/foo'}` returns full payload including `brvConfig`. This locks the WebUI happy path.
  3. Valid token + body `{}` returns authorized without `brvConfig`. Confirms the optional contract.
  4. Missing token + any body returns `{isAuthorized: false}`. Confirms the not-logged-in check still wins.
  5. Expired token + any body returns `{isAuthorized: false}`. Confirms token expiry still wins.

## User-visible changes

- TUI: `brv` (no args) now drops the user straight into the REPL when the user is logged in and byterover is the active provider, instead of forcing the provider-chooser screen.
- CLI commands (`brv status`, `brv providers list`, `brv login`, `brv logout`): unchanged.
- WebUI: unchanged.
- No config, default, or flag changes.

## Evidence

Before the fix, the new regression-guard test fails:

```
$ npx mocha --forbid-only "test/unit/infra/transport/handlers/auth-handler.test.ts"
  setupGetState
    1) returns isAuthorized=true and skips brvConfig when body is undefined (TUI sends no body)
    ✔ returns full state including brvConfig when body has projectPath (WebUI happy path)
    ✔ returns isAuthorized=true and skips brvConfig when body is empty object
    ✔ returns isAuthorized=false when token is missing, regardless of body
    ✔ returns isAuthorized=false when token is expired, regardless of body

  23 passing (236ms)
  1 failing

  1) AuthHandler — setupExternalAuthSync
       setupGetState
         returns isAuthorized=true and skips brvConfig when body is undefined (TUI sends no body):
      AssertionError: expected false to equal true
```

After the fix:

```
$ npx mocha --forbid-only "test/unit/infra/transport/handlers/auth-handler.test.ts"
  setupGetState
    ✔ returns isAuthorized=true and skips brvConfig when body is undefined (TUI sends no body)
    ✔ returns full state including brvConfig when body has projectPath (WebUI happy path)
    ✔ returns isAuthorized=true and skips brvConfig when body is empty object
    ✔ returns isAuthorized=false when token is missing, regardless of body
    ✔ returns isAuthorized=false when token is expired, regardless of body

  24 passing (228ms)

$ npm test
  8338 passing (30s)
  16 pending
  (0 failing)

$ npm run typecheck
  > tsc --noEmit && tsc --noEmit -p src/webui/tsconfig.json
  (clean exit)
```

## Checklist

- [x] Tests added or updated and passing (`npm test`)
- [ ] Lint passes (`npm run lint`) - pre-existing submodule config error on `main` (`packages/byterover-packages/ui/...` cannot resolve `@workspace/typescript-config/react-library.json`); reproduced on a clean `main` checkout, not introduced by this PR. The pre-commit `lint:fix` hook scoped to the three changed files passes.
- [x] Type check passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated (if applicable) - N/A
- [x] No breaking changes (or clearly documented above) - widening `projectPath: string` to `projectPath?: string` is strictly more permissive; all existing callers continue to type-check
- [x] Branch is up to date with `main`

## Risks and mitigations

- Risk: any future caller of `auth:getState` that omits the body will now receive `{isAuthorized: true}` with `brvConfig: undefined` instead of an error, so a caller that silently depends on `brvConfig` being populated could read `undefined` where it previously got a hard failure.
  - Mitigation: grep across `src/` and `test/` confirms only two callers exist today: WebUI (always sends `{projectPath}`, behavior unchanged) and TUI (never read `brvConfig` from this response). Five new tests pin the contract for both shapes.
- Risk: the broad `} catch { return {isAuthorized: false} }` inside `setupGetState` still silently downgrades `userService.getCurrentUser` failures to "not logged in", so a flaky network can still flip the TUI to onboarding intermittently.
  - Mitigation: this is a pre-existing latent issue predating #653, separate from ENG-2941's "always stuck on every startup" symptom. Out of scope for this PR; can be filed as a follow-up if desired.
