### PR TITLE
feat(ENG-2810): prompt to migrate Markdown context tree to HTML

### DIFF
--- a/src/webui/features/context/components/context-layout.tsx
+++ b/src/webui/features/context/components/context-layout.tsx
@@ -1,5 +1,6 @@
 import {ChevronsRight} from 'lucide-react'
 
+import {MigrateContextTreeButton} from '../../migrate/components/migrate-context-tree-button'
 import {useContextLayout} from '../hooks/use-context-layout'
 import {useContextTree} from '../hooks/use-context-tree'
 import {isFilePath} from '../utils/tree-utils'
@@ -17,7 +18,8 @@ export function ContextLayout() {
     <div className="flex h-full gap-4">
       {/* Left panel: tree navigation */}
       {isLeftPanelOpen ? (
-        <div className="w-72 shrink-0 overflow-y-auto">
+        <div className="flex w-72 shrink-0 flex-col gap-2 overflow-y-auto">
+          <MigrateContextTreeButton />
           <ContextTreePanel onCollapse={toggleLeftPanel} />
         </div>
       ) : (

--- a/src/webui/features/migrate/api/check-migration-needed.ts
+++ b/src/webui/features/migrate/api/check-migration-needed.ts
@@ -1,0 +1,51 @@
+import {queryOptions, useQuery} from '@tanstack/react-query'
+
+import type {QueryConfig} from '../../../lib/react-query'
+
+import {
+  MigrateEvents,
+  type MigrateRunRequest,
+  type MigrateRunResponse,
+} from '../../../../shared/transport/events/migrate-events'
+import {useTransportStore} from '../../../stores/transport-store'
+
+export type MigrationNeededResult = {
+  archiveRoot: string | undefined
+  migratedCount: number
+  needed: boolean
+  projectRoot: string
+}
+
+export const checkMigrationNeeded = async (): Promise<MigrationNeededResult> => {
+  const {apiClient} = useTransportStore.getState()
+  if (!apiClient) throw new Error('Not connected')
+
+  const response = await apiClient.request<MigrateRunResponse, MigrateRunRequest>(MigrateEvents.RUN, {dryRun: true})
+  const {report} = response
+  return {
+    archiveRoot: report.archiveRoot,
+    migratedCount: report.summary.migrated,
+    needed: report.summary.migrated > 0,
+    projectRoot: report.projectRoot,
+  }
+}
+
+export const checkMigrationNeededQueryOptions = (projectRoot: null | string | undefined) =>
+  queryOptions({
+    enabled: Boolean(projectRoot),
+    queryFn: checkMigrationNeeded,
+    queryKey: ['migrate', 'check', projectRoot ?? ''],
+    retry: false,
+    staleTime: Number.POSITIVE_INFINITY,
+  })
+
+type UseCheckMigrationNeededOptions = {
+  projectRoot: null | string | undefined
+  queryConfig?: QueryConfig<typeof checkMigrationNeededQueryOptions>
+}
+
+export const useCheckMigrationNeeded = ({projectRoot, queryConfig}: UseCheckMigrationNeededOptions) =>
+  useQuery({
+    ...checkMigrationNeededQueryOptions(projectRoot),
+    ...queryConfig,
+  })

--- a/src/webui/features/migrate/api/run-migration.ts
+++ b/src/webui/features/migrate/api/run-migration.ts
@@ -1,0 +1,27 @@
+import {useMutation} from '@tanstack/react-query'
+
+import type {MutationConfig} from '../../../lib/react-query'
+
+import {
+  MigrateEvents,
+  type MigrateRunRequest,
+  type MigrateRunResponse,
+} from '../../../../shared/transport/events/migrate-events'
+import {useTransportStore} from '../../../stores/transport-store'
+
+export const runMigration = (): Promise<MigrateRunResponse> => {
+  const {apiClient} = useTransportStore.getState()
+  if (!apiClient) return Promise.reject(new Error('Not connected'))
+
+  return apiClient.request<MigrateRunResponse, MigrateRunRequest>(MigrateEvents.RUN, {dryRun: false})
+}
+
+type UseRunMigrationOptions = {
+  mutationConfig?: MutationConfig<typeof runMigration>
+}
+
+export const useRunMigration = ({mutationConfig}: UseRunMigrationOptions = {}) =>
+  useMutation({
+    ...mutationConfig,
+    mutationFn: runMigration,
+  })

--- a/src/webui/features/migrate/components/migrate-context-tree-button.tsx
+++ b/src/webui/features/migrate/components/migrate-context-tree-button.tsx
@@ -1,0 +1,25 @@
+import {Button} from '@campfirein/byterover-packages/components/button'
+import {ArrowUpRight} from 'lucide-react'
+
+import {useTransportStore} from '../../../stores/transport-store'
+import {useCheckMigrationNeeded} from '../api/check-migration-needed'
+import {useMigrationDialogStore} from '../stores/migration-dialog-store'
+
+export function MigrateContextTreeButton() {
+  const selectedProject = useTransportStore((s) => s.selectedProject)
+  const isConnected = useTransportStore((s) => s.isConnected)
+  const setForceOpen = useMigrationDialogStore((s) => s.setForceOpen)
+
+  const {data} = useCheckMigrationNeeded({
+    projectRoot: selectedProject && isConnected ? selectedProject : undefined,
+  })
+
+  if (!data?.needed) return null
+
+  return (
+    <Button className="w-full justify-start gap-1.5" onClick={() => setForceOpen(true)} variant="outline">
+      <ArrowUpRight className="size-3.5" />
+      Migrate {data.migratedCount} topic{data.migratedCount === 1 ? '' : 's'} to HTML
+    </Button>
+  )
+}

--- a/src/webui/features/migrate/components/migration-dialog.tsx
+++ b/src/webui/features/migrate/components/migration-dialog.tsx
@@ -1,0 +1,198 @@
+import {Button} from '@campfirein/byterover-packages/components/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@campfirein/byterover-packages/components/dialog'
+import {useState} from 'react'
+import {useNavigate} from 'react-router-dom'
+import {toast} from 'sonner'
+
+import type {MigrateRunReport} from '../../../../shared/transport/events/migrate-events'
+
+import {formatError} from '../../../lib/error-messages'
+import {useRunMigration} from '../api/run-migration'
+
+type MigrationDialogProps = {
+  migratedCount: number
+  onClose: () => void
+  onDismiss: () => void
+  open: boolean
+}
+
+export function MigrationDialog({migratedCount, onClose, onDismiss, open}: MigrationDialogProps) {
+  const run = useRunMigration()
+  const [report, setReport] = useState<MigrateRunReport | undefined>()
+  const navigate = useNavigate()
+
+  const isRunning = run.isPending
+  const isDone = Boolean(report)
+  const failed = report?.summary.failed ?? 0
+  const migrated = report?.summary.migrated ?? 0
+  const archived = report?.summary.archived ?? 0
+  const isSuccess = isDone && failed === 0
+  const isPartialFailure = isDone && failed > 0
+
+  const handleMigrate = async () => {
+    try {
+      const response = await run.mutateAsync()
+      setReport(response.report)
+      if (response.report.summary.failed === 0) {
+        toast.success(`Migrated ${response.report.summary.migrated} topics to HTML`)
+      }
+    } catch (error) {
+      toast.error(formatError(error, 'Migration failed'))
+    }
+  }
+
+  const handleOpenChange = (next: boolean) => {
+    if (next) return
+    if (isRunning) return
+    if (isDone) onClose()
+    else onDismiss()
+  }
+
+  return (
+    <Dialog onOpenChange={handleOpenChange} open={open}>
+      <DialogContent className="w-full max-w-md">
+        {!isDone && (
+          <>
+            <DialogHeader>
+              <DialogTitle>Migrate context tree to HTML</DialogTitle>
+              <DialogDescription>
+                ByteRover 4.0 stores topics as <code className="bg-muted rounded px-1 py-0.5 text-xs">{'<bv-topic>'}</code>{' '}
+                HTML. Your context tree still has Markdown topics.
+              </DialogDescription>
+            </DialogHeader>
+
+            <dl className="divide-border divide-y text-sm">
+              <div className="flex items-baseline justify-between gap-4 pb-2">
+                <dt className="text-muted-foreground">Markdown topics</dt>
+                <dd className="font-mono tabular-nums">{migratedCount}</dd>
+              </div>
+              <div className="flex items-baseline justify-between gap-4 py-2">
+                <dt className="text-muted-foreground">Location</dt>
+                <dd className="font-mono text-xs">.brv/context-tree/</dd>
+              </div>
+              <div className="flex items-baseline justify-between gap-4 pt-2">
+                <dt className="text-muted-foreground">Reversible</dt>
+                <dd className="font-mono text-xs">brv migrate --rollback</dd>
+              </div>
+            </dl>
+
+            {isRunning ? (
+              <p className="border-muted-foreground/40 text-muted-foreground border-l-2 pl-2.5 text-xs">
+                Converting topics… please don&apos;t close this tab.
+              </p>
+            ) : (
+              <p className="text-muted-foreground border-l-2 border-amber-500 pl-2.5 text-xs">
+                Don&apos;t run while <code className="bg-muted rounded px-1 py-0.5 text-[11px]">brv curate</code> or{' '}
+                <code className="bg-muted rounded px-1 py-0.5 text-[11px]">brv dream</code> is active.
+              </p>
+            )}
+
+            <DialogFooter>
+              <Button disabled={isRunning} onClick={onDismiss} variant="ghost">
+                Not now
+              </Button>
+              <Button disabled={isRunning} onClick={handleMigrate}>
+                {isRunning ? 'Migrating…' : 'Migrate now'}
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+
+        {isSuccess && report && (
+          <>
+            <DialogHeader>
+              <DialogTitle>Migration complete</DialogTitle>
+              <DialogDescription>Your context tree is now stored as HTML topics.</DialogDescription>
+            </DialogHeader>
+
+            <dl className="divide-border divide-y text-sm">
+              <div className="flex items-baseline justify-between gap-4 pb-2">
+                <dt className="text-muted-foreground">Migrated</dt>
+                <dd className="font-mono tabular-nums">{migrated}</dd>
+              </div>
+              <div className="flex items-baseline justify-between gap-4 py-2">
+                <dt className="text-muted-foreground">Archived</dt>
+                <dd className="font-mono tabular-nums">{archived}</dd>
+              </div>
+              <div className="flex items-baseline justify-between gap-4 pt-2">
+                <dt className="text-muted-foreground">Failed</dt>
+                <dd className="font-mono tabular-nums">0</dd>
+              </div>
+            </dl>
+
+            <p className="text-muted-foreground text-xs">
+              Review the new HTML topics in the Changes tab, then commit and push to sync with your team.
+            </p>
+
+            <DialogFooter>
+              <Button onClick={onClose} variant="ghost">
+                Done
+              </Button>
+              <Button
+                onClick={() => {
+                  onClose()
+                  navigate('/changes')
+                }}
+              >
+                Review changes
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+
+        {isPartialFailure && report && (
+          <>
+            <DialogHeader>
+              <DialogTitle>Migration finished with errors</DialogTitle>
+              <DialogDescription>Failed sources were archived — nothing was lost.</DialogDescription>
+            </DialogHeader>
+
+            <dl className="divide-border divide-y text-sm">
+              <div className="flex items-baseline justify-between gap-4 pb-2">
+                <dt className="text-muted-foreground">Migrated</dt>
+                <dd className="font-mono tabular-nums">{migrated}</dd>
+              </div>
+              <div className="flex items-baseline justify-between gap-4 py-2">
+                <dt className="text-muted-foreground">Archived</dt>
+                <dd className="font-mono tabular-nums">{archived}</dd>
+              </div>
+              <div className="flex items-baseline justify-between gap-4 pt-2">
+                <dt className="text-muted-foreground">Failed</dt>
+                <dd className="text-destructive font-mono tabular-nums">{failed}</dd>
+              </div>
+            </dl>
+
+            <ul className="max-h-40 space-y-1 overflow-y-auto text-xs">
+              {report.files
+                .filter((f) => f.outcome === 'failed')
+                .slice(0, 20)
+                .map((f) => (
+                  <li className="text-muted-foreground" key={f.sourceRelPath}>
+                    <span className="text-destructive">✗</span> <code>{f.sourceRelPath}</code>
+                    {f.reason ? <span> — {f.reason}</span> : null}
+                  </li>
+                ))}
+            </ul>
+
+            <p className="text-muted-foreground text-xs">
+              Roll back with <code className="bg-muted rounded px-1 py-0.5">brv migrate --rollback</code>
+            </p>
+
+            <DialogFooter>
+              <Button onClick={onClose} variant="ghost">
+                Close
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/webui/features/migrate/components/migration-prompt.tsx
+++ b/src/webui/features/migrate/components/migration-prompt.tsx
@@ -1,0 +1,55 @@
+import {useEffect, useState} from 'react'
+
+import {useTransportStore} from '../../../stores/transport-store'
+import {useCheckMigrationNeeded} from '../api/check-migration-needed'
+import {dismissMigrationPrompt, isMigrationPromptDismissed} from '../hooks/migration-dismissal'
+import {useMigrationDialogStore} from '../stores/migration-dialog-store'
+import {MigrationDialog} from './migration-dialog'
+
+export function MigrationPrompt() {
+  const selectedProject = useTransportStore((s) => s.selectedProject)
+  const isConnected = useTransportStore((s) => s.isConnected)
+  const forceOpen = useMigrationDialogStore((s) => s.forceOpen)
+  const setForceOpen = useMigrationDialogStore((s) => s.setForceOpen)
+
+  const [dismissed, setDismissed] = useState(false)
+  const [closed, setClosed] = useState(false)
+
+  // Re-evaluate dismissal whenever the active project changes.
+  useEffect(() => {
+    setClosed(false)
+    if (!selectedProject) {
+      setDismissed(false)
+      return
+    }
+
+    setDismissed(isMigrationPromptDismissed(selectedProject))
+  }, [selectedProject])
+
+  const connected = Boolean(selectedProject) && isConnected
+  // The dialog opens either automatically (first detection) or via the
+  // Context-tab "Migrate" button. Both paths still gate on `closed` so
+  // success / failure states stay closed after the user clicks Done.
+  const shouldOpen = connected && !closed && (forceOpen || !dismissed)
+
+  const {data} = useCheckMigrationNeeded({
+    projectRoot: shouldOpen ? selectedProject : undefined,
+  })
+
+  if (!shouldOpen || !data?.needed) return null
+
+  const handleDismiss = () => {
+    if (selectedProject) dismissMigrationPrompt(selectedProject)
+    setDismissed(true)
+    setForceOpen(false)
+  }
+
+  const handleClose = () => {
+    setClosed(true)
+    setForceOpen(false)
+  }
+
+  return (
+    <MigrationDialog migratedCount={data.migratedCount} onClose={handleClose} onDismiss={handleDismiss} open />
+  )
+}

--- a/src/webui/features/migrate/hooks/migration-dismissal.ts
+++ b/src/webui/features/migrate/hooks/migration-dismissal.ts
@@ -1,0 +1,52 @@
+const KEY_PREFIX = 'brv:migrate-dismissed:'
+
+// djb2 — small, deterministic, no crypto dependency. We just need a
+// stable opaque key; collisions don't have security implications here
+// because the value is a boolean flag scoped to one local user.
+function hashProjectRoot(projectRoot: string): string {
+  let hash = 5381
+  for (const char of projectRoot) {
+    const code = char.codePointAt(0) ?? 0
+    // eslint-disable-next-line no-bitwise
+    hash = Math.imul(hash, 33) ^ code
+  }
+
+  // eslint-disable-next-line no-bitwise
+  return (hash >>> 0).toString(16).padStart(8, '0')
+}
+
+export function migrationDismissalKey(projectRoot: string): string {
+  return `${KEY_PREFIX}${hashProjectRoot(projectRoot)}`
+}
+
+type StorageLike = globalThis.Storage
+
+function safeStorage(storage?: StorageLike): StorageLike | undefined {
+  if (storage) return storage
+  if (typeof globalThis === 'undefined') return undefined
+  try {
+    return globalThis.localStorage
+  } catch {
+    return undefined
+  }
+}
+
+export function isMigrationPromptDismissed(projectRoot: string, storage?: StorageLike): boolean {
+  const store = safeStorage(storage)
+  if (!store) return false
+  try {
+    return store.getItem(migrationDismissalKey(projectRoot)) === '1'
+  } catch {
+    return false
+  }
+}
+
+export function dismissMigrationPrompt(projectRoot: string, storage?: StorageLike): void {
+  const store = safeStorage(storage)
+  if (!store) return
+  try {
+    store.setItem(migrationDismissalKey(projectRoot), '1')
+  } catch {
+    // ignore (private browsing, quota, etc.)
+  }
+}

--- a/src/webui/features/migrate/stores/migration-dialog-store.ts
+++ b/src/webui/features/migrate/stores/migration-dialog-store.ts
@@ -1,0 +1,11 @@
+import {create} from 'zustand'
+
+type MigrationDialogState = {
+  forceOpen: boolean
+  setForceOpen: (open: boolean) => void
+}
+
+export const useMigrationDialogStore = create<MigrationDialogState>((set) => ({
+  forceOpen: false,
+  setForceOpen: (open) => set({forceOpen: open}),
+}))

--- a/src/webui/layouts/main-layout.tsx
+++ b/src/webui/layouts/main-layout.tsx
@@ -2,6 +2,7 @@ import {Badge} from '@campfirein/byterover-packages/components/badge'
 import {cn} from '@campfirein/byterover-packages/lib/utils'
 import {NavLink, Outlet} from 'react-router-dom'
 
+import {MigrationPrompt} from '../features/migrate/components/migration-prompt'
 import {useTaskCounts} from '../features/tasks/stores/task-store'
 import {useGetVcStatus} from '../features/vc/api/get-vc-status'
 import {statusToFiles} from '../features/vc/utils/status-to-files'
@@ -79,6 +80,8 @@ export function MainLayout() {
       <main className="min-h-0 flex-1 overflow-y-auto p-4">
         <Outlet />
       </main>
+
+      <MigrationPrompt />
     </div>
   )
 }

--- a/test/unit/webui/features/migrate/api/check-migration-needed.test.ts
+++ b/test/unit/webui/features/migrate/api/check-migration-needed.test.ts
@@ -1,0 +1,69 @@
+import {expect} from 'chai'
+import {createSandbox, type SinonSandbox, type SinonStub} from 'sinon'
+
+import type {BrvApiClient} from '../../../../../../src/webui/lib/api-client.js'
+
+import {MigrateEvents, type MigrateRunReport} from '../../../../../../src/shared/transport/events/migrate-events.js'
+import {checkMigrationNeeded} from '../../../../../../src/webui/features/migrate/api/check-migration-needed.js'
+import {useTransportStore} from '../../../../../../src/webui/stores/transport-store.js'
+
+function buildReport(overrides: Partial<MigrateRunReport['summary']> = {}): MigrateRunReport {
+  return {
+    archiveRoot: undefined,
+    completedAt: '2026-05-29T00:00:00Z',
+    dryRun: true,
+    files: [],
+    projectRoot: '/tmp/proj',
+    startedAt: '2026-05-29T00:00:00Z',
+    summary: {archived: 0, failed: 0, migrated: 0, skipped: 0, ...overrides},
+  }
+}
+
+describe('checkMigrationNeeded', () => {
+  let sandbox: SinonSandbox
+  let request: SinonStub
+
+  beforeEach(() => {
+    sandbox = createSandbox()
+    request = sandbox.stub()
+    useTransportStore.setState({
+      apiClient: {on: sandbox.stub(), request} as unknown as BrvApiClient,
+    })
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+    useTransportStore.setState({apiClient: null})
+  })
+
+  it('emits migrate:run with dryRun:true', async () => {
+    request.resolves({report: buildReport()})
+    await checkMigrationNeeded()
+    expect(request.firstCall.args[0]).to.equal(MigrateEvents.RUN)
+    expect(request.firstCall.args[1]).to.deep.equal({dryRun: true})
+  })
+
+  it('returns needed=true when migrated > 0', async () => {
+    request.resolves({report: buildReport({migrated: 42})})
+    const result = await checkMigrationNeeded()
+    expect(result.needed).to.equal(true)
+    expect(result.migratedCount).to.equal(42)
+  })
+
+  it('returns needed=false when migrated === 0', async () => {
+    request.resolves({report: buildReport({migrated: 0, skipped: 99})})
+    const result = await checkMigrationNeeded()
+    expect(result.needed).to.equal(false)
+    expect(result.migratedCount).to.equal(0)
+  })
+
+  it('rejects when not connected', async () => {
+    useTransportStore.setState({apiClient: null})
+    try {
+      await checkMigrationNeeded()
+      expect.fail('expected to reject')
+    } catch (error) {
+      expect((error as Error).message).to.equal('Not connected')
+    }
+  })
+})

--- a/test/unit/webui/features/migrate/api/run-migration.test.ts
+++ b/test/unit/webui/features/migrate/api/run-migration.test.ts
@@ -1,0 +1,53 @@
+import {expect} from 'chai'
+import {createSandbox, type SinonSandbox, type SinonStub} from 'sinon'
+
+import type {BrvApiClient} from '../../../../../../src/webui/lib/api-client.js'
+
+import {MigrateEvents} from '../../../../../../src/shared/transport/events/migrate-events.js'
+import {runMigration} from '../../../../../../src/webui/features/migrate/api/run-migration.js'
+import {useTransportStore} from '../../../../../../src/webui/stores/transport-store.js'
+
+describe('runMigration', () => {
+  let sandbox: SinonSandbox
+  let request: SinonStub
+
+  beforeEach(() => {
+    sandbox = createSandbox()
+    request = sandbox.stub()
+    useTransportStore.setState({
+      apiClient: {on: sandbox.stub(), request} as unknown as BrvApiClient,
+    })
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+    useTransportStore.setState({apiClient: null})
+  })
+
+  it('emits migrate:run with dryRun:false', async () => {
+    request.resolves({
+      report: {
+        archiveRoot: '/tmp/proj/.brv/_migrations/x',
+        completedAt: '2026-05-29T00:00:00Z',
+        dryRun: false,
+        files: [],
+        projectRoot: '/tmp/proj',
+        startedAt: '2026-05-29T00:00:00Z',
+        summary: {archived: 1, failed: 0, migrated: 1, skipped: 0},
+      },
+    })
+    await runMigration()
+    expect(request.firstCall.args[0]).to.equal(MigrateEvents.RUN)
+    expect(request.firstCall.args[1]).to.deep.equal({dryRun: false})
+  })
+
+  it('rejects when not connected', async () => {
+    useTransportStore.setState({apiClient: null})
+    try {
+      await runMigration()
+      expect.fail('expected to reject')
+    } catch (error) {
+      expect((error as Error).message).to.equal('Not connected')
+    }
+  })
+})

--- a/test/unit/webui/features/migrate/hooks/migration-dismissal.test.ts
+++ b/test/unit/webui/features/migrate/hooks/migration-dismissal.test.ts
@@ -1,0 +1,78 @@
+import {expect} from 'chai'
+
+import {
+  dismissMigrationPrompt,
+  isMigrationPromptDismissed,
+  migrationDismissalKey,
+} from '../../../../../../src/webui/features/migrate/hooks/migration-dismissal.js'
+
+interface StorageLike {
+  clear(): void
+  getItem(key: string): null | string
+  removeItem(key: string): void
+  setItem(key: string, value: string): void
+}
+
+function createMemoryStorage(): StorageLike {
+  const store = new Map<string, string>()
+  return {
+    clear() {
+      store.clear()
+    },
+    getItem(key) {
+      return store.has(key) ? (store.get(key) as string) : null
+    },
+    removeItem(key) {
+      store.delete(key)
+    },
+    setItem(key, value) {
+      store.set(key, value)
+    },
+  }
+}
+
+describe('migration dismissal storage', () => {
+  let storage: StorageLike
+
+  beforeEach(() => {
+    storage = createMemoryStorage()
+  })
+
+  it('produces a hashed, project-scoped key (no raw path)', () => {
+    const a = migrationDismissalKey('/tmp/a')
+    const b = migrationDismissalKey('/tmp/b')
+    expect(a).to.match(/^brv:migrate-dismissed:[\da-f]{8}$/)
+    expect(b).to.match(/^brv:migrate-dismissed:[\da-f]{8}$/)
+    expect(a).to.not.equal(b)
+    expect(a).to.not.include('/tmp/a')
+  })
+
+  it('is deterministic for the same projectRoot', () => {
+    expect(migrationDismissalKey('/tmp/a')).to.equal(migrationDismissalKey('/tmp/a'))
+  })
+
+  it('is not dismissed by default', () => {
+    expect(isMigrationPromptDismissed('/tmp/a', storage as unknown as globalThis.Storage)).to.equal(false)
+  })
+
+  it('marks dismissed per project', () => {
+    dismissMigrationPrompt('/tmp/a', storage as unknown as globalThis.Storage)
+    expect(isMigrationPromptDismissed('/tmp/a', storage as unknown as globalThis.Storage)).to.equal(true)
+    expect(isMigrationPromptDismissed('/tmp/b', storage as unknown as globalThis.Storage)).to.equal(false)
+  })
+
+  it('returns false when storage access throws (private browsing)', () => {
+    const broken = {
+      getItem() {
+        throw new Error('blocked')
+      },
+      setItem() {
+        throw new Error('blocked')
+      },
+    } as unknown as globalThis.Storage
+    expect(isMigrationPromptDismissed('/tmp/a', broken)).to.equal(false)
+    expect(() => {
+      dismissMigrationPrompt('/tmp/a', broken)
+    }).to.not.throw()
+  })
+})


### PR DESCRIPTION
Add a dialog in the local web app that detects a legacy Markdown context tree (via `migrate:run --dry-run`) and offers to convert it to the 4.0 HTML format in place. On success it routes users to the Changes tab to commit and push the new topics.

Dismissed projects still surface a "Migrate N topics to HTML" button at the top of the Context tab, so users can return to the dialog without losing the ability to act.

Dismissals persist in localStorage keyed by a djb2-hashed project root, so raw paths don't leak into the key.