### PR TITLE
feat: [ENG-2621] move AnalyticsPanel into a new Privacy tab in Configuration

### DIFF
--- a/src/webui/pages/configuration/general.tsx
+++ b/src/webui/pages/configuration/general.tsx
@@ -1,4 +1,3 @@
-import { AnalyticsPanel } from '../../features/analytics/components/analytics-panel'
 import {ConcurrencyPanel} from '../../features/settings/components/concurrency-panel'
 import {LlmPanel} from '../../features/settings/components/llm-panel'
 import {TaskHistoryPanel} from '../../features/settings/components/task-history-panel'
@@ -11,7 +10,6 @@ export function GeneralSection() {
       <LlmPanel />
       <TaskHistoryPanel />
       <UpdatesPanel />
-      <AnalyticsPanel />
     </>
   )
 }

--- a/src/webui/pages/configuration/layout.tsx
+++ b/src/webui/pages/configuration/layout.tsx
@@ -13,6 +13,7 @@ const SECTIONS: readonly SectionDef[] = [
   {end: true, label: 'General', path: '.'},
   {label: 'Connectors', path: 'connectors'},
   {label: 'Version control', path: 'version-control'},
+  {label: 'Privacy', path: 'privacy'},
 ]
 
 export function ConfigurationLayout() {

--- a/src/webui/pages/configuration/privacy.tsx
+++ b/src/webui/pages/configuration/privacy.tsx
@@ -1,0 +1,5 @@
+import {AnalyticsPanel} from '../../features/analytics/components/analytics-panel'
+
+export function PrivacySection() {
+  return <AnalyticsPanel />
+}

--- a/src/webui/router.tsx
+++ b/src/webui/router.tsx
@@ -7,6 +7,7 @@ import {ChangesPage} from './pages/changes-page'
 import {ConnectorsSection} from './pages/configuration/connectors'
 import {GeneralSection} from './pages/configuration/general'
 import {ConfigurationLayout} from './pages/configuration/layout'
+import {PrivacySection} from './pages/configuration/privacy'
 import {VersionControlSection} from './pages/configuration/version-control'
 import {ContextsPage} from './pages/contexts-page'
 import {HomePage} from './pages/home-page'
@@ -36,6 +37,7 @@ export const router = createBrowserRouter([
               {element: <GeneralSection />, index: true},
               {element: <ConnectorsSection />, path: 'connectors'},
               {element: <VersionControlSection />, path: 'version-control'},
+              {element: <PrivacySection />, path: 'privacy'},
             ],
             element: <ConfigurationLayout />,
             path: 'configuration',


### PR DESCRIPTION
## Summary

- The Configuration page was reorganised into a sidebar + sub-routes layout (`General` / `Connectors` / `Version control`) after PR #670 landed.
- This PR adds a new **Privacy** section under the same layout and re-mounts the existing `AnalyticsPanel` there, so the analytics opt-in lives in its own tab.
- Three small touches: a new `src/webui/pages/configuration/privacy.tsx`, one line each in `layout.tsx` (nav entry) and `router.tsx` (route).

## Test plan

- [ ] `npm run dev:ui` → `brv webui` → Configuration → click **Privacy** in the sidebar → `AnalyticsPanel` renders
- [ ] Toggle on/off still works (enable disclosure dialog + disable confirm dialog)
- [ ] `./bin/dev.js analytics status` reflects the toggle
- [ ] Other sub-routes (General / Connectors / Version control) still render correctly
- [ ] `npm run lint`, `npm run typecheck`, `npm test` green