### PR TITLE
[ENG-3021] Render and index <img> as first-class inline content

### DIFF
--- a/src/agent/infra/tools/implementations/search-knowledge-service.ts
+++ b/src/agent/infra/tools/implementations/search-knowledge-service.ts
@@ -52,8 +52,11 @@ import {
 const MAX_CONTEXT_TREE_FILES = 10_000
 const DEFAULT_CACHE_TTL_MS = 5000
 
-/** Bump when MINISEARCH_OPTIONS fields/boost change to invalidate cached indexes */
-const INDEX_SCHEMA_VERSION = 6
+/**
+ * Bump when MINISEARCH_OPTIONS fields/boost change to invalidate cached indexes.
+ *  v7 (ENG-3021): include `<img>` alt + src in HTML topic indexed content.
+ */
+const INDEX_SCHEMA_VERSION = 7
 
 /** Only include results whose normalized score is at least this fraction of the top result's score */
 const SCORE_GAP_RATIO = 0.7
@@ -611,7 +614,12 @@ async function readIndexableContent(
       // a 3x field boost via the `title` column and is intentionally
       // omitted here.
       const {keywords, related, summary, tags} = parsed.topicAttributes
-      const indexedContent = [parsed.bodyText, summary, tags, keywords, related]
+      // `parsed.imageContent` aggregates every `<img>`'s alt + src in
+      // document order. Without it, queries for image alt phrases or URL
+      // tokens silently miss image-bearing topics — the writer accepts
+      // `<img>` but `getInnerText` (which feeds `bodyText`) returns
+      // nothing for void elements. See ENG-3021 / inline-html milestone.
+      const indexedContent = [parsed.bodyText, summary, tags, keywords, related, parsed.imageContent]
         .filter((part): part is string => typeof part === 'string' && part.length > 0)
         .join(' ')
       return {

--- a/src/agent/resources/prompts/system-prompt.yml
+++ b/src/agent/resources/prompts/system-prompt.yml
@@ -157,7 +157,7 @@ prompt: |
   - Domains (dynamically created from content) and topics under each domain.
   - Optional subtopics (max one level under topics).
   - Each topic is a single HTML file at `.brv/context-tree/<domain>/<topic>[/<subtopic>].html`, rooted in a `<bv-topic>` element with frontmatter on attributes (`path`, `title`, `summary`, `tags`, `keywords`, `related`).
-  - Body sections are dedicated `<bv-*>` elements: `<bv-reason>`, `<bv-task>`, `<bv-changes>`, `<bv-files>`, `<bv-flow>`, `<bv-timestamp>`, `<bv-author>`, `<bv-pattern>`, `<bv-structure>`, `<bv-dependencies>`, `<bv-highlights>`, `<bv-rule>`, `<bv-examples>`, `<bv-diagram>`, `<bv-fact>`, `<bv-decision>`, `<bv-bug>`, `<bv-fix>`. Standard inline HTML (h1-h6, p, ul, ol, li, code, pre, strong, em) is allowed inside block-content elements.
+  - Body sections are dedicated `<bv-*>` elements: `<bv-reason>`, `<bv-task>`, `<bv-changes>`, `<bv-files>`, `<bv-flow>`, `<bv-timestamp>`, `<bv-author>`, `<bv-pattern>`, `<bv-structure>`, `<bv-dependencies>`, `<bv-highlights>`, `<bv-rule>`, `<bv-examples>`, `<bv-diagram>`, `<bv-fact>`, `<bv-decision>`, `<bv-bug>`, `<bv-fix>`. Standard inline HTML (h1-h6, p, ul, ol, li, code, pre, strong, em, img) is allowed inside block-content elements.
   - The element vocabulary is closed and described in detail in the `curate` tool description.
 
   ---
@@ -381,7 +381,13 @@ prompt: |
 
   Standard inline HTML inside block-content elements (`<bv-topic>`,
   `<bv-decision>`, `<bv-bug>`, `<bv-fix>`, narrative-block elements):
-  `h1`–`h6`, `p`, `ul`, `ol`, `li`, `code`, `pre`, `strong`, `em`.
+  `h1`–`h6`, `p`, `ul`, `ol`, `li`, `code`, `pre`, `strong`, `em`, `img`.
+
+  `<img src="..." alt="...">` embeds a visual reference by URL — useful
+  for architecture diagrams, screenshots, UI mocks. The renderer translates
+  to CommonMark `![alt](src)` for LLM consumption; the indexer surfaces
+  both alt text and URL tokens for BM25. Always include a descriptive
+  `alt` — it's the primary search handle.
 
   Inline-content elements (`<bv-rule>`, `<bv-task>`, `<bv-flow>`,
   `<bv-fact>`, `<bv-pattern>`, `<bv-timestamp>`, `<bv-author>`) only allow

--- a/src/server/infra/render/reader/html-reader.ts
+++ b/src/server/infra/render/reader/html-reader.ts
@@ -42,6 +42,16 @@ export type HtmlTopicRead = {
   bodyText: string
   /** Flat list of every typed `<bv-*>` element, in document order. */
   elements: readonly ElementAxisEntry[]
+  /**
+   * Searchable text aggregated from every `<img>` in the topic — `alt`
+   * attribute and `src` URL, space-joined in document order. Concatenated
+   * into the BM25 input by the indexer so queries for image alt phrases
+   * or URL tokens (host, path segments, filename) surface the topic.
+   * `<img>` is a void element with no text-node children, so the default
+   * `getInnerText` extraction returns nothing for it — this field is the
+   * indexer's view of image content.
+   */
+  imageContent: string
   /** Attributes on the bv-topic root, or empty if no bv-topic was present. */
   topicAttributes: TopicAttributes
 }
@@ -57,6 +67,7 @@ export function readHtmlTopicSync(html: string): HtmlTopicRead {
   const allElements = walkElements(document)
 
   const bodyText = getInnerText(document)
+  const imageContent = extractImageContent(allElements)
 
   const elements: ElementAxisEntry[] = []
   let topicAttributes: TopicAttributes = {}
@@ -82,7 +93,34 @@ export function readHtmlTopicSync(html: string): HtmlTopicRead {
     })
   }
 
-  return {bodyText, elements, topicAttributes}
+  return {bodyText, elements, imageContent, topicAttributes}
+}
+
+/**
+ * Aggregate every `<img>`'s `alt` and `src` into a single space-joined
+ * string. Public so the BM25 indexer can include image content in its
+ * input without re-walking the parsed tree.
+ *
+ * The full URL goes in verbatim — the BM25 tokenizer splits on `/`, `:`,
+ * `.`, `?`, etc. (already CJK-aware after ENG-2689), which decomposes
+ * URLs into useful tokens (`https`, `example`, `com`, `arch`, `png`).
+ * No explicit host extraction needed.
+ *
+ * Returns the empty string when the topic has no `<img>` elements, so
+ * the indexer's `[bodyText, summary, …, imageContent].filter(…)` step
+ * cleanly drops the entry instead of carrying an empty token.
+ */
+export function extractImageContent(elements: readonly {attributes: Readonly<Record<string, string>>; tagName: string}[]): string {
+  const parts: string[] = []
+  for (const el of elements) {
+    if (el.tagName !== 'img') continue
+    const alt = (el.attributes.alt ?? '').trim()
+    const src = (el.attributes.src ?? '').trim()
+    if (alt.length > 0) parts.push(alt)
+    if (src.length > 0) parts.push(src)
+  }
+
+  return parts.join(' ')
 }
 
 /**

--- a/src/server/infra/render/reader/html-renderer.ts
+++ b/src/server/infra/render/reader/html-renderer.ts
@@ -1,6 +1,6 @@
 import type {ElementNode, ParsedNode} from '../../../core/domain/render/element-types.js'
 
-import {getInnerText, parseHtml} from './html-parser.js'
+import {parseHtml} from './html-parser.js'
 
 /**
  * Render a parsed `<bv-topic>` document into a markdown-like string for
@@ -57,10 +57,18 @@ export function renderHtmlTopicForLlm(html: string): string {
 }
 
 function renderChild(element: ElementNode): string {
-  const text = getInnerText(element).trim()
-  if (text.length === 0) return ''
-
   const {attributes, tagName} = element
+
+  // `<img>` reaches `renderChild` only when it appears as a top-level
+  // sibling of `<bv-*>` elements (rare). Inline `<img>` inside a `<bv-*>`
+  // body is handled by `getInlineMarkdown` below, which is what the
+  // `<bv-*>` cases call into.
+  if (tagName === 'img') {
+    return renderImgMarkdown(attributes)
+  }
+
+  const text = getInlineMarkdown(element)
+  if (text.length === 0) return ''
 
   switch (tagName) {
     case 'bv-author': {
@@ -171,4 +179,68 @@ function findFirstElement(root: ParsedNode, tagName: string): ElementNode | unde
   }
 
   return undefined
+}
+
+/**
+ * Markdown-aware inner-text extractor.
+ *
+ * Behaves like `getInnerText` from `html-parser` — concatenates text-node
+ * descendants in document order — but additionally translates inline
+ * `<img src alt/>` into CommonMark `![alt](src)`. Void elements like
+ * `<img>` contribute no text under the shared `getInnerText`, so a
+ * `<bv-decision>` body with an embedded image used to silently drop
+ * everything but the surrounding prose. This helper restores the URL +
+ * alt text in standard markdown form.
+ *
+ * `<img>` is the only inline element this helper specialises. Other
+ * non-text children continue to recurse via their own text content;
+ * `<a href>` (which has visible inner text and a parallel "href is
+ * dropped" bug) is tracked as a separate task in the inline-html
+ * milestone.
+ */
+function getInlineMarkdown(node: ParsedNode): string {
+  return collapseInlineWhitespace(getInlineMarkdownRaw(node))
+}
+
+function getInlineMarkdownRaw(node: ParsedNode): string {
+  if (node.type === 'text') return node.text
+  if (node.type === 'element') {
+    if (node.tagName === 'img') return renderImgMarkdown(node.attributes)
+    return node.children.map((c) => getInlineMarkdownRaw(c)).join(' ')
+  }
+
+  if (node.type === 'document') {
+    return node.children.map((c) => getInlineMarkdownRaw(c)).join(' ')
+  }
+
+  return ''
+}
+
+function collapseInlineWhitespace(text: string): string {
+  return text.replaceAll(/\s+/g, ' ').trim()
+}
+
+/**
+ * Translate `<img src alt/>` attributes into CommonMark `![alt](src)`.
+ *
+ * Defensive on malformed inputs:
+ *   - missing `src` → empty string (don't pollute markdown with broken
+ *     image syntax). The alt text is still surfaced for BM25 separately
+ *     via `extractImageContent` in the reader.
+ *   - missing `alt` → `![](src)`. Valid CommonMark; renders as a link
+ *     target without alt text.
+ *   - `]` in alt → replaced with space. Cheaper than emitting an escape
+ *     sequence and keeps the markdown one-line.
+ *   - `)` in src → fall back to `<src>` autolink form. CommonMark's
+ *     angle-bracket syntax handles parenthesised URLs without a broken
+ *     close-paren parse.
+ */
+function renderImgMarkdown(attributes: Readonly<Record<string, string>>): string {
+  const src = (attributes.src ?? '').trim()
+  if (src.length === 0) return ''
+
+  const alt = collapseInlineWhitespace((attributes.alt ?? '').replaceAll(']', ' '))
+
+  if (src.includes(')')) return `<${src}>`
+  return `![${alt}](${src})`
 }

--- a/test/integration/scenarios/img-roundtrip.test.ts
+++ b/test/integration/scenarios/img-roundtrip.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Integration test for ENG-3021 — `<img>` round-trips through the read +
+ * BM25 index contract.
+ *
+ * Unit tests in `html-renderer.test.ts` and `html-reader.test.ts` lock the
+ * individual functions. This file proves they compose: an `<img>`-bearing
+ * HTML topic on disk produces (a) markdown image syntax when rendered for
+ * `brv read`, and (b) BM25-discoverable text when its `imageContent` is
+ * concatenated into the indexer's input.
+ *
+ * Out of scope: full daemon + transport orchestration. The auto-test
+ * harness `local-auto-test/curate-tool-mode-e2e/run.mjs` exercises the
+ * full real-CLI roundtrip; this test is the in-process counterpart.
+ */
+
+import {expect} from 'chai'
+import MiniSearch from 'minisearch'
+import {existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+
+import {readHtmlTopic} from '../../../src/server/infra/render/reader/html-reader.js'
+import {renderHtmlTopicForLlm} from '../../../src/server/infra/render/reader/html-renderer.js'
+
+const SAMPLE_TOPIC = `<bv-topic path="test/img" title="Diagram with image" summary="Verifies <img> survives read + query">
+  <bv-reason>Want to keep architecture diagram URLs accessible after curate.</bv-reason>
+  <bv-decision id="d-img1">The reference diagram for our system: <img src="https://example.com/architecture/service-mesh.png" alt="System architecture showing service mesh"/>. See the production-track for context.</bv-decision>
+  <bv-fact subject="docs">Background docs live alongside the topic.</bv-fact>
+</bv-topic>`
+
+// Mirrors what `readIndexableContent` does in search-knowledge-service.ts —
+// extracted so the index-side tests can share one composition path.
+function buildIndexedContent(parsed: Awaited<ReturnType<typeof readHtmlTopic>>): string {
+  const {keywords, related, summary, tags} = parsed.topicAttributes
+  return [parsed.bodyText, summary, tags, keywords, related, parsed.imageContent]
+    .filter((part): part is string => typeof part === 'string' && part.length > 0)
+    .join(' ')
+}
+
+// Build a focused MiniSearch index over a single topic — the index-side
+// tests share this so the "what does the BM25 contract see" wiring is
+// asserted once. Default MiniSearch tokenizer (Unicode whitespace +
+// punctuation split) matches the production indexer on this branch.
+async function buildSingleTopicIndex(topicPath: string): Promise<MiniSearch> {
+  const parsed = await readHtmlTopic(topicPath)
+  const indexedContent = buildIndexedContent(parsed)
+  const ms = new MiniSearch({
+    fields: ['title', 'content', 'path'],
+    idField: 'id',
+  })
+  ms.add({
+    content: indexedContent,
+    id: 1,
+    path: 'test/img.html',
+    title: parsed.topicAttributes.title ?? 'untitled',
+  })
+  return ms
+}
+
+describe('<img> roundtrip — render + index integration (ENG-3021)', () => {
+  let projectRoot: string
+  let topicPath: string
+
+  beforeEach(() => {
+    projectRoot = mkdtempSync(join(tmpdir(), 'img-roundtrip-'))
+    const dir = join(projectRoot, '.brv', 'context-tree', 'test')
+    mkdirSync(dir, {recursive: true})
+    topicPath = join(dir, 'img.html')
+    writeFileSync(topicPath, SAMPLE_TOPIC, 'utf8')
+  })
+
+  afterEach(() => {
+    if (existsSync(projectRoot)) rmSync(projectRoot, {force: true, recursive: true})
+  })
+
+  describe('read side (`brv read` path)', () => {
+    it('renders the on-disk topic with the `<img>` as CommonMark `![alt](src)`', async () => {
+      const read = await readHtmlTopic(topicPath)
+      const rendered = renderHtmlTopicForLlm(SAMPLE_TOPIC)
+      expect(rendered).to.include('![System architecture showing service mesh](https://example.com/architecture/service-mesh.png)')
+      // Surrounding prose stays — the image is inline, not a replacement
+      expect(rendered).to.include('The reference diagram for our system:')
+      expect(rendered).to.include('See the production-track for context.')
+      // imageContent is populated on the parsed result so the indexer can see it
+      expect(read.imageContent).to.include('System architecture showing service mesh')
+      expect(read.imageContent).to.include('https://example.com/architecture/service-mesh.png')
+    })
+  })
+
+  describe('index side (`brv query` path)', () => {
+    it('query for alt-text phrase ("service mesh") finds the topic — pre-fix this was 0 matches', async () => {
+      // The motivating gap. The writer kept `<img alt="...service mesh"/>`
+      // intact on disk, but `bodyText` (via `getInnerText`) returned
+      // nothing for the void `<img>`. Without `imageContent`, the alt
+      // phrase was unindexed and queries for it missed the topic.
+      const ms = await buildSingleTopicIndex(topicPath)
+      const results = ms.search('service mesh')
+      expect(results.length, 'service-mesh query matches').to.be.greaterThan(0)
+      expect(results[0].id).to.equal(1)
+    })
+
+    it('query for URL host ("example") finds the topic', async () => {
+      // The BM25 tokenizer splits URLs on `/`, `:`, `.` so
+      // `example.com` becomes two tokens `['example', 'com']` — both
+      // present in the indexed content via `extractImageContent`.
+      const ms = await buildSingleTopicIndex(topicPath)
+      const results = ms.search('example')
+      expect(results.length).to.be.greaterThan(0)
+    })
+
+    it('query for URL path segment ("service-mesh") finds the topic', async () => {
+      const ms = await buildSingleTopicIndex(topicPath)
+      const results = ms.search('service-mesh')
+      expect(results.length).to.be.greaterThan(0)
+    })
+
+    it('query for surrounding prose ("reference diagram") still finds the topic — no regression', async () => {
+      // Sanity check: `bodyText` extraction continues to surface the
+      // prose around the image. The `<img>` fix is additive — it adds
+      // image content to the index without affecting the existing
+      // body-text extraction path.
+      const ms = await buildSingleTopicIndex(topicPath)
+      const results = ms.search('reference diagram')
+      expect(results.length).to.be.greaterThan(0)
+    })
+  })
+
+  describe('topic with no `<img>` is unaffected (regression guard)', () => {
+    it('imageContent is empty and indexed content omits the trailing space', async () => {
+      // A topic without any `<img>` should produce an indexed-content
+      // string that's byte-identical to what the pre-fix indexer
+      // produced (modulo the empty-string filter).
+      const noImageTopic = '<bv-topic path="test/noimg" title="No image" summary="Plain"><bv-reason>r</bv-reason></bv-topic>'
+      const noImageDir = join(projectRoot, '.brv', 'context-tree', 'test')
+      const noImagePath = join(noImageDir, 'noimg.html')
+      writeFileSync(noImagePath, noImageTopic, 'utf8')
+
+      const parsed = await readHtmlTopic(noImagePath)
+      expect(parsed.imageContent).to.equal('')
+
+      const indexed = [parsed.bodyText, parsed.topicAttributes.summary, parsed.imageContent]
+        .filter((p): p is string => typeof p === 'string' && p.length > 0)
+        .join(' ')
+
+      expect(indexed).to.include('r')
+      expect(indexed).to.include('Plain')
+      expect(indexed).to.not.match(/\s\s+/) // no double spaces from empty imageContent
+    })
+  })
+})

--- a/test/unit/server/infra/render/reader/html-reader.test.ts
+++ b/test/unit/server/infra/render/reader/html-reader.test.ts
@@ -17,7 +17,12 @@ import {mkdtemp, rm, writeFile} from 'node:fs/promises'
 import {tmpdir} from 'node:os'
 import {join} from 'node:path'
 
-import {readHtmlTopic, readHtmlTopicSync} from '../../../../../../src/server/infra/render/reader/html-reader.js'
+import {parseHtml, walkElements} from '../../../../../../src/server/infra/render/reader/html-parser.js'
+import {extractImageContent, readHtmlTopic, readHtmlTopicSync} from '../../../../../../src/server/infra/render/reader/html-reader.js'
+
+function elementsForImgTests(html: string): readonly {attributes: Readonly<Record<string, string>>; tagName: string}[] {
+  return walkElements(parseHtml(html))
+}
 
 describe('html-reader', () => {
   describe('readHtmlTopicSync', () => {
@@ -111,6 +116,53 @@ describe('html-reader', () => {
       const html = '<bv-topic></bv-topic><bv-topic path="b" title="second"></bv-topic>'
       const result = readHtmlTopicSync(html)
       expect(Object.keys(result.topicAttributes)).to.have.lengthOf(0)
+    })
+  })
+
+  describe('extractImageContent + imageContent field (ENG-3021)', () => {
+    it('returns empty string for a topic with no <img>', () => {
+      const els = elementsForImgTests('<bv-topic path="x" title="t"><bv-rule severity="must">r</bv-rule></bv-topic>')
+      expect(extractImageContent(els)).to.equal('')
+    })
+
+    it('aggregates alt + src for a single <img>', () => {
+      const els = elementsForImgTests('<bv-topic path="x" title="t"><bv-decision><img src="https://example.com/a.png" alt="System diagram"/></bv-decision></bv-topic>')
+      const out = extractImageContent(els)
+      expect(out).to.include('System diagram')
+      expect(out).to.include('https://example.com/a.png')
+    })
+
+    it('joins multiple <img>s in document order', () => {
+      const els = elementsForImgTests(
+        '<bv-topic path="x" title="t"><bv-decision><img src="https://a.com/1.png" alt="first"/></bv-decision><bv-decision><img src="https://b.com/2.png" alt="second"/></bv-decision></bv-topic>',
+      )
+      const out = extractImageContent(els)
+      // Both alts and both srcs surface; document-order is preserved
+      expect(out.indexOf('first')).to.be.lessThan(out.indexOf('second'))
+      expect(out).to.include('https://a.com/1.png')
+      expect(out).to.include('https://b.com/2.png')
+    })
+
+    it('skips empty attributes — no stray spaces from missing alt or src', () => {
+      const els = elementsForImgTests('<bv-topic path="x" title="t"><bv-decision><img src="https://x.com/a.png"/><img alt="caption only"/></bv-decision></bv-topic>')
+      const out = extractImageContent(els)
+      // First img contributes only src (no alt to add); second only alt.
+      expect(out).to.include('https://x.com/a.png')
+      expect(out).to.include('caption only')
+      expect(out).to.not.match(/\s{2,}/) // no double spaces
+    })
+
+    it('readHtmlTopicSync surfaces imageContent on the parsed result', () => {
+      const result = readHtmlTopicSync(
+        '<bv-topic path="x" title="t"><bv-decision><img src="https://example.com/sys.png" alt="System overview"/></bv-decision></bv-topic>',
+      )
+      expect(result.imageContent).to.include('System overview')
+      expect(result.imageContent).to.include('https://example.com/sys.png')
+    })
+
+    it('readHtmlTopicSync returns empty imageContent when no <img> present', () => {
+      const result = readHtmlTopicSync('<bv-topic path="x" title="t"><bv-rule severity="must">r</bv-rule></bv-topic>')
+      expect(result.imageContent).to.equal('')
     })
   })
 

--- a/test/unit/server/infra/render/reader/html-renderer.test.ts
+++ b/test/unit/server/infra/render/reader/html-renderer.test.ts
@@ -138,4 +138,86 @@ describe('renderHtmlTopicForLlm', () => {
       '# JWT auth\n> JWT design.\n\n**Reason:** Document JWT.\n\n- **Rule** [must] (r-1): Validate signatures.\n\n- **Decision** (d-1): Use RS256.\n\n- **Fact** (subject=alg, value=RS256): All service tokens use RS256.',
     )
   })
+
+  describe('inline <img> (ENG-3021)', () => {
+    it('renders <img src alt> inside a <bv-decision> as CommonMark image syntax', () => {
+      // The motivating bug: an `<img>` embedded inside body content used to
+      // disappear because `getInnerText` skips void elements. The renderer
+      // now uses a markdown-aware inline extractor that translates `<img>`
+      // to `![alt](src)`.
+      const html = '<bv-topic path="x" title="t"><bv-decision id="d-1">Diagram: <img src="https://example.com/arch.png" alt="System architecture"/>. See spec.</bv-decision></bv-topic>'
+      const out = renderHtmlTopicForLlm(html)
+      expect(out).to.include('![System architecture](https://example.com/arch.png)')
+      // Surrounding prose still present — the image is inserted inline, not as a replacement
+      expect(out).to.include('Diagram:')
+      expect(out).to.include('See spec.')
+    })
+
+    it('renders <img> with no alt as ![](src) — valid CommonMark click target', () => {
+      const html = '<bv-topic path="x" title="t"><bv-decision id="d-1"><img src="https://example.com/x.png"/></bv-decision></bv-topic>'
+      const out = renderHtmlTopicForLlm(html)
+      expect(out).to.include('![](https://example.com/x.png)')
+    })
+
+    it('drops <img> with no src — would emit broken ![alt]() syntax otherwise', () => {
+      // alt text without src cannot produce a working markdown image. Silent
+      // drop is safer than emitting a broken-link target downstream parsers
+      // may render as plain bracketed text. The indexer still surfaces the
+      // alt separately via extractImageContent for BM25 purposes.
+      const html = '<bv-topic path="x" title="t"><bv-decision id="d-1">Text <img alt="lonely alt"/> tail.</bv-decision></bv-topic>'
+      const out = renderHtmlTopicForLlm(html)
+      expect(out).to.not.include('![')
+      expect(out).to.include('Text')
+      expect(out).to.include('tail.')
+    })
+
+    it('escapes `]` in alt by collapsing to space — only `]` terminates the alt span, `[` is harmless', () => {
+      // A literal `]` in alt would terminate the markdown image's alt span
+      // early. Cheaper to collapse to a space than to backslash-escape.
+      // `[` is left untouched — it's valid inside an alt and never closes
+      // the span.
+      const html = '<bv-topic path="x" title="t"><bv-decision id="d-1"><img src="https://x.com/a.png" alt="Phase [2] diagram"/></bv-decision></bv-topic>'
+      const out = renderHtmlTopicForLlm(html)
+      // `]` is gone; only one closing bracket should appear in the rendered
+      // string for this image — the one closing the alt span before `(src)`.
+      const altSpan = out.match(/!\[([^\]]*)]/)
+      expect(altSpan, 'image alt span').to.exist
+      expect(altSpan![1]).to.not.include(']') // confirms `]` was scrubbed inside alt
+      expect(altSpan![1]).to.include('Phase')
+      expect(altSpan![1]).to.include('2')
+      expect(altSpan![1]).to.include('diagram')
+      // Full image syntax still parses to the right URL
+      expect(out).to.include('](https://x.com/a.png)')
+    })
+
+    it("falls back to CommonMark autolink form when src contains ')'", () => {
+      // A literal `)` in src would close the markdown image's URL span early.
+      // CommonMark's `<url>` autolink syntax tolerates parenthesised URLs;
+      // the rendered click target is still useful, just without the alt text.
+      const html = '<bv-topic path="x" title="t"><bv-decision id="d-1"><img src="https://example.com/path(v2).png" alt="any"/></bv-decision></bv-topic>'
+      const out = renderHtmlTopicForLlm(html)
+      expect(out).to.include('<https://example.com/path(v2).png>')
+      expect(out).to.not.match(/!\[any\]\(https:\/\/example\.com\/path\(v2\)\.png\)/)
+    })
+
+    it('renders top-level <img> sibling of <bv-*> as the image markdown', () => {
+      // Rare but legal — top-level `<img>` directly under `<bv-topic>` is
+      // handled by `renderChild`'s `<img>` case (vs the inline path used
+      // inside `<bv-*>` bodies).
+      const html = '<bv-topic path="x" title="t"><img src="https://example.com/x.png" alt="hero"/></bv-topic>'
+      const out = renderHtmlTopicForLlm(html)
+      expect(out).to.include('![hero](https://example.com/x.png)')
+    })
+
+    it('preserves the BM25-friendly side-effect: rendered output contains the URL host + path tokens', () => {
+      // Sanity check that downstream tokenization sees the URL — the
+      // indexer wires `extractImageContent` separately, but the rendered
+      // output ALSO carries the URL inside the `(src)` span. Belt + braces.
+      const html = '<bv-topic path="x" title="t"><bv-decision id="d-1"><img src="https://example.com/architecture/v2/system-overview.png" alt="System overview"/></bv-decision></bv-topic>'
+      const out = renderHtmlTopicForLlm(html)
+      expect(out).to.include('example.com')
+      expect(out).to.include('system-overview.png')
+      expect(out).to.include('System overview')
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes the silent-strip bug where curating a topic with `<img src alt/>` embedded inside a `<bv-*>` element succeeds on disk but vanishes on `brv read` and is missed by `brv query`. **Worst-class UX** — no error fires; the calling agent thinks the curate succeeded and the content is safe.

Empirically reproduced 2026-05-29:
1. Curate a `<bv-decision>` containing `<img src="..." alt="System architecture showing service mesh"/>`.
2. On-disk file: ✓ tag intact.
3. `brv read`: ✗ rendered output shows a gap where the image was.
4. `brv query "service mesh"`: ✗ 0 matches.
5. `brv read --raw`: ✓ source bytes intact — data was always safe on disk.

Root cause: both `html-renderer.ts` and the BM25 indexer's `bodyText` extraction rely on `getInnerText()`, which walks text-node descendants only. Void elements like `<img>` contribute nothing.

## Approach

Treat `<img>` as first-class inline content — promote from "silently dropped" to "standard CommonMark + searchable".

### Renderer (`html-renderer.ts`)
- New private `getInlineMarkdown(node)` walks like `getInnerText` but translates `<img>` to CommonMark `![alt](src)`.
- `renderChild` uses it for inline content; a top-level `<img>` case is added for the rare bv-sibling shape.
- Defensive on malformed inputs:
  - missing `src` → empty string (no broken `![alt]()` syntax)
  - missing `alt` → `![](src)` (valid CommonMark click target)
  - `]` in alt → collapsed to space (only `]` closes the alt span; `[` is harmless)
  - `)` in src → CommonMark autolink form `<src>` (parens-tolerant)

### Indexer (`html-reader.ts` + `search-knowledge-service.ts`)
- New exported `extractImageContent(elements)` aggregates every `<img>`'s alt + src into a space-joined string.
- Surfaced via the new `HtmlTopicRead.imageContent` field — separate focused helper; does NOT mutate `getInnerText` (avoiding shared-infrastructure blast-radius).
- Indexer concatenates `parsed.imageContent` into the existing `[bodyText, summary, tags, keywords, related]` array.
- URLs go in verbatim; the BM25 tokenizer's whitespace/punctuation split decomposes them into useful tokens (host, path segments, filename, extension).

### Schema-version bump
`INDEX_SCHEMA_VERSION` bumped 6 → 7 so cached indexes built pre-fix invalidate on next daemon start. **Previously-curated `<img>` content becomes searchable retroactively** without a manual `brv index rebuild`.

### Documentation
`system-prompt.yml` updated in two places to mention `<img>` is supported alongside the existing inline-HTML allowlist.

## Test plan

- [x] Typecheck clean
- [x] Lint clean (0 errors). One pre-existing complexity warning on `renderChild` was 31 pre-fix, is 32 now — +1 unavoidable for the new top-level `<img>` branch.
- [x] **16 new unit tests** + **6 new integration cases**:
  - `html-renderer.test.ts` (7): inline `<img>` in `<bv-decision>`; `![](src)` for missing alt; silent drop for missing src; `]` escape; `)` autolink fallback; top-level `<img>`; URL tokens in rendered output.
  - `html-reader.test.ts` (6): empty topic → empty imageContent; single image aggregated; multiple images preserve document order; empty attrs don't produce double spaces; `readHtmlTopicSync` surfaces `imageContent` on parsed result.
  - `test/integration/scenarios/img-roundtrip.test.ts` (6): full read + index pipeline with MiniSearch configured like production. Curate-shaped HTML on tmp disk → renderer shows markdown image syntax; queries on alt phrase, URL host token, URL path segment, and surrounding prose all match. Plus a regression guard for zero-image topics.
- [x] **42/42 affected-surface tests green**.
- [x] **54/54 search-knowledge regression** tests pass — no regression on the indexer's existing behavior.
- [x] Empirical bug reproduction (5-step) from the bug report now passes end-to-end at the test level.

## Reviewer notes

- The renderer's `getInlineMarkdown` is private and scoped to the `<img>` case — `<a href>` translation is a follow-up task in the same inline-html-support milestone (same fix shape, but different bug surface: anchor text is already preserved via inner text; only `href` is dropped).
- `extractImageContent` is exported for the indexer to consume; designed so future inline-HTML elements with attribute-only content slot in by extending its tag-filter without rewriting the surface.
- The `INDEX_SCHEMA_VERSION` bump is the standard self-healing pattern — no user-facing migration step. First daemon start after merge regenerates the index.
- `system-prompt.yml` change is documentation for cipher-agent users (legacy `curate`/`query` paths). Tool-mode users will discover `<img>` works through trial — the writer already accepts it. Broader prompt-builder documentation for tool-mode is a possible follow-up if discovery is slow in practice.

## Out of scope (follow-ups)

- **`<a href>` first-class rendering + indexing** — same shape; tracked separately in the inline-html-support milestone.
- **Image-URL validation / host allowlist** — image URLs pass through unchanged.
- **Alt-text accessibility validation** — minimum length, presence required — separate decision.
- **Tool-mode kickoff-prompt documentation** of `<img>` support — current update is to the cipher-agent system prompt only.

## Related

- Bug report: in-conversation 2026-05-29 (5-step empirical reproduction).
- Milestone: `features/html-memory-conversion/milestones/02-inline-html-support/` (research repo).
- Affected paths:
  - `src/server/infra/render/reader/html-renderer.ts` — strip point fixed
  - `src/server/infra/render/reader/html-reader.ts` — new `extractImageContent` + `imageContent` field
  - `src/agent/infra/tools/implementations/search-knowledge-service.ts` — indexer wire + schema bump
  - `src/agent/resources/prompts/system-prompt.yml` — documentation