### PR TITLE
[ENG-2687] Language selection 1/5 — foundation (BrvConfig.language + language-clause module)

### DIFF
--- a/src/server/core/domain/entities/brv-config.ts
+++ b/src/server/core/domain/entities/brv-config.ts
@@ -3,6 +3,20 @@ import {Agent, AGENT_VALUES} from './agent.js'
 import {Space} from './space.js'
 
 /**
+ * Per-project language preference. Drives the language-preservation clause
+ * surfaced through the curate kickoff / correction prompts.
+ *
+ * - `auto`: instruct the LLM to match the user's input language.
+ * - `fixed`: instruct the LLM to write in a specific language (ISO 639-1).
+ *   `code` is required when `mode === 'fixed'`; the loader rejects fixed
+ *   without code so silent fallback to English is structurally impossible.
+ */
+export type BrvConfigLanguage = {
+  code?: string
+  mode: 'auto' | 'fixed'
+}
+
+/**
  * Parameters for creating a BrvConfig instance.
  * chatLogPath, cwd, ide, and cloud fields (spaceId, spaceName, teamId, teamName)
  * are optional to support local-only configs and partial configs.
@@ -15,6 +29,7 @@ export type BrvConfigParams = {
   createdAt: string
   cwd?: string
   ide?: Agent
+  language?: BrvConfigLanguage
   reviewDisabled?: boolean
   spaceId?: string
   spaceName?: string
@@ -61,6 +76,23 @@ const isCodingAgent = (value: unknown): value is Agent => {
 }
 
 /**
+ * Validate the shape of a `language` field on a config JSON object.
+ * Accepts `undefined` (the field is optional). For present values:
+ * - must be a non-null object with `mode: 'auto' | 'fixed'`
+ * - `code` is required when `mode === 'fixed'` (silent fallback to
+ *   English would otherwise be possible at prompt time)
+ */
+const isOptionalLanguageJson = (value: unknown): boolean => {
+  if (value === undefined) return true
+  if (typeof value !== 'object' || value === null) return false
+  const lang = value as Record<string, unknown>
+  if (lang.mode !== 'auto' && lang.mode !== 'fixed') return false
+  if (lang.code !== undefined && typeof lang.code !== 'string') return false
+  if (lang.mode === 'fixed' && typeof lang.code !== 'string') return false
+  return true
+}
+
+/**
  * Type guard for BrvConfigFromJson - validates JSON structure at runtime.
  * Note: version is optional in this check (old configs may not have it).
  * chatLogPath, cwd, and ide are optional to support partial configs.
@@ -90,6 +122,7 @@ const isBrvConfigJson = (json: unknown): json is BrvConfigFromJson => {
   if (obj.cipherAgentModes !== undefined && !Array.isArray(obj.cipherAgentModes)) return false
   if (obj.version !== undefined && typeof obj.version !== 'string') return false
   if (obj.reviewDisabled !== undefined && typeof obj.reviewDisabled !== 'boolean') return false
+  if (!isOptionalLanguageJson(obj.language)) return false
 
   return true
 }
@@ -106,6 +139,7 @@ export class BrvConfig {
   public readonly createdAt: string
   public readonly cwd?: string
   public readonly ide?: Agent
+  public readonly language?: BrvConfigLanguage
   public readonly reviewDisabled?: boolean
   public readonly spaceId?: string
   public readonly spaceName?: string
@@ -125,6 +159,7 @@ export class BrvConfig {
     this.createdAt = params.createdAt
     this.cwd = params.cwd
     this.ide = params.ide
+    this.language = params.language
     this.reviewDisabled = params.reviewDisabled
     this.spaceId = params.spaceId
     this.spaceName = params.spaceName
@@ -218,6 +253,7 @@ export class BrvConfig {
       createdAt: this.createdAt,
       cwd: this.cwd,
       ide: this.ide,
+      language: this.language,
       reviewDisabled: this.reviewDisabled,
       spaceId: this.spaceId,
       spaceName: this.spaceName,
@@ -252,6 +288,7 @@ export class BrvConfig {
       createdAt: this.createdAt,
       cwd: this.cwd,
       ide: this.ide,
+      language: this.language,
       reviewDisabled,
       spaceId: this.spaceId,
       spaceName: this.spaceName,
@@ -273,6 +310,7 @@ export class BrvConfig {
       createdAt: new Date().toISOString(),
       cwd: this.cwd,
       ide: this.ide,
+      language: this.language,
       reviewDisabled: this.reviewDisabled,
       spaceId: space.id,
       spaceName: space.name,
@@ -294,6 +332,7 @@ export class BrvConfig {
       createdAt: this.createdAt,
       cwd: this.cwd,
       ide: this.ide,
+      language: this.language,
       reviewDisabled: this.reviewDisabled,
       spaceId: this.spaceId,
       spaceName: this.spaceName,

--- a/src/server/core/domain/render/language-clause.ts
+++ b/src/server/core/domain/render/language-clause.ts
@@ -1,0 +1,88 @@
+/**
+ * Language-preservation clause for curate prompts.
+ *
+ * Single source of truth for the clause text. Every downstream injection
+ * surface — `buildGeneratePrompt`, `buildCorrectionPrompt`, and the MCP
+ * `brv-curate` tool description — imports `buildLanguageClause` and
+ * emits the same string. A wording revision is a one-file change.
+ *
+ * Schema-key invariant: the clause must mention that tag names, attribute
+ * names, attribute enum values, and `path` stay English. The element-
+ * registry Zod schemas enforce this structurally at the writer boundary —
+ * the clause mentions it so the calling agent's LLM doesn't burn a
+ * correction round-trip authoring `<bv-решение>` or `path="безопасность/..."`
+ * that would fail validation downstream.
+ */
+
+import type {BrvConfigLanguage} from '../entities/brv-config.js'
+
+/**
+ * ISO-639-1 code → English language name. Inline (~24 entries) rather than
+ * pulling the `iso-639-1` package — runtime dependency surface stays
+ * minimal. Codes not in this map degrade gracefully via the raw-code
+ * fallback in `buildLanguageClause`.
+ */
+export const LANGUAGE_NAMES: Record<string, string> = {
+  ar: 'Arabic',
+  de: 'German',
+  el: 'Greek',
+  en: 'English',
+  es: 'Spanish',
+  fi: 'Finnish',
+  fr: 'French',
+  he: 'Hebrew',
+  hi: 'Hindi',
+  id: 'Indonesian',
+  it: 'Italian',
+  ja: 'Japanese',
+  ko: 'Korean',
+  nl: 'Dutch',
+  no: 'Norwegian',
+  pl: 'Polish',
+  pt: 'Portuguese',
+  ru: 'Russian',
+  sv: 'Swedish',
+  th: 'Thai',
+  tr: 'Turkish',
+  uk: 'Ukrainian',
+  vi: 'Vietnamese',
+  zh: 'Chinese',
+}
+
+const AUTO_CLAUSE =
+  "Match the user's input language for human-readable content: body text of `<bv-*>` elements, list items, and the `title` / `summary` attributes on `<bv-topic>`. Keep tag names, attribute names, enum values, and the `path` attribute in English for tooling consistency. Code snippets and identifiers stay verbatim."
+
+function buildFixedClause(languageName: string): string {
+  return `Write all human-readable content (body text of \`<bv-*>\` elements, list items, \`title\` / \`summary\` attrs) in ${languageName}. Keep tag names, attribute names, enum values, and \`path\` in English. Code snippets and identifiers stay verbatim.`
+}
+
+/**
+ * Return the language-preservation clause text for a config's language
+ * preference.
+ *
+ * - `undefined` or `{mode: 'auto'}` → the auto clause: "match the user's
+ *   input language".
+ * - `{mode: 'fixed', code}` where `code` is in `LANGUAGE_NAMES` → the
+ *   fixed clause referencing the mapped English name (e.g. "Russian").
+ * - `{mode: 'fixed', code}` where `code` is unknown → the fixed clause
+ *   with the raw code in double quotes (e.g. `in "xx"`). Degrades
+ *   gracefully so a future ISO code we haven't mapped yet still produces
+ *   a usable clause.
+ *
+ * `{mode: 'fixed'}` without `code` is rejected by `isBrvConfigJson` at
+ * load time and cannot reach here under normal operation; the function
+ * still defends against it by returning the auto clause rather than
+ * throwing — a malformed config should degrade, not crash a write path.
+ */
+export function buildLanguageClause(language?: BrvConfigLanguage): string {
+  if (language === undefined || language.mode === 'auto') {
+    return AUTO_CLAUSE
+  }
+
+  if (language.code === undefined) {
+    return AUTO_CLAUSE
+  }
+
+  const name = LANGUAGE_NAMES[language.code] ?? `"${language.code}"`
+  return buildFixedClause(name)
+}

