### PR TITLE
Feat/eng 2974

### DIFF
--- a/src/oclif/commands/config/set.ts
+++ b/src/oclif/commands/config/set.ts
@@ -48,6 +48,15 @@ export default class ConfigSet extends Command {
     const {args, flags} = await this.parse(ConfigSet)
     const format = flags.format as 'json' | 'text'
 
+    if (args.key === 'language.mode' || args.key === 'language.code') {
+      this.fail(
+        format,
+        'deprecated-key',
+        `'${args.key}' has moved to global settings. Run: brv settings set ${args.key} ${args.value}`,
+      )
+      return
+    }
+
     const projectRoot = resolveProjectRoot()
     const store = new ProjectConfigStore()
     const current = await store.read(projectRoot)

--- a/src/oclif/commands/curate/index.ts
+++ b/src/oclif/commands/curate/index.ts
@@ -2,7 +2,9 @@ import {Args, Command, Flags} from '@oclif/core'
 
 import type {BrvConfigLanguage} from '../../../server/core/domain/entities/brv-config.js'
 
+import {SETTINGS_KEYS} from '../../../server/core/domain/entities/settings.js'
 import {ProjectConfigStore} from '../../../server/infra/config/file-config-store.js'
+import {FileSettingsStore} from '../../../server/infra/storage/file-settings-store.js'
 import {continueSession, kickoffSession, resolveProjectRoot} from '../../lib/curate-session.js'
 import {type DaemonClientOptions, formatConnectionError, withDaemonRetry} from '../../lib/daemon-client.js'
 import {writeJsonResponse} from '../../lib/json-response.js'
@@ -262,18 +264,36 @@ Bad examples:
   }
 
   /**
-   * Read the per-project language preference from `.brv/config.json`.
-   * Missing config (fresh project) or missing field returns `undefined`,
-   * which the kickoff / correction prompts treat as the auto clause —
-   * match the user's input language. Read failures degrade silently to
-   * `undefined` so a corrupt config never blocks curate.
+   * Resolve the language preference. Reads from daemon settings (the
+   * source of truth) and falls back to `.brv/config.json` for users who
+   * still have a per-project override from before language moved to
+   * global settings. Missing or default values return `undefined`,
+   * which the prompts treat as the auto clause.
    */
   private async resolveLanguagePreference(projectRoot: string): Promise<BrvConfigLanguage | undefined> {
+    const fromSettings = await readLanguageFromSettings()
+    if (fromSettings !== undefined) return fromSettings
+
     try {
       const config = await new ProjectConfigStore().read(projectRoot)
       return config?.language
     } catch {
       return undefined
     }
+  }
+}
+
+async function readLanguageFromSettings(): Promise<BrvConfigLanguage | undefined> {
+  try {
+    const store = new FileSettingsStore()
+    const items = await store.list()
+    const byKey = new Map(items.map((item) => [item.key, item.current]))
+    const mode = byKey.get(SETTINGS_KEYS.LANGUAGE_MODE)
+    const code = byKey.get(SETTINGS_KEYS.LANGUAGE_CODE)
+    if (mode !== 'fixed') return undefined
+    if (typeof code !== 'string') return undefined
+    return {code, mode: 'fixed'}
+  } catch {
+    return undefined
   }
 }

--- a/src/oclif/commands/curate/index.ts
+++ b/src/oclif/commands/curate/index.ts
@@ -2,13 +2,15 @@ import {Args, Command, Flags} from '@oclif/core'
 
 import type {BrvConfigLanguage} from '../../../server/core/domain/entities/brv-config.js'
 
-import {SETTINGS_KEYS} from '../../../server/core/domain/entities/settings.js'
 import {ProjectConfigStore} from '../../../server/infra/config/file-config-store.js'
-import {FileSettingsStore} from '../../../server/infra/storage/file-settings-store.js'
+import {SettingsEvents, type SettingsListResponse} from '../../../shared/transport/events/settings-events.js'
 import {continueSession, kickoffSession, resolveProjectRoot} from '../../lib/curate-session.js'
 import {type DaemonClientOptions, formatConnectionError, withDaemonRetry} from '../../lib/daemon-client.js'
 import {writeJsonResponse} from '../../lib/json-response.js'
 import {argvRequestsJsonFormat, CURATE_REMOVED_FLAGS, findRemovedFlagMessage} from '../../lib/removed-flags.js'
