### PR TITLE
[ENG-2688] Language selection 2/5 — tool-mode injection (kickoff + correction + MCP tool description)

### DIFF
--- a/src/oclif/commands/curate/index.ts
+++ b/src/oclif/commands/curate/index.ts
@@ -1,5 +1,8 @@
 import {Args, Command, Flags} from '@oclif/core'
 
+import type {BrvConfigLanguage} from '../../../server/core/domain/entities/brv-config.js'
+
+import {ProjectConfigStore} from '../../../server/infra/config/file-config-store.js'
 import {continueSession, kickoffSession, resolveProjectRoot} from '../../lib/curate-session.js'
 import {type DaemonClientOptions, formatConnectionError, withDaemonRetry} from '../../lib/daemon-client.js'
 import {writeJsonResponse} from '../../lib/json-response.js'
@@ -202,13 +205,16 @@ Bad examples:
     // to emit the generate prompt.
     const {response} = flags
     const confirmOverwrite = flags.overwrite ?? false
+    const projectRoot = resolveProjectRoot()
+    const language = await this.resolveLanguagePreference(projectRoot)
     try {
       await withDaemonRetry(async (client) => {
         const envelope = await continueSession({
           client,
           confirmOverwrite,
           format,
-          projectRoot: resolveProjectRoot(),
+          language,
+          projectRoot,
           response,
           sessionId,
         })
@@ -249,7 +255,25 @@ Bad examples:
       return
     }
 
-    const envelope = await kickoffSession({content, projectRoot: resolveProjectRoot()})
+    const projectRoot = resolveProjectRoot()
+    const language = await this.resolveLanguagePreference(projectRoot)
+    const envelope = await kickoffSession({content, language, projectRoot})
     this.emitToolModeEnvelope(envelope, format)
+  }
+
+  /**
+   * Read the per-project language preference from `.brv/config.json`.
+   * Missing config (fresh project) or missing field returns `undefined`,
+   * which the kickoff / correction prompts treat as the auto clause —
+   * match the user's input language. Read failures degrade silently to
+   * `undefined` so a corrupt config never blocks curate.
+   */
+  private async resolveLanguagePreference(projectRoot: string): Promise<BrvConfigLanguage | undefined> {
+    try {
+      const config = await new ProjectConfigStore().read(projectRoot)
+      return config?.language
+    } catch {
+      return undefined
+    }
   }
 }

--- a/src/oclif/lib/curate-session.ts
+++ b/src/oclif/lib/curate-session.ts
@@ -6,6 +6,7 @@ import {mkdir, readFile, rm, writeFile} from 'node:fs/promises'
 import {dirname, join} from 'node:path'
 import {z} from 'zod'
 
+import type {BrvConfigLanguage} from '../../server/core/domain/entities/brv-config.js'
 import type {CurateHtmlDirectResult} from '../../server/core/interfaces/executor/i-curate-executor.js'
 import type {HtmlWriteError} from '../../server/infra/render/writer/html-writer.js'
 import type {CurateMeta} from '../../shared/curate-meta.js'
