### PR TITLE
[ENG-2689] Language selection 3/5 — CJK-aware MiniSearch tokenizer

### DIFF
--- a/src/agent/infra/tools/implementations/cjk-tokenizer.ts
+++ b/src/agent/infra/tools/implementations/cjk-tokenizer.ts
@@ -1,0 +1,159 @@
+/**
+ * BM25 tokenizer with CJK bigram segmentation.
+ *
+ * MiniSearch 7.2.0's default tokenizer splits on `\p{Z}\p{P}` (Unicode
+ * whitespace + punctuation). Latin / Cyrillic / Vietnamese / European
+ * scripts use whitespace between words and tokenize correctly. CJK scripts
+ * do not — a sentence like `认证系统使用JWT令牌` becomes a single token,
+ * so a query for `认证` against indexed CJK content returns zero matches.
+ *
+ * Empirical confirmation before this fix (MiniSearch 7.2.0):
+ *
+ *   const ms = new MiniSearch({fields: ['t'], idField: 'id'})
+ *   ms.addAll([{id: 1, t: '认证系统使用JWT令牌'}])
+ *   ms.search('认证')           // → [] — broken
+ *   ms.search('Привет мир')   // → matches as expected
+ *
+ * This tokenizer preserves the default behavior for whitespace-separated
+ * scripts and adds overlapping-bigram segmentation for CJK runs. Mixed
+ * Latin+CJK tokens (e.g. `JWT令牌`) split at the script boundary so the
+ * Latin portion stays a real word token.
+ *
+ * Wired via the top-level `tokenize` option on MiniSearch — per the
+ * library docs and source (`MiniSearch.js:1564-1566`), that single option
+ * applies at both index and query time unless `searchOptions.tokenize`
+ * is set, which we leave unset.
+ */
+
+/**
+ * Unicode ranges treated as CJK for the purposes of bigram segmentation.
+ * Anything outside these ranges is "non-CJK" and tokenizes by whitespace
+ * boundaries only.
+ *
+ * - `0x4E00–0x9FFF`: CJK Unified Ideographs (Chinese, Japanese kanji)
+ * - `0x3040–0x309F`: Hiragana
+ * - `0x30A0–0x30FF`: Katakana
+ * - `0xAC00–0xD7AF`: Hangul Syllables (Korean)
+ *
+ * CJK Extension A/B/C/… are deliberately excluded — they appear in academic
+ * / historical text but rarely in user content. If a user's corpus needs
+ * them, extend this list and bump `INDEX_SCHEMA_VERSION` in
+ * `search-knowledge-service.ts` so cached indexes invalidate.
+ */
+const CJK_RANGES: ReadonlyArray<readonly [number, number]> = [
+  [0x4E_00, 0x9F_FF],
+  [0x30_40, 0x30_9F],
+  [0x30_A0, 0x30_FF],
+  [0xAC_00, 0xD7_AF],
+]
+
+function isCjkCodePoint(cp: number): boolean {
+  for (const [lo, hi] of CJK_RANGES) {
+    if (cp >= lo && cp <= hi) return true
+  }
+
+  return false
+}
+
+/**
+ * Whitespace + punctuation split, matching MiniSearch's default
+ * `SPACE_OR_PUNCTUATION` regex. Kept verbatim so a future upstream tweak
+ * is easy to spot via diff.
+ */
+const SPACE_OR_PUNCTUATION = /[\p{Z}\p{P}]+/u
+
+/**
+ * Split a token at boundaries between CJK and non-CJK runs.
+ *
+ * - `'JWT令牌'`  → `['JWT', '令牌']` (script boundary at index 3)
+ * - `'认证'`     → `['认证']`        (single CJK run)
+ * - `'JWT'`      → `['JWT']`          (single non-CJK run)
+ */
+function splitAtCjkBoundary(token: string): string[] {
+  const segments: string[] = []
+  let current = ''
+  let currentIsCjk: boolean | undefined
+
+  // Iterate by code point so any future range extension into the
+  // supplementary plane handles surrogate pairs correctly. The current
+  // four ranges are all BMP, so `for...of` is equivalent to char-by-char
+  // here — but cheap to be correct.
+  for (const ch of token) {
+    const cp = ch.codePointAt(0)
+    if (cp === undefined) continue
+    const charIsCjk = isCjkCodePoint(cp)
+
+    if (currentIsCjk === undefined) {
+      current = ch
+      currentIsCjk = charIsCjk
+    } else if (charIsCjk === currentIsCjk) {
+      current += ch
+    } else {
+      segments.push(current)
+      current = ch
+      currentIsCjk = charIsCjk
+    }
+  }
+
+  if (current.length > 0) segments.push(current)
+
+  return segments
+}
+
+/**
+ * Emit overlapping bigrams for a CJK run.
+ *
+ * - `'认证系统'` (4 chars) → `['认证', '证系', '系统']`
+ * - `'认证'`     (2 chars) → `['认证']`
+ * - `'认'`       (1 char)  → `['认']` (unigram fallback so single-char tokens are searchable)
+ *
+ * Bigrams are the standard CJK IR compromise: unigrams are too noisy
+ * (common chars like `的` dominate scoring), trigrams are too sparse
+ * (miss 2-character compound matches).
+ */
+function cjkBigrams(run: string): string[] {
+  const chars = [...run]
+  if (chars.length <= 1) return chars
+
+  const grams: string[] = []
+  for (let i = 0; i < chars.length - 1; i++) {
+    grams.push(chars[i] + chars[i + 1])
+  }
+
+  return grams
+}
+
+/**
+ * Tokenize text for BM25 indexing and querying.
+ *
+ * Algorithm:
+ *   1. Split on Unicode whitespace + punctuation (matches MiniSearch default).
+ *   2. For each resulting token, split at CJK ↔ non-CJK script boundaries.
+ *   3. For non-CJK segments, emit the segment as-is.
+ *   4. For CJK segments, emit overlapping bigrams.
+ *
+ * The result is the union — Latin / Cyrillic / Vietnamese behave exactly
+ * as the MiniSearch default, while CJK runs become searchable.
+ */
+export function tokenizeWithCjk(text: string): string[] {
+  const out: string[] = []
+
+  for (const wsToken of text.split(SPACE_OR_PUNCTUATION)) {
+    if (wsToken.length === 0) continue
+
+    for (const segment of splitAtCjkBoundary(wsToken)) {
+      if (segment.length === 0) continue
+
+      // `splitAtCjkBoundary` returns single-script segments, so the
+      // first code point's classification applies to the whole segment.
+      const firstCp = segment.codePointAt(0)
+      if (firstCp !== undefined && isCjkCodePoint(firstCp)) {
+        out.push(...cjkBigrams(segment))
+      } else {
+        out.push(segment)
+      }
+    }
+  }
+
+  return out
+}

