### PR TITLE
Feat/eng 2697

### DIFF
--- a/src/server/templates/skill/SKILL.md
+++ b/src/server/templates/skill/SKILL.md
@@ -120,7 +120,7 @@ digraph brv_flow {
 | Inspect past curates/queries | `brv curate view` / `brv query-log view` | `history.md` |
 | Track context-tree changes (git-style) | `brv vc` | `vc.md` |
 | Consolidate / dedupe / prune the context tree | `brv dream` | `dream.md` |
-| Visually browse / view curated knowledge in a browser | `http://localhost:<served-port>` | `curate.md` |
+| Visually browse / view curated knowledge in a browser | `brv webui` | `curate.md` |
 | Find project paths | `brv locations` | `brv locations --help` |
 | Diagnose a `brv` error | `brv status` | `brv status --help` |
 
@@ -174,7 +174,7 @@ Each detail file lives in this skill directory. Read the relevant one before inv
 - `brv swarm <query|curate|status>` — cross-source memory federation. See `swarm.md`.
 - `brv vc <init|status|add|commit|...>` — git-style version control of the context tree. See `vc.md`.
 - `brv dream <scan|finalize|undo>` — three-phase context-tree cleanup (link / merge / prune / synthesize). See `dream.md`.
-- `brv webui [--port <n>]` — open or reconfigure the ByteRover dashboard when needed. For routine curate and onboarding closeouts, share the served Web UI link directly: `http://localhost:<served-port>`; default `http://localhost:7700` unless a custom port is already serving. The **Contexts page** renders everything saved under `.brv/context-tree/`. If that link does not open, tell the user they can run `brv webui` to open the dashboard; use `brv webui --port <port>` only when the user asks to open/change the dashboard port or the current port has a conflict. See `curate.md`.
+- `brv webui [--port <n>]` — open or reconfigure the ByteRover dashboard when needed. For routine curate and onboarding closeouts, share `http://localhost:7700`; if a known custom Web UI port is already serving, share that localhost URL instead. The **Contexts page** renders everything saved under `.brv/context-tree/`. If that link does not open, tell the user they can run `brv webui` to open the dashboard; use `brv webui --port <port>` only when the user asks to open/change the dashboard port or the current port has a conflict. See `curate.md`.
 - `brv curate view` / `brv query-log view|summary` — inspect history. See `history.md`.
 - `brv locations` — list registered projects and their context tree paths. Use `-f json` for machine-readable output. Run `brv locations --help` for flags.
 - `brv status` — diagnose any `brv` error (auth + project state). Run first when a command misbehaves.

--- a/src/server/templates/skill/SKILL.md
+++ b/src/server/templates/skill/SKILL.md
@@ -120,7 +120,7 @@ digraph brv_flow {
 | Inspect past curates/queries | `brv curate view` / `brv query-log view` | `history.md` |
 | Track context-tree changes (git-style) | `brv vc` | `vc.md` |
 | Consolidate / dedupe / prune the context tree | `brv dream` | `dream.md` |
-| Visually browse / view curated knowledge in a browser | `brv webui` (or `brv webui --port <port>`) | `curate.md` |
+| Visually browse / view curated knowledge in a browser | `http://localhost:<served-port>` | `curate.md` |
 | Find project paths | `brv locations` | `brv locations --help` |
 | Diagnose a `brv` error | `brv status` | `brv status --help` |
 
@@ -174,7 +174,7 @@ Each detail file lives in this skill directory. Read the relevant one before inv
 - `brv swarm <query|curate|status>` — cross-source memory federation. See `swarm.md`.
 - `brv vc <init|status|add|commit|...>` — git-style version control of the context tree. See `vc.md`.
 - `brv dream <scan|finalize|undo>` — three-phase context-tree cleanup (link / merge / prune / synthesize). See `dream.md`.
-- `brv webui [--port <n>]` — open the ByteRover dashboard in the browser and print the active Web UI URL. The **Contexts page** renders everything saved under `.brv/context-tree/`. Share the printed Web UI URL with the user; if the current port is busy or they need another port, run `brv webui --port <port>` and share the new printed URL. See `curate.md`.
+- `brv webui [--port <n>]` — open or reconfigure the ByteRover dashboard when needed. For routine curate and onboarding closeouts, share the served Web UI link directly: `http://localhost:<served-port>`; default `http://localhost:7700` unless a custom port is already serving. The **Contexts page** renders everything saved under `.brv/context-tree/`. If that link does not open, tell the user they can run `brv webui` to open the dashboard; use `brv webui --port <port>` only when the user asks to open/change the dashboard port or the current port has a conflict. See `curate.md`.
 - `brv curate view` / `brv query-log view|summary` — inspect history. See `history.md`.
 - `brv locations` — list registered projects and their context tree paths. Use `-f json` for machine-readable output. Run `brv locations --help` for flags.
 - `brv status` — diagnose any `brv` error (auth + project state). Run first when a command misbehaves.

--- a/src/server/templates/skill/SKILL.md
+++ b/src/server/templates/skill/SKILL.md
@@ -120,6 +120,7 @@ digraph brv_flow {
 | Inspect past curates/queries | `brv curate view` / `brv query-log view` | `history.md` |
 | Track context-tree changes (git-style) | `brv vc` | `vc.md` |
 | Consolidate / dedupe / prune the context tree | `brv dream` | `dream.md` |
+| Visually browse / view curated knowledge in a browser | `brv webui` (or open `http://localhost:7700`) | `curate.md` |
 | Find project paths | `brv locations` | `brv locations --help` |
 | Diagnose a `brv` error | `brv status` | `brv status --help` |
 
@@ -173,6 +174,7 @@ Each detail file lives in this skill directory. Read the relevant one before inv
 - `brv swarm <query|curate|status>` — cross-source memory federation. See `swarm.md`.
 - `brv vc <init|status|add|commit|...>` — git-style version control of the context tree. See `vc.md`.
 - `brv dream <scan|finalize|undo>` — three-phase context-tree cleanup (link / merge / prune / synthesize). See `dream.md`.
+- `brv webui [--port <n>]` — open the ByteRover dashboard in the browser. The **Contexts page** renders everything saved under `.brv/context-tree/`. The daemon already serves it at `http://localhost:7700` by default, so that URL is clickable without running anything. See `curate.md`.
 - `brv curate view` / `brv query-log view|summary` — inspect history. See `history.md`.
 - `brv locations` — list registered projects and their context tree paths. Use `-f json` for machine-readable output. Run `brv locations --help` for flags.
 - `brv status` — diagnose any `brv` error (auth + project state). Run first when a command misbehaves.

--- a/src/server/templates/skill/SKILL.md
+++ b/src/server/templates/skill/SKILL.md
@@ -120,7 +120,7 @@ digraph brv_flow {
 | Inspect past curates/queries | `brv curate view` / `brv query-log view` | `history.md` |
 | Track context-tree changes (git-style) | `brv vc` | `vc.md` |
 | Consolidate / dedupe / prune the context tree | `brv dream` | `dream.md` |
-| Visually browse / view curated knowledge in a browser | `brv webui` (or open `http://localhost:7700`) | `curate.md` |
+| Visually browse / view curated knowledge in a browser | `brv webui` (or `brv webui --port <port>`) | `curate.md` |
 | Find project paths | `brv locations` | `brv locations --help` |
 | Diagnose a `brv` error | `brv status` | `brv status --help` |
 
@@ -174,7 +174,7 @@ Each detail file lives in this skill directory. Read the relevant one before inv
 - `brv swarm <query|curate|status>` — cross-source memory federation. See `swarm.md`.
 - `brv vc <init|status|add|commit|...>` — git-style version control of the context tree. See `vc.md`.
 - `brv dream <scan|finalize|undo>` — three-phase context-tree cleanup (link / merge / prune / synthesize). See `dream.md`.
-- `brv webui [--port <n>]` — open the ByteRover dashboard in the browser. The **Contexts page** renders everything saved under `.brv/context-tree/`. The daemon already serves it at `http://localhost:7700` by default, so that URL is clickable without running anything. See `curate.md`.
+- `brv webui [--port <n>]` — open the ByteRover dashboard in the browser and print the active Web UI URL. The **Contexts page** renders everything saved under `.brv/context-tree/`. Share the printed Web UI URL with the user; if the current port is busy or they need another port, run `brv webui --port <port>` and share the new printed URL. See `curate.md`.
 - `brv curate view` / `brv query-log view|summary` — inspect history. See `history.md`.
 - `brv locations` — list registered projects and their context tree paths. Use `-f json` for machine-readable output. Run `brv locations --help` for flags.
 - `brv status` — diagnose any `brv` error (auth + project state). Run first when a command misbehaves.

--- a/src/server/templates/skill/curate.md
+++ b/src/server/templates/skill/curate.md
@@ -28,8 +28,8 @@ brv curate "Authentication middleware validates JWTs in src/middleware/auth.ts a
 brv curate "Retry helper in src/retry.ts treats HTTP 429 as retryable with exponential backoff."
 brv curate view --detail
 brv review pending --format json
-# After a successful curate, share the served Web UI link: http://localhost:<served-port>
-# default http://localhost:7700 unless a custom Web UI port is already serving
+# After a successful curate, share the Web UI link: http://localhost:7700
+# If a known custom Web UI port is already serving, share that localhost URL instead
 # If that link does not open, tell the user they can run brv webui
 ```
 
@@ -47,7 +47,7 @@ Curate runs as request -> response -> request:
    brv curate --session <data.sessionId> --response "<your bv-topic html>" --format json
    ```
 4. Branch on `data.status`:
-   - `done` - report `data.filePath`, then give the user the served Web UI link, such as `http://localhost:<served-port>`, so they can see the saved topic in the Contexts page. Use default `http://localhost:7700` unless a custom port is already serving. If that link does not open, tell the user they can run `brv webui` to open the dashboard; use `brv webui --port <port>` only when the user asks to open/change the dashboard port or the current port has a conflict.
+   - `done` - report `data.filePath`, then give the user `http://localhost:7700` so they can see the saved topic in the Contexts page. If a known custom Web UI port is already serving, share that localhost URL instead. If that link does not open, tell the user they can run `brv webui` to open the dashboard; use `brv webui --port <port>` only when the user asks to open/change the dashboard port or the current port has a conflict.
    - `needs-llm-step` with `step: "correct-html"` - fix validation errors from `data.errors[]` and continue the same session.
    - `failed` - report the error messages.
 
@@ -109,7 +109,7 @@ Every `--format json` response is wrapped in `{ "command", "data", "success", "t
 }
 ```
 
-→ Only now is the topic saved. Report `data.filePath` and hand the user the served Web UI link, such as `http://localhost:<served-port>`, so they can open the Contexts page and see it. Use default `http://localhost:7700` unless a custom port is already serving. If that link does not open, tell the user they can run `brv webui` to open the dashboard; use `brv webui --port <port>` only when the user asks to open/change the dashboard port or the current port has a conflict.
+→ Only now is the topic saved. Report `data.filePath` and hand the user `http://localhost:7700`, so they can open the Contexts page and see it. If a known custom Web UI port is already serving, share that localhost URL instead. If that link does not open, tell the user they can run `brv webui` to open the dashboard; use `brv webui --port <port>` only when the user asks to open/change the dashboard port or the current port has a conflict.
 
 ## HTML Topic Contract
 
@@ -193,7 +193,7 @@ Then tell the user what needs review.
 
 On `data.status: "done"`, the topic is written to `.brv/context-tree/<data.filePath>`. To let the user actually see it, point them at the dashboard:
 
-- Give the user the served Web UI link, such as `http://localhost:<served-port>`; default `http://localhost:7700` unless a custom port is already serving. It opens the **Contexts page**, which renders the whole `.brv/context-tree/`. The path you just saved (e.g. `security/auth`) shows up as a node in the tree with its rendered content, edit controls, change history, and last-updated metadata.
+- Give the user `http://localhost:7700`; if a known custom Web UI port is already serving, share that localhost URL instead. It opens the **Contexts page**, which renders the whole `.brv/context-tree/`. The path you just saved (e.g. `security/auth`) shows up as a node in the tree with its rendered content, edit controls, change history, and last-updated metadata.
 - If that link does not open, tell the user they can run `brv webui` to open the dashboard. Use `brv webui --port <port>` only when the user asks to open/change the dashboard port or the current port has a conflict.
 
 ## Common Mistakes
@@ -204,4 +204,4 @@ On `data.status: "done"`, the topic is written to `.brv/context-tree/<data.fileP
 | Omitting `keywords` when retrieval terms are obvious | Add comma-separated `keywords` on `<bv-topic>` |
 | Reporting completion before a session reaches `data.status: "done"` | Wait for `done` before telling the user the topic is saved |
 | Overwriting an existing path without preserving prior facts | Merge existing content unless the user explicitly wants replacement |
-| Saying the topic is saved without showing the user where to see it | After `done`, give the user `data.filePath` and the served Web UI link, such as `http://localhost:<served-port>` |
+| Saying the topic is saved without showing the user where to see it | After `done`, give the user `data.filePath` and the Web UI link, usually `http://localhost:7700` |

--- a/src/server/templates/skill/curate.md
+++ b/src/server/templates/skill/curate.md
@@ -28,6 +28,7 @@ brv curate "Authentication middleware validates JWTs in src/middleware/auth.ts a
 brv curate "Retry helper in src/retry.ts treats HTTP 429 as retryable with exponential backoff."
 brv curate view --detail
 brv review pending --format json
+# After a successful curate, view the topic in the dashboard: http://localhost:7700 (Contexts page)
 ```
 
 ## Session Protocol
@@ -44,11 +45,69 @@ Curate runs as request -> response -> request:
    brv curate --session <data.sessionId> --response "<your bv-topic html>" --format json
    ```
 4. Branch on `data.status`:
-   - `done` - report `data.filePath`.
+   - `done` - report `data.filePath`, then give the user the clickable dashboard URL `http://localhost:7700` so they can see the saved topic in the Contexts page (the daemon is already serving it).
    - `needs-llm-step` with `step: "correct-html"` - fix validation errors from `data.errors[]` and continue the same session.
    - `failed` - report the error messages.
 
 If `data.errors[]` includes `kind: "path-exists"`, prefer merging the existing topic with the new facts and continue with `--overwrite`. Choose a different path only when the collision is accidental. Replace existing content only when the user explicitly asked for replacement.
+
+## Example Session Responses
+
+Every `--format json` response is wrapped in `{ "command", "data", "success", "timestamp" }`. Branch on `data.status`. The three envelopes below show a full session: kickoff, one correction turn, then completion.
+
+1. Kickoff (`brv curate "<intent>" --format json`) returns a live session asking you to author HTML:
+
+```json
+{
+  "command": "curate",
+  "data": {
+    "ok": true,
+    "status": "needs-llm-step",
+    "step": "generate-html",
+    "sessionId": "550e8400-e29b-41d4-a716-446655440000",
+    "prompt": "<instructions describing the bv-topic HTML to author>"
+  },
+  "success": true,
+  "timestamp": "2026-05-29T14:30:45.123Z"
+}
+```
+
+2. If your HTML fails validation, the same session stays open with `step: "correct-html"` and the errors to fix:
+
+```json
+{
+  "command": "curate",
+  "data": {
+    "ok": false,
+    "status": "needs-llm-step",
+    "step": "correct-html",
+    "sessionId": "550e8400-e29b-41d4-a716-446655440000",
+    "errors": [
+      {"kind": "unknown-bv-element", "message": "Unknown element <bv-note>", "tag": "bv-note"}
+    ],
+    "prompt": "<correction instructions, with the prior errors inlined>"
+  },
+  "success": false,
+  "timestamp": "2026-05-29T14:30:50.456Z"
+}
+```
+
+3. On success, `data.status` is `done` and `data.filePath` is the topic path under `.brv/context-tree/`:
+
+```json
+{
+  "command": "curate",
+  "data": {
+    "ok": true,
+    "status": "done",
+    "filePath": "security/auth.html"
+  },
+  "success": true,
+  "timestamp": "2026-05-29T14:30:55.789Z"
+}
+```
+
+→ Only now is the topic saved. Report `data.filePath` and hand the user the dashboard URL `http://localhost:7700` so they can open the Contexts page and see it.
 
 ## HTML Topic Contract
 
@@ -128,6 +187,13 @@ brv review pending --format json
 
 Then tell the user what needs review.
 
+## View What You Saved
+
+On `data.status: "done"`, the topic is written to `.brv/context-tree/<data.filePath>`. To let the user actually see it, point them at the dashboard:
+
+- Give the user the clickable URL `http://localhost:7700` — it opens the **Contexts page**, which renders the whole `.brv/context-tree/`. The path you just saved (e.g. `security/auth`) shows up as a node in the tree with its rendered content, edit controls, change history, and last-updated metadata.
+- The dashboard is already running — the daemon serves it on port `7700` by default, so the URL works the moment a curate succeeds; nothing extra to start. (`brv webui` opens the same dashboard in the browser if the user prefers a command.)
+
 ## Common Mistakes
 
 | Mistake | Correct behavior |
@@ -136,3 +202,4 @@ Then tell the user what needs review.
 | Omitting `keywords` when retrieval terms are obvious | Add comma-separated `keywords` on `<bv-topic>` |
 | Reporting completion before a session reaches `data.status: "done"` | Wait for `done` before telling the user the topic is saved |
 | Overwriting an existing path without preserving prior facts | Merge existing content unless the user explicitly wants replacement |
+| Saying the topic is saved without showing the user where to see it | After `done`, give the user the dashboard URL (`http://localhost:7700`, Contexts page) and the `filePath` |

--- a/src/server/templates/skill/curate.md
+++ b/src/server/templates/skill/curate.md
@@ -28,8 +28,9 @@ brv curate "Authentication middleware validates JWTs in src/middleware/auth.ts a
 brv curate "Retry helper in src/retry.ts treats HTTP 429 as retryable with exponential backoff."
 brv curate view --detail
 brv review pending --format json
-# After a successful curate, run brv webui and share the printed Web UI URL (Contexts page)
-# If the port is busy, run brv webui --port <port> and share that printed URL instead
+# After a successful curate, share the served Web UI link: http://localhost:<served-port>
+# default http://localhost:7700 unless a custom Web UI port is already serving
+# If that link does not open, tell the user they can run brv webui
 ```
 
 ## Session Protocol
@@ -46,7 +47,7 @@ Curate runs as request -> response -> request:
    brv curate --session <data.sessionId> --response "<your bv-topic html>" --format json
    ```
 4. Branch on `data.status`:
-   - `done` - report `data.filePath`, then run `brv webui` and give the user the printed Web UI URL so they can see the saved topic in the Contexts page. If the command reports a port conflict, run `brv webui --port <port>` and share that printed URL instead.
+   - `done` - report `data.filePath`, then give the user the served Web UI link, such as `http://localhost:<served-port>`, so they can see the saved topic in the Contexts page. Use default `http://localhost:7700` unless a custom port is already serving. If that link does not open, tell the user they can run `brv webui` to open the dashboard; use `brv webui --port <port>` only when the user asks to open/change the dashboard port or the current port has a conflict.
    - `needs-llm-step` with `step: "correct-html"` - fix validation errors from `data.errors[]` and continue the same session.
    - `failed` - report the error messages.
 
@@ -108,7 +109,7 @@ Every `--format json` response is wrapped in `{ "command", "data", "success", "t
 }
 ```
 
-→ Only now is the topic saved. Report `data.filePath`, run `brv webui`, and hand the user the printed Web UI URL so they can open the Contexts page and see it. If the command reports a port conflict, run `brv webui --port <port>` and share that printed URL instead.
+→ Only now is the topic saved. Report `data.filePath` and hand the user the served Web UI link, such as `http://localhost:<served-port>`, so they can open the Contexts page and see it. Use default `http://localhost:7700` unless a custom port is already serving. If that link does not open, tell the user they can run `brv webui` to open the dashboard; use `brv webui --port <port>` only when the user asks to open/change the dashboard port or the current port has a conflict.
 
 ## HTML Topic Contract
 
@@ -192,8 +193,8 @@ Then tell the user what needs review.
 
 On `data.status: "done"`, the topic is written to `.brv/context-tree/<data.filePath>`. To let the user actually see it, point them at the dashboard:
 
-- Run `brv webui` and give the user the printed Web UI URL. It opens the **Contexts page**, which renders the whole `.brv/context-tree/`. The path you just saved (e.g. `security/auth`) shows up as a node in the tree with its rendered content, edit controls, change history, and last-updated metadata.
-- If `brv webui` reports a port conflict or the user needs a different port, run `brv webui --port <port>` and give the user that newly printed URL instead.
+- Give the user the served Web UI link, such as `http://localhost:<served-port>`; default `http://localhost:7700` unless a custom port is already serving. It opens the **Contexts page**, which renders the whole `.brv/context-tree/`. The path you just saved (e.g. `security/auth`) shows up as a node in the tree with its rendered content, edit controls, change history, and last-updated metadata.
+- If that link does not open, tell the user they can run `brv webui` to open the dashboard. Use `brv webui --port <port>` only when the user asks to open/change the dashboard port or the current port has a conflict.
 
 ## Common Mistakes
 
@@ -203,4 +204,4 @@ On `data.status: "done"`, the topic is written to `.brv/context-tree/<data.fileP
 | Omitting `keywords` when retrieval terms are obvious | Add comma-separated `keywords` on `<bv-topic>` |
 | Reporting completion before a session reaches `data.status: "done"` | Wait for `done` before telling the user the topic is saved |
 | Overwriting an existing path without preserving prior facts | Merge existing content unless the user explicitly wants replacement |
-| Saying the topic is saved without showing the user where to see it | After `done`, give the user `data.filePath`, run `brv webui`, and share the printed Web UI URL for the Contexts page |
+| Saying the topic is saved without showing the user where to see it | After `done`, give the user `data.filePath` and the served Web UI link, such as `http://localhost:<served-port>` |

--- a/src/server/templates/skill/curate.md
+++ b/src/server/templates/skill/curate.md
@@ -28,7 +28,8 @@ brv curate "Authentication middleware validates JWTs in src/middleware/auth.ts a
 brv curate "Retry helper in src/retry.ts treats HTTP 429 as retryable with exponential backoff."
 brv curate view --detail
 brv review pending --format json
-# After a successful curate, view the topic in the dashboard: http://localhost:7700 (Contexts page)
+# After a successful curate, run brv webui and share the printed Web UI URL (Contexts page)
+# If the port is busy, run brv webui --port <port> and share that printed URL instead
 ```
 
 ## Session Protocol
@@ -45,7 +46,7 @@ Curate runs as request -> response -> request:
    brv curate --session <data.sessionId> --response "<your bv-topic html>" --format json
    ```
 4. Branch on `data.status`:
-   - `done` - report `data.filePath`, then give the user the clickable dashboard URL `http://localhost:7700` so they can see the saved topic in the Contexts page (the daemon is already serving it).
+   - `done` - report `data.filePath`, then run `brv webui` and give the user the printed Web UI URL so they can see the saved topic in the Contexts page. If the command reports a port conflict, run `brv webui --port <port>` and share that printed URL instead.
    - `needs-llm-step` with `step: "correct-html"` - fix validation errors from `data.errors[]` and continue the same session.
    - `failed` - report the error messages.
 
@@ -107,7 +108,7 @@ Every `--format json` response is wrapped in `{ "command", "data", "success", "t
 }
 ```
 
-→ Only now is the topic saved. Report `data.filePath` and hand the user the dashboard URL `http://localhost:7700` so they can open the Contexts page and see it.
+→ Only now is the topic saved. Report `data.filePath`, run `brv webui`, and hand the user the printed Web UI URL so they can open the Contexts page and see it. If the command reports a port conflict, run `brv webui --port <port>` and share that printed URL instead.
 
 ## HTML Topic Contract
 
@@ -191,8 +192,8 @@ Then tell the user what needs review.
 
 On `data.status: "done"`, the topic is written to `.brv/context-tree/<data.filePath>`. To let the user actually see it, point them at the dashboard:
 
-- Give the user the clickable URL `http://localhost:7700` — it opens the **Contexts page**, which renders the whole `.brv/context-tree/`. The path you just saved (e.g. `security/auth`) shows up as a node in the tree with its rendered content, edit controls, change history, and last-updated metadata.
-- The dashboard is already running — the daemon serves it on port `7700` by default, so the URL works the moment a curate succeeds; nothing extra to start. (`brv webui` opens the same dashboard in the browser if the user prefers a command.)
+- Run `brv webui` and give the user the printed Web UI URL. It opens the **Contexts page**, which renders the whole `.brv/context-tree/`. The path you just saved (e.g. `security/auth`) shows up as a node in the tree with its rendered content, edit controls, change history, and last-updated metadata.
+- If `brv webui` reports a port conflict or the user needs a different port, run `brv webui --port <port>` and give the user that newly printed URL instead.
 
 ## Common Mistakes
 
@@ -202,4 +203,4 @@ On `data.status: "done"`, the topic is written to `.brv/context-tree/<data.fileP
 | Omitting `keywords` when retrieval terms are obvious | Add comma-separated `keywords` on `<bv-topic>` |
 | Reporting completion before a session reaches `data.status: "done"` | Wait for `done` before telling the user the topic is saved |
 | Overwriting an existing path without preserving prior facts | Merge existing content unless the user explicitly wants replacement |
-| Saying the topic is saved without showing the user where to see it | After `done`, give the user the dashboard URL (`http://localhost:7700`, Contexts page) and the `filePath` |
+| Saying the topic is saved without showing the user where to see it | After `done`, give the user `data.filePath`, run `brv webui`, and share the printed Web UI URL for the Contexts page |

--- a/src/server/templates/skill/onboarding.md
+++ b/src/server/templates/skill/onboarding.md
@@ -100,7 +100,7 @@ Saved:
 <pain-naming + commitment paragraph — 2 short sentences>
 
 Lives at .brv/context-tree/ — local-only.
-See it in your browser: http://localhost:<served-port>  — or run brv webui if that link doesn't open.
+See it in your browser: http://localhost:7700  — or run brv webui if that link doesn't open.
 Also version-controlled, cloud-syncable, and shareable across agents — more at the end.
 ```
 
@@ -127,7 +127,7 @@ model, your reliability stance, and the context you just shared. You
 stop re-explaining. You start where you left off.
 
 Lives at .brv/context-tree/ — local-only.
-See it in your browser: http://localhost:<served-port>
+See it in your browser: http://localhost:7700
 Also version-controlled, cloud-syncable, and shareable across agents — more at the end.
 ```
 
@@ -135,7 +135,7 @@ Also version-controlled, cloud-syncable, and shareable across agents — more at
 
 The browser URL is the **verifiable** trust proof — the user can click it in 2 seconds and see their memory in a real local dashboard. Stronger than any worded assurance.
 
-Use the served Web UI link, such as `http://localhost:<served-port>`; default `http://localhost:7700` unless a custom port is already serving. Do NOT run `brv webui` as part of every tour closeout just to produce this link. If that link does not open, tell the user they can run `brv webui` to open the dashboard. Use `brv webui --port <port>` only when the user asks to open/change the dashboard port or the current port has a conflict.
+Use `http://localhost:7700` for the Web UI link unless a known custom Web UI port is already serving, in which case use that localhost URL. Do NOT run `brv webui` as part of every tour closeout just to produce this link. If that link does not open, tell the user they can run `brv webui` to open the dashboard. Use `brv webui --port <port>` only when the user asks to open/change the dashboard port or the current port has a conflict.
 
 Do NOT ask "is this right?" — that turns the artifact into a form. Users who want to correct it will; users who don't, won't be slowed down.
 

--- a/src/server/templates/skill/onboarding.md
+++ b/src/server/templates/skill/onboarding.md
@@ -100,7 +100,7 @@ Saved:
 <pain-naming + commitment paragraph — 2 short sentences>
 
 Lives at .brv/context-tree/ — local-only.
-See it in your browser: http://localhost:7700
+See it in your browser: <printed Web UI URL from brv webui>
 Also version-controlled, cloud-syncable, and shareable across agents — more at the end.
 ```
 
@@ -127,7 +127,7 @@ model, your reliability stance, and the context you just shared. You
 stop re-explaining. You start where you left off.
 
 Lives at .brv/context-tree/ — local-only.
-See it in your browser: http://localhost:7700
+See it in your browser: <printed Web UI URL from brv webui>
 Also version-controlled, cloud-syncable, and shareable across agents — more at the end.
 ```
 
@@ -135,7 +135,7 @@ Also version-controlled, cloud-syncable, and shareable across agents — more at
 
 The browser URL is the **verifiable** trust proof — the user can click it in 2 seconds and see their memory in a real local dashboard. Stronger than any worded assurance.
 
-Do NOT tell the user to "run `brv webui`" — the daemon auto-starts the web server on the persisted port (default 7700). The URL works as soon as the daemon is alive, which it already is.
+Run `brv webui` to get the current dashboard URL, then give the user the printed Web UI URL. Do NOT hardcode a localhost port; the daemon may be using a remembered custom port. If `brv webui` reports a port conflict, run `brv webui --port <port>` and use that newly printed URL.
 
 Do NOT ask "is this right?" — that turns the artifact into a form. Users who want to correct it will; users who don't, won't be slowed down.
 

--- a/src/server/templates/skill/onboarding.md
+++ b/src/server/templates/skill/onboarding.md
@@ -100,7 +100,7 @@ Saved:
 <pain-naming + commitment paragraph — 2 short sentences>
 
 Lives at .brv/context-tree/ — local-only.
-See it in your browser: <printed Web UI URL from brv webui>
+See it in your browser: http://localhost:<served-port>  — or run brv webui if that link doesn't open.
 Also version-controlled, cloud-syncable, and shareable across agents — more at the end.
 ```
 
@@ -127,7 +127,7 @@ model, your reliability stance, and the context you just shared. You
 stop re-explaining. You start where you left off.
 
 Lives at .brv/context-tree/ — local-only.
-See it in your browser: <printed Web UI URL from brv webui>
+See it in your browser: http://localhost:<served-port>
 Also version-controlled, cloud-syncable, and shareable across agents — more at the end.
 ```
 
@@ -135,7 +135,7 @@ Also version-controlled, cloud-syncable, and shareable across agents — more at
 
 The browser URL is the **verifiable** trust proof — the user can click it in 2 seconds and see their memory in a real local dashboard. Stronger than any worded assurance.
 
-Run `brv webui` to get the current dashboard URL, then give the user the printed Web UI URL. Do NOT hardcode a localhost port; the daemon may be using a remembered custom port. If `brv webui` reports a port conflict, run `brv webui --port <port>` and use that newly printed URL.
+Use the served Web UI link, such as `http://localhost:<served-port>`; default `http://localhost:7700` unless a custom port is already serving. Do NOT run `brv webui` as part of every tour closeout just to produce this link. If that link does not open, tell the user they can run `brv webui` to open the dashboard. Use `brv webui --port <port>` only when the user asks to open/change the dashboard port or the current port has a conflict.
 
 Do NOT ask "is this right?" — that turns the artifact into a form. Users who want to correct it will; users who don't, won't be slowed down.
 

--- a/test/unit/infra/connectors/skill/skill-connector.test.ts
+++ b/test/unit/infra/connectors/skill/skill-connector.test.ts
@@ -157,6 +157,7 @@ describe('SkillConnector', () => {
       expect(content).to.include('brv query')
       expect(content).to.include('brv curate')
       expect(content).to.include('brv curate view')
+      expect(content).to.include('brv webui')
       expect(content).to.include('## When To Use')
       expect(content).to.include('## Quick Reference')
       expect(content).not.to.include('<<<<<<<')
@@ -195,6 +196,8 @@ describe('SkillConnector', () => {
       expect(curateContent).to.include('<bv-topic')
       expect(curateContent).to.include('bv-rule')
       expect(curateContent).to.include('--overwrite')
+      expect(curateContent).to.include('localhost:7700')
+      expect(curateContent).to.include('## Example Session Responses')
     })
 
     it('should create sibling guides with When-To and Common Mistakes sections', async () => {

--- a/test/unit/infra/connectors/skill/skill-connector.test.ts
+++ b/test/unit/infra/connectors/skill/skill-connector.test.ts
@@ -158,6 +158,9 @@ describe('SkillConnector', () => {
       expect(content).to.include('brv curate')
       expect(content).to.include('brv curate view')
       expect(content).to.include('brv webui')
+      expect(content).to.include('printed Web UI URL')
+      expect(content).to.include('brv webui --port <port>')
+      expect(content).not.to.include('http://localhost:7700')
       expect(content).to.include('## When To Use')
       expect(content).to.include('## Quick Reference')
       expect(content).not.to.include('<<<<<<<')
@@ -182,6 +185,25 @@ describe('SkillConnector', () => {
       expect(swarmContent).to.include('parallel')
     })
 
+    it('should avoid fixed Web UI localhost ports in installed skill docs', async () => {
+      const agent = 'Claude Code' as const
+      const {projectPath} = SKILL_CONNECTOR_CONFIGS[agent]
+      await skillConnector.install(agent)
+
+      const skillDir = path.join(testDir, projectPath, BRV_SKILL_NAME)
+      const contents = await Promise.all(
+        SKILL_FILE_NAMES.map((fileName) => readFile(path.join(skillDir, fileName), 'utf8')),
+      )
+
+      for (const content of contents) {
+        expect(content).not.to.include('http://localhost:7700')
+      }
+
+      const onboardingContent = await readFile(path.join(skillDir, 'onboarding.md'), 'utf8')
+      expect(onboardingContent).to.include('printed Web UI URL')
+      expect(onboardingContent).to.include('brv webui --port <port>')
+    })
+
     it('should create curate.md documenting the session protocol and bv-topic contract', async () => {
       const agent = 'Claude Code' as const
       const {projectPath} = SKILL_CONNECTOR_CONFIGS[agent]
@@ -196,8 +218,10 @@ describe('SkillConnector', () => {
       expect(curateContent).to.include('<bv-topic')
       expect(curateContent).to.include('bv-rule')
       expect(curateContent).to.include('--overwrite')
-      expect(curateContent).to.include('localhost:7700')
       expect(curateContent).to.include('## Example Session Responses')
+      expect(curateContent).to.include('printed Web UI URL')
+      expect(curateContent).to.include('brv webui --port <port>')
+      expect(curateContent).not.to.include('http://localhost:7700')
     })
 
     it('should create sibling guides with When-To and Common Mistakes sections', async () => {

--- a/test/unit/infra/connectors/skill/skill-connector.test.ts
+++ b/test/unit/infra/connectors/skill/skill-connector.test.ts
@@ -158,10 +158,11 @@ describe('SkillConnector', () => {
       expect(content).to.include('brv curate')
       expect(content).to.include('brv curate view')
       expect(content).to.include('brv webui')
-      expect(content).to.include('http://localhost:<served-port>')
-      expect(content).to.include('default `http://localhost:7700`')
+      expect(content).to.include('http://localhost:7700')
+      expect(content).to.include('known custom Web UI port is already serving')
       expect(content).to.include('If that link does not open, tell the user they can run `brv webui`')
       expect(content).to.include('brv webui --port <port>')
+      expect(content).not.to.include('http://localhost:<served-port>')
       expect(content).not.to.include('printed Web UI URL')
       expect(content).to.include('## When To Use')
       expect(content).to.include('## Quick Reference')
@@ -187,7 +188,7 @@ describe('SkillConnector', () => {
       expect(swarmContent).to.include('parallel')
     })
 
-    it('should guide installed skill docs to share the served Web UI link with command fallback', async () => {
+    it('should guide installed skill docs to share the default Web UI link with command fallback', async () => {
       const agent = 'Claude Code' as const
       const {projectPath} = SKILL_CONNECTOR_CONFIGS[agent]
       await skillConnector.install(agent)
@@ -199,12 +200,13 @@ describe('SkillConnector', () => {
 
       for (const content of contents) {
         expect(content).not.to.include('printed Web UI URL')
+        expect(content).not.to.include('http://localhost:<served-port>')
         expect(content).not.to.include('run `brv webui` after every successful curate')
       }
 
       const onboardingContent = await readFile(path.join(skillDir, 'onboarding.md'), 'utf8')
-      expect(onboardingContent).to.include('http://localhost:<served-port>')
-      expect(onboardingContent).to.include('default `http://localhost:7700`')
+      expect(onboardingContent).to.include('http://localhost:7700')
+      expect(onboardingContent).to.include('known custom Web UI port is already serving')
       expect(onboardingContent).to.include('If that link does not open, tell the user they can run `brv webui`')
       expect(onboardingContent).to.include('brv webui --port <port>')
     })
@@ -224,10 +226,11 @@ describe('SkillConnector', () => {
       expect(curateContent).to.include('bv-rule')
       expect(curateContent).to.include('--overwrite')
       expect(curateContent).to.include('## Example Session Responses')
-      expect(curateContent).to.include('http://localhost:<served-port>')
-      expect(curateContent).to.include('default `http://localhost:7700`')
+      expect(curateContent).to.include('http://localhost:7700')
+      expect(curateContent).to.include('known custom Web UI port is already serving')
       expect(curateContent).to.include('If that link does not open, tell the user they can run `brv webui`')
       expect(curateContent).to.include('brv webui --port <port>')
+      expect(curateContent).not.to.include('http://localhost:<served-port>')
       expect(curateContent).not.to.include('printed Web UI URL')
     })
 

--- a/test/unit/infra/connectors/skill/skill-connector.test.ts
+++ b/test/unit/infra/connectors/skill/skill-connector.test.ts
@@ -158,9 +158,11 @@ describe('SkillConnector', () => {
       expect(content).to.include('brv curate')
       expect(content).to.include('brv curate view')
       expect(content).to.include('brv webui')
-      expect(content).to.include('printed Web UI URL')
+      expect(content).to.include('http://localhost:<served-port>')
+      expect(content).to.include('default `http://localhost:7700`')
+      expect(content).to.include('If that link does not open, tell the user they can run `brv webui`')
       expect(content).to.include('brv webui --port <port>')
-      expect(content).not.to.include('http://localhost:7700')
+      expect(content).not.to.include('printed Web UI URL')
       expect(content).to.include('## When To Use')
       expect(content).to.include('## Quick Reference')
       expect(content).not.to.include('<<<<<<<')
@@ -185,7 +187,7 @@ describe('SkillConnector', () => {
       expect(swarmContent).to.include('parallel')
     })
 
-    it('should avoid fixed Web UI localhost ports in installed skill docs', async () => {
+    it('should guide installed skill docs to share the served Web UI link with command fallback', async () => {
       const agent = 'Claude Code' as const
       const {projectPath} = SKILL_CONNECTOR_CONFIGS[agent]
       await skillConnector.install(agent)
@@ -196,11 +198,14 @@ describe('SkillConnector', () => {
       )
 
       for (const content of contents) {
-        expect(content).not.to.include('http://localhost:7700')
+        expect(content).not.to.include('printed Web UI URL')
+        expect(content).not.to.include('run `brv webui` after every successful curate')
       }
 
       const onboardingContent = await readFile(path.join(skillDir, 'onboarding.md'), 'utf8')
-      expect(onboardingContent).to.include('printed Web UI URL')
+      expect(onboardingContent).to.include('http://localhost:<served-port>')
+      expect(onboardingContent).to.include('default `http://localhost:7700`')
+      expect(onboardingContent).to.include('If that link does not open, tell the user they can run `brv webui`')
       expect(onboardingContent).to.include('brv webui --port <port>')
     })
 
@@ -219,9 +224,11 @@ describe('SkillConnector', () => {
       expect(curateContent).to.include('bv-rule')
       expect(curateContent).to.include('--overwrite')
       expect(curateContent).to.include('## Example Session Responses')
-      expect(curateContent).to.include('printed Web UI URL')
+      expect(curateContent).to.include('http://localhost:<served-port>')
+      expect(curateContent).to.include('default `http://localhost:7700`')
+      expect(curateContent).to.include('If that link does not open, tell the user they can run `brv webui`')
       expect(curateContent).to.include('brv webui --port <port>')
-      expect(curateContent).not.to.include('http://localhost:7700')
+      expect(curateContent).not.to.include('printed Web UI URL')
     })
 
     it('should create sibling guides with When-To and Common Mistakes sections', async () => {


### PR DESCRIPTION
## Summary

- Problem: On a successful `brv curate`, the skill instructed the in-daemon agent to report only `data.filePath`. It never pointed users at the ByteRover dashboard where the saved topic is actually viewable, so users had no obvious way to *see* what was just curated.
- Why it matters: The dashboard already exists and the daemon serves it on `http://localhost:7700` by default — but the skill never surfaced it, leaving a working capability undiscovered and the curate loop ending at "a file path" instead of "here's your knowledge, rendered."
- What changed: Updated the skill templates the curate agent reads at runtime. On `done`, the agent now hands the user the clickable dashboard URL (Contexts page) alongside `filePath`. Added `brv webui` to SKILL.md's Quick Reference + command list, an "Example Session Responses" JSON walkthrough and a "View What You Saved" section to curate.md, plus a new Common Mistakes row. Tightened the connector test to guard the new content.
- What did NOT change (scope boundary): No runtime, CLI, or transport code. The `brv webui` command, the webui server, the curate engine, and port handling are untouched — this is documentation/behavioral-contract text plus a test assertion. The `7700` default is referenced, not introduced.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [x] Documentation
- [x] Test
- [ ] Chore (build, dependencies, CI)

## Scope (select all touched areas)

- [ ] TUI / REPL
- [ ] Agent / Tools
- [ ] LLM Providers
- [ ] Server / Daemon
- [ ] Shared (constants, types, transport events)
- [ ] CLI Commands (oclif)
- [x] Hub / Connectors
- [ ] Cloud Sync
- [ ] CI/CD / Infra

(Skill templates live under `src/server/templates/skill/` and are deployed/read via the SkillConnector in `server/infra/connectors/skill/`.)

## Linked issues

- Closes #N/A (tracker is Linear, no GitHub issue)
- Related: Linear ENG-2697 — "Rewrite ByteRover skill based on Superpowers skill" (https://linear.app/byterover/issue/ENG-2697). This is an enhancement layered on that rewrite.

## Root cause (bug fixes only, otherwise write `N/A`)

- Root cause: N/A
- Why this was not caught earlier: N/A

## Test plan

- Coverage added:
  - [x] Unit test
  - [ ] Integration test
  - [ ] Manual verification only
- Test file(s): `test/unit/infra/connectors/skill/skill-connector.test.ts`
- Key scenario(s) covered:
  - Installed `SKILL.md` includes `brv webui`.
  - Installed `curate.md` includes `localhost:7700` and the `## Example Session Responses` section.

## User-visible changes

- After a successful `brv curate`, the agent now gives the user the dashboard URL `http://localhost:7700` (Contexts page) alongside the saved `filePath`, instead of reporting only the path.
- `SKILL.md` Quick Reference and command list now document `brv webui`.
- No `brv` CLI flags, defaults, or command output changed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording

Before (old templates against the new assertions):

37 passing
2 failing
AssertionError: expected '---\nname: byterover...' to include 'brv webui'
AssertionError: expected '---\nname: byterover-curate...' to include 'localhost:7700'


After (`npx mocha "test/unit/infra/connectors/skill/skill-connector.test.ts"`):
39 passing (62ms)

## Checklist

- [x] Tests added or updated and passing (ran the touched suite — 39 passing; full `npm test` not run locally)
- [ ] Lint passes (`npm run lint`) — not run
- [ ] Type check passes (`npm run typecheck`) — not run
- [ ] Build succeeds (`npm run build`) — not run
- [x] Commits follow Conventional Commits format (`docs(skill): point users to the webui dashboard after curate`)
- [x] Documentation updated (this PR is the documentation)
- [x] No breaking changes
- [x] Branch is up to date with `main` (origin/main is an ancestor of HEAD)

## Risks and mitigations

- Risk: The dashboard URL is hardcoded to `http://localhost:7700`; if the user changed the webui port (`BRV_WEBUI_PORT` or a persisted port), the URL the agent surfaces will be wrong.
  - Mitigation: `7700` is the documented first-run default and the most common case; the docs also tell the agent that `brv webui` opens the same dashboard. Templating the actual port into the message is a reasonable follow-up.
- Risk: The agent may surface the URL even when the daemon/webui isn't reachable.
  - Mitigation: The daemon serves the dashboard by default whenever `brv` is running, so a curate succeeding implies the daemon is up; worst case is a stale link, no functional impact.