+
+const LANGUAGE_MODE_KEY = 'language.mode'
+const LANGUAGE_CODE_KEY = 'language.code'
 
 /** Parsed flags type */
 type CurateFlags = {
@@ -264,11 +266,20 @@ Bad examples:
   }
 
   /**
-   * Resolve the language preference. Reads from daemon settings (the
-   * source of truth) and falls back to `.brv/config.json` for users who
-   * still have a per-project override from before language moved to
-   * global settings. Missing or default values return `undefined`,
-   * which the prompts treat as the auto clause.
+   * Resolve the language preference. Daemon settings (the source of
+   * truth) take precedence; a per-project `.brv/config.json language`
+   * field acts as a fallback for users who configured language before
+   * it moved to global settings.
+   *
+   * Note on precedence: only daemon `mode: 'fixed'` short-circuits the
+   * fallback. An explicit daemon `mode: 'auto'` reads as "no opinion"
+   * and falls through to project config, so a stale project-config
+   * `fixed/X` will still win. This is intentional for the migration
+   * window — distinguishing "user explicitly chose auto" from "user
+   * never touched settings" needs raw-overrides access that the
+   * transport doesn't expose today, and the bug only manifests for
+   * users with a pre-existing per-project `language` field. Revisit
+   * once project-config language is fully sunset.
    */
   private async resolveLanguagePreference(projectRoot: string): Promise<BrvConfigLanguage | undefined> {
     const fromSettings = await readLanguageFromSettings()
@@ -285,11 +296,12 @@ Bad examples:
 
 async function readLanguageFromSettings(): Promise<BrvConfigLanguage | undefined> {
   try {
-    const store = new FileSettingsStore()
-    const items = await store.list()
-    const byKey = new Map(items.map((item) => [item.key, item.current]))
-    const mode = byKey.get(SETTINGS_KEYS.LANGUAGE_MODE)
-    const code = byKey.get(SETTINGS_KEYS.LANGUAGE_CODE)
+    const response = await withDaemonRetry<SettingsListResponse>(async (client) =>
+      client.requestWithAck<SettingsListResponse>(SettingsEvents.LIST),
+    )
+    const byKey = new Map(response.items.map((item) => [item.key, item.current]))
+    const mode = byKey.get(LANGUAGE_MODE_KEY)
+    const code = byKey.get(LANGUAGE_CODE_KEY)
     if (mode !== 'fixed') return undefined
     if (typeof code !== 'string') return undefined
     return {code, mode: 'fixed'}

--- a/src/oclif/commands/settings/get.ts
+++ b/src/oclif/commands/settings/get.ts
@@ -103,8 +103,9 @@ export default class SettingsGet extends Command {
   }
 }
 
-function renderValue(item: SettingsItemDTO, value: boolean | number): string {
+function renderValue(item: SettingsItemDTO, value: boolean | number | string): string {
   if (typeof value === 'boolean') return value ? 'true' : 'false'
+  if (typeof value === 'string') return value
   return renderInteger(item, value)
 }
 

--- a/src/oclif/commands/settings/index.ts
+++ b/src/oclif/commands/settings/index.ts
@@ -5,22 +5,15 @@ import {
   type SettingsItemDTO,
   type SettingsListResponse,
 } from '../../../shared/transport/events/settings-events.js'
+import {
+  CATEGORY_HEADERS,
+  CATEGORY_ORDER,
+  type SettingsRowCategory,
+  toRowCategory,
+} from '../../../shared/types/settings-row.js'
 import {formatCount, formatDuration} from '../../../shared/utils/format-duration.js'
 import {type DaemonClientOptions, formatConnectionError, withDaemonRetry} from '../../lib/daemon-client.js'
 import {writeJsonResponse} from '../../lib/json-response.js'
-
-type CategoryName = 'concurrency' | 'llm' | 'task-history' | 'updates'
-
-const CATEGORY_ORDER: readonly CategoryName[] = ['concurrency', 'llm', 'task-history', 'updates']
-
-const CATEGORY_HEADERS: Readonly<Record<CategoryName, string>> = {
-  concurrency: 'CONCURRENCY',
-  llm: 'LLM',
-  'task-history': 'TASK HISTORY',
-  updates: 'UPDATES',
-}
-
-const OTHER_HEADER = 'OTHER'
 
 export default class Settings extends Command {
   public static description =
@@ -83,22 +76,15 @@ export default class Settings extends Command {
       this.log('')
     }
 
-    const otherRows = byCategory.get('__other__')
-    if (otherRows && otherRows.length > 0) {
-      this.log(OTHER_HEADER)
-      for (const row of otherRows) this.log(formatRow(row))
-      this.log('')
-    }
-
     this.log('Set:   brv settings set <key> <value>')
     this.log('Reset: brv settings reset <key>')
   }
 }
 
-function groupByCategory(items: readonly SettingsItemDTO[]): Map<string, SettingsItemDTO[]> {
-  const map = new Map<string, SettingsItemDTO[]>()
+function groupByCategory(items: readonly SettingsItemDTO[]): Map<SettingsRowCategory, SettingsItemDTO[]> {
+  const map = new Map<SettingsRowCategory, SettingsItemDTO[]>()
   for (const item of items) {
-    const bucket = item.category ?? '__other__'
+    const bucket: SettingsRowCategory = toRowCategory(item.category)
     const list = map.get(bucket) ?? []
     list.push(item)
     map.set(bucket, list)

--- a/src/oclif/commands/settings/index.ts
+++ b/src/oclif/commands/settings/index.ts
@@ -114,8 +114,9 @@ function formatRow(item: SettingsItemDTO): string {
   return `  ${pad(item.key, 40)}  ${pad(current, 7)}  (default ${defaultStr})${''.padEnd(Math.max(0, 8 - defaultStr.length))}  ${range}`
 }
 
-function renderValue(item: SettingsItemDTO, value: boolean | number): string {
+function renderValue(item: SettingsItemDTO, value: boolean | number | string): string {
   if (typeof value === 'boolean') return value ? 'true' : 'false'
+  if (typeof value === 'string') return value
   return renderInteger(item, value)
 }
 

--- a/src/oclif/commands/settings/reset.ts
+++ b/src/oclif/commands/settings/reset.ts
@@ -97,8 +97,9 @@ export default class SettingsReset extends Command {
   }
 }
 
-function renderValue(item: SettingsItemDTO, value: boolean | number): string {
+function renderValue(item: SettingsItemDTO, value: boolean | number | string): string {
   if (typeof value === 'boolean') return value ? 'true' : 'false'
+  if (typeof value === 'string') return value
   if (item.unit === 'ms') return formatDuration(value)
   return formatCount(value)
 }

--- a/src/oclif/commands/settings/set.ts
+++ b/src/oclif/commands/settings/set.ts
@@ -119,7 +119,7 @@ export default class SettingsSet extends Command {
 
   protected async writeSetting(
     key: string,
-    value: boolean | number,
+    value: boolean | number | string,
     options?: DaemonClientOptions,
   ): Promise<SettingsSetResponse> {
     return withDaemonRetry<SettingsSetResponse>(
@@ -131,7 +131,7 @@ export default class SettingsSet extends Command {
 }
 
 type ParseResult =
-  | {readonly display: string; readonly kind: 'ok'; readonly value: boolean | number}
+  | {readonly display: string; readonly kind: 'ok'; readonly value: boolean | number | string}
   | {readonly kind: 'error'; readonly message: string}
 
 const BOOLEAN_TOKENS = new Map<string, boolean>([
@@ -149,8 +149,22 @@ const BOOLEAN_TOKENS_HINT = 'true, false, on, off, 1, 0, yes, no'
 
 function parseValue(descriptor: SettingsItemDTO, raw: string): ParseResult {
   if (descriptor.type === 'boolean') return parseAsBoolean(descriptor, raw)
+  if (descriptor.type === 'enum') return parseAsEnum(descriptor, raw)
   if (descriptor.unit === 'ms') return parseAsDuration(descriptor, raw)
   return parseAsCount(descriptor, raw)
+}
+
+function parseAsEnum(descriptor: SettingsItemDTO, raw: string): ParseResult {
+  const trimmed = raw.trim()
+  const options = descriptor.options ?? []
+  if (!options.includes(trimmed)) {
+    return {
+      kind: 'error',
+      message: `${descriptor.key} expected one of [${options.join(', ')}], got '${raw}'.`,
+    }
+  }
+
+  return {display: trimmed, kind: 'ok', value: trimmed}
 }
 
 function parseAsBoolean(descriptor: SettingsItemDTO, raw: string): ParseResult {

--- a/src/server/core/domain/entities/settings.ts
+++ b/src/server/core/domain/entities/settings.ts
@@ -6,13 +6,14 @@ import {
   TASK_HISTORY_DEFAULT_MAX_ENTRIES,
   UPDATE_CHECK_FOR_UPDATES_DEFAULT,
 } from '../../../constants.js'
+import {LANGUAGE_NAMES} from '../render/language-clause.js'
 
 /**
  * High-level concern the setting controls. Drives group headers in CLI
  * and TUI render output (uppercased). Web docs / WebUI consume this
  * field to render the same groupings independently of key naming.
  */
-export type SettingCategory = 'concurrency' | 'llm' | 'task-history' | 'updates'
+export type SettingCategory = 'concurrency' | 'language' | 'llm' | 'task-history' | 'updates'
 
 /**
  * Value-kind for dispatch between the duration formatter / parser
@@ -48,15 +49,21 @@ export type BooleanSettingDescriptor = BaseSettingDescriptor & {
   readonly type: 'boolean'
 }
 
+export type EnumSettingDescriptor = BaseSettingDescriptor & {
+  readonly default: string
+  readonly options: readonly string[]
+  readonly type: 'enum'
+}
+
 /**
  * Descriptor for a single user-configurable setting. Discriminated on
  * `type` so consumers narrow with a single check before reading
- * type-specific fields (`min`/`max` on integers, etc).
+ * type-specific fields (`min`/`max` on integers, `options` on enums, etc).
  *
  * Defaults reference the existing constants module so a constant change
  * automatically updates the setting's default.
  */
-export type SettingDescriptor = BooleanSettingDescriptor | IntegerSettingDescriptor
+export type SettingDescriptor = BooleanSettingDescriptor | EnumSettingDescriptor | IntegerSettingDescriptor
 
 /**
  * View of one setting: the key, the user's current override (or the default
@@ -64,8 +71,8 @@ export type SettingDescriptor = BooleanSettingDescriptor | IntegerSettingDescrip
  * shapes; consumers narrow on the corresponding descriptor's `type`.
  */
 export type SettingItem = {
-  readonly current: boolean | number
-  readonly default: boolean | number
+  readonly current: boolean | number | string
+  readonly default: boolean | number | string
   readonly key: string
   readonly restartRequired: boolean
 }
@@ -79,6 +86,8 @@ export type SettingItem = {
 export const SETTINGS_KEYS = {
   AGENT_POOL_MAX_CONCURRENT_TASKS: 'agentPool.maxConcurrentTasksPerProject',
   AGENT_POOL_MAX_SIZE: 'agentPool.maxSize',
+  LANGUAGE_CODE: 'language.code',
+  LANGUAGE_MODE: 'language.mode',
   LLM_ITERATION_BUDGET_MS: 'llm.iterationBudgetMs',
   LLM_REQUEST_TIMEOUT_MS: 'llm.requestTimeoutMs',
   TASK_HISTORY_MAX_ENTRIES: 'taskHistory.maxEntries',
@@ -145,6 +154,24 @@ export const SETTINGS_REGISTRY: readonly SettingDescriptor[] = [
     key: SETTINGS_KEYS.UPDATE_CHECK_FOR_UPDATES,
     restartRequired: false,
     type: 'boolean',
+  },
+  {
+    category: 'language',
+    default: 'auto',
+    description: 'Match input language (auto) or force a fixed language for written output',
+    key: SETTINGS_KEYS.LANGUAGE_MODE,
+    options: ['auto', 'fixed'],
+    restartRequired: false,
+    type: 'enum',
+  },
+  {
+    category: 'language',
+    default: 'en',
+    description: 'ISO-639-1 code applied when mode is fixed; ignored in auto mode',
+    key: SETTINGS_KEYS.LANGUAGE_CODE,
+    options: Object.keys(LANGUAGE_NAMES),
+    restartRequired: false,
+    type: 'enum',
   },
 ]
 

--- a/src/server/core/domain/entities/settings.ts
+++ b/src/server/core/domain/entities/settings.ts
@@ -1,3 +1,4 @@
+import {LANGUAGE_NAMES} from '../../../../shared/language/language-names.js'
 import {
   AGENT_LLM_ITERATION_BUDGET_MS,
   AGENT_LLM_REQUEST_TIMEOUT_MS,
@@ -6,7 +7,6 @@ import {
   TASK_HISTORY_DEFAULT_MAX_ENTRIES,
   UPDATE_CHECK_FOR_UPDATES_DEFAULT,
 } from '../../../constants.js'
-import {LANGUAGE_NAMES} from '../render/language-clause.js'
 
 /**
  * High-level concern the setting controls. Drives group headers in CLI

--- a/src/server/core/domain/render/language-clause.ts
+++ b/src/server/core/domain/render/language-clause.ts
@@ -16,38 +16,9 @@
 
 import type {BrvConfigLanguage} from '../entities/brv-config.js'
 
-/**
- * ISO-639-1 code → English language name. Inline (~24 entries) rather than
- * pulling the `iso-639-1` package — runtime dependency surface stays
- * minimal. Codes not in this map degrade gracefully via the raw-code
- * fallback in `buildLanguageClause`.
- */
-export const LANGUAGE_NAMES: Record<string, string> = {
-  ar: 'Arabic',
-  de: 'German',
-  el: 'Greek',
-  en: 'English',
-  es: 'Spanish',
-  fi: 'Finnish',
-  fr: 'French',
-  he: 'Hebrew',
-  hi: 'Hindi',
-  id: 'Indonesian',
-  it: 'Italian',
-  ja: 'Japanese',
-  ko: 'Korean',
-  nl: 'Dutch',
-  no: 'Norwegian',
-  pl: 'Polish',
-  pt: 'Portuguese',
-  ru: 'Russian',
-  sv: 'Swedish',
-  th: 'Thai',
-  tr: 'Turkish',
-  uk: 'Ukrainian',
-  vi: 'Vietnamese',
-  zh: 'Chinese',
-}
+export {LANGUAGE_NAMES} from '../../../../shared/language/language-names.js'
+
+import {LANGUAGE_NAMES as LANGUAGE_NAMES_LOCAL} from '../../../../shared/language/language-names.js'
 
 const AUTO_CLAUSE =
   "Match the user's input language for human-readable content: body text of `<bv-*>` elements, list items, and the `title` / `summary` attributes on `<bv-topic>`. Keep tag names, attribute names, enum values, and the `path` attribute in English for tooling consistency. Code snippets and identifiers stay verbatim."
@@ -83,6 +54,6 @@ export function buildLanguageClause(language?: BrvConfigLanguage): string {
     return AUTO_CLAUSE
   }
 
-  const name = LANGUAGE_NAMES[language.code] ?? `"${language.code}"`
+  const name = LANGUAGE_NAMES_LOCAL[language.code] ?? `"${language.code}"`
   return buildFixedClause(name)
 }

--- a/src/server/core/interfaces/storage/i-settings-store.ts
+++ b/src/server/core/interfaces/storage/i-settings-store.ts
@@ -12,7 +12,7 @@ export type SettingsStartupSnapshot = {
    * Daemon startup logs this once; all values fall back to defaults.
    */
   readonly parseError?: string
-  readonly values: Readonly<Record<string, boolean | number>>
+  readonly values: Readonly<Record<string, boolean | number | string>>
 }
 
 /**

--- a/src/server/infra/storage/file-settings-store.ts
+++ b/src/server/infra/storage/file-settings-store.ts
@@ -132,7 +132,7 @@ export class FileSettingsStore implements ISettingsStore {
     return join(this.baseDir, SETTINGS_FILE)
   }
 
-  private async readOverrides(): Promise<Record<string, boolean | number>> {
+  private async readOverrides(): Promise<Record<string, boolean | number | string>> {
     const raw = await this.readRawValues()
     const {valid} = this.validator.partition(raw)
     return {...valid}

--- a/src/server/infra/storage/settings-validator.ts
+++ b/src/server/infra/storage/settings-validator.ts
@@ -1,5 +1,6 @@
 import type {
   BooleanSettingDescriptor,
+  EnumSettingDescriptor,
   IntegerSettingDescriptor,
   SettingDescriptor,
 } from '../../core/domain/entities/settings.js'
@@ -30,7 +31,7 @@ export class InvalidSettingValueError extends Error {
 
 export type PartitionedSettings = {
   readonly invalid: ReadonlyArray<{readonly key: string; readonly reason: string; readonly value: unknown}>
-  readonly valid: Readonly<Record<string, boolean | number>>
+  readonly valid: Readonly<Record<string, boolean | number | string>>
 }
 
 export type CouplingViolation = {
@@ -56,7 +57,7 @@ export class SettingsValidator {
    * log a warning about.
    */
   public partition(record: Record<string, unknown>): PartitionedSettings {
-    const valid: Record<string, boolean | number> = {}
+    const valid: Record<string, boolean | number | string> = {}
     const invalid: Array<{key: string; reason: string; value: unknown}> = []
 
     for (const [key, value] of Object.entries(record)) {
@@ -97,9 +98,9 @@ export class SettingsValidator {
   /**
    * Validates a single key/value pair. Throws on unknown key or invalid value.
    * Returns the coerced value on success (integer for integer descriptors,
-   * boolean for boolean descriptors).
+   * boolean for boolean descriptors, the canonical option for enum descriptors).
    */
-  public validate(key: string, value: unknown): boolean | number {
+  public validate(key: string, value: unknown): boolean | number | string {
     const descriptor = this.validateKey(key)
     return this.validateAgainst(descriptor, value)
   }
@@ -136,10 +137,31 @@ export class SettingsValidator {
     return descriptor
   }
 
-  private validateAgainst(descriptor: SettingDescriptor, value: unknown): boolean | number {
+  private validateAgainst(descriptor: SettingDescriptor, value: unknown): boolean | number | string {
     if (descriptor.type === 'boolean') return validateBoolean(descriptor, value)
+    if (descriptor.type === 'enum') return validateEnum(descriptor, value)
     return validateInteger(descriptor, value)
   }
+}
+
+function validateEnum(descriptor: EnumSettingDescriptor, value: unknown): string {
+  if (typeof value !== 'string') {
+    throw new InvalidSettingValueError(
+      descriptor.key,
+      value,
+      `expected one of [${descriptor.options.join(', ')}], got ${describeType(value)}`,
+    )
+  }
+
+  if (!descriptor.options.includes(value)) {
+    throw new InvalidSettingValueError(
+      descriptor.key,
+      value,
+      `'${value}' is not one of [${descriptor.options.join(', ')}]`,
+    )
+  }
+
+  return value
 }
 
 function validateInteger(descriptor: IntegerSettingDescriptor, value: unknown): number {
@@ -174,7 +196,7 @@ function validateBoolean(descriptor: BooleanSettingDescriptor, value: unknown): 
   return value
 }
 
-function numericSubset(values: Readonly<Record<string, boolean | number>>): Record<string, number> {
+function numericSubset(values: Readonly<Record<string, boolean | number | string>>): Record<string, number> {
   const result: Record<string, number> = {}
   for (const [key, value] of Object.entries(values)) {
     if (typeof value === 'number') result[key] = value

--- a/src/server/infra/transport/handlers/settings-handler.ts
+++ b/src/server/infra/transport/handlers/settings-handler.ts
@@ -110,7 +110,7 @@ function restartRequiredFor(key: string): boolean {
  * Range, coupling, and fractional-number violations are left to the store's
  * validator and still surface as `invalid_value`.
  */
-function checkValueType(key: string, value: boolean | number): SettingsErrorDTO | undefined {
+function checkValueType(key: string, value: boolean | number | string): SettingsErrorDTO | undefined {
   const descriptor = findSettingDescriptor(key)
   if (descriptor === undefined) return undefined
 
@@ -137,6 +137,17 @@ function checkValueType(key: string, value: boolean | number): SettingsErrorDTO 
     }
   }
 
+  if (descriptor.type === 'enum' && got !== 'string') {
+    return {
+      code: 'invalid_value_type',
+      expected: 'enum',
+      got,
+      key,
+      message: `expected string for '${key}', got ${got}`,
+      value,
+    }
+  }
+
   return undefined
 }
 
@@ -149,7 +160,7 @@ function toItemDTO(item: SettingItem): SettingsItemDTO {
   return descriptorToDTO(descriptor, item.current)
 }
 
-function descriptorToDTO(descriptor: SettingDescriptor, current: boolean | number): SettingsItemDTO {
+function descriptorToDTO(descriptor: SettingDescriptor, current: boolean | number | string): SettingsItemDTO {
   const dto: SettingsItemDTO = {
     current,
     default: descriptor.default,
@@ -163,6 +174,10 @@ function descriptorToDTO(descriptor: SettingDescriptor, current: boolean | numbe
     dto.min = descriptor.min
     dto.max = descriptor.max
     if (descriptor.unit !== undefined) dto.unit = descriptor.unit
+  }
+
+  if (descriptor.type === 'enum') {
+    dto.options = descriptor.options
   }
 
   return dto

--- a/src/shared/language/language-names.ts
+++ b/src/shared/language/language-names.ts
@@ -1,0 +1,33 @@
+/**
+ * ISO-639-1 code → English language name. Single source of truth for
+ * surfaces that need a human-readable label alongside the canonical
+ * wire-format code: language-clause builder, WebUI / TUI pickers, CLI
+ * error messages. Codes not in this map degrade gracefully via the
+ * raw-code fallback in `buildLanguageClause`.
+ */
+export const LANGUAGE_NAMES: Record<string, string> = {
+  ar: 'Arabic',
+  de: 'German',
+  el: 'Greek',
+  en: 'English',
+  es: 'Spanish',
+  fi: 'Finnish',
+  fr: 'French',
+  he: 'Hebrew',
+  hi: 'Hindi',
+  id: 'Indonesian',
+  it: 'Italian',
+  ja: 'Japanese',
+  ko: 'Korean',
+  nl: 'Dutch',
+  no: 'Norwegian',
+  pl: 'Polish',
+  pt: 'Portuguese',
+  ru: 'Russian',
+  sv: 'Swedish',
+  th: 'Thai',
+  tr: 'Turkish',
+  uk: 'Ukrainian',
+  vi: 'Vietnamese',
+  zh: 'Chinese',
+}

--- a/src/shared/transport/events/settings-events.ts
+++ b/src/shared/transport/events/settings-events.ts
@@ -11,31 +11,30 @@ export const SettingsEvents = {
  * surfaces (CLI / TUI / WebUI) can consume it without crossing the
  * server import boundary.
  *
- * M7 T2 added three optional fields (`category`, `unit`, `scope`); T1 of
- * the Update-check toggle project widened `type`, `current`, `default`,
- * and `restartRequired` to also cover boolean descriptors, and made
- * `min` / `max` optional (only integer descriptors carry them). All
- * widenings are additive at the JSON layer, so consumers that read
- * existing integer fields continue to parse the wire format.
+ * Backward-compat: every widening here is additive at the JSON layer, so
+ * consumers that read pre-existing integer / boolean fields continue to
+ * parse the wire format unchanged.
  */
 export interface SettingsItemDTO {
-  category?: 'concurrency' | 'llm' | 'task-history' | 'updates'
-  current: boolean | number
-  default: boolean | number
+  category?: 'concurrency' | 'language' | 'llm' | 'task-history' | 'updates'
+  current: boolean | number | string
+  default: boolean | number | string
   description: string
   key: string
   max?: number
   min?: number
+  /** Allowed values for `type === 'enum'`. Omitted otherwise. */
+  options?: readonly string[]
   restartRequired: boolean
   scope?: 'global' | 'project'
-  type: 'boolean' | 'integer'
+  type: 'boolean' | 'enum' | 'integer'
   unit?: 'count' | 'ms'
 }
 
 export interface SettingsErrorDTO {
   code: 'invalid_value' | 'invalid_value_type' | 'unknown_key'
   /** Expected runtime kind, only set when `code === 'invalid_value_type'`. */
-  expected?: 'boolean' | 'integer'
+  expected?: 'boolean' | 'enum' | 'integer'
   /** `typeof` of the offending value, only set when `code === 'invalid_value_type'`. */
   got?: string
   key: string
@@ -59,7 +58,7 @@ export type SettingsGetResponse =
 
 export interface SettingsSetRequest {
   key: string
-  value: boolean | number
+  value: boolean | number | string
 }
 
 export type SettingsSetResponse =

--- a/src/shared/types/settings-row.ts
+++ b/src/shared/types/settings-row.ts
@@ -42,3 +42,42 @@ export const CATEGORY_ORDER: readonly SettingsRowCategory[] = [
   'language',
   'other',
 ]
+
+/**
+ * Display label shown above each category's row group in the TUI settings
+ * page and in `brv settings list` text output. Adding a new category here
+ * (and a corresponding entry in `CATEGORY_ORDER`) is the only edit needed
+ * for both consumers to render it — `oclif/commands/settings/index.ts`
+ * and `tui/features/settings/utils/format-settings.ts` both import from
+ * this module, so the surfaces never drift.
+ */
+export const CATEGORY_HEADERS: Readonly<Record<SettingsRowCategory, string>> = {
+  concurrency: 'CONCURRENCY',
+  language: 'LANGUAGE',
+  llm: 'LLM',
+  other: 'OTHER',
+  'task-history': 'TASK HISTORY',
+  updates: 'UPDATES',
+}
+
+const CATEGORY_SET: ReadonlySet<string> = new Set<string>(CATEGORY_ORDER)
+
+/**
+ * Type guard derived from `CATEGORY_ORDER` so the membership check never
+ * drifts from the canonical list. Adding a new category to
+ * `SettingsRowCategory` + `CATEGORY_ORDER` + `CATEGORY_HEADERS` is the
+ * only edit needed — this guard picks it up automatically.
+ */
+export function isSettingsRowCategory(value: unknown): value is SettingsRowCategory {
+  return typeof value === 'string' && CATEGORY_SET.has(value)
+}
+
+/**
+ * Folds an arbitrary incoming category value into a canonical
+ * `SettingsRowCategory`. Unknown / missing categories fall through to
+ * `'other'` so an unexpected category emitted by the daemon still renders
+ * under the OTHER header instead of getting silently dropped.
+ */
+export function toRowCategory(category: unknown): SettingsRowCategory {
+  return isSettingsRowCategory(category) ? category : 'other'
+}

--- a/src/shared/types/settings-row.ts
+++ b/src/shared/types/settings-row.ts
@@ -1,10 +1,10 @@
-export type SettingsRowCategory = 'concurrency' | 'llm' | 'other' | 'task-history' | 'updates'
+export type SettingsRowCategory = 'concurrency' | 'language' | 'llm' | 'other' | 'task-history' | 'updates'
 export type SettingsRowUnit = 'count' | 'ms'
 
 /**
  * View-model for one settings row consumed by the TUI. Discriminated on
  * `type` so the renderer narrows before reading integer-only fields
- * (`min`, `max`, `unit`) or treating `current` / `default` as numeric.
+ * (`min`, `max`, `unit`) or enum-only fields (`options`).
  *
  * Restart requirement is propagated from the descriptor verbatim (no
  * literal `true` constraint) so the dirty-banner filter on the page can
@@ -12,8 +12,8 @@ export type SettingsRowUnit = 'count' | 'ms'
  */
 export interface SettingsRow {
   readonly category: SettingsRowCategory
-  readonly current: boolean | number
-  readonly default: boolean | number
+  readonly current: boolean | number | string
+  readonly default: boolean | number | string
   readonly description: string
   readonly displayCurrent: string
   readonly displayDefault: string
@@ -23,13 +23,15 @@ export interface SettingsRow {
   readonly max?: number
   readonly min?: number
   readonly modified: boolean
+  /** Allowed values for `type === 'enum'`. Omitted otherwise. */
+  readonly options?: readonly string[]
   readonly restartRequired: boolean
-  readonly type: 'boolean' | 'integer'
+  readonly type: 'boolean' | 'enum' | 'integer'
   readonly unit?: SettingsRowUnit
 }
 
 export type RowParseResult =
-  | {readonly displayValue: string; readonly kind: 'ok'; readonly value: number}
+  | {readonly displayValue: string; readonly kind: 'ok'; readonly value: number | string}
   | {readonly kind: 'error'; readonly message: string}
 
 export const CATEGORY_ORDER: readonly SettingsRowCategory[] = [
@@ -37,5 +39,6 @@ export const CATEGORY_ORDER: readonly SettingsRowCategory[] = [
   'llm',
   'task-history',
   'updates',
+  'language',
   'other',
 ]

--- a/src/shared/utils/format-settings.ts
+++ b/src/shared/utils/format-settings.ts
@@ -1,7 +1,7 @@
 import type {SettingsItemDTO} from '../transport/events/settings-events.js'
-import type {RowParseResult, SettingsRow, SettingsRowCategory, SettingsRowUnit} from '../types/settings-row.js'
+import type {RowParseResult, SettingsRow, SettingsRowUnit} from '../types/settings-row.js'
 
-import {CATEGORY_ORDER} from '../types/settings-row.js'
+import {CATEGORY_ORDER, toRowCategory} from '../types/settings-row.js'
 import {formatCount, formatDuration, parseDuration} from './format-duration.js'
 
 export function buildSettingsRows(items: readonly SettingsItemDTO[]): SettingsRow[] {
@@ -176,20 +176,6 @@ function toEnumRow(item: EnumSettingsItemDTO): SettingsRow {
 
 function renderBoolean(value: boolean): string {
   return value ? '[ on ]' : '[ off ]'
-}
-
-function toRowCategory(category: SettingsItemDTO['category']): SettingsRowCategory {
-  if (
-    category === 'concurrency' ||
-    category === 'language' ||
-    category === 'llm' ||
-    category === 'task-history' ||
-    category === 'updates'
-  ) {
-    return category
-  }
-
-  return 'other'
 }
 
 function formatIntegerRange(item: IntegerSettingsItemDTO, unit: SettingsRowUnit): string {

--- a/src/shared/utils/format-settings.ts
+++ b/src/shared/utils/format-settings.ts
@@ -12,6 +12,11 @@ export function buildSettingsRows(items: readonly SettingsItemDTO[]): SettingsRo
       continue
     }
 
+    if (isEnumItem(item)) {
+      rows.push(toEnumRow(item))
+      continue
+    }
+
     if (isIntegerItem(item)) rows.push(toIntegerRow(item))
   }
 
@@ -22,8 +27,19 @@ export function parseRowInput(row: SettingsRow, raw: string): RowParseResult {
   const trimmed = raw.trim()
   if (trimmed === '') return {kind: 'error', message: 'Value is required'}
 
+  if (row.type === 'enum') return parseAsEnum(row, raw)
   if (row.unit === 'ms') return parseAsDuration(row, raw)
   return parseAsCount(row, raw)
+}
+
+function parseAsEnum(row: SettingsRow, raw: string): RowParseResult {
+  const trimmed = raw.trim()
+  const options = row.options ?? []
+  if (!options.includes(trimmed)) {
+    return {kind: 'error', message: `Expected one of [${options.join(', ')}], got '${raw}'`}
+  }
+
+  return {displayValue: trimmed, kind: 'ok', value: trimmed}
 }
 
 function parseAsDuration(row: SettingsRow, raw: string): RowParseResult {
@@ -124,12 +140,52 @@ function toBooleanRow(item: SettingsItemDTO, current: boolean, defaultValue: boo
   }
 }
 
+type EnumSettingsItemDTO = Omit<SettingsItemDTO, 'current' | 'default' | 'options' | 'type'> & {
+  readonly current: string
+  readonly default: string
+  readonly options: readonly string[]
+  readonly type: 'enum'
+}
+
+function isEnumItem(item: SettingsItemDTO): item is EnumSettingsItemDTO {
+  return (
+    item.type === 'enum' &&
+    typeof item.current === 'string' &&
+    typeof item.default === 'string' &&
+    Array.isArray(item.options)
+  )
+}
+
+function toEnumRow(item: EnumSettingsItemDTO): SettingsRow {
+  return {
+    category: toRowCategory(item.category),
+    current: item.current,
+    default: item.default,
+    description: item.description,
+    displayCurrent: `[ ${item.current} ]`,
+    displayDefault: item.default,
+    displayRange: '',
+    key: item.key,
+    label: item.key,
+    modified: item.current !== item.default,
+    options: item.options,
+    restartRequired: item.restartRequired,
+    type: 'enum',
+  }
+}
+
 function renderBoolean(value: boolean): string {
   return value ? '[ on ]' : '[ off ]'
 }
 
 function toRowCategory(category: SettingsItemDTO['category']): SettingsRowCategory {
-  if (category === 'concurrency' || category === 'llm' || category === 'task-history' || category === 'updates') {
+  if (
+    category === 'concurrency' ||
+    category === 'language' ||
+    category === 'llm' ||
+    category === 'task-history' ||
+    category === 'updates'
+  ) {
     return category
   }
 

--- a/src/tui/features/settings/components/settings-page.tsx
+++ b/src/tui/features/settings/components/settings-page.tsx
@@ -29,8 +29,9 @@ export function SettingsPage({onCancel, onComplete}: CustomDialogCallbacks): Rea
   const rows = useMemo<SettingsRow[]>(() => (data ? buildSettingsRows(data.items) : []), [data])
   const groups = useMemo(() => groupRowsByCategory(rows), [rows])
   const focusedRow = rows[cursor]
-  const hintMode: 'browse' | 'edit' | 'edit-error' | 'saving' =
-    mode === 'edit' && rowError !== undefined ? 'edit-error' : mode
+  const isEnumEdit = mode === 'edit' && focusedRow?.type === 'enum'
+  const hintMode: 'browse' | 'edit' | 'edit-enum' | 'edit-error' | 'saving' =
+    mode === 'edit' && rowError !== undefined ? 'edit-error' : isEnumEdit ? 'edit-enum' : mode
 
   // Restart warning fires only when at least one dirty key actually
   // requires a daemon restart. Boolean toggles (e.g. update.checkForUpdates,
@@ -170,6 +171,27 @@ export function SettingsPage({onCancel, onComplete}: CustomDialogCallbacks): Rea
 
       if (key.return) {
         commitEdit(rows[cursor], editBuffer).catch(() => {})
+        return
+      }
+
+      const focused = rows[cursor]
+      if (focused?.type === 'enum' && focused.options !== undefined) {
+        const {options} = focused
+        const currentIndex = options.indexOf(editBuffer)
+        if (key.leftArrow) {
+          const previousIndex = currentIndex <= 0 ? options.length - 1 : currentIndex - 1
+          setEditBuffer(options[previousIndex])
+          setRowError(undefined)
+          return
+        }
+
+        if (key.rightArrow) {
+          const nextIndex = currentIndex < 0 || currentIndex >= options.length - 1 ? 0 : currentIndex + 1
+          setEditBuffer(options[nextIndex])
+          setRowError(undefined)
+          return
+        }
+
         return
       }
 

--- a/src/tui/features/settings/utils/format-settings.ts
+++ b/src/tui/features/settings/utils/format-settings.ts
@@ -3,6 +3,7 @@ import {formatDuration} from '../../../../shared/utils/format-duration.js'
 
 const CATEGORY_HEADERS: Readonly<Record<SettingsRowCategory, string>> = {
   concurrency: 'CONCURRENCY',
+  language: 'LANGUAGE',
   llm: 'LLM',
   other: 'OTHER',
   'task-history': 'TASK HISTORY',
@@ -32,7 +33,10 @@ export function groupRowsByCategory(rows: readonly SettingsRow[]): ReadonlyArray
   return result
 }
 
-export function bottomHintFor(mode: 'browse' | 'edit' | 'edit-error' | 'saving', focusedKey?: string): string {
+export function bottomHintFor(
+  mode: 'browse' | 'edit' | 'edit-enum' | 'edit-error' | 'saving',
+  focusedKey?: string,
+): string {
   switch (mode) {
     case 'browse': {
       return 'Up/Down move | Enter edit | R reset | Esc exit'
@@ -40,6 +44,10 @@ export function bottomHintFor(mode: 'browse' | 'edit' | 'edit-error' | 'saving',
 
     case 'edit': {
       return `Editing ${focusedKey ?? ''} | Enter save | Esc cancel`
+    }
+
+    case 'edit-enum': {
+      return `Editing ${focusedKey ?? ''} | Left/Right cycle options | Enter save | Esc cancel`
     }
 
     case 'edit-error': {
@@ -53,10 +61,10 @@ export function bottomHintFor(mode: 'browse' | 'edit' | 'edit-error' | 'saving',
 }
 
 export function preFillBufferFor(row: SettingsRow): string {
-  // preFillBufferFor only runs when entering integer text-input mode.
-  // Boolean rows take the toggle path in the page and never reach here;
-  // guard the narrowing so the function still compiles under the wider
-  // SettingsRow union.
+  // preFillBufferFor only runs when entering integer text-input mode for
+  // numeric rows or enum cycling for enum rows. Boolean rows take the
+  // toggle path and never reach here.
+  if (row.type === 'enum') return String(row.current)
   if (typeof row.current !== 'number') return String(row.current)
   if (row.unit === 'ms') return formatDuration(row.current)
   return String(row.current)

--- a/src/tui/features/settings/utils/format-settings.ts
+++ b/src/tui/features/settings/utils/format-settings.ts
@@ -1,14 +1,10 @@
-import {CATEGORY_ORDER, type SettingsRow, type SettingsRowCategory} from '../../../../shared/types/settings-row.js'
+import {
+  CATEGORY_HEADERS,
+  CATEGORY_ORDER,
+  type SettingsRow,
+  type SettingsRowCategory,
+} from '../../../../shared/types/settings-row.js'
 import {formatDuration} from '../../../../shared/utils/format-duration.js'
-
-const CATEGORY_HEADERS: Readonly<Record<SettingsRowCategory, string>> = {
-  concurrency: 'CONCURRENCY',
-  language: 'LANGUAGE',
-  llm: 'LLM',
-  other: 'OTHER',
-  'task-history': 'TASK HISTORY',
-  updates: 'UPDATES',
-}
 
 export function groupRowsByCategory(rows: readonly SettingsRow[]): ReadonlyArray<{
   readonly category: SettingsRowCategory

--- a/src/webui/features/settings/components/enum-settings-row.tsx
+++ b/src/webui/features/settings/components/enum-settings-row.tsx
@@ -1,0 +1,83 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@campfirein/byterover-packages/components/select'
+import {useId} from 'react'
+import {toast} from 'sonner'
+
+import type {SettingsRow as SettingsRowData} from '../../../../shared/types/settings-row'
+
+import {LANGUAGE_NAMES} from '../../../../shared/language/language-names'
+import {formatError} from '../../../lib/error-messages'
+import {noop} from '../../../lib/noop'
+import {useSetSetting} from '../api/set-setting'
+import {labelFor} from '../lib/labels'
+import {useRestartBannerStore} from '../stores/restart-banner-store'
+
+type Props = {
+  row: SettingsRowData
+}
+
+export function EnumSettingsRow({row}: Props) {
+  const setMutation = useSetSetting()
+  const markDirty = useRestartBannerStore((s) => s.markDirty)
+  const descriptionId = useId()
+
+  const label = labelFor(row.key)
+  const current = typeof row.current === 'string' ? row.current : String(row.current)
+  const options = row.options ?? []
+
+  const choose = async (next: string) => {
+    if (next === current) return
+    try {
+      const response = await setMutation.mutateAsync({key: row.key, value: next})
+      if (response.ok) {
+        markDirty(row.key, row.restartRequired)
+        toast.success(`${label} set to ${displayLabel(row.key, next)}`)
+        return
+      }
+
+      toast.error(response.error.message)
+    } catch (error) {
+      toast.error(formatError(error, `Failed to update ${label}`))
+    }
+  }
+
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <div className="flex min-w-0 flex-col gap-0.5">
+        <span className="text-foreground text-sm font-medium">{label}</span>
+        <span className="text-muted-foreground text-xs leading-snug" id={descriptionId}>
+          {row.description}
+        </span>
+      </div>
+      <Select
+        disabled={setMutation.isPending}
+        onValueChange={(next) => {
+          choose(next).catch(noop)
+        }}
+        value={current}
+      >
+        <SelectTrigger aria-describedby={descriptionId} className="h-8 w-44 text-xs" size="sm">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((option) => (
+            <SelectItem key={option} value={option}>
+              {displayLabel(row.key, option)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}
+
+function displayLabel(key: string, option: string): string {
+  if (key !== 'language.code') return option
+  const name = LANGUAGE_NAMES[option]
+  return name ? `${option} — ${name}` : option
+}

--- a/src/webui/features/settings/components/enum-settings-row.tsx
+++ b/src/webui/features/settings/components/enum-settings-row.tsx
@@ -57,6 +57,7 @@ export function EnumSettingsRow({row}: Props) {
       <Select
         disabled={setMutation.isPending}
         onValueChange={(next) => {
+          if (next === null) return
           choose(next).catch(noop)
         }}
         value={current}

--- a/src/webui/features/settings/components/language-panel.tsx
+++ b/src/webui/features/settings/components/language-panel.tsx
@@ -1,0 +1,42 @@
+import {LoaderCircle} from 'lucide-react'
+import {Fragment, useMemo} from 'react'
+
+import {buildSettingsRows} from '../../../../shared/utils/format-settings'
+import {noop} from '../../../lib/noop'
+import {SettingsSection} from '../../vc/components/settings-section'
+import {useGetSettings} from '../api/list-settings'
+import {SettingsRow} from './settings-row'
+import {SettingsSkeleton} from './settings-skeleton'
+
+export function LanguagePanel() {
+  const {data, error, isError, isLoading, refetch} = useGetSettings()
+
+  const rows = useMemo(() => {
+    if (!data) return []
+    return buildSettingsRows(data.items).filter((row) => row.category === 'language')
+  }, [data?.items])
+
+  return (
+    <SettingsSection
+      action={isLoading ? <LoaderCircle className="text-muted-foreground mt-1 size-4 animate-spin" /> : undefined}
+      description="Language used when ByteRover writes context. Auto matches your input language."
+      error={isError ? error : undefined}
+      errorFallback="Failed to load language settings"
+      onRetry={() => refetch().catch(noop)}
+      title="Language"
+    >
+      {data ? (
+        <div className="flex flex-col gap-5">
+          {rows.map((row, index) => (
+            <Fragment key={row.key}>
+              <SettingsRow row={row} />
+              {index < rows.length - 1 && <div className="border-b" />}
+            </Fragment>
+          ))}
+        </div>
+      ) : (
+        <SettingsSkeleton />
+      )}
+    </SettingsSection>
+  )
+}

--- a/src/webui/features/settings/components/settings-row.tsx
+++ b/src/webui/features/settings/components/settings-row.tsx
@@ -15,6 +15,7 @@ import {useSetSetting} from '../api/set-setting'
 import {labelFor} from '../lib/labels'
 import {useRestartBannerStore} from '../stores/restart-banner-store'
 import {BooleanSettingsRow} from './boolean-settings-row'
+import {EnumSettingsRow} from './enum-settings-row'
 
 type Props = {
   row: SettingsRowData
@@ -22,6 +23,7 @@ type Props = {
 
 export function SettingsRow({row}: Props) {
   if (row.type === 'boolean') return <BooleanSettingsRow row={row} />
+  if (row.type === 'enum') return <EnumSettingsRow row={row} />
 
   return <IntegerSettingsRow row={row} />
 }

--- a/src/webui/features/settings/components/settings-row.tsx
+++ b/src/webui/features/settings/components/settings-row.tsx
@@ -56,6 +56,11 @@ function IntegerSettingsRow({row}: Props) {
       return
     }
 
+    if (typeof parsed.value !== 'number') {
+      setError(`Expected an integer for ${row.key}`)
+      return
+    }
+
     if (parsed.value === row.current) {
       setError(undefined)
       setBuffer(String(parsed.value))
@@ -64,11 +69,12 @@ function IntegerSettingsRow({row}: Props) {
     }
 
     setError(undefined)
-    const response = await setMutation.mutateAsync({key: row.key, value: parsed.value})
+    const numericValue: number = parsed.value
+    const response = await setMutation.mutateAsync({key: row.key, value: numericValue})
     if (response.ok) {
       markDirty(row.key, row.restartRequired)
       isUserEditingRef.current = false
-      toast.success(`${label} set to ${toastValue(parsed.value)}`)
+      toast.success(`${label} set to ${toastValue(numericValue)}`)
       return
     }
 

--- a/src/webui/features/settings/lib/labels.ts
+++ b/src/webui/features/settings/lib/labels.ts
@@ -1,6 +1,8 @@
 const LABELS: Record<string, string> = {
   'agentPool.maxConcurrentTasksPerProject': 'Max parallel tasks per project',
   'agentPool.maxSize': 'Max concurrent projects',
+  'language.code': 'Language',
+  'language.mode': 'Language mode',
   'llm.iterationBudgetMs': 'Agentic loop budget',
   'llm.requestTimeoutMs': 'LLM request timeout',
   'taskHistory.maxEntries': 'Task history size',

--- a/src/webui/pages/configuration/general.tsx
+++ b/src/webui/pages/configuration/general.tsx
@@ -1,4 +1,5 @@
 import {ConcurrencyPanel} from '../../features/settings/components/concurrency-panel'
+import {LanguagePanel} from '../../features/settings/components/language-panel'
 import {LlmPanel} from '../../features/settings/components/llm-panel'
 import {TaskHistoryPanel} from '../../features/settings/components/task-history-panel'
 import {UpdatesPanel} from '../../features/settings/components/updates-panel'
@@ -9,6 +10,7 @@ export function GeneralSection() {
       <ConcurrencyPanel />
       <LlmPanel />
       <TaskHistoryPanel />
+      <LanguagePanel />
       <UpdatesPanel />
     </>
   )

--- a/test/commands/settings/index.test.ts
+++ b/test/commands/settings/index.test.ts
@@ -7,6 +7,15 @@ import sinon, {restore, stub} from 'sinon'
 
 import Settings from '../../../src/oclif/commands/settings/index.js'
 import {SettingsEvents} from '../../../src/shared/transport/events/settings-events.js'
+import {CATEGORY_HEADERS, CATEGORY_ORDER} from '../../../src/shared/types/settings-row.js'
+
+function findHeaderIndex(messages: readonly string[], header: string): number {
+  for (const [i, m] of messages.entries()) {
+    if (m.includes(header)) return i
+  }
+
+  return -1
+}
 
 class TestableSettings extends Settings {
   private readonly mockConnector: () => Promise<ConnectionResult>
@@ -373,6 +382,179 @@ describe('brv settings (index)', () => {
       const output = loggedMessages.join('\n')
 
       expect(output).to.not.include('UPDATES')
+    })
+  })
+
+  describe('enum rows (LANGUAGE group)', () => {
+    it('renders a LANGUAGE section with both enum rows when the daemon returns language items', async () => {
+      const requestStub = mockClient.requestWithAck as sinon.SinonStub
+      requestStub.resolves({
+        items: [
+          {
+            category: 'concurrency',
+            current: 10,
+            default: 10,
+            description: 'h',
+            key: 'agentPool.maxSize',
+            max: 100,
+            min: 1,
+            restartRequired: true,
+            type: 'integer',
+          },
+          {
+            category: 'language',
+            current: 'fixed',
+            default: 'auto',
+            description: 'Match input language (auto) or force a fixed language for written output',
+            key: 'language.mode',
+            options: ['auto', 'fixed'],
+            restartRequired: false,
+            type: 'enum',
+          },
+          {
+            category: 'language',
+            current: 'ja',
+            default: 'en',
+            description: 'ISO-639-1 code applied when mode is fixed; ignored in auto mode',
+            key: 'language.code',
+            options: ['ar', 'de', 'el', 'en', 'es', 'ja', 'ko', 'ru', 'vi', 'zh'],
+            restartRequired: false,
+            type: 'enum',
+          },
+        ],
+      })
+
+      await createCommand().run()
+      const output = loggedMessages.join('\n')
+
+      expect(output, 'LANGUAGE header must appear').to.include('LANGUAGE')
+
+      const modeRow = loggedMessages.find((m) => m.includes('language.mode'))
+      expect(modeRow, 'row for language.mode').to.exist
+      expect(modeRow).to.include('fixed')
+      expect(modeRow).to.match(/default\s*auto/)
+
+      const codeRow = loggedMessages.find((m) => m.includes('language.code'))
+      expect(codeRow, 'row for language.code').to.exist
+      expect(codeRow).to.include('ja')
+      expect(codeRow).to.match(/default\s*en/)
+
+      // Numeric range column is meaningless for enums and must not be rendered.
+      expect(modeRow).to.not.match(/\d+\s*-\s*\d+/)
+      expect(codeRow).to.not.match(/\d+\s*-\s*\d+/)
+    })
+
+    it('omits the LANGUAGE section entirely when the daemon returns no language items', async () => {
+      const requestStub = mockClient.requestWithAck as sinon.SinonStub
+      requestStub.resolves({
+        items: [
+          {
+            category: 'concurrency',
+            current: 10,
+            default: 10,
+            description: 'h',
+            key: 'agentPool.maxSize',
+            max: 100,
+            min: 1,
+            restartRequired: true,
+            type: 'integer',
+          },
+        ],
+      })
+
+      await createCommand().run()
+      const output = loggedMessages.join('\n')
+
+      expect(output).to.not.include('LANGUAGE')
+    })
+
+    it('renders LANGUAGE after UPDATES, matching the shared CATEGORY_ORDER', async () => {
+      const requestStub = mockClient.requestWithAck as sinon.SinonStub
+      requestStub.resolves({
+        items: [
+          {
+            category: 'language',
+            current: 'auto',
+            default: 'auto',
+            description: '',
+            key: 'language.mode',
+            options: ['auto', 'fixed'],
+            restartRequired: false,
+            type: 'enum',
+          },
+          {
+            category: 'updates',
+            current: true,
+            default: true,
+            description: '',
+            key: 'update.checkForUpdates',
+            restartRequired: false,
+            type: 'boolean',
+          },
+        ],
+      })
+
+      await createCommand().run()
+
+      const updatesIdx = loggedMessages.findIndex((m) => m.includes('UPDATES'))
+      const languageIdx = loggedMessages.findIndex((m) => m.includes('LANGUAGE'))
+      expect(updatesIdx).to.be.greaterThan(-1)
+      expect(languageIdx).to.be.greaterThan(-1)
+      expect(updatesIdx).to.be.lessThan(languageIdx)
+    })
+  })
+
+  describe('canonical category coverage (regression guard for future categories)', () => {
+    it('renders every category in the shared CATEGORY_ORDER when the daemon returns one item per category', async () => {
+      const requestStub = mockClient.requestWithAck as sinon.SinonStub
+      // Synthesize one item per canonical category. Adding a new category to
+      // SettingsRowCategory + CATEGORY_ORDER + CATEGORY_HEADERS without updating
+      // the print loop should fail this test.
+      const items = CATEGORY_ORDER.map((category, idx) => ({
+        category,
+        current: 'placeholder',
+        default: 'placeholder',
+        description: '',
+        key: `canonical.${category}.item.${idx}`,
+        options: ['placeholder'],
+        restartRequired: false,
+        type: 'enum' as const,
+      }))
+      requestStub.resolves({items})
+
+      await createCommand().run()
+      const output = loggedMessages.join('\n')
+
+      for (const category of CATEGORY_ORDER) {
+        const header = CATEGORY_HEADERS[category]
+        expect(output, `header for ${category}`).to.include(header)
+      }
+    })
+
+    it('renders headers in CATEGORY_ORDER sequence', async () => {
+      const requestStub = mockClient.requestWithAck as sinon.SinonStub
+      const items = CATEGORY_ORDER.map((category, idx) => ({
+        category,
+        current: 'placeholder',
+        default: 'placeholder',
+        description: '',
+        key: `canonical.${category}.item.${idx}`,
+        options: ['placeholder'],
+        restartRequired: false,
+        type: 'enum' as const,
+      }))
+      requestStub.resolves({items})
+
+      await createCommand().run()
+
+      const indices: number[] = []
+      for (const category of CATEGORY_ORDER) {
+        indices.push(findHeaderIndex(loggedMessages, CATEGORY_HEADERS[category]))
+      }
+
+      for (let i = 1; i < indices.length; i++) {
+        expect(indices[i], `${CATEGORY_ORDER[i]} after ${CATEGORY_ORDER[i - 1]}`).to.be.greaterThan(indices[i - 1])
+      }
     })
   })
 })

--- a/test/unit/core/domain/entities/settings-registry.test.ts
+++ b/test/unit/core/domain/entities/settings-registry.test.ts
@@ -22,6 +22,7 @@ describe('settings registry — M7 T2 shape', () => {
     for (const descriptor of SETTINGS_REGISTRY) {
       expect(descriptor.category, `key ${descriptor.key} missing category`).to.be.oneOf([
         'concurrency',
+        'language',
         'llm',
         'task-history',
         'updates',
@@ -124,6 +125,60 @@ describe('settings registry — M7 T2 shape', () => {
         expect(min).to.be.lessThan(max)
       } else {
         expect.fail('expected integer descriptor for agentPool.maxSize')
+      }
+    })
+  })
+
+  describe('language.* enum descriptors', () => {
+    it('exposes LANGUAGE_MODE + LANGUAGE_CODE on SETTINGS_KEYS', () => {
+      expect(SETTINGS_KEYS.LANGUAGE_MODE).to.equal('language.mode')
+      expect(SETTINGS_KEYS.LANGUAGE_CODE).to.equal('language.code')
+    })
+
+    it('registers language.mode as enum with default=auto and options=[auto, fixed]', () => {
+      const descriptor = findSettingDescriptor(SETTINGS_KEYS.LANGUAGE_MODE)
+      expect(descriptor?.type).to.equal('enum')
+      if (descriptor?.type === 'enum') {
+        expect(descriptor.default).to.equal('auto')
+        expect([...descriptor.options]).to.deep.equal(['auto', 'fixed'])
+      } else {
+        expect.fail('expected enum descriptor for language.mode')
+      }
+    })
+
+    it('registers language.code as enum with default=en and options including ko + ja + zh', () => {
+      const descriptor = findSettingDescriptor(SETTINGS_KEYS.LANGUAGE_CODE)
+      expect(descriptor?.type).to.equal('enum')
+      if (descriptor?.type === 'enum') {
+        expect(descriptor.default).to.equal('en')
+        expect(descriptor.options).to.include('ko')
+        expect(descriptor.options).to.include('ja')
+        expect(descriptor.options).to.include('zh')
+        expect(descriptor.options).to.include('en')
+      } else {
+        expect.fail('expected enum descriptor for language.code')
+      }
+    })
+
+    it('groups both language entries under category=language', () => {
+      expect(findSettingDescriptor(SETTINGS_KEYS.LANGUAGE_MODE)?.category).to.equal('language')
+      expect(findSettingDescriptor(SETTINGS_KEYS.LANGUAGE_CODE)?.category).to.equal('language')
+    })
+
+    it('marks language settings as restart-not-required (live config)', () => {
+      expect(findSettingDescriptor(SETTINGS_KEYS.LANGUAGE_MODE)?.restartRequired).to.equal(false)
+      expect(findSettingDescriptor(SETTINGS_KEYS.LANGUAGE_CODE)?.restartRequired).to.equal(false)
+    })
+
+    it('narrows enum descriptors to EnumSettingDescriptor when descriptor.type === enum', () => {
+      const descriptor = findSettingDescriptor(SETTINGS_KEYS.LANGUAGE_MODE)
+      if (descriptor?.type === 'enum') {
+        const defaultValue: string = descriptor.default
+        const {options} = descriptor
+        expect(defaultValue).to.equal('auto')
+        expect(options.length).to.be.greaterThan(0)
+      } else {
+        expect.fail('expected enum descriptor for language.mode')
       }
     })
   })

--- a/test/unit/infra/storage/file-settings-store.test.ts
+++ b/test/unit/infra/storage/file-settings-store.test.ts
@@ -49,6 +49,8 @@ describe('FileSettingsStore', () => {
       expect(keys).to.deep.equal([
         'agentPool.maxConcurrentTasksPerProject',
         'agentPool.maxSize',
+        'language.code',
+        'language.mode',
         'llm.iterationBudgetMs',
         'llm.requestTimeoutMs',
         'taskHistory.maxEntries',

--- a/test/unit/infra/transport/handlers/settings-handler.test.ts
+++ b/test/unit/infra/transport/handlers/settings-handler.test.ts
@@ -86,6 +86,8 @@ describe('SettingsHandler', () => {
       expect(result.items.map((i) => i.key).sort()).to.deep.equal([
         'agentPool.maxConcurrentTasksPerProject',
         'agentPool.maxSize',
+        'language.code',
+        'language.mode',
         'llm.iterationBudgetMs',
         'llm.requestTimeoutMs',
         'taskHistory.maxEntries',
@@ -135,6 +137,23 @@ describe('SettingsHandler', () => {
       for (const item of result.items) {
         expect(item.scope).to.equal(undefined)
       }
+    })
+
+    it('exposes options on enum-typed items and omits options on non-enum items', async () => {
+      store.listResult = []
+      const result = await invokeList()
+      const byKey = new Map(result.items.map((i) => [i.key, i]))
+
+      const mode = byKey.get('language.mode')
+      expect(mode?.type).to.equal('enum')
+      expect(mode?.options).to.deep.equal(['auto', 'fixed'])
+
+      const code = byKey.get('language.code')
+      expect(code?.type).to.equal('enum')
+      expect(code?.options).to.include('ko')
+
+      expect(byKey.get('agentPool.maxSize')?.options).to.equal(undefined)
+      expect(byKey.get('update.checkForUpdates')?.options).to.equal(undefined)
     })
   })
 
@@ -267,6 +286,29 @@ describe('SettingsHandler', () => {
 
         expect(result.ok).to.be.false
         if (!result.ok) expect(result.error.code).to.equal('unknown_key')
+      })
+
+      it('rejects a numeric value sent to an enum key', async () => {
+        const result = await invokeSet({key: 'language.mode', value: 5})
+
+        expect(result.ok).to.be.false
+        if (!result.ok) {
+          expect(result.error.code).to.equal('invalid_value_type')
+          expect(result.error.key).to.equal('language.mode')
+          expect(result.error.expected).to.equal('enum')
+          expect(result.error.got).to.equal('number')
+        }
+
+        expect(store.calls.filter((c) => c.method === 'set')).to.have.lengthOf(0)
+      })
+
+      it('accepts a string value sent to an enum key and forwards to the store', async () => {
+        const result = await invokeSet({key: 'language.mode', value: 'fixed'})
+
+        expect(result.ok).to.be.true
+        const setCalls = store.calls.filter((c) => c.method === 'set')
+        expect(setCalls).to.have.lengthOf(1)
+        expect(setCalls[0].args).to.deep.equal(['language.mode', 'fixed'])
       })
 
       it('still surfaces a range violation as invalid_value (not invalid_value_type)', async () => {

--- a/test/unit/shared/utils/format-settings.test.ts
+++ b/test/unit/shared/utils/format-settings.test.ts
@@ -32,6 +32,20 @@ function makeBooleanItem(current: boolean): SettingsItemDTO {
   }
 }
 
+function makeEnumItem(overrides: Partial<SettingsItemDTO> = {}): SettingsItemDTO {
+  return {
+    category: 'language',
+    current: 'auto',
+    default: 'auto',
+    description: 'desc',
+    key: 'language.mode',
+    options: ['auto', 'fixed'],
+    restartRequired: false,
+    type: 'enum',
+    ...overrides,
+  }
+}
+
 function makeRow(overrides: Partial<SettingsRow> = {}): SettingsRow {
   return {
     category: 'concurrency',
@@ -251,6 +265,61 @@ describe('format-settings (shared)', () => {
         makeItem({category: 'concurrency', key: 'agentPool.maxSize'}),
       ])
       expect(rows.map((r) => r.category)).to.deep.equal(['concurrency', 'task-history', 'updates'])
+    })
+  })
+
+  describe('enum rows', () => {
+    it('includes enum items in the output with options propagated', () => {
+      const rows = buildSettingsRows([makeEnumItem()])
+      expect(rows).to.have.lengthOf(1)
+      expect(rows[0].type).to.equal('enum')
+      expect(rows[0].options).to.deep.equal(['auto', 'fixed'])
+    })
+
+    it('formats current=auto as "[ auto ]" and default verbatim', () => {
+      const row = buildSettingsRows([makeEnumItem({current: 'auto'})])[0]
+      expect(row.displayCurrent).to.equal('[ auto ]')
+      expect(row.displayDefault).to.equal('auto')
+    })
+
+    it('marks the row as modified when current differs from default', () => {
+      const row = buildSettingsRows([makeEnumItem({current: 'fixed'})])[0]
+      expect(row.modified).to.equal(true)
+    })
+
+    it('groups language enum rows under category=language', () => {
+      const row = buildSettingsRows([makeEnumItem()])[0]
+      expect(row.category).to.equal('language')
+    })
+
+    it('orders the language category after updates', () => {
+      const rows = buildSettingsRows([
+        makeEnumItem(),
+        makeItem({category: 'concurrency', key: 'agentPool.maxSize'}),
+        makeBooleanItem(true),
+      ])
+      expect(rows.map((r) => r.category)).to.deep.equal(['concurrency', 'updates', 'language'])
+    })
+
+    it('skips enum items with missing or wrong-typed fields (defensive narrowing)', () => {
+      const wonky = {...makeEnumItem(), current: 5} as unknown as SettingsItemDTO
+      expect(buildSettingsRows([wonky])).to.have.lengthOf(0)
+    })
+
+    it('parseRowInput: accepts a valid option as ok and rejects an unknown option', () => {
+      const row = buildSettingsRows([makeEnumItem()])[0]
+      const ok = parseRowInput(row, 'fixed')
+      expect(ok.kind).to.equal('ok')
+      if (ok.kind === 'ok') {
+        expect(ok.value).to.equal('fixed')
+        expect(ok.displayValue).to.equal('fixed')
+      }
+
+      const bad = parseRowInput(row, 'pidgin')
+      expect(bad.kind).to.equal('error')
+      if (bad.kind === 'error') {
+        expect(bad.message).to.match(/Expected one of \[auto, fixed\]/)
+      }
     })
   })
 })


### PR DESCRIPTION
## Summary

- Problem: ENG-2691 shipped language selection but only through `brv config set language.*` (project-config flat file). TUI users and WebUI users had no way to discover or change their language — the panels listed by `brv settings list` weren't aware of language at all.
- Why it matters: every other user-configurable knob (concurrency, LLM budgets, task-history size, update checks) is in `brv settings`. Language being the lone outlier in project config made it invisible to non-CLI users and forced docs to explain two separate "settings" surfaces.
- What changed: extended the `SETTINGS_REGISTRY` type system with an `enum` descriptor variant, registered `language.mode` (`auto` / `fixed`) and `language.code` (24 ISO-639-1 options) under a new `'language'` category, and wired the wire/CLI/TUI/WebUI layers to render and mutate them. The curate read site now consults daemon settings first; `brv config set language.*` is sunset with a clear pointer to the new command.
- What did NOT change (scope boundary): per-curate `--lang` flag, per-domain language overrides, first-run language wizard, and the MCP `brv-curate-tool` tool description (still built at server-boot from the auto clause — separate follow-up). The 24-entry `LANGUAGE_NAMES` map is unchanged; it was extracted to `src/shared/language/language-names.ts` so settings + WebUI + language-clause share one source.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [x] TUI / REPL
- [ ] Agent / Tools
- [ ] LLM Providers
- [x] Server / Daemon
- [x] Shared (constants, types, transport events)
- [x] CLI Commands (oclif)
- [ ] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

## Linked issues

- Closes ENG-2974
- Related ENG-2691 (foundation; original `brv config set language.*`)

## Root cause (bug fixes only, otherwise write `N/A`)

N/A — feature work.

## Test plan

- Coverage added:
  - [x] Unit test
  - [ ] Integration test
  - [x] Manual verification only
- Test file(s):
  - `test/unit/core/domain/entities/settings-registry.test.ts` — enum narrowing, `language.*` entries, category propagation
  - `test/unit/infra/transport/handlers/settings-handler.test.ts` — LIST exposes `options`, SET rejects non-string to enum keys
  - `test/unit/shared/utils/format-settings.test.ts` — enum row builder + parser + category ordering
  - `test/unit/infra/storage/file-settings-store.test.ts` — keyset assertion updated
- Key scenario(s) covered:
  - `findSettingDescriptor('language.mode')` narrows to `EnumSettingDescriptor` with `options: ['auto', 'fixed']`
  - `SettingsHandler.LIST` includes both language entries; `options` is omitted from non-enum DTOs
  - `SettingsHandler.SET` rejects `language.mode: 5` with `expected: 'enum'`, accepts `language.mode: 'fixed'`
  - `buildSettingsRows` produces enum row with `displayCurrent: '[ auto ]'`, category-ordered after `updates`
  - `parseRowInput` accepts a valid option, rejects unknown options with the allowed list
  - Full suite: 8869 passing, 16 pending, 0 failing

## User-visible changes

- `brv settings list` adds a `LANGUAGE` section with two rows: `language.mode` (`[ auto ]` / `[ fixed ]`) and `language.code` (e.g. `[ en ]`).
- `brv settings set language.mode fixed` — accepted; rejects invalid values with `expected one of [auto, fixed]`.
- `brv settings set language.code ko` — accepted; rejects unknown codes with the full ISO list in the error.
- `brv settings get language.code` — prints `current`, `default`, `scope` like other settings.
- TUI Settings page → new `LANGUAGE` group; Enter enters edit mode; Left/Right cycles options; Enter saves; Esc cancels.
- WebUI Configuration → General → new `Language` panel (between Task history and Updates) with Select dropdowns. `language.code` rows show `ja — Japanese` for readability.
- `brv config set language.mode | language.code` now fails with `'language.{mode,code}' has moved to global settings. Run: brv settings set language.{mode,code} <value>`. Other project-config keys (none today; dispatcher kept for future use) keep working unchanged.
- `brv curate` reads language from daemon settings first, falls back to `.brv/config.json` for users who haven't migrated — no setting is lost on upgrade.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording

before any changes:
$ brv settings list | grep -i language
(no output — language was invisible to settings UI)

# after:
$ brv settings list | grep -i language
language.mode                              auto      (default auto)
language.code                              en        (default en)

$ brv settings set language.mode fixed
Setting saved: language.mode = fixed.

$ brv settings set language.code xx
language.code expected one of [ar, de, el, en, es, fi, fr, he, hi, id, it, ja, ko, nl, no, pl, pt, ru, sv, th, tr, uk, vi, zh], got 'xx'.

$ brv config set language.mode fixed
'language.mode' has moved to global settings. Run: brv settings set language.mode fixed
```

Full suite:
```
$ npm test
  8869 passing (21s)
  16 pending

$ npm run lint
 279 problems (0 errors, 279 warnings)   # all pre-existing warnings in unrelated test files

$ npm run build
✓ tsc -b
✓ vite build src/webui (built in 7.32s)
```

## Checklist

- [x] Tests added or updated and passing (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Type check passes (`npm run build` covers `tsc -b` + WebUI strict tsc)
- [x] Build succeeds (`npm run build`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Documentation updated (if applicable) — `byterover-docs` settings reference still mentions `brv config set language.*`; will update under a docs-only follow-up after merge
- [x] No breaking changes (or clearly documented above) — `brv config set language.*` returns a non-zero exit with a clear pointer; existing `.brv/config.json` values still read at runtime
- [x] Branch is up to date with `proj/language-selection`

## Risks and mitigations

- Risk: existing users who set `brv config set language.code ko` before this lands will see no behavior change at first (good — fallback path still reads `.brv/config.json`), but any *new* change must go through `brv settings set`. If they re-run `brv config set language.*` thinking it still works, they'll get the deprecation error.
  - Mitigation: the deprecation error message names the exact replacement command with the user's same arguments — copy-paste resolves it.
- Risk: the MCP `brv-curate-tool` tool description is still built at server-boot from `buildLanguageClause()` (no args → auto clause). Users who set `language.mode: fixed` via `brv settings set` and then call brv via Claude Code's MCP still see auto behavior.
  - Mitigation: known limitation, documented in `brv-curate-tool.ts:53-57`, exists today on the project-config path too — not a regression. Filed separately as a "make MCP tool description dynamic" follow-up; users wanting fixed mode under MCP should write their prompt to Claude in the target language (per the auto clause's contract).
- Risk: `SettingDescriptor` widening from `Boolean | Integer` to `Boolean | Enum | Integer` is a structural API change for any consumer that did exhaustive narrowing.
  - Mitigation: `tsc -b` catches every consumer at build time; the 4 consumer sites (validator, store, handler, format-settings) were all updated in one commit (`19c9b6b47`) so the widening lands atomic.