### PR TITLE
Fix OpenClaw ByteRover plugin version for v3

### DIFF
--- a/scripts/openclaw-setup.sh
+++ b/scripts/openclaw-setup.sh
@@ -12,6 +12,7 @@ set -eu
 # ─── Constants ────────────────────────────────────────────────────────────────
 
 CONFIG_PATH="$HOME/.openclaw/openclaw.json"
+BYTEROVER_OPENCLAW_PLUGIN_VERSION="1.1.8"
 
 # ─── Colors (respects NO_COLOR and non-terminal) ─────────────────────────────
 
@@ -378,9 +379,9 @@ configure_context_plugin() {
   # Clean slate: remove old local files + previous CLI install to avoid conflicts
   remove_existing_byterover_plugin
 
-  info "Installing @byterover/byterover plugin..."
-  if ! retry_with_backoff openclaw plugins install @byterover/byterover@latest; then
-    error "Failed to install @byterover/byterover plugin after multiple attempts."
+  info "Installing @byterover/byterover plugin v${BYTEROVER_OPENCLAW_PLUGIN_VERSION}..."
+  if ! retry_with_backoff openclaw plugins install "@byterover/byterover@${BYTEROVER_OPENCLAW_PLUGIN_VERSION}"; then
+    error "Failed to install @byterover/byterover plugin v${BYTEROVER_OPENCLAW_PLUGIN_VERSION} after multiple attempts."
   fi
   success "Plugin installed."
 


### PR DESCRIPTION
## Summary
- Pin the OpenClaw ByteRover plugin install to `@byterover/byterover@1.1.8` for v3 users.
- Surface the pinned version in installer logs and failure messages.

## Tests
- `bash -n scripts/openclaw-setup.sh`
- Push hook: `npm run typecheck`