--- a/test/unit/core/domain/entities/brv-config.test.ts
+++ b/test/unit/core/domain/entities/brv-config.test.ts
@@ -304,4 +304,102 @@ describe('BrvConfig', () => {
       expect(config.createdAt).to.be.a('string')
     })
   })
+
+  describe('language', () => {
+    const fixedRu: BrvConfigParams['language'] = {code: 'ru', mode: 'fixed'}
+
+    it('defaults to undefined when not set', () => {
+      const config = new BrvConfig(validConstructorArgs)
+      expect(config.language).to.be.undefined
+    })
+
+    it('preserves auto-mode through the constructor', () => {
+      const config = new BrvConfig({...validConstructorArgs, language: {mode: 'auto'}})
+      expect(config.language).to.deep.equal({mode: 'auto'})
+    })
+
+    it('preserves fixed-mode with code through the constructor', () => {
+      const config = new BrvConfig({...validConstructorArgs, language: fixedRu})
+      expect(config.language).to.deep.equal(fixedRu)
+    })
+
+    it('round-trips auto-mode through toJson/fromJson', () => {
+      const config = new BrvConfig({...validConstructorArgs, language: {mode: 'auto'}})
+      const restored = BrvConfig.fromJson(config.toJson())
+      expect(restored.language).to.deep.equal({mode: 'auto'})
+    })
+
+    it('round-trips fixed-mode with code through toJson/fromJson', () => {
+      const config = new BrvConfig({...validConstructorArgs, language: fixedRu})
+      const restored = BrvConfig.fromJson(config.toJson())
+      expect(restored.language).to.deep.equal(fixedRu)
+    })
+
+    it('round-trips undefined language through toJson/fromJson', () => {
+      // Existing configs (no `language` field) must load cleanly post-rollout.
+      const config = new BrvConfig(validConstructorArgs)
+      const restored = BrvConfig.fromJson(config.toJson())
+      expect(restored.language).to.be.undefined
+    })
+
+    it('rejects mode: fixed without code in fromJson', () => {
+      // `mode: 'fixed'` without `code` would silently fall back to English
+      // at prompt time. The loader rejects it so the failure mode is
+      // structurally impossible.
+      expect(() =>
+        BrvConfig.fromJson({...validConstructorArgs, language: {mode: 'fixed'}}),
+      ).to.throw('Invalid BrvConfig JSON structure')
+    })
+
+    it('rejects unknown mode value in fromJson', () => {
+      expect(() =>
+        BrvConfig.fromJson({...validConstructorArgs, language: {mode: 'always-english'}}),
+      ).to.throw('Invalid BrvConfig JSON structure')
+    })
+
+    it('rejects non-string code in fromJson', () => {
+      expect(() =>
+        BrvConfig.fromJson({...validConstructorArgs, language: {code: 123, mode: 'fixed'}}),
+      ).to.throw('Invalid BrvConfig JSON structure')
+    })
+
+    it('rejects non-object language in fromJson', () => {
+      expect(() =>
+        BrvConfig.fromJson({...validConstructorArgs, language: 'ru'}),
+      ).to.throw('Invalid BrvConfig JSON structure')
+    })
+
+    it('rejects null language in fromJson', () => {
+      expect(() =>
+        BrvConfig.fromJson({...validConstructorArgs, language: null}),
+      ).to.throw('Invalid BrvConfig JSON structure')
+    })
+
+    it('preserves language through withSpace', () => {
+      const original = new BrvConfig({...validConstructorArgs, language: fixedRu})
+      const space = new Space({
+        id: 'space-789',
+        isDefault: false,
+        name: 'my-space',
+        teamId: 'team-abc',
+        teamName: 'my-team',
+      })
+      expect(original.withSpace(space).language).to.deep.equal(fixedRu)
+    })
+
+    it('preserves language through withoutSpace', () => {
+      const original = new BrvConfig({...validConstructorArgs, language: fixedRu})
+      expect(original.withoutSpace().language).to.deep.equal(fixedRu)
+    })
+
+    it('preserves language through withReviewDisabled', () => {
+      const original = new BrvConfig({...validConstructorArgs, language: fixedRu})
+      expect(original.withReviewDisabled(true).language).to.deep.equal(fixedRu)
+    })
+
+    it('preserves language through withVersion', () => {
+      const original = new BrvConfig({...validConstructorArgs, language: fixedRu})
+      expect(original.withVersion('9.9.9').language).to.deep.equal(fixedRu)
+    })
+  })
 })