--- a/src/agent/infra/tools/implementations/search-knowledge-service.ts
+++ b/src/agent/infra/tools/implementations/search-knowledge-service.ts
@@ -36,6 +36,7 @@ import {
 import {getFormatForRead} from '../../../../server/infra/render/format/format-detector.js'
 import {ElementAxisIndex} from '../../../../server/infra/render/reader/element-axis-index.js'
 import {readHtmlTopicSync} from '../../../../server/infra/render/reader/html-reader.js'
+import {tokenizeWithCjk} from './cjk-tokenizer.js'
 import {isPathLikeQuery, matchMemoryPath, parseSymbolicQuery} from './memory-path-matcher.js'
 import {
   buildReferenceIndex,
@@ -53,7 +54,7 @@ const MAX_CONTEXT_TREE_FILES = 10_000
 const DEFAULT_CACHE_TTL_MS = 5000
 
 /** Bump when MINISEARCH_OPTIONS fields/boost change to invalidate cached indexes */
-const INDEX_SCHEMA_VERSION = 6
+const INDEX_SCHEMA_VERSION = 7
 
 /** Only include results whose normalized score is at least this fraction of the top result's score */
 const SCORE_GAP_RATIO = 0.7
@@ -171,6 +172,12 @@ const MINISEARCH_OPTIONS = {
     prefix: true,
   },
   storeFields: ['title', 'path'] as string[],
+  // Custom tokenizer adds CJK bigram segmentation alongside the default
+  // whitespace split. Without it, queries against Chinese / Japanese /
+  // Korean content return zero matches even when the content is curated
+  // correctly — see `cjk-tokenizer.ts`. Top-level `tokenize` applies to
+  // both indexing and querying per MiniSearch's API.
+  tokenize: tokenizeWithCjk,
 }
 
 interface IndexedDocument {

--- a/test/unit/agent/infra/tools/implementations/cjk-tokenizer.test.ts
+++ b/test/unit/agent/infra/tools/implementations/cjk-tokenizer.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for `tokenizeWithCjk` — the BM25 tokenizer that fixes MiniSearch's
+ * CJK blind spot.
+ *
+ * Whitespace-separated scripts (Latin, Cyrillic, Vietnamese, …) must
+ * tokenize byte-identical to the MiniSearch default; CJK runs must emit
+ * overlapping bigrams; mixed Latin+CJK tokens must split at the script
+ * boundary so the Latin portion stays a real word token. The integration
+ * block at the end exercises the wired-up MiniSearch contract — the CJK
+ * gate — and confirms English scoring is preserved.
+ */
+
+import {expect} from 'chai'
+import MiniSearch from 'minisearch'
+
+import {tokenizeWithCjk} from '../../../../../../src/agent/infra/tools/implementations/cjk-tokenizer.js'
+
+function buildMiniSearchIndex(docs: Array<{id: number; t: string}>): MiniSearch {
+  const ms = new MiniSearch({
+    fields: ['t'],
+    idField: 'id',
+    tokenize: tokenizeWithCjk,
+  })
+  ms.addAll(docs)
+  return ms
+}
+
+describe('cjk-tokenizer', () => {
+  describe('tokenizeWithCjk — non-CJK scripts behave like the MiniSearch default', () => {
+    it('English: splits on whitespace, preserves word tokens verbatim', () => {
+      expect(tokenizeWithCjk('Hello world JWT auth')).to.deep.equal([
+        'Hello', 'world', 'JWT', 'auth',
+      ])
+    })
+
+    it('Russian (Cyrillic): preserves whitespace tokenization, no CJK side effects', () => {
+      expect(tokenizeWithCjk('Привет мир программирования')).to.deep.equal([
+        'Привет', 'мир', 'программирования',
+      ])
+    })
+
+    it('Vietnamese (Latin-non-English): diacritics survive intact', () => {
+      // The proof point that LLM-in-call detection beats a Unicode-block
+      // heuristic — Vietnamese is Latin script and tokenizes via whitespace
+      // just like English. Diacritics are part of the word, not separators.
+      expect(tokenizeWithCjk('Cách triển khai xác thực')).to.deep.equal([
+        'Cách', 'triển', 'khai', 'xác', 'thực',
+      ])
+    })
+
+    it('punctuation acts as a separator (matches MiniSearch default)', () => {
+      // Default MiniSearch splits on `\p{Z}\p{P}+`; commas, periods, parens
+      // all become token boundaries.
+      expect(tokenizeWithCjk('one, two; three.')).to.deep.equal(['one', 'two', 'three'])
+    })
+  })
+
+  describe('tokenizeWithCjk — CJK scripts emit overlapping bigrams', () => {
+    it('Chinese: 4-character run → 3 overlapping bigrams', () => {
+      expect(tokenizeWithCjk('认证系统')).to.deep.equal(['认证', '证系', '系统'])
+    })
+
+    it('Chinese: 2-character run → single bigram (the whole token)', () => {
+      expect(tokenizeWithCjk('认证')).to.deep.equal(['认证'])
+    })
+
+    it('Japanese: kanji + katakana both segmented as CJK', () => {
+      // `認証システム` contains both kanji (`認証`) and katakana
+      // (`システム`). The tokenizer treats them as a single CJK run since
+      // both ranges are CJK-classified, producing overlapping bigrams
+      // across the whole string.
+      const tokens = tokenizeWithCjk('認証システム')
+      expect(tokens).to.deep.include('認証')
+      expect(tokens).to.deep.include('証シ')
+      expect(tokens).to.deep.include('シス')
+      expect(tokens).to.deep.include('ステ')
+      expect(tokens).to.deep.include('テム')
+    })
+
+    it('Korean (Hangul Syllables): segmented into bigrams', () => {
+      // Whitespace-separated Korean tokens still bigram within each token.
+      // `'인증 시스템'` → `'인증'` (single bigram == whole token) plus
+      // bigrams of `'시스템'` (`'시스'`, `'스템'`).
+      const tokens = tokenizeWithCjk('인증 시스템')
+      expect(tokens).to.deep.include('인증')
+      expect(tokens).to.deep.include('시스')
+      expect(tokens).to.deep.include('스템')
+    })
+
+    it('single-character CJK input falls back to unigram', () => {
+      // Edge case for BM25 — a lone character has no bigram, but should
+      // still be searchable as itself. The unigram fallback prevents the
+      // tokenizer from emitting an empty array (which MiniSearch would
+      // interpret as "this document has no content for this field").
+      expect(tokenizeWithCjk('认')).to.deep.equal(['认'])
+    })
+  })
+
+  describe('tokenizeWithCjk — mixed Latin + CJK tokens split at the script boundary', () => {
+    it('whitespace-separated Latin and CJK tokens stay independent', () => {
+      // `'JWT 令牌'` is already two whitespace-separated tokens. Latin
+      // stays Latin, the 2-char CJK run emits one bigram (the whole thing).
+      expect(tokenizeWithCjk('JWT 令牌')).to.deep.equal(['JWT', '令牌'])
+    })
+
+    it('no-whitespace mixed token splits at the script boundary', () => {
+      // `'JWT令牌'` has no whitespace — but the script boundary between
+      // 'T' (Latin) and '令' (CJK) is still a token boundary. Otherwise
+      // the Latin portion would get lost in a CJK bigram smear.
+      expect(tokenizeWithCjk('JWT令牌')).to.deep.equal(['JWT', '令牌'])
+    })
+
+    it('multiple boundaries in one token: alternating Latin/CJK runs', () => {
+      // `'API请求JSON响应'` → Latin/CJK/Latin/CJK boundaries.
+      // Each non-CJK run stays as one token; each CJK run emits bigrams.
+      expect(tokenizeWithCjk('API请求JSON响应')).to.deep.equal([
+        'API',
+        '请求',
+        'JSON',
+        '响应',
+      ])
+    })
+  })
+
+  describe('MiniSearch integration — the CJK gate', () => {
+    // The unit tests above lock the tokenizer's input/output contract.
+    // These integration tests prove the contract holds when the tokenizer
+    // is wired into a real MiniSearch instance — what
+    // `search-knowledge-service.ts:MINISEARCH_OPTIONS` does in production.
+
+    it('Chinese query matches Chinese content (was broken before this fix)', () => {
+      // The motivating test. Pre-fix: empirical run returned [] because
+      // `'认证系统使用JWT令牌'` tokenized as a single token under the
+      // MiniSearch default. With the bigram tokenizer, the query `'认证'`
+      // tokenizes to ['认证'] and finds doc 1's `'认证'` bigram.
+      const ms = buildMiniSearchIndex([
+        {id: 1, t: '认证系统使用JWT令牌'},
+        {id: 2, t: 'JWT auth tokens'},
+      ])
+      const results = ms.search('认证')
+      expect(results.length, 'Chinese query returns at least one match').to.be.greaterThan(0)
+      expect(results[0].id).to.equal(1)
+    })
+
+    it('Japanese query matches Japanese content', () => {
+      const ms = buildMiniSearchIndex([{id: 1, t: '認証システムはJWTトークンを使用'}])
+      const results = ms.search('認証')
+      expect(results.length).to.be.greaterThan(0)
+    })
+
+    it('Korean query matches Korean content', () => {
+      const ms = buildMiniSearchIndex([{id: 1, t: '인증 시스템은 JWT 토큰을 사용합니다'}])
+      const results = ms.search('인증')
+      expect(results.length).to.be.greaterThan(0)
+    })
+
+    it('Russian query matches Russian content (regression, was working pre-fix)', () => {
+      // Cyrillic is whitespace-separated → the default tokenizer already
+      // handled it. Locking the regression so a future tokenizer rewrite
+      // doesn't accidentally break a script that used to work.
+      const ms = buildMiniSearchIndex([{id: 1, t: 'Привет мир программирования'}])
+      const results = ms.search('программирования')
+      expect(results.length).to.be.greaterThan(0)
+    })
+
+    it('English query against English content returns the expected match', () => {
+      // Sanity check: the Latin path is byte-identical to the default
+      // MiniSearch behavior, so the existing BM25 ranking story is
+      // preserved end-to-end.
+      const ms = buildMiniSearchIndex([
+        {id: 1, t: 'JWT authentication tokens'},
+        {id: 2, t: 'session cookies and CSRF'},
+      ])
+      const results = ms.search('JWT')
+      expect(results.length).to.equal(1)
+      expect(results[0].id).to.equal(1)
+    })
+
+    it('English query does NOT match unrelated CJK content', () => {
+      // Cross-script isolation: a CJK doc shouldn't drag into English
+      // queries (and vice versa). The bigram tokenization is opaque to
+      // Latin queries; no false positives leak across scripts.
+      const ms = buildMiniSearchIndex([
+        {id: 1, t: '认证系统'},
+        {id: 2, t: 'JWT authentication'},
+      ])
+      const englishResults = ms.search('JWT')
+      expect(englishResults.length).to.equal(1)
+      expect(englishResults[0].id).to.equal(2)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Commit 3 of 5 for the language-selection initiative (issue [#616](https://github.com/campfirein/byterover-cli/issues/616)). Fixes a confirmed BM25 search bug that makes Chinese / Japanese / Korean content unsearchable, even when the content is curated correctly.

**Without this fix**, the language preservation from ENG-2687 / ENG-2688 is invisible to CJK users — their curate output is in Chinese / Japanese / Korean but every query returns zero matches.

Plan: `features/language-selection/plan.md`. Spec: `tasks/commit-03-tokenizer.md`.

## The bug

MiniSearch 7.2.0's default tokenizer splits on `\p{Z}\p{P}` (Unicode whitespace + punctuation). CJK scripts have no whitespace between characters, so a whole sentence becomes one token. Empirical confirmation before this fix:

```js
const ms = new MiniSearch({fields: ['t'], idField: 'id'})
ms.addAll([{id: 1, t: '认证系统使用JWT令牌'}])
ms.search('认证')          // → [] — broken
ms.search('Привет мир')  // → matches as expected
```

## The fix

New `cjk-tokenizer.ts` module wired via the top-level `tokenize` option on `MINISEARCH_OPTIONS`. The algorithm:

1. Split on Unicode whitespace + punctuation (matches MiniSearch default).
2. For each token, split at CJK ↔ non-CJK script boundaries.
3. Non-CJK segments emit as-is — Latin / Cyrillic / Vietnamese / European behave byte-identical to the default.
4. CJK segments emit overlapping bigrams; single-char input falls back to unigram so it stays searchable.

CJK Unicode ranges covered: U+4E00–9FFF (Unified Ideographs), U+3040–309F (Hiragana), U+30A0–30FF (Katakana), U+AC00–D7AF (Hangul Syllables).

Bigrams are the standard CJK IR compromise — unigrams are too noisy (common characters like `的` dominate scoring), trigrams are too sparse. Per the MiniSearch source (`MiniSearch.js:1564-1566`), the top-level `tokenize` option applies at both index and query time, so a single setting covers both paths.

No new runtime deps — `Intl.Segmenter` is available in Node 16+ but its CJK quality varies by ICU version; inline bigrams are deterministic across Node versions and platforms.

`INDEX_SCHEMA_VERSION` bumped 6 → 7 so any cached index built with the default tokenizer invalidates and rebuilds on first daemon start.

## Test plan

- [x] Typecheck clean
- [x] Lint clean (0 errors; 9 pre-existing warnings on unrelated functions in `search-knowledge-service.ts` unchanged)
- [x] **18 new tests**:
  - 4 non-CJK regression cases (English, Russian, Vietnamese, punctuation) asserting byte-identical behavior to the MiniSearch default
  - 5 CJK cases (Chinese 4-char → 3 bigrams, Chinese 2-char → 1 bigram, Japanese kanji+katakana, Korean Hangul, single-char unigram fallback)
  - 3 mixed Latin+CJK cases (`JWT 令牌`, `JWT令牌`, `API请求JSON响应`)
  - 6 MiniSearch integration cases — the production wiring contract: Chinese / Japanese / Korean queries return matches; Russian regression; English regression; cross-script isolation (English query does NOT match CJK content)
- [x] **58/58 existing search-knowledge-service tests** pass — no regression on the production indexer
- [x] **175/175 tests from PRs #710 and #711** still pass

## Reviewer notes

- The single-char CJK fallback (unigram for length-1 input) is documented and tested. Without it, a sentence like `'认'` would emit `[]` and MiniSearch would treat the document as having no content for that field.
- Cross-script isolation: the integration test "English query does NOT match unrelated CJK content" pins the contract that bigrams stay opaque to Latin queries. If a future refactor accidentally widens this, the test will catch it.
- Hex literal style — auto-fix converted to `0x4E_00` (numeric-separator) style. Matches the codebase convention.
- The MiniSearch 7.x API exposes `searchOptions.tokenize` for per-query overrides; left unset so the top-level option auto-applies. Confirmed in MiniSearch source at line 1564-1566.
- `INDEX_SCHEMA_VERSION` bump is conservative — even non-CJK indexes will rebuild once, but the rebuild is fast (~filesystem walk + indexer pass) and the alternative (selective invalidation) is more code for a one-time hit.

## What's next

- **Commit 04** (validation): RU / VI / ZH / JA fixtures, cross-language E2E, English regression byte-identical.
- **Commit 05** (CLI): `brv config set language.*` + release notes crediting #616 reporter.

After this commit lands, the language-selection feature works end-to-end for every target script. CJK users can curate AND query in their language.