@@ -174,6 +175,13 @@ type CurateSessionState = {
 
 type KickoffOptions = {
   content: string
+  /**
+   * Per-project language preference loaded from `.brv/config.json`. Threaded
+   * into the kickoff prompt so the calling agent's LLM authors body text in
+   * the configured language. `undefined` (no config or no language field)
+   * defaults to the auto clause — match the user's input language.
+   */
+  language?: BrvConfigLanguage
   projectRoot: string
 }
 
@@ -195,6 +203,12 @@ type ContinueOptions = {
    * mode). Defaults to 'json' — matches the agent-facing default.
    */
   format?: 'json' | 'text'
+  /**
+   * Per-project language preference loaded from `.brv/config.json`. Threaded
+   * into the correction prompt — read fresh on each continuation, so a
+   * mid-session config change (rare) is honored on the next retry.
+   */
+  language?: BrvConfigLanguage
   projectRoot: string
   response: string
   sessionId: string
@@ -207,7 +221,7 @@ type ContinueOptions = {
  * to author HTML".
  */
 export async function kickoffSession(options: KickoffOptions): Promise<CurateSessionEnvelope> {
-  const {content, projectRoot} = options
+  const {content, language, projectRoot} = options
   const sessionId = randomUUID()
 
   const state: CurateSessionState = {
@@ -222,7 +236,7 @@ export async function kickoffSession(options: KickoffOptions): Promise<CurateSes
 
   return {
     ok: true,
-    prompt: buildGeneratePrompt({userIntent: content}),
+    prompt: buildGeneratePrompt({language, userIntent: content}),
     sessionId,
     status: 'needs-llm-step',
     step: 'generate-html',
@@ -299,7 +313,7 @@ export function parseCurateResponse(raw: string): {html: string; meta?: CurateMe
  * is the session-protocol envelope only.
  */
 export async function continueSession(options: ContinueOptions): Promise<CurateSessionEnvelope> {
-  const {client, confirmOverwrite = false, format = 'json', projectRoot, response, sessionId} = options
+  const {client, confirmOverwrite = false, format = 'json', language, projectRoot, response, sessionId} = options
 
   // Reject non-uuid session ids before any path join — see SESSION_ID_RE
   // for the threat model. Same `kind` as "session not found" because
@@ -401,6 +415,7 @@ export async function continueSession(options: ContinueOptions): Promise<CurateS
     ok: false,
     prompt: buildCorrectionPrompt({
       errors: writeResult.errors,
+      language,
       previousHtml: response,
       userIntent: state.userIntent,
     }),

--- a/src/server/core/domain/render/curate-prompt-builder.ts
+++ b/src/server/core/domain/render/curate-prompt-builder.ts
@@ -1,7 +1,9 @@
 import type {HtmlWriteError} from '../../../infra/render/writer/html-writer.js'
+import type {BrvConfigLanguage} from '../entities/brv-config.js'
 
 import {ELEMENT_REGISTRY} from '../../../infra/render/elements/registry.js'
 import {ELEMENT_NAMES} from './element-types.js'
+import {buildLanguageClause} from './language-clause.js'
 
 /**
  * Curate-prompt builder for tool mode.
@@ -52,7 +54,7 @@ export const CURATE_SCHEMA_PROMPT: string = buildSchemaPrompt()
  * agent ingested (READMEs, files, prior chat) so it cannot be
  * trusted as plain text.
  */
-export function buildGeneratePrompt(options: {userIntent: string}): string {
+export function buildGeneratePrompt(options: {language?: BrvConfigLanguage; userIntent: string}): string {
   return [
     'You are authoring a `<bv-topic>` HTML document for a knowledge base.',
     '',
@@ -63,6 +65,10 @@ export function buildGeneratePrompt(options: {userIntent: string}): string {
     '# Path format',
     '',
     PATH_FORMAT,
+    '',
+    '# Language',
+    '',
+    buildLanguageClause(options.language),
     '',
     '# Element vocabulary (closed)',
     '',
@@ -88,10 +94,11 @@ export function buildGeneratePrompt(options: {userIntent: string}): string {
  */
 export function buildCorrectionPrompt(options: {
   errors: readonly HtmlWriteError[]
+  language?: BrvConfigLanguage
   previousHtml: string
   userIntent: string
 }): string {
-  const {errors, previousHtml, userIntent} = options
+  const {errors, language, previousHtml, userIntent} = options
 
   const fixInstructions = errors.length === 0
     ? 'No structured errors were reported. Re-emit the document carefully and double-check every required attribute.'
@@ -129,6 +136,10 @@ export function buildCorrectionPrompt(options: {
     '# Output contract',
     '',
     OUTPUT_CONTRACT,
+    '',
+    '# Language',
+    '',
+    buildLanguageClause(language),
     '',
     '# Errors to fix',
     '',

--- a/src/server/infra/mcp/tools/brv-curate-tool.ts
+++ b/src/server/infra/mcp/tools/brv-curate-tool.ts
@@ -12,6 +12,7 @@ import type {HtmlWriteError} from '../../render/writer/html-writer.js'
 import {CurateMetaSchema} from '../../../../shared/curate-meta.js'
 import {encodeCurateHtmlContent} from '../../../../shared/transport/curate-html-content.js'
 import {CURATE_SCHEMA_PROMPT} from '../../../core/domain/render/curate-prompt-builder.js'
+import {buildLanguageClause} from '../../../core/domain/render/language-clause.js'
 import {TransportTaskEventNames} from '../../../core/domain/transport/schemas.js'
 import {appendDriftFooter} from './drift-footer.js'
 import {associateProjectWithRetry, type McpStartupProjectContext, resolveMcpTaskContext} from './mcp-project-context.js'
@@ -47,6 +48,16 @@ const TOOL_DESCRIPTION = [
   '- Do not emit `importance`, `maturity`, `recency`, `createdat`, or `updatedat` on <bv-topic> — those are system-managed.',
   '- Inside `<li>`, write plain text only — no leading `-`, `*`, `•`, `1.`/`2.` markers; the renderer adds them via CSS.',
   '- `<bv-diagram>` body: emit directly with HTML entities for `<`, `>`, `&`. Do NOT wrap in `<![CDATA[…]]>` — HTML5 parses CDATA as a bogus comment that the first `-->` closes. Example: `<bv-diagram type="mermaid">graph LR; A --&gt;|x| B</bv-diagram>`.',
+  '',
+  // Auto clause unconditional: the MCP tool description is built once at
+  // server-boot, so it cannot read live config. Per-call fixed-mode is
+  // honored via the oclif `brv curate` kickoff prompt (which IS dynamic).
+  // MCP-only consumers under `language: { mode: 'fixed' }` see the auto
+  // clause here; their input language still gets preserved because auto
+  // says "match the input language".
+  '# Language',
+  '',
+  buildLanguageClause(),
   '',
   '# Path format',
   '- The `path` attribute on <bv-topic> is `<domain>/<topic>` or `<domain>/<topic>/<subtopic>`, snake_case segments.',

--- a/test/unit/infra/mcp/tools/brv-curate-tool.test.ts
+++ b/test/unit/infra/mcp/tools/brv-curate-tool.test.ts
@@ -298,6 +298,27 @@ describe('brv-curate-tool', () => {
       // dropping it would silently regress the Skill ↔ MCP output parity.
       expect(description).to.include('Place section titles INSIDE the container')
     })
+
+    it('embeds the auto-mode language-preservation clause', () => {
+      // MCP's TOOL_DESCRIPTION is built once at server-boot and cannot
+      // read live config, so it carries the auto clause unconditionally:
+      // "match the user's input language". Per-call fixed-mode is honored
+      // via the oclif `brv curate` kickoff prompt instead.
+      // The schema-key carve-out (tag names / attribute names / enum values
+      // stay English) prevents the calling agent's LLM from translating
+      // `<bv-decision>` for non-English input — which would fail Zod
+      // validation at the writer boundary.
+      const {getDescription} = setupHandler({
+        getClient: () => createMockClient().client,
+        getWorkingDirectory: () => '/project/root',
+      })
+
+      const description = getDescription()
+      expect(description).to.include('# Language')
+      expect(description).to.include("Match the user's input language")
+      expect(description).to.include('tag names')
+      expect(description).to.include('enum values')
+    })
   })
 
   describe('dispatch — task type + payload', () => {

--- a/test/unit/oclif/lib/curate-session.test.ts
+++ b/test/unit/oclif/lib/curate-session.test.ts
@@ -219,6 +219,25 @@ describe('curate-session', () => {
       const b = await kickoffSession({content: 'b', projectRoot})
       expect(a.sessionId).to.not.equal(b.sessionId)
     })
+
+    it('threads `language` into the kickoff prompt (auto when omitted)', async () => {
+      // End-to-end threading proof: orchestrator → buildGeneratePrompt →
+      // buildLanguageClause. Auto when no language preference is set.
+      const env = await kickoffSession({content: 'x', projectRoot})
+      expect(env.prompt).to.include("Match the user's input language")
+    })
+
+    it('threads `language` into the kickoff prompt (fixed-mode emits the mapped name)', async () => {
+      // A regression dropping the param in the orchestrator would surface
+      // here as the auto clause leaking into a fixed-mode kickoff.
+      const env = await kickoffSession({
+        content: 'x',
+        language: {code: 'ru', mode: 'fixed'},
+        projectRoot,
+      })
+      expect(env.prompt).to.include('in Russian')
+      expect(env.prompt).to.not.include("Match the user's input language")
+    })
   })
 
   // ─── continueSession — dispatch to daemon ────────────────────────────────────

--- a/test/unit/server/core/domain/render/curate-prompt-builder.test.ts
+++ b/test/unit/server/core/domain/render/curate-prompt-builder.test.ts
@@ -249,11 +249,48 @@ describe('curate-prompt-builder', () => {
       // Schema slice is ~2-3 KB; the surrounding prose adds ~1.5 KB
       // for explicit contract rules covering `<li>` bullet prefixes,
       // `<bv-diagram>` CDATA, and `related` file-vs-folder routing;
-      // the user intent is bounded by the caller. Each rule prevents
-      // a distinct FE-breaking output class. Bumping the budget should
-      // be a deliberate decision, not a silent drift.
+      // the language clause adds ~340 chars; the user intent is bounded
+      // by the caller. Each rule prevents a distinct FE-breaking output
+      // class. Bumping the budget should be a deliberate decision, not a
+      // silent drift.
       const prompt = buildGeneratePrompt({userIntent: 'remember we use RS256'})
       expect(prompt.length).to.be.lessThan(6144)
+    })
+
+    it('emits a `# Language` section between path format and element vocabulary', () => {
+      // Section ordering matters: the language clause is part of the
+      // byterover-controlled framing that must commit BEFORE the
+      // element vocabulary (so the LLM authors `<bv-*>` body text in
+      // the configured language) and BEFORE the user-intent block (so
+      // a malicious intent can't shadow it).
+      const prompt = buildGeneratePrompt({userIntent: 'x'})
+      const pathIdx = prompt.indexOf('# Path format')
+      const languageIdx = prompt.indexOf('# Language')
+      const schemaIdx = prompt.indexOf('# Element vocabulary')
+
+      expect(languageIdx, 'language section present').to.be.greaterThan(-1)
+      expect(languageIdx, 'language section after path format').to.be.greaterThan(pathIdx)
+      expect(languageIdx, 'language section before element vocabulary').to.be.lessThan(schemaIdx)
+    })
+
+    it('emits the auto-mode clause when language is not provided', () => {
+      const prompt = buildGeneratePrompt({userIntent: 'x'})
+      expect(prompt).to.include("Match the user's input language")
+    })
+
+    it('emits the auto-mode clause when language.mode is auto', () => {
+      const prompt = buildGeneratePrompt({language: {mode: 'auto'}, userIntent: 'x'})
+      expect(prompt).to.include("Match the user's input language")
+    })
+
+    it('emits the fixed-mode clause with the mapped language name', () => {
+      // Threading proof — confirms `language` from options reaches
+      // buildLanguageClause. A regression dropping the param (e.g. a
+      // future destructuring miss in the orchestrator) would surface
+      // here as the auto clause leaking into fixed-mode prompts.
+      const prompt = buildGeneratePrompt({language: {code: 'ru', mode: 'fixed'}, userIntent: 'x'})
+      expect(prompt).to.include('in Russian')
+      expect(prompt).to.not.include("Match the user's input language")
     })
   })
 
@@ -424,6 +461,45 @@ describe('curate-prompt-builder', () => {
         userIntent,
       })
       expect(prompt).to.not.include(CURATE_SCHEMA_PROMPT)
+    })
+
+    it('emits a `# Language` section between output contract and errors', () => {
+      // Correction prompts can't drop the language clause — if the
+      // first attempt failed validation, the LLM may also have drifted
+      // off language. The clause reasserts the contract on every
+      // retry.
+      const prompt = buildCorrectionPrompt({
+        errors: [{kind: 'missing-path-attribute', message: 'm'}],
+        previousHtml,
+        userIntent,
+      })
+      const contractIdx = prompt.indexOf('# Output contract')
+      const languageIdx = prompt.indexOf('# Language')
+      const errorsIdx = prompt.indexOf('# Errors to fix')
+
+      expect(languageIdx, 'language section present').to.be.greaterThan(-1)
+      expect(languageIdx, 'language after output contract').to.be.greaterThan(contractIdx)
+      expect(languageIdx, 'language before errors block').to.be.lessThan(errorsIdx)
+    })
+
+    it('emits the auto-mode clause when language is not provided', () => {
+      const prompt = buildCorrectionPrompt({
+        errors: [{kind: 'missing-path-attribute', message: 'm'}],
+        previousHtml,
+        userIntent,
+      })
+      expect(prompt).to.include("Match the user's input language")
+    })
+
+    it('emits the fixed-mode clause with the mapped language name', () => {
+      const prompt = buildCorrectionPrompt({
+        errors: [{kind: 'missing-path-attribute', message: 'm'}],
+        language: {code: 'ru', mode: 'fixed'},
+        previousHtml,
+        userIntent,
+      })
+      expect(prompt).to.include('in Russian')
+      expect(prompt).to.not.include("Match the user's input language")
     })
   })
 })


### PR DESCRIPTION
## Summary

Commit 2 of 5 for the language-selection initiative (issue [#616](https://github.com/campfirein/byterover-cli/issues/616)). Wires the language-preservation clause from #710 (ENG-2687) into every tool-mode prompt surface the calling agent's LLM consumes during curate.

**After this lands**, a tool-mode user under `language: { mode: 'fixed', code: 'ru' }` gets their `<bv-*>` body text authored in Russian; schema (tag names, attribute names, enum values, `path`) stays English because the clause carves it out. **Closes #616 for Cyrillic / Vietnamese / European Latin users.** CJK users still need commit 03 (CJK-aware MiniSearch tokenizer) before queries find matches.

Plan: \`features/language-selection/plan.md\` in the research repo. Spec: \`tasks/commit-02-tool-mode-injection.md\`.

## Three injection points

1. **\`buildGeneratePrompt\`** (\`curate-prompt-builder.ts:55\`) — accepts \`language?: BrvConfigLanguage\`; emits a \`# Language\` section between Path format and Element vocabulary (byterover-controlled framing that commits BEFORE the user-intent block).
2. **\`buildCorrectionPrompt\`** (\`curate-prompt-builder.ts:89\`) — same param; emits the clause between Output contract and Errors-to-fix (reasserts the contract on every retry).
3. **\`brv-curate-tool.ts:TOOL_DESCRIPTION\`** (MCP listing) — appends the auto clause unconditionally. The description is built once at server-boot and cannot read live config; fixed-mode is honored via the oclif kickoff prompt instead (which IS dynamic). MCP-only consumers under \`mode: 'fixed'\` still get language preservation because the auto clause says \"match the input language\".

All three import \`buildLanguageClause\` from the shared module (#710) — single source of truth for the wording.

## Threading

\`kickoffSession\` / \`continueSession\` in \`curate-session.ts\` now accept \`language?\` and pass it to the builders. The oclif \`brv curate\` command loads \`BrvConfig.language\` via \`ProjectConfigStore.read()\` and threads it into both kickoff and continuation. A try/catch around the read degrades a corrupt config to \`undefined → auto\` — never blocks curate. \`language\` is re-read on every continuation so a mid-session \`brv config set language.code <iso>\` is honored on the next retry.

\`grep 'buildGeneratePrompt('\` and \`grep 'buildCorrectionPrompt('\` show only \`curate-session.ts\` as the call site — every caller is threaded.

## What's deliberately not in scope

- CJK-aware MiniSearch tokenizer → **commit 03** (ENG-26??).
- Non-English fixtures + cross-language E2E + English regression → **commit 04**.
- \`brv config set language.*\` CLI → **commit 05**.
- Legacy daemon-side surfaces (legacy \`curate\` / \`query\` task types, \`summary-generation.ts\`, \`generateGhostCue\`, \`curate-folder\`) → deferred to backlog; vestigial in the modern tool-mode-HTML flow.

## Test plan

- [x] Typecheck clean
- [x] Lint clean (pre-existing \`max-params\` warning on \`registerBrvCurateTool\` is unchanged — confirmed via stash-and-relint)
- [x] 10 new tests added:
  - 4 on \`buildGeneratePrompt\` (section ordering, auto-default, auto-mode, fixed-RU emits 'in Russian' and not the auto string)
  - 3 on \`buildCorrectionPrompt\` (section ordering, auto-default, fixed-RU)
  - 2 integration cases on \`kickoffSession\` confirming end-to-end orchestrator → builder threading (auto + fixed-RU)
  - 1 on \`TOOL_DESCRIPTION\` self-containment asserting auto clause + schema-key carve-out present
- [x] All existing prompt + MCP + session tests pass (175/175 across the affected surfaces)
- [x] Budget test still passes (kickoff prompt stays under 6 KB with the ~370 added chars)

## Reviewer notes

- The commit-02 task spec mentioned threading at \`agent-process.ts:687\` \`case 'curate-tool-mode'\`. That AC was slightly mis-worded — that handler doesn't build prompts (HTML is already authored upstream by the calling agent). The actual seam is the oclif command → \`curate-session.ts\` layer, where this PR lands the threading. Intent satisfied at the right architectural seam.
- The MCP tool description is static at server-boot; fixed-mode-on-MCP consumers see the auto clause. This asymmetry is deliberate (per plan §7) — making MCP descriptions dynamic across the spec is more cost than benefit; auto-mode \"match the input language\" already preserves the user's language end-to-end for the common case.
- \`resolveLanguagePreference\` on the command degrades silently on read errors. A corrupt \`.brv/config.json\` should never block a curate; the language preference is best-effort.
- Section placement was chosen so the byterover-controlled framing (output contract / path format / **language** / element vocabulary) all commits before the user-intent block. A malicious intent containing a fake \`# Language\` section is still bracketed by the explicit data-not-instructions warning.