--- a/test/unit/server/core/domain/render/language-clause.test.ts
+++ b/test/unit/server/core/domain/render/language-clause.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for buildLanguageClause and the LANGUAGE_NAMES map.
+ *
+ * The clause is load-bearing for the language-selection feature — every
+ * downstream injection surface (kickoff prompt, correction prompt, MCP
+ * tool description) emits this exact string. The "schema-key invariant"
+ * test below is the contract the clause must hold so that LLM authoring
+ * doesn't drift into translating tag names / enum values, which would
+ * fail Zod validation at the writer boundary.
+ */
+
+import {expect} from 'chai'
+
+import {buildLanguageClause, LANGUAGE_NAMES} from '../../../../../../src/server/core/domain/render/language-clause.js'
+
+describe('language-clause', () => {
+  describe('LANGUAGE_NAMES', () => {
+    it('includes Russian (the #616 reporter language)', () => {
+      expect(LANGUAGE_NAMES.ru).to.equal('Russian')
+    })
+
+    it('includes the four scripts covered by the validation matrix', () => {
+      expect(LANGUAGE_NAMES.vi).to.equal('Vietnamese')
+      expect(LANGUAGE_NAMES.zh).to.equal('Chinese')
+      expect(LANGUAGE_NAMES.ja).to.equal('Japanese')
+    })
+
+    it('includes English so the CLI accepts the restoration code', () => {
+      // Release notes recommend `language: { mode: 'fixed', code: 'en' }`
+      // as the opt-out path for users who want forced English. The CLI
+      // (commit 05) rejects codes not in this map, so `en` must be here.
+      expect(LANGUAGE_NAMES.en).to.equal('English')
+    })
+  })
+
+  describe('buildLanguageClause', () => {
+    it('returns the auto clause when language is undefined', () => {
+      const clause = buildLanguageClause()
+      expect(clause).to.include("Match the user's input language")
+    })
+
+    it('returns the auto clause when mode is auto', () => {
+      const clause = buildLanguageClause({mode: 'auto'})
+      expect(clause).to.include("Match the user's input language")
+    })
+
+    it('returns the fixed clause with mapped English name for a known code', () => {
+      const clause = buildLanguageClause({code: 'ru', mode: 'fixed'})
+      expect(clause).to.include('in Russian')
+    })
+
+    it('returns the fixed clause for Chinese (CJK)', () => {
+      const clause = buildLanguageClause({code: 'zh', mode: 'fixed'})
+      expect(clause).to.include('in Chinese')
+    })
+
+    it('returns the fixed clause for Vietnamese (Latin-non-English)', () => {
+      const clause = buildLanguageClause({code: 'vi', mode: 'fixed'})
+      expect(clause).to.include('in Vietnamese')
+    })
+
+    it('falls back to the raw code in quotes for an unknown ISO code', () => {
+      // Forward-compat: a future code we haven't mapped yet still
+      // produces a usable clause. Degrades to `in "xx"` rather than
+      // failing the entire prompt build.
+      const clause = buildLanguageClause({code: 'xx', mode: 'fixed'})
+      expect(clause).to.include('in "xx"')
+    })
+
+    it('degrades to auto when fixed-mode arrives without a code', () => {
+      // `isBrvConfigJson` rejects this shape at load time; the function
+      // defends against the case anyway so a malformed config degrades
+      // rather than crashing a write path.
+      const clause = buildLanguageClause({mode: 'fixed'})
+      expect(clause).to.include("Match the user's input language")
+    })
+
+    it('every clause variant mentions the schema-key invariant', () => {
+      // Load-bearing — if the clause is loose enough that this assertion
+      // fails, the LLM may translate tag names like `<bv-decision>` to a
+      // localized form, which fails Zod validation downstream.
+      const auto = buildLanguageClause()
+      const fixedKnown = buildLanguageClause({code: 'ru', mode: 'fixed'})
+      const fixedUnknown = buildLanguageClause({code: 'xx', mode: 'fixed'})
+
+      for (const clause of [auto, fixedKnown, fixedUnknown]) {
+        expect(clause).to.include('tag names')
+        expect(clause).to.include('attribute names')
+        expect(clause).to.include('enum values')
+        expect(clause).to.include('`path`')
+      }
+    })
+
+    it('all clauses preserve code snippets verbatim', () => {
+      const auto = buildLanguageClause()
+      const fixed = buildLanguageClause({code: 'ru', mode: 'fixed'})
+
+      expect(auto).to.include('Code snippets and identifiers stay verbatim')
+      expect(fixed).to.include('Code snippets and identifiers stay verbatim')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

First commit of the language-selection initiative (issue [#616](https://github.com/campfirein/byterover-cli/issues/616)). Pure scaffolding — adds the config field and the shared clause module that every subsequent commit will import from. **No surface is wired yet**; this commit is observably a no-op at runtime.

Plan: `features/language-selection/plan.md` (in the `research` repo). Per-commit spec: `tasks/commit-01-foundation.md`. Five commits total — this one + tool-mode injection / tokenizer / validation / CLI.

## What landed

- `BrvConfig.language?: { mode: 'auto' | 'fixed'; code? }` — exported `BrvConfigLanguage` type for downstream commits to reuse.
- Round-trips through `toJson` / `fromJson` and every `with*` method.
- `isOptionalLanguageJson` validation: `mode: 'fixed'` without `code` is rejected at load. Silent fallback to English is structurally impossible.
- `src/server/core/domain/render/language-clause.ts`:
  - `LANGUAGE_NAMES` inline (~24 ISO-639-1 → English entries; no `iso-639-1` dependency per the project's dependency-minimization principle).
  - `buildLanguageClause(language?)` — single source of truth for the clause text. Every downstream injection surface (kickoff prompt, correction prompt, MCP tool description) imports this so a wording revision is a one-file change.
  - Schema-key invariant baked into both auto and fixed clauses: tag names, attribute names, enum values, and \`path\` stay English so the LLM doesn't author \`<bv-решение>\` and trip Zod validation.

## What's deliberately not in scope

- Wiring the clause into prompt builders → **commit 02**.
- CJK-aware MiniSearch tokenizer → **commit 03**.
- Non-English fixtures + cross-language E2E + English regression → **commit 04**.
- \`brv config set language.*\` CLI → **commit 05**.
- Legacy daemon-side surfaces (legacy \`curate\` / \`query\` task types, \`summary-generation.ts\`, \`generateGhostCue\`, \`curate-folder\`) → deferred to backlog; vestigial in the modern tool-mode-HTML flow.

## Test plan

- [x] Typecheck clean
- [x] Lint clean (1 pre-existing complexity warning on \`isBrvConfigJson\`, +1 over baseline 30; unavoidable for a new validation case)
- [x] New unit tests:
  - 13 \`BrvConfig\` language tests (round-trip auto / fixed-RU / undefined; reject fixed-without-code, unknown mode, non-string code, non-object, null; preserve through all four \`with*\` methods)
  - 14 \`language-clause\` tests (auto / fixed-known / fixed-unknown / undefined / defensive fixed-without-code; schema-key invariant present in every variant; code-snippets-verbatim instruction present)
- [x] All 19 existing \`validate-brv-config\` tests pass — no regression on the BrvConfig consumer
- [x] 73/73 total green (27 existing BrvConfig + 13 new + 14 clause + 19 validate)

## Reviewer notes

- The auto-mode clause's wording is the artifact downstream commits depend on. Read it once and assert the carve-out for tag/attribute/enum names — a loose wording would let the LLM translate \`<bv-decision>\` for Russian input, which fails Zod at the writer boundary.
- \`BrvConfigLanguage\` is exported; commit 02 will import it to thread \`language?\` into \`buildGeneratePrompt\` / \`buildCorrectionPrompt\` options.
- \`LANGUAGE_NAMES\` is the same map the CLI (commit 05) will validate \`code\` against; English (\`en\`) is included so the release-notes restoration recipe (\`mode: 'fixed', code: 'en'\`) is accepted.