### PR TITLE
feat: [ENG-2621] open the analytics disclosure by default in the Privacy tab

### DIFF
--- a/src/webui/features/analytics/components/analytics-panel.tsx
+++ b/src/webui/features/analytics/components/analytics-panel.tsx
@@ -18,7 +18,7 @@ export function AnalyticsPanel() {
   const {data, error, isError, isLoading, refetch} = useGetGlobalConfig()
   const setAnalytics = useSetAnalytics()
   const [pendingIntent, setPendingIntent] = useState<'disable' | 'enable' | undefined>()
-  const [detailsOpen, setDetailsOpen] = useState(false)
+  const [detailsOpen, setDetailsOpen] = useState(true)
 
   const analytics = data?.analytics ?? false
 


### PR DESCRIPTION
## Summary

- Default \`detailsOpen\` to \`true\` so the "What data will be collected?" disclosure panel inside the Privacy tab renders expanded on first view.
- Surfaces the disclosure proactively — fits the spirit of an opt-in privacy surface (user shouldn't have to hunt for what the toggle implies).
- One-line change in \`src/webui/features/analytics/components/analytics-panel.tsx\`.

## Test plan

- [ ] \`npm run dev:ui\` → \`brv webui\` → Configuration → Privacy → "What data will be collected?" is expanded on initial render
- [ ] Clicking the trigger collapses it; clicking again re-expands
- [ ] Toggle on/off still routes to the correct confirm dialog
- [ ] \`npm run lint\`, \`npm run typecheck\`, \`npm test